### PR TITLE
Added clarity to delete and revoke confirmation page, and added highl…

### DIFF
--- a/src/badges/templates/badges/assertion_confirm_delete.html
+++ b/src/badges/templates/badges/assertion_confirm_delete.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to Revoke this achievment?<p>
+  <p>Are you sure you want to Revoke this achievment? The instance of this bade will remain. However, only {{object.user}}'s badge will be revoked<p>
   <div class="well">
     <p>Achievement: {{object}}</p>
     <p>User: {{object.user}}</p>

--- a/src/badges/templates/badges/badge_confirm_delete.html
+++ b/src/badges/templates/badges/badge_confirm_delete.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to Delete this Achievement?  All rewardings will be deleted.<p>
+  <p>Are you sure you want to Delete this Achievement? All instances of "{{object.name}}" badge will be deleted. Therefore, this badge will be removed from all users.<p>
   <div class="well">
     <p>Badge Name: {{object.name}}</p>
     <p>Badge ID: {{object.id}}</p>

--- a/src/badges/templates/badges/snippets/badge_popover_content.html
+++ b/src/badges/templates/badges/snippets/badge_popover_content.html
@@ -26,7 +26,7 @@
 {% for assertion in assertions_of_this_badge %}
   <li>{{assertion.timestamp}}
     {% if request.user.is_staff %} {# staff can revoke badges #}
-    <a class='btn btn-danger btn-xs' href='{% url "badges:revoke" assertion.id %}' role='button'>
+    <a class='btn btn-danger btn-xs' title='Revoke' href='{% url "badges:revoke" assertion.id %}' role='button'>
       <i class='fa fa-trash-o'></i>
     </a>
     {% endif %}


### PR DESCRIPTION
…ight over revoke button; Closes #894

Made a hover-help text for the revoke button titled 'Revoke' but cant screenshot because it disappears every time I press a button (including my screenshot button). So just take my word for it

Revoke badge confirmation page:
![image](https://user-images.githubusercontent.com/39788517/170159418-c3dd1dfb-1ed4-46cb-8b40-76dbe5dc3eba.png)
Delete badge confirmation page:
![image](https://user-images.githubusercontent.com/39788517/170159561-49dc6379-ec1f-4d2a-89cd-f1529e9b804f.png)


GOT A WEIRD GLITCH 
src/templates/badges/snippets/bade_popover_content.html (line 29)
<a class='btn btn-danger btn-xs' title='Revoke' ...>

content in popover 'overfills' when using double quotes, but doesnt when using single quotes in title attribute

with title='Revoke':
![image](https://user-images.githubusercontent.com/39788517/170159947-eb8e68f9-d988-45ae-b87d-5a9c0c79f654.png)
with title="Revoke":
![image](https://user-images.githubusercontent.com/39788517/170159970-452b9a5e-d154-453f-8303-48865e3eea00.png)

so far I have no idea what's going on with that.  There should be no difference between single and double quotes


