### PR TITLE
Revamp semester frontend

### DIFF
--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -18,5 +18,8 @@
   {{ form | crispy }}
   <a href="{% url 'courses:semester_list' %}" role="button" class="btn btn-danger">Cancel</a>
   <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success">
+  {% if update_via_admin %}
+    <a href="{% url 'admin:courses_semester_change' object.id %}" role="button" class="btn btn-default">via Admin</a>
+  {% endif %}
 </form>
 {% endblock %}

--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -13,7 +13,6 @@
 {% block content %}
 <table class="table table-striped">
   <tr>
-    <th></th>
     <th>First Day</th>
     <th>Last Day</th>
     <th>Closed</th>
@@ -21,7 +20,6 @@
   </tr>
   {% for object in object_list %}
   <tr>
-    <td>{{ object }}</td>
     <td>{{ object.first_day }}</td>
     <td>{{ object.last_day }}</td>
     <td>{{ object.closed }}</td>
@@ -33,6 +31,26 @@
   </tr>
   {% endfor %}
 </table>
+
+<hr>
+<div class="col-sm-4">
+  <a id="end-semester" href="{% url 'courses:end_active_semester' %}" class="btn btn-danger">End current semester</a>
+</div>
+<div class="col-sm-8">
+  <p>This will permanently record all student marks for the semester.
+    Which means changing or deleting quests, submissions, or badges
+    will no longer affect their marks for that semester.</p>
+</div>
 {% endblock %}
 
-{% block js %}{% endblock %}
+{% block js %}
+
+<script>
+  $('body').on('click', '#end-semester', function(e) {
+      if(!confirm("Are you sure?")) {
+          e.preventDefault();
+          return;
+      }
+  })
+</script>
+{% endblock %}

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -158,6 +158,7 @@ class SemesterUpdate(NonPublicOnlyViewMixin, LoginRequiredMixin, UpdateView):
 
         kwargs['heading'] = 'Update Semester'
         kwargs['submit_btn_value'] = 'Update'
+        kwargs['update_via_admin'] = True
 
         return super().get_context_data(**kwargs)
 

--- a/src/templates/configuration.html
+++ b/src/templates/configuration.html
@@ -17,16 +17,8 @@
     <div class="col-sm-12">
         <p>
             <a class="btn btn-default"
-               href="/admin/courses/semester/">Semester Admin</a>
+               href="{% url 'admin:courses_semester_add' %}">Semester Admin</a>
         </p>
-    </div>
-    <div class="col-sm-4">
-        <a href="{% url 'courses:end_active_semester' %}" class="btn btn-danger">End current semester</a>
-    </div>
-    <div class="col-sm-8">
-        <p>This will permanently record all student marks for the semester.
-            Which means changing or deleting quests, submissions, or badges
-            will no longer affect their marks for that semester.</p>
     </div>
 </div>
 


### PR DESCRIPTION
- Added semester backend links to frontend
- Removed semester name from table
- Moved End current semester to Semester page

Closes #683 

![Screen Shot 2020-10-31 at 5 20 40 PM](https://user-images.githubusercontent.com/10972027/97775706-da3a4780-1b9d-11eb-987e-f2a0914bd660.png)

![Screen Shot 2020-10-31 at 5 20 51 PM](https://user-images.githubusercontent.com/10972027/97775710-ddcdce80-1b9d-11eb-8484-1e4b152c8b37.png)
