### PR TITLE
Fix broken packed images in details and approvals

### DIFF
--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -124,6 +124,8 @@
                       else {
                           $(hidden_selector).append("<i class='fa fa-fw'></i> ");
                       }
+
+                      $('div.pack').pack()
                   },
                   error: function (xhr, errmsg, err) {
                       if (xhr.status == 500) {

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -12,8 +12,9 @@
 
 <script src="{% static 'js/custom.js' %}"></script>
 
-<script src="{% static 'js/jquery-double-submission.js?v=1.1' %}"></script>
-<script src="{% static 'js/jquery-packed-img-strip.js?v=1.0' %}"></script>
+<script src="{% static 'js/jquery-double-submission.js' %}?v=1.1"></script>
+<script src="{% static 'js/jquery-packed-img-strip.js' %}?v=1.0"></script>
+
 
 <script>
     $(function() {
@@ -153,7 +154,7 @@
                  // INSERT NOTIFICATION ITEMS HERE (as <li>)
                 <li><a href="/notifications/"> View All Notifications</a></li>
               </ul>
-            </li> 
+            </li>
             */
 
             if(count!=0) {
@@ -162,8 +163,8 @@
               // Add a menu item and remove button for each notification
               $(data.notifications).each(function(){
                 if (this.removable) {
-                  remove_link = "<a class='notification-mark-read' title='Remove' href='#' data-id='" + 
-                                this.id + 
+                  remove_link = "<a class='notification-mark-read' title='Remove' href='#' data-id='" +
+                                this.id +
                                 "'><i class='fa fa-times fa-fw text-muted'></i></a>";
                   $menu_item = $("<li class='dropdown-horizontal-group'>"+ this.link + remove_link + "</li>");
                 }


### PR DESCRIPTION
When I tried viewing the source, it was returning

```html
<script src="/static/js/jquery-double-submission.js%3Fv%3D1.1"></script>
<script src="/static/js/jquery-packed-img-strip.js%3Fv%3D1.0"></script>
```

Also added call to `.pack()` inside the success callback

Closes #814 
Closes #744 