### PR TITLE
Create badge rarities upon initialization; closes #981

### DIFF
--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -21,15 +21,15 @@ class BadgeRarityTestModel(TenantTestCase):
         self.assertEqual(str(self.common), self.common.name)
 
     def test_get_rarity(self):
-        self.common = baker.make(BadgeRarity, percentile=100.0)
-        self.rare = baker.make(BadgeRarity, percentile=50.0)
-        self.ultrarare = baker.make(BadgeRarity, percentile=1.0)
+        """rarity values used are chosen to avoid conflicts with defaults"""
+        self.common = baker.make(BadgeRarity, percentile=90.0)
+        self.rare = baker.make(BadgeRarity, percentile=80.0)
+        self.ultrarare = baker.make(BadgeRarity, percentile=70.0)
 
-        self.assertEqual(BadgeRarity.objects.get_rarity(0.5), self.ultrarare)
-        self.assertEqual(BadgeRarity.objects.get_rarity(49.0), self.rare)
-        self.assertEqual(BadgeRarity.objects.get_rarity(50.0), self.rare)
-        self.assertEqual(BadgeRarity.objects.get_rarity(100.0), self.common)
-        self.assertEqual(BadgeRarity.objects.get_rarity(110.0), self.common)
+        self.assertEqual(BadgeRarity.objects.get_rarity(69.0), self.ultrarare)
+        self.assertEqual(BadgeRarity.objects.get_rarity(79.0), self.rare)
+        self.assertEqual(BadgeRarity.objects.get_rarity(80.0), self.rare)
+        self.assertEqual(BadgeRarity.objects.get_rarity(90.0), self.common)
 
 
 class BadgeTypeTestModel(TenantTestCase):

--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 
 from courses.models import Grade, Rank, Course, Block
 from quest_manager.models import Quest, Category
-from badges.models import Badge, BadgeType
+from badges.models import Badge, BadgeType, BadgeRarity
 from prerequisites.models import Prereq
 from siteconfig.models import SiteConfig
 
@@ -24,6 +24,7 @@ def load_initial_tenant_data():
     create_initial_ranks()
     create_initial_grades()
     create_initial_badge_types()
+    create_initial_badge_rarities()
     create_initial_badges()
     create_orientation_campaign() 
 
@@ -107,6 +108,45 @@ def create_initial_badge_types():
         description="Awards are badges that are manually granted by teachers.",
         repeatable=True,
         fa_icon="fa-diamond"
+    )
+
+
+def create_initial_badge_rarities():
+    BadgeRarity.objects.create(
+        name="Common", 
+        percentile=100.0,
+        color="gray",
+        fa_icon="fa-certificate"
+    )
+    BadgeRarity.objects.create(
+        name="Uncommon", 
+        percentile=30.0,
+        color="green",
+        fa_icon="fa-certificate"
+    )
+    BadgeRarity.objects.create(
+        name="Rare", 
+        percentile=16.0,
+        color="royalblue",
+        fa_icon="fa-certificate"
+    )
+    BadgeRarity.objects.create(
+        name="Epic", 
+        percentile=4.0,
+        color="purple",
+        fa_icon="fa-certificate"
+    )
+    BadgeRarity.objects.create(
+        name="Legendary", 
+        percentile=1.0,
+        color="orangered",
+        fa_icon="fa-certificate"
+    )
+    BadgeRarity.objects.create(
+        name="Mythic", 
+        percentile=0.25,
+        color="gold",
+        fa_icon="fa-certificate"
     )
 
 

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -1,0 +1,18 @@
+from django_tenants.test.cases import TenantTestCase
+
+from badges.models import BadgeRarity
+
+
+class TenantInitializationTest(TenantTestCase):
+
+    def test_default_badge_rarities_created(self):
+        """When a new tenant is created, the initialization script should create 6 default BadgeRarity objects."""
+        self.assertTrue(BadgeRarity.objects.filter(name="Common").exists())
+        self.assertTrue(BadgeRarity.objects.filter(name="Uncommon").exists())
+        self.assertTrue(BadgeRarity.objects.filter(name="Rare").exists())
+        self.assertTrue(BadgeRarity.objects.filter(name="Epic").exists())
+        self.assertTrue(BadgeRarity.objects.filter(name="Legendary").exists())
+        self.assertTrue(BadgeRarity.objects.filter(name="Mythic").exists())
+    
+    def test_only_default_rarities_created(self):
+        self.assertEqual(BadgeRarity.objects.count(), 6)


### PR DESCRIPTION
creates 6 default rarities when a new tenant is made in tenant/initialization.py
![image](https://user-images.githubusercontent.com/105619909/170626793-a74d734f-e6ff-43ad-8b0f-094814e940fd.png)
