### PR TITLE
Add margin to action buttons

### DIFF
--- a/src/announcements/templates/announcements/form.html
+++ b/src/announcements/templates/announcements/form.html
@@ -12,11 +12,17 @@
 
 {% block content %}
 <form action="" enctype="multipart/form-data" method="post">{% csrf_token %}
-  <a href="{% url 'announcements:list' %}" role="button" class="btn btn-danger">Cancel</a>
-  <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success" />
+  <div class="announcement-action-btns">
+    <a href="{% url 'announcements:list' %}" role="button" class="btn btn-danger">Cancel</a>
+    <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success" />
+  </div>
+
   {{ form|crispy }}
-  <a href="{% url 'announcements:list' %}" role="button" class="btn btn-danger">Cancel</a>
-  <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success" />
+
+  <div class="announcement-action-btns">
+    <a href="{% url 'announcements:list' %}" role="button" class="btn btn-danger">Cancel</a>
+    <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success" />
+  </div>
 </form>
 {% endblock %}
 

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -410,6 +410,10 @@ ol > ol > ol {
     overflow-wrap: break-word;
 }
 
+.announcement-action-btns {
+    margin: 10px 0;
+}
+
 /*********** Bootstrap BADGES **************************/
 
 .badge.list-group-item-badge {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/10604391/91918571-276e6b80-ec78-11ea-8eec-81f0402d4eb2.png)

After
<img width="877" alt="Screen Shot 2020-09-07 at 4 19 17 PM" src="https://user-images.githubusercontent.com/10972027/92364715-09948100-f126-11ea-9e61-d06c72fbdaae.png">


Closes #632 