### PR TITLE
Removed 'join a course message' from staff accounts; Closes #953

### DIFF
--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -107,41 +107,41 @@
          </h3>
        </div>
        <ul class="list-group">
-         {% if courses %}
-             {% for course in courses %}
-               <li class="list-group-item">
-                 {{course.course}} {{course.grade_fk}}
-                 {% if request.user.is_staff %}
-                   (<a href="/admin/courses/coursestudent/{{course.id}}/">edit</a>)
-                 {% endif %}
-                 <br/>
-                 <small>{{course.block}} Block, Semester {{course.semester}}
-                 {% if course.xp_adjustment != 0 %}<br/>XP Adjustment: {{course.xp_adjustment}} XP
-                 (reason: {{course.xp_adjust_explanation}})
-                 {% endif %}
-                 </small>
-               </li>
-             {% endfor %}
-         {% else %}
-           <li class="list-group-item">You have not joined a course yet for this semester.
-             <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
-           </li>
-         {% endif %}
-         {% if courses_old %}
-             {% for course in courses_old %}
-               <li class="list-group-item text-muted">
-                 {{course.course}} {{course.grade_fk}}
-                 {% if request.user.is_staff %}
-                   (<a href="/admin/courses/coursestudent/{{course.id}}/">edit</a>)
-                 {% endif %}
-                 <br/>
-                 <small>{{course.block}} Block, {{course.semester}}
-                 <br/>Final XP: {{course.final_xp}}
-                 </small>
-               </li>
-             {% endfor %}
-         {% endif %}
-       </ul>
+          {% if courses %}
+              {% for course in courses %}
+                <li class="list-group-item">
+                  {{course.course}} {{course.grade_fk}}
+                  {% if request.user.is_staff %}
+                    (<a href="/admin/courses/coursestudent/{{course.id}}/">edit</a>)
+                  {% endif %}
+                  <br/>
+                  <small>{{course.block}} Block, Semester {{course.semester}}
+                  {% if course.xp_adjustment != 0 %}<br/>XP Adjustment: {{course.xp_adjustment}} XP
+                  (reason: {{course.xp_adjust_explanation}})
+                  {% endif %}
+                  </small>
+                </li>
+              {% endfor %}
+          {% elif not request.user.is_staff %}
+            <li class="list-group-item">You have not joined a course yet for this semester.
+              <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
+            </li>
+          {% endif %}
+          {% if courses_old %}
+              {% for course in courses_old %}
+                <li class="list-group-item text-muted">
+                  {{course.course}} {{course.grade_fk}}
+                  {% if request.user.is_staff %}
+                    (<a href="/admin/courses/coursestudent/{{course.id}}/">edit</a>)
+                  {% endif %}
+                  <br/>
+                  <small>{{course.block}} Block, {{course.semester}}
+                  <br/>Final XP: {{course.final_xp}}
+                  </small>
+                </li>
+              {% endfor %}
+          {% endif %}
+        </ul>
       </div> <!--panel -->
     <!-- QUESTS -->
      <div class="panel panel-primary">


### PR DESCRIPTION
Fixed. comparison screenshots below

Admin with no courses:
![image](https://user-images.githubusercontent.com/39788517/170144874-09a4c2ec-8c54-462a-bc45-914c85fa33f1.png)
Admin with course:
![image](https://user-images.githubusercontent.com/39788517/170144894-f70fc41c-a7a5-4339-af0f-36da042aa175.png)
Standard user:
![image](https://user-images.githubusercontent.com/39788517/170144928-5d92eead-e04c-4e4e-a2bc-a10f3f35fce0.png)
