### PR TITLE
Added ability to change what grade ranges are for pass, b, and a; Closes #939

### DIFF
--- a/src/courses/templates/courses/chart_xp_progress.html
+++ b/src/courses/templates/courses/chart_xp_progress.html
@@ -61,7 +61,7 @@
 
   var GradeAData = {
       type: 'line',
-      label: 'A (86%)',
+      label: 'A {% if not a_p %} (86%){%else%} ({{a_p.minimum_mark|floatformat}}%){%endif%}',
       pointRadius: 0,
       backgroundColor: "rgba(255,255,0,0)",
       borderColor: "rgba(255, 236, 179,50)",
@@ -70,7 +70,7 @@
 
   var GradeFData = {
       type: 'line',
-      label: 'Pass (50%)',
+      label: 'Pass{% if not pass_p %} (50%){%else%} ({{pass_p.minimum_mark|floatformat}}%){%endif%}',
       pointRadius: 0,
       backgroundColor: "rgba(255, 0, 0, 0)",
       borderColor: "rgba(255, 179, 179, 50)",
@@ -80,7 +80,7 @@
   // Chillax Line Data Set = B
   var ChillaxLineData = {
       type: 'line',
-      label: 'B (73%)',
+      label: 'B {% if not b_p %} (50%){%else%} ({{b_p.minimum_mark|floatformat}}%){%endif%}',
       pointRadius: 0,
       backgroundColor: "rgba(0,255,255,0)",
       borderColor: "rgba(0,255,255,255)",
@@ -240,10 +240,14 @@
     GradeAData.data = [];
     GradeFData.data = [];
 
+    var chillaxPercentage = {% if not b_p %} 0.725 {%else%} {{b_float}} {% endif %};
+    var aPercentage = {% if not a_p %} 0.855 {%else%} {{a_float}} {% endif %};
+    var fPercentage = {% if not pass_p %} 0.495 {%else%} {{pass_float}} {% endif %};
+
     for (var i = 1; i <= days; i++) {
-        var p = new DataPoint(i, Math.floor(i * max_xp*0.725 / days));
-        var pA = new DataPoint(i, Math.floor(i * max_xp*0.855 / days));
-        var pF = new DataPoint(i, Math.floor(i * max_xp*0.495 / days));
+        var p = new DataPoint(i, Math.floor(i * max_xp*chillaxPercentage / days));
+        var pA = new DataPoint(i, Math.floor(i * max_xp*aPercentage / days));
+        var pF = new DataPoint(i, Math.floor(i * max_xp*fPercentage / days));
         ChillaxLineData.data.push(p);
         GradeAData.data.push(pA);
         GradeFData.data.push(pF);

--- a/src/courses/templates/courses/chart_xp_progress.html
+++ b/src/courses/templates/courses/chart_xp_progress.html
@@ -61,7 +61,7 @@
 
   var GradeAData = {
       type: 'line',
-      label: 'A {% if not a_p %} (86%){%else%} ({{a_p.minimum_mark|floatformat}}%){%endif%}',
+      label: 'A (86%)',
       pointRadius: 0,
       backgroundColor: "rgba(255,255,0,0)",
       borderColor: "rgba(255, 236, 179,50)",
@@ -70,7 +70,7 @@
 
   var GradeFData = {
       type: 'line',
-      label: 'Pass{% if not pass_p %} (50%){%else%} ({{pass_p.minimum_mark|floatformat}}%){%endif%}',
+      label: 'Pass (50%)',
       pointRadius: 0,
       backgroundColor: "rgba(255, 0, 0, 0)",
       borderColor: "rgba(255, 179, 179, 50)",
@@ -80,7 +80,7 @@
   // Chillax Line Data Set = B
   var ChillaxLineData = {
       type: 'line',
-      label: 'B {% if not b_p %} (50%){%else%} ({{b_p.minimum_mark|floatformat}}%){%endif%}',
+      label: 'B (73%)',
       pointRadius: 0,
       backgroundColor: "rgba(0,255,255,0)",
       borderColor: "rgba(0,255,255,255)",
@@ -240,14 +240,10 @@
     GradeAData.data = [];
     GradeFData.data = [];
 
-    var chillaxPercentage = {% if not b_p %} 0.725 {%else%} {{b_float}} {% endif %};
-    var aPercentage = {% if not a_p %} 0.855 {%else%} {{a_float}} {% endif %};
-    var fPercentage = {% if not pass_p %} 0.495 {%else%} {{pass_float}} {% endif %};
-
     for (var i = 1; i <= days; i++) {
-        var p = new DataPoint(i, Math.floor(i * max_xp*chillaxPercentage / days));
-        var pA = new DataPoint(i, Math.floor(i * max_xp*aPercentage / days));
-        var pF = new DataPoint(i, Math.floor(i * max_xp*fPercentage / days));
+        var p = new DataPoint(i, Math.floor(i * max_xp*0.725 / days));
+        var pA = new DataPoint(i, Math.floor(i * max_xp*0.855 / days));
+        var pF = new DataPoint(i, Math.floor(i * max_xp*0.495 / days));
         ChillaxLineData.data.push(p);
         GradeAData.data.push(pA);
         GradeFData.data.push(pF);

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -9,8 +9,6 @@ from courses.models import Block, Course, Semester, Rank
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
 from siteconfig.models import SiteConfig
 
-import random
-
 User = get_user_model()
 
 
@@ -134,45 +132,6 @@ class CourseViewTests(ViewTestUtilsMixin, TenantTestCase):
             'course': self.course.pk,
             'grade_fk': self.grade.pk
         }
-
-        def test_mark_calculations__variable_mark_ranges(self):
-            """
-            see if xp chart is 'as expected'
-            """
-            INSTANCE = SiteConfig.get()  # but this doesnt (2) # i dont event think this is pass by data, just pass by reference
-            INSTANCE = SiteConfig.objects.get(id=INSTANCE.id)  # why does this work with save (1)
-            INSTANCE.display_marks_calculation = True
-            INSTANCE.save()
-
-            # login and join course for student # so xp mark calc can render
-            baker.make('courses.CourseStudent', user=self.test_student1, course=self.course,)
-            self.client.force_login(self.test_student1)
-
-            #           check for 404s and contains
-            # base. No added mark ranges ====
-            [baker.make('courses.MarkRange') for x in range(7)]
-
-            # should be true if display_marks_calculation = True
-            self.assert200('courses:marks', args=[self.test_student1.id])  # they go to same page?
-            self.assert200('courses:my_marks')
-
-            # check for default values
-            # response = self.client.get(reverse('courses:my_marks'))
-            # self.assertContains(response, '<html')
-            # [self.assertContains(response, text) for text in ['A (86%)', 'B (73%)', 'Pass (50%)']]
-
-            # with mark ranges ==============
-            mark_data = {name: random.randint(1, 100) for name in ['Chillax Line', 'a', 'pass']}
-
-            for name, mark in mark_data.items():
-                baker.make('courses.MarkRange', name=name, minimum_mark=mark)
-
-            self.assert200('courses:marks', args=[self.test_student1.id])
-            self.assert200('courses:my_marks')
-
-            # #check for new values
-            # response = self.client.get(reverse('courses:my_marks'))
-            # [self.assertContains(response,f"({mark_data[key]}%)") for key in mark_data.keys()]
 
     def test_all_page_status_codes_for_anonymous(self):
         ''' If not logged in then all views should redirect to home page or admin login '''

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -9,6 +9,8 @@ from courses.models import Block, Course, Semester, Rank
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
 from siteconfig.models import SiteConfig
 
+import random
+
 User = get_user_model()
 
 
@@ -132,6 +134,45 @@ class CourseViewTests(ViewTestUtilsMixin, TenantTestCase):
             'course': self.course.pk,
             'grade_fk': self.grade.pk
         }
+
+        def test_mark_calculations__variable_mark_ranges(self):
+            """
+            see if xp chart is 'as expected'
+            """
+            INSTANCE = SiteConfig.get()  # but this doesnt (2) # i dont event think this is pass by data, just pass by reference
+            INSTANCE = SiteConfig.objects.get(id=INSTANCE.id)  # why does this work with save (1)
+            INSTANCE.display_marks_calculation = True
+            INSTANCE.save()
+
+            # login and join course for student # so xp mark calc can render
+            baker.make('courses.CourseStudent', user=self.test_student1, course=self.course,)
+            self.client.force_login(self.test_student1)
+
+            #           check for 404s and contains
+            # base. No added mark ranges ====
+            [baker.make('courses.MarkRange') for x in range(7)]
+
+            # should be true if display_marks_calculation = True
+            self.assert200('courses:marks', args=[self.test_student1.id])  # they go to same page?
+            self.assert200('courses:my_marks')
+
+            # check for default values
+            # response = self.client.get(reverse('courses:my_marks'))
+            # self.assertContains(response, '<html')
+            # [self.assertContains(response, text) for text in ['A (86%)', 'B (73%)', 'Pass (50%)']]
+
+            # with mark ranges ==============
+            mark_data = {name: random.randint(1, 100) for name in ['Chillax Line', 'a', 'pass']}
+
+            for name, mark in mark_data.items():
+                baker.make('courses.MarkRange', name=name, minimum_mark=mark)
+
+            self.assert200('courses:marks', args=[self.test_student1.id])
+            self.assert200('courses:my_marks')
+
+            # #check for new values
+            # response = self.client.get(reverse('courses:my_marks'))
+            # [self.assertContains(response,f"({mark_data[key]}%)") for key in mark_data.keys()]
 
     def test_all_page_status_codes_for_anonymous(self):
         ''' If not logged in then all views should redirect to home page or admin login '''

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -18,7 +18,7 @@ from siteconfig.models import SiteConfig
 from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 
 from .forms import BlockForm, CourseStudentForm, SemesterForm
-from .models import Block, Course, CourseStudent, Rank, Semester
+from .models import Block, Course, CourseStudent, Rank, Semester, MarkRange
 
 
 # Create your views here.
@@ -44,12 +44,29 @@ def mark_calculations(request, user_id=None):
     else:
         xp_per_course = None
 
+    pass_mr = MarkRange.objects.filter(name__iexact="pass").first() or None
+    pass_float = float(pass_mr.minimum_mark / 100) if pass_mr else -1
+
+    a_mr = MarkRange.objects.filter(name__iexact="a").first() or None
+    a_float = float(a_mr.minimum_mark / 100) if a_mr else -1
+
+    b_mr = MarkRange.objects.filter(name__iexact="chillax line").first() or None
+    b_float = float(b_mr.minimum_mark / 100) if b_mr else -1
+
     context = {
         'user': user,
         'obj': course_student,
         'courses': courses,
         'xp_per_course': xp_per_course,
         'num_courses': num_courses,
+
+        # for mark ranges
+        'pass_p': pass_mr,
+        'pass_float': pass_float,
+        'a_p': a_mr,
+        'a_float': a_float,
+        'b_p': b_mr,
+        'b_float': b_float,
     }
     return render(request, template_name, context)
 

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -18,7 +18,7 @@ from siteconfig.models import SiteConfig
 from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 
 from .forms import BlockForm, CourseStudentForm, SemesterForm
-from .models import Block, Course, CourseStudent, Rank, Semester, MarkRange
+from .models import Block, Course, CourseStudent, Rank, Semester
 
 
 # Create your views here.
@@ -44,29 +44,12 @@ def mark_calculations(request, user_id=None):
     else:
         xp_per_course = None
 
-    pass_mr = MarkRange.objects.filter(name__iexact="pass").first() or None
-    pass_float = float(pass_mr.minimum_mark / 100) if pass_mr else -1
-
-    a_mr = MarkRange.objects.filter(name__iexact="a").first() or None
-    a_float = float(a_mr.minimum_mark / 100) if a_mr else -1
-
-    b_mr = MarkRange.objects.filter(name__iexact="chillax line").first() or None
-    b_float = float(b_mr.minimum_mark / 100) if b_mr else -1
-
     context = {
         'user': user,
         'obj': course_student,
         'courses': courses,
         'xp_per_course': xp_per_course,
         'num_courses': num_courses,
-
-        # for mark ranges
-        'pass_p': pass_mr,
-        'pass_float': pass_float,
-        'a_p': a_mr,
-        'a_float': a_float,
-        'b_p': b_mr,
-        'b_float': b_float,
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
Grade ranges for pass, b, and a can be changed by adding them (with their respective names) in admin MarkRanges

All this change really does (visually) is change the percentages of a, b, and pass. As well as change the line graphs intersect

![image](https://user-images.githubusercontent.com/39788517/170625967-3447e674-751d-4d63-b8a2-9a9ae4abb1d2.png)
![image](https://user-images.githubusercontent.com/39788517/170625972-6a63210f-eb61-4511-89aa-b83d260f7735.png)