### PR TITLE
Use SummernoteTextFormField

### DIFF
--- a/src/announcements/forms.py
+++ b/src/announcements/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.utils import timezone
 
 from bootstrap_datepicker_plus import DateTimePickerInput
-from django_summernote.widgets import SummernoteInplaceWidget
+from django_summernote.fields import SummernoteTextFormField
 
 from .models import Announcement
 
@@ -22,11 +22,14 @@ class AnnouncementForm(forms.ModelForm):
         model = Announcement
         exclude = ['author', 'icon']
 
+        field_classes = {
+            'content': SummernoteTextFormField,
+        }
+
         # SUMMERNOTE:
         # > If you don't like <iframe>, then use inplace widget
         # > Or if you're using django-crispy-forms, please use this.
         widgets = {
-            'content': SummernoteInplaceWidget(),
             'sticky_until': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
             'datetime_released': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
             'datetime_expires': DateTimePickerInput(format='%Y-%m-%d %H:%M'),

--- a/src/portfolios/forms.py
+++ b/src/portfolios/forms.py
@@ -1,16 +1,17 @@
-from bootstrap_datepicker_plus import DatePickerInput
 from django import forms
-from django_summernote.widgets import SummernoteInplaceWidget
 
-from portfolios.models import Portfolio, Artwork
+from bootstrap_datepicker_plus import DatePickerInput
+from django_summernote.fields import SummernoteTextFormField
+
+from portfolios.models import Artwork, Portfolio
 
 
 class PortfolioForm(forms.ModelForm):
     class Meta:
         model = Portfolio
         fields = ['description', 'listed_locally', 'listed_publicly', ]
-        widgets = {
-            'description': SummernoteInplaceWidget(),
+        field_classes = {
+            'description': SummernoteTextFormField,
         }
 
 

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,4 +1,3 @@
-
 from datetime import date
 
 from django import forms
@@ -10,7 +9,6 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Layout
 from django_select2.forms import ModelSelect2MultipleWidget, ModelSelect2Widget, Select2Widget
 from django_summernote.fields import SummernoteTextFormField
-from django_summernote.widgets import SummernoteInplaceWidget
 
 from badges.models import Badge
 from utilities.fields import RestrictedFileFormField
@@ -49,10 +47,6 @@ class QuestForm(forms.ModelForm):
         required=False,
     )
 
-    instructions = SummernoteTextFormField(required=False)
-    submission_details = SummernoteTextFormField(required=False)
-    instructor_notes = SummernoteTextFormField(required=False)
-
     class Meta:
         model = Quest
         fields = ('name', 'visible_to_students', 'xp', 'icon', 'short_description',
@@ -64,6 +58,12 @@ class QuestForm(forms.ModelForm):
                   'specific_teacher_to_notify', 'blocking',
                   'hideable', 'sort_order', 'date_available', 'time_available', 'date_expired', 'time_expired',
                   'available_outside_course', 'archived', 'editor')
+
+        field_classes = {
+            'instructions': SummernoteTextFormField,
+            'submission_details': SummernoteTextFormField,
+            'instructor_notes': SummernoteTextFormField,
+        }
 
         date_options = {
             'showMeridian': False,
@@ -195,8 +195,7 @@ class TAQuestForm(QuestForm):
 
 
 class SubmissionForm(forms.Form):
-    comment_text = forms.CharField(label='', required=False, widget=SummernoteInplaceWidget())
-
+    comment_text = SummernoteTextFormField(label='', required=False)
     attachments = RestrictedFileFormField(required=False,
                                           max_upload_size=16777216,
                                           widget=forms.ClearableFileInput(attrs={'multiple': True}),

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -8,11 +8,13 @@ from bootstrap_datepicker_plus import DatePickerInput, TimePickerInput
 from crispy_forms.bootstrap import Accordion, AccordionGroup
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Layout
+from django_select2.forms import ModelSelect2MultipleWidget, ModelSelect2Widget, Select2Widget
+from django_summernote.fields import SummernoteTextFormField
 from django_summernote.widgets import SummernoteInplaceWidget
-from django_select2.forms import Select2Widget, ModelSelect2Widget, ModelSelect2MultipleWidget
 
-from utilities.fields import RestrictedFileFormField
 from badges.models import Badge
+from utilities.fields import RestrictedFileFormField
+
 from .models import Quest
 
 
@@ -47,6 +49,10 @@ class QuestForm(forms.ModelForm):
         required=False,
     )
 
+    instructions = SummernoteTextFormField(required=False)
+    submission_details = SummernoteTextFormField(required=False)
+    instructor_notes = SummernoteTextFormField(required=False)
+
     class Meta:
         model = Quest
         fields = ('name', 'visible_to_students', 'xp', 'icon', 'short_description',
@@ -73,10 +79,6 @@ class QuestForm(forms.ModelForm):
         }
 
         widgets = {
-            'instructions': SummernoteInplaceWidget(),
-            'submission_details': SummernoteInplaceWidget(),
-            'instructor_notes': SummernoteInplaceWidget(),
-
             'date_available': DatePickerInput(format='%Y-%m-%d'),
 
             'time_available': TimePickerInput(),
@@ -164,7 +166,7 @@ class QuestForm(forms.ModelForm):
                 style="margin-top: 10px;"
             )
         )
-    
+
     def clean(self):
         cleaned_data = super().clean()
 
@@ -182,6 +184,7 @@ class QuestForm(forms.ModelForm):
 
 class TAQuestForm(QuestForm):
     """ Modified QuestForm that removes some fields TAs should not be able to set. """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # SET visible to students here to?

--- a/src/quest_manager/tests/test_forms.py
+++ b/src/quest_manager/tests/test_forms.py
@@ -22,7 +22,7 @@ class QuestFormTest(TenantTestCase):
         """The minimal_valid_data provided in the setup method should be valid!"""
         form = QuestForm(data=self.minimal_valid_data)
         self.assertTrue(form.is_valid())
-    
+
     def test_hideable_blocking_both_true(self):
         """If a quest is Blocking then it should not validate if it is also Hideable"""
         form_data = self.minimal_valid_data

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -294,7 +294,7 @@ blockquote {
     margin: 5px;
 }
 
-iframe, .embed-responsive video {
+.embed-responsive video {
     border-radius: 8px;
 }
 
@@ -1001,16 +1001,16 @@ div.btn-group.action-btn-group {
     font-size: 14px !important;
     line-height: 1.42857143 !important;
   }
-  
+
   .select2-container--bootstrap .select2-selection--multiple {
     min-height: 38px !important;
     padding-top: 2px !important;
   }
-  
+
   .select2-container--bootstrap .select2-search--dropdown .select2-search__field {
     padding-left: 8px;
   }
-  
+
   .select2-container .select2-selection--single .select2-selection__rendered,
   .select2-container--bootstrap .select2-selection--single .select2-selection__rendered {
     padding-left: 0px !important;


### PR DESCRIPTION
Finally got some progress for this after blaming crispy forms for the error (sorry crispy-forms)

This was also the reason why django-admin seems to be working properly was that it was using an iframe instead of in place widgets

See https://github.com/summernote/django-summernote/pull/396

Also from django-summernote's README:

> Warning: Please mind, that the widget does not provide any escaping. If you expose the widget to external users without taking care of this, it could potentially lead to an injection vulnerability. Therefore you can use the SummernoteTextFormField or SummernoteTextField, which escape all harmful tags through mozilla's package bleach:


The patch for HTML escape hasn't been released to PyPI yet but using the `SummernoteTextFormField` somehow works already

![2021-01-27 at 21 25 23 - Rational Lobot](https://user-images.githubusercontent.com/10972027/105997262-60572300-60e6-11eb-90ea-5adc264d426c.gif)

Closes #697 