### PR TITLE
Fix failing ajax calls

### DIFF
--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -172,6 +172,8 @@ class SemesterModelTest(TenantTestCase):
         with freeze_time(date(2019, 10, 15), tz_offset=0):
             self.assertEqual(self.semester.num_days(upto_today=True), 20)
 
+        self.assertIsInstance(self.semester.num_days(), int)
+
     def test_num_days_upto_today(self):
         """The number of classes in the semester SO FAR up to today
         """


### PR DESCRIPTION
* Use numpy.int64.item() to get regular int
* Bring back deleted method

Closes #655 