### PR TITLE
Search quest using campaign name; Closes #545

### DIFF
--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -171,7 +171,7 @@ class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, SummernoteModelAdmin, Impo
                     'editor', 'specific_teacher_to_notify', 'common_data', 'campaign')
     list_filter = ['archived', 'visible_to_students', 'max_repeats', 'verification_required', 'editor', 
                    'specific_teacher_to_notify', 'common_data', 'campaign']
-    search_fields = ['name', 'instructions', 'submission_details', 'short_description']
+    search_fields = ['name', 'instructions', 'submission_details', 'short_description', 'campaign__title']
     inlines = [
         # TaggedItemInline
         PrereqInline,


### PR DESCRIPTION
Ability to use the search box to filter quests by their associated campaign

![image](https://user-images.githubusercontent.com/39788517/171066836-0034c3bf-2383-4aac-914a-a4d5a1b152f8.png)
