### PR TITLE
Added a way to seach by campaign using the search box in quests admin…

### DIFF
--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -171,7 +171,7 @@ class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, SummernoteModelAdmin, Impo
                     'editor', 'specific_teacher_to_notify', 'common_data', 'campaign')
     list_filter = ['archived', 'visible_to_students', 'max_repeats', 'verification_required', 'editor', 
                    'specific_teacher_to_notify', 'common_data', 'campaign']
-    search_fields = ['name', 'instructions', 'submission_details', 'short_description']
+    search_fields = ['name', 'instructions', 'submission_details', 'short_description', 'campaign__title']
     inlines = [
         # TaggedItemInline
         PrereqInline,


### PR DESCRIPTION
…; Closes #545

Ability to use search bar instead of filter

![image](https://user-images.githubusercontent.com/39788517/170171896-c53af58e-eeba-48cc-8d78-ec9f514bc018.png)
