### PR TITLE
add detail view for campaigns; closes #895

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -37,6 +37,15 @@ class Category(IsAPrereqMixin, models.Model):
     def __str__(self):
         return self.title
 
+    def get_absolute_url(self):
+        return reverse('quests:category_detail', kwargs={'pk': self.id})
+
+    def get_icon_url(self):
+        if self.icon and hasattr(self.icon, 'url'):
+            return self.icon.url
+        else:
+            return SiteConfig.get().get_default_icon_url()
+
     def xp_sum(self):
         """ Returns the total XP available from completing all visible quests in this campaign.
         Repeating quests are only counted once."""

--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -1,0 +1,22 @@
+{% extends "quest_manager/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block heading_inner %} {{ object.title }} Campaign{% endblock %}
+
+{% block content %}
+    <div class="pull-right">
+        <a class="btn btn-warning" href="{% url 'quests:category_update' object.id %}" role="button"
+            title = "Edit this campaign" >
+        <i class="fa fa-edit"></i>
+        </a>
+        <a class="btn btn-danger" href="{% url 'quests:category_delete' object.id %}" role="button"
+            title = "Delete this campaign" >
+        <i class="fa fa-trash-o"></i>
+        </a>
+    </div>
+
+    {% with object as category %}
+        {% include "quest_manager/category_detail_content.html" %}
+    {% endwith %}
+
+{% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -1,0 +1,82 @@
+
+<div class="media">
+  <div class="media-left">
+    <img class="media-object icon-lg img-rounded" src="{{ category.get_icon_url }}" alt="icon" />
+  </div>
+  <div class="media-body">
+    <p>Total XP available in this campaign: {{ category.xp_sum }}</p>
+  </div>
+</div>
+
+{% if category.quest_set.all %}
+  <div class="row panel-heading">
+    <div class="col-sm-1 col-xs-2 col-icon"></div>
+    <div class="col-sm-5 col-xs-8">Quest</div>
+    <div class="col-sm-1 col-xs-2 text-right">XP</div>
+    <div class="col-sm-2 hidden-xs"><!-- status_icons --></div>
+  </div>
+  <div class="panel-group panel-group-packed" id="accordion-available"
+    role="tablist" aria-multiselectable="true">
+
+  {% for q in category.quest_set.all %}
+
+    <div class="panel accordian
+      {% if not q.visible_to_students %}panel-danger
+      {% elif q.expired %}panel-warning
+      {% else %}panel-default
+      {% endif %}
+      {% if q.id == active_q_id %} active {% endif %}">
+      <div class="panel-heading accordian accordian-trigger panel-heading-tall
+        {% if q.id == active_q_id %} active {% endif %}"
+        role="tab"
+        id="heading-quest-{{q.id}}"
+        aria-expanded="{% if q.id == active_q_id %}true{% else %}false{% endif %}"
+        aria-controls="collapse-quest-{{q.id}}"
+        data-parent="#accordion-available" data-toggle="collapse"
+        data-target="#collapse-quest-{{q.id}}">
+
+        <div class="row">
+          <h4 class="panel-title">
+            <!-- COLUMNS -->
+            <div class="col-sm-1 col-xs-2 col-icon">
+              <img class="img-responsive panel-title-img img-rounded"
+                src="{{ q.get_icon_url }}" alt="icon"/>
+            </div>
+            <div class="col-sm-5 col-xs-8">{{q.name}}</div>
+            <div class="col-sm-1 col-xs-2 text-right">{{q.xp}}</div>
+            <div class="col-sm-2 hidden-xs text-center"><small>
+            </small></div>
+            <div id="status-icon-{{q.id}}" class="col-xs-2 hidden-xs text-muted"></div>
+
+          </h4>
+        </div> <!-- row -->
+      </div> <!-- accordian section heading -->
+
+      <div id="collapse-quest-{{q.id}}"
+        class="panel-collapse collapse {% if q.id == active_q_id %} in {% endif %}"
+        role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
+        <ul class="list-group">
+          <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
+              <p>
+                <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+                &nbsp;Loading content...
+                <!-- preview_content_quests_avail.html via AJAX -->
+              </p>
+          </li>
+        </ul>
+      </div> <!-- accordian panel-collapse -->
+
+
+    </div> <!-- accordian -->
+
+  {% endfor %} <!-- for each quest -->
+
+  </div> <!-- accordian panel group -->
+
+{% else %}
+  <p>There are no quests in this campaign.</p>
+{% endif %}
+
+{% block js %}
+  {% include "quest_manager/ajax_content_loading.html" %}
+{% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -24,6 +24,9 @@
     <td>{% if object.icon %}<img class="img-responsive panel-title-img img-rounded" src="{{ object.icon.url }}">{% endif %}</td>
     <td>{{ object.active }}</td>
     <td>
+      <a class="btn btn-info" href="{% url 'quests:category_detail' object.id %}" role="button" title="View Details: view the content of this campaign.">
+       <i class="fa fa-fw fa-info-circle"></i>
+      </a>
       <a class="btn btn-warning" href="{% url 'quests:category_update' object.id %}" role="button" title="Edit this campaign">
         <i class="fa fa-edit"></i>
       </a>

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -18,6 +18,7 @@ from siteconfig.models import SiteConfig
 
 class CategoryTestModel(TenantTestCase):  # aka Campaigns
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.category = baker.make(Category, title="Test Campaign")
 
     def test_category_type_creation(self):
@@ -52,6 +53,12 @@ class CategoryTestModel(TenantTestCase):  # aka Campaigns
 
         # But other random user still doesn't meet prereq
         self.assertFalse(self.category.condition_met_as_prerequisite(user2))
+
+    def test_category_icon(self):
+        pass
+
+    def test_category_url(self):
+        self.assertEqual(self.client.get(self.category.get_absolute_url(), follow=True).status_code, 200)
 
     def test_xp_sum(self):
         """ Test that the XP sum of all quests in a campaign is returned correctly """

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1286,6 +1286,7 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         ''' If not logged in then all views should redirect to home page or admin login '''
 
         self.assertRedirectsAdmin('quests:categories')
+        self.assertRedirectsAdmin('quests:category_detail', kwargs={"pk": 1})
         self.assertRedirectsAdmin('quests:category_create')
         self.assertRedirectsAdmin('quests:category_update', args=[1])
         self.assertRedirectsAdmin('quests:category_delete', args=[1])
@@ -1296,6 +1297,7 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         # Staff access only
         self.assertRedirectsAdmin('quests:categories')
+        self.assertRedirectsAdmin('quests:category_detail', kwargs={"pk": 1})
         self.assertRedirectsAdmin('quests:category_create')
         self.assertRedirectsAdmin('quests:category_update', args=[1])
         self.assertRedirectsAdmin('quests:category_delete', args=[1])
@@ -1311,6 +1313,12 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         """ Admin should be able to view course list """
         self.client.force_login(self.test_teacher)
         response = self.client.get(reverse('quests:categories'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_CategoryDetail_view(self):
+        """ Admin should be able to view course details """
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:category_detail', kwargs={"pk": 1}))
         self.assertEqual(response.status_code, 200)
 
     def test_CategoryCreate_view(self):

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -94,8 +94,8 @@ urlpatterns = [
     # Campaigns / Categories
     path('campaigns/', views.CategoryList.as_view(), name='categories'),
     path('campaigns/add/', views.CategoryCreate.as_view(), name='category_create'),
+    path('campaigns/<pk>/', views.CategoryDetail.as_view(), name='category_detail'),
     path('campaigns/<pk>/edit/', views.CategoryUpdate.as_view(), name='category_update'),
     path('campaigns/<pk>/delete/', views.CategoryDelete.as_view(), name='category_delete'),
-
     # url(r'^in-progress/(?P<pk>[0-9]+)/delete/$', views.SubmissionDelete.as_view(), name='sub_delete'),
 ]

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -52,6 +52,11 @@ class CategoryList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
 
 
 @method_decorator(staff_member_required, name='dispatch')
+class CategoryDetail(NonPublicOnlyViewMixin, DetailView):
+    model = Category
+
+
+@method_decorator(staff_member_required, name='dispatch')
 class CategoryCreate(NonPublicOnlyViewMixin, CreateView):
     fields = ('title', 'icon', 'active')
     model = Category


### PR DESCRIPTION
Added a detail view for campaigns, from which you can view every quest in them.

![image](https://user-images.githubusercontent.com/105619909/172512412-17eb3d70-369c-47b3-b5d3-5b74ff0885a3.png)

You can also preview and view/edit/etc. quests directly from this view.

![image](https://user-images.githubusercontent.com/105619909/172512583-d86facdf-8f26-49aa-a848-970b75f2b49a.png)

