### PR TITLE
Added clarity to delete and revoke confirmation page, and added tooltip on revoke button; Closes #894

### DIFF
--- a/src/badges/templates/badges/assertion_confirm_delete.html
+++ b/src/badges/templates/badges/assertion_confirm_delete.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to Revoke this achievment? The instance of this bade will remain. However, only {{object.user}}'s badge will be revoked<p>
+  <p>Are you sure you want to revoke this badge from {{ object.user }}?<p>
   <div class="well">
     <p>Achievement: {{object}}</p>
     <p>User: {{object.user}}</p>

--- a/src/badges/templates/badges/assertion_confirm_delete.html
+++ b/src/badges/templates/badges/assertion_confirm_delete.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to Revoke this achievment?<p>
+  <p>Are you sure you want to Revoke this achievment? The instance of this bade will remain. However, only {{object.user}}'s badge will be revoked<p>
   <div class="well">
     <p>Achievement: {{object}}</p>
     <p>User: {{object.user}}</p>

--- a/src/badges/templates/badges/badge_confirm_delete.html
+++ b/src/badges/templates/badges/badge_confirm_delete.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to Delete this Achievement? All instances of "{{object.name}}" badge will be deleted. Therefore, this badge will be removed from all users.<p>
+  <p>Are you sure you want to delete this badge? This badge will be removed from all users that have earned it. This action is irreversible.<p>
   <div class="well">
     <p>Badge Name: {{object.name}}</p>
     <p>Badge ID: {{object.id}}</p>

--- a/src/badges/templates/badges/badge_confirm_delete.html
+++ b/src/badges/templates/badges/badge_confirm_delete.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to Delete this Achievement?  All rewardings will be deleted.<p>
+  <p>Are you sure you want to Delete this Achievement? All instances of "{{object.name}}" badge will be deleted. Therefore, this badge will be removed from all users.<p>
   <div class="well">
     <p>Badge Name: {{object.name}}</p>
     <p>Badge ID: {{object.id}}</p>

--- a/src/badges/templates/badges/snippets/badge_popover_content.html
+++ b/src/badges/templates/badges/snippets/badge_popover_content.html
@@ -26,7 +26,7 @@
 {% for assertion in assertions_of_this_badge %}
   <li>{{assertion.timestamp}}
     {% if request.user.is_staff %} {# staff can revoke badges #}
-    <a class='btn btn-danger btn-xs' href='{% url "badges:revoke" assertion.id %}' role='button'>
+    <a class='btn btn-danger btn-xs' title='Revoke' href='{% url "badges:revoke" assertion.id %}' role='button'>
       <i class='fa fa-trash-o'></i>
     </a>
     {% endif %}


### PR DESCRIPTION
Made a hover-help text for the revoke button titled 'Revoke' but cant screenshot because it disappears every time I press a button (including my screenshot button). So just take my word for it

Revoke badge confirmation page:
![image](https://user-images.githubusercontent.com/39788517/170806311-4d642acb-8670-4e88-83b5-ac3bf4d4f1a9.png)
Delete badge confirmation page:
![image](https://user-images.githubusercontent.com/39788517/170806327-b4ffe8a4-c99d-42fc-b9be-3275a6056c55.png)
