### PR TITLE
Fix overlapping announcement menus

### DIFF
--- a/src/announcements/templates/announcements/list.html
+++ b/src/announcements/templates/announcements/list.html
@@ -164,14 +164,14 @@
     // https://stackoverflow.com/a/37406402/3788603
     $('.announcement-dropdown .dropdown-toggle').click(function(e) {
       e.stopPropagation();
+      $('.announcement-dropdown.open').removeClass('open');
       $(this).closest('.dropdown').toggleClass('open');
-      $('.annoncement-dropdown .open').removeClass('open');
     });
 
     $('.announcement--delete, .announcement--edit, .announcement--copy').click(function(e) {
       e.stopPropagation();
+      $('.announcement-dropdown.open').removeClass('open');
       $(this).closest('.dropdown').toggleClass('open');
-      $('.annoncement-dropdown .open').removeClass('open');
     });
 
 


### PR DESCRIPTION
- Close all open announcement menus and then open the once that was
  clicked


Closes #736