### PR TITLE
Added and tested CRUDL views for Ranks; Closes #847

### DIFF
--- a/src/courses/templates/courses/rank_confirm_delete.html
+++ b/src/courses/templates/courses/rank_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends "courses/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block heading_inner %} Delete Rank {% endblock %}
+
+{% block content %}
+<form action="" method="post">{% csrf_token %}
+  <p>Are you sure you want to delete this rank?<p>
+  <div class="well">
+    <p>Name: {{object.name}}</p>
+    <p>XP: {{object.xp}}</p>
+    <p>Icon: {{object.icon}}</p>
+    <p>fa_icon: {{object.fa_icon}}</p>
+  </div>
+  <a href="{% url 'courses:ranks' %}" role="button" class="btn btn-info">Cancel</a>
+  <input type="submit" value="Delete" class="btn btn-danger" />
+</form>
+{% endblock %}

--- a/src/courses/templates/courses/rank_form.html
+++ b/src/courses/templates/courses/rank_form.html
@@ -1,0 +1,12 @@
+{% extends "courses/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block heading_inner %} {{ heading }} {% endblock %}
+
+{% block content %}
+<form method="post">{% csrf_token %}
+  {{ form | crispy }}
+  <a href="{% url 'courses:ranks' %}" role="button" class="btn btn-danger">Cancel</a>
+  <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success">
+</form>
+{% endblock %}

--- a/src/courses/templates/courses/rank_list.html
+++ b/src/courses/templates/courses/rank_list.html
@@ -6,19 +6,20 @@
 {% block content_first %}{% endblock %}
 {% block heading %}<i class="fa fa-star pull-right"></i>Ranks
   {% if request.user.is_staff %}
-    <a class="btn btn-primary" href="/admin/courses/rank/" role="button">Edit</a>
+    <a class="btn btn-primary" href="{% url 'courses:rank_create' %}" role="button">New</a>
   {% endif %}
 {% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-sm-6">
     <table class="table table-striped">
       <tr>
         <th></th>
         <th>Rank</th>
         <th>XP</th>
         <th>Quest Map</th>
+        {% if request.user.is_staff %}
+        <th>Action</th>
+        {% endif %}
       </tr>
       {% for object in object_list %}
         <tr>
@@ -30,11 +31,20 @@
             <a href="{{object.get_map.get_absolute_url}}"><i class="fa fa-map-signs"></i> </a>
             {% endif %}
           </td>
+          {% if request.user.is_staff %}
+          
+            <td>
+            <a class="btn btn-warning" href="{% url 'courses:rank_update' object.id %}" role="button" title="Edit this rank">
+              <i class="fa fa-edit"></i>
+            </a>
+            <a class="btn btn-danger" href="{% url 'courses:rank_delete' object.id %}" role="button" title="Delete this rank" style="margin-left: 3px">
+              <i class="fa fa-trash-o"></i>
+            </a>
+          </td>
+          {% endif %}
         </tr>
       {% endfor %}
     </table>
-  </div>
-</div>
 {% endblock %}
 
 {% block js %}{% endblock %}

--- a/src/courses/urls.py
+++ b/src/courses/urls.py
@@ -27,6 +27,9 @@ urlpatterns = [
 
     # Ranks
     path('ranks/', views.RankList.as_view(), name='ranks'),
+    path('ranks/create/', views.RankCreate.as_view(), name='rank_create'),
+    path('ranks/<pk>/edit/', views.RankUpdate.as_view(), name='rank_update'),
+    path('ranks/<pk>/delete/', views.RankDelete.as_view(), name='rank_delete'),
 
     # Marks
     path('marks/', views.mark_calculations, name='my_marks'),

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -59,6 +59,39 @@ class RankList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
 
 
 @method_decorator(staff_member_required, name='dispatch')
+class RankCreate(NonPublicOnlyViewMixin, CreateView):
+    fields = ('name', 'xp', 'icon', 'fa_icon')
+    model = Rank
+    success_url = reverse_lazy('courses:ranks')
+
+    def get_context_data(self, **kwargs):
+
+        kwargs['heading'] = 'Create New Rank'
+        kwargs['submit_btn_value'] = 'Create'
+
+        return super().get_context_data(**kwargs)
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class RankUpdate(NonPublicOnlyViewMixin, UpdateView):
+    fields = ('name', 'xp', 'icon', 'fa_icon')
+    model = Rank
+    success_url = reverse_lazy('courses:ranks')
+
+    def get_context_data(self, **kwargs):
+        kwargs['heading'] = 'Update Rank'
+        kwargs['submit_btn_value'] = 'Update'
+
+        return super().get_context_data(**kwargs)
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class RankDelete(NonPublicOnlyViewMixin, DeleteView):
+    model = Rank
+    success_url = reverse_lazy('courses:ranks')
+
+
+@method_decorator(staff_member_required, name='dispatch')
 class CourseList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
     model = Course
 


### PR DESCRIPTION
When staff users go to the ranks section of the site, buttons show up for creating a new rank, editing a specific rank, and deleting a specific rank. If non-staff users try to access pages for these editing options, they are redirected accordingly. Tests for all of these behaviours were also added to the test_views.py module.

In the future, a section should be added for ranks in the admin drop-down menu, as there is currently no way for staff users to access these editing pages. 