### PR TITLE
Teacher and student get different text in courses tab in profile detail; Closes #953

### DIFF
--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -122,10 +122,12 @@
                  </small>
                </li>
              {% endfor %}
-         {% else %}
+         {% elif not request.user.is_staff %}
            <li class="list-group-item">You have not joined a course yet for this semester.
              <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
            </li>
+           {% else %}
+            <li class="list-group-item">Not applicable to staff users.</li>
          {% endif %}
          {% if courses_old %}
              {% for course in courses_old %}

--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -100,33 +100,35 @@
        <div class="panel-heading">
          <i class="pull-right fa fa-fw fa-book"></i>
          <h3 class="panel-title">Courses
-           {% if request.user.is_staff %}
+           {% if request.user.is_staff and not object.user.is_staff %}
              &nbsp;&nbsp;<a class="btn btn-xs btn-warning"
              href="{% url 'courses:join' object.user.id %}" role="button">Add</a>
            {% endif %}
          </h3>
        </div>
        <ul class="list-group">
-         {% if courses %}
-             {% for course in courses %}
-               <li class="list-group-item">
-                 {{course.course}} {{course.grade_fk}}
-                 {% if request.user.is_staff %}
-                   (<a href="/admin/courses/coursestudent/{{course.id}}/">edit</a>)
-                 {% endif %}
-                 <br/>
-                 <small>{{course.block}} Block, Semester {{course.semester}}
-                 {% if course.xp_adjustment != 0 %}<br/>XP Adjustment: {{course.xp_adjustment}} XP
-                 (reason: {{course.xp_adjust_explanation}})
-                 {% endif %}
-                 </small>
-               </li>
-             {% endfor %}
-         {% elif not request.user.is_staff %}
-           <li class="list-group-item">You have not joined a course yet for this semester.
-             <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
-           </li>
-           {% else %}
+         {% if not object.user.is_staff %}
+          {% if courses %}
+              {% for course in courses %}
+                <li class="list-group-item">
+                  {{course.course}} {{course.grade_fk}}
+                  {% if request.user.is_staff %}
+                    (<a href="/admin/courses/coursestudent/{{course.id}}/">edit</a>)
+                  {% endif %}
+                  <br/>
+                  <small>{{course.block}} Block, Semester {{course.semester}}
+                  {% if course.xp_adjustment != 0 %}<br/>XP Adjustment: {{course.xp_adjustment}} XP
+                  (reason: {{course.xp_adjust_explanation}})
+                  {% endif %}
+                  </small>
+                </li>
+              {% endfor %}
+          {% else %}
+            <li class="list-group-item">You have not joined a course yet for this semester.
+              <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
+            </li>
+          {%endif%}
+        {% else %}
             <li class="list-group-item">Not applicable to staff users.</li>
          {% endif %}
          {% if courses_old %}

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -34,6 +34,43 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
     def tearDown(self):
         cache.clear()
 
+    def test_courses_right_text(self):
+        """
+            Admin without that has not joined a course should see: 'Not applicable to staff users.'
+            else should see course
+            Students should only be able to see: 'You have not joined a course yet for this semester'
+            else should see course
+        """
+        course = baker.make('courses.Course', title='Test Course')
+        tpk = self.test_teacher.profile.pk
+        spk = self.test_student1.profile.pk
+
+        # login as teacher/admin and check if 'add course' doesnt exists
+        success = self.client.login(username=self.test_teacher.username, password=self.test_password)
+        self.assertTrue(success)
+
+        # no course
+        request = self.client.get(reverse('profiles:profile_detail', args=[tpk]))
+        self.assertContains(request, 'Not applicable to staff users.')
+
+        # with course
+        baker.make('courses.CourseStudent', user=self.test_teacher, course=course)
+        request = self.client.get(reverse('profiles:profile_detail', args=[tpk]))
+        self.assertContains(request, course.title)
+
+        # login as student and check if 'add course' and 'course' exists
+        success = self.client.login(username=self.test_student1.username, password=self.test_password)
+        self.assertTrue(success)
+
+        # no course
+        request = self.client.get(reverse('profiles:profile_detail', args=[spk]))
+        self.assertContains(request, 'You have not joined a course yet for this semester')
+
+        # with course
+        baker.make('courses.CourseStudent', user=self.test_student1, course=course)
+        request = self.client.get(reverse('profiles:profile_detail', args=[spk]))
+        self.assertContains(request, course.title)
+
     def test_all_profile_page_status_codes_for_anonymous(self):
         """ If not logged in then all views should redirect to home page  """
 

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -34,11 +34,10 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
     def tearDown(self):
         cache.clear()
 
-    def test_courses_right_text(self):
+    def test_courses_correct_displayed_text(self):
         """
-            Admin without that has not joined a course should see: 'Not applicable to staff users.'
-            else should see course
-            Students should only be able to see: 'You have not joined a course yet for this semester'
+            Admins in their course tab should only see: 'Not applicable to staff users.'
+            Students that havent joined a course should only be able to see: 'You have not joined a course yet for this semester'
             else should see course
         """
         course = baker.make('courses.Course', title='Test Course')
@@ -56,7 +55,7 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
         # with course
         baker.make('courses.CourseStudent', user=self.test_teacher, course=course)
         request = self.client.get(reverse('profiles:profile_detail', args=[tpk]))
-        self.assertContains(request, course.title)
+        self.assertContains(request, 'Not applicable to staff users.')
 
         # login as student and check if 'add course' and 'course' exists
         success = self.client.login(username=self.test_student1.username, password=self.test_password)


### PR DESCRIPTION
Teacher with no courses:
![image](https://user-images.githubusercontent.com/39788517/170804986-e2c37627-4a32-4905-ab65-e70a816ecb7b.png)

Teacher with courses (via /admin/)
![image](https://user-images.githubusercontent.com/39788517/170804989-9d610d16-9393-4fee-b370-a92104a613cd.png)

Student with no courses
![image](https://user-images.githubusercontent.com/39788517/170804997-176a6de5-8849-4697-a8d8-c396666e48f7.png)
