### PR TITLE
Feat: MarkRange model shows on MarkRange graph; Closes: #939

### DIFF
--- a/src/courses/templates/courses/chart_xp_progress.html
+++ b/src/courses/templates/courses/chart_xp_progress.html
@@ -59,43 +59,62 @@
       data: [{x: 0, y: 0}],
   };
 
-  var GradeAData = {
-      type: 'line',
-      label: 'A (86%)',
-      pointRadius: 0,
-      backgroundColor: "rgba(255,255,0,0)",
-      borderColor: "rgba(255, 236, 179,50)",
-      data: [{x: 0, y: 0}],
-  };
+  
+  // var GradeAData = {
+  //     type: 'line',
+  //     label: 'A (86%)',
+  //     pointRadius: 0,
+  //     backgroundColor: "rgba(255,255,0,0)",
+  //     borderColor: "rgba(255, 236, 179,50)",
+  //     data: [{x: 0, y: 0}],
+  // };
 
-  var GradeFData = {
-      type: 'line',
-      label: 'Pass (50%)',
-      pointRadius: 0,
-      backgroundColor: "rgba(255, 0, 0, 0)",
-      borderColor: "rgba(255, 179, 179, 50)",
-      data: [{x: 0, y: 0}],
-  };
+  // var GradeFData = {
+  //     type: 'line',
+  //     label: 'Pass (50%)',
+  //     pointRadius: 0,
+  //     backgroundColor: "rgba(255, 0, 0, 0)",
+  //     borderColor: "rgba(255, 179, 179, 50)",
+  //     data: [{x: 0, y: 0}],
+  // };
 
-  // Chillax Line Data Set = B
-  var ChillaxLineData = {
-      type: 'line',
-      label: 'B (73%)',
-      pointRadius: 0,
-      backgroundColor: "rgba(0,255,255,0)",
-      borderColor: "rgba(0,255,255,255)",
-      data: [{x: 0, y: 0}],
-  };
+  // // Chillax Line Data Set = B
+  // var ChillaxLineData = {
+  //     type: 'line',
+  //     label: 'B (73%)',
+  //     pointRadius: 0,
+  //     backgroundColor: "rgba(0,255,255,0)",
+  //     borderColor: "rgba(0,255,255,255)",
+  //     data: [{x: 0, y: 0}],
+  // };
+  
+
+  var markranges = []
+  {% for mr in markranges %}
+  var border;
+  {% if request.user.profile.dark_theme %}
+  border = "{{ mr.color_dark }}";
+  {% else %}
+  border = "{{ mr.color_light }}";
+  {% endif %}
+
+  markranges.push({
+    type: 'line',
+    label: '{{ mr.name }} ({{ mr.minimum_mark|floatformat:"0" }}%)',
+    mark: {{ mr.minimum_mark }},
+    pointRadius: 0,
+    backgroundColor: "rgb(0,0,0,0)",
+    borderColor: border,
+    data: [{x: 0, y: 0}],
+  });
+  {% endfor %}
 
   var data = {
       datasets: [
           XPData,
 {#          XPDataBar,#}
           XPTrendData,
-          GradeFData,
-          ChillaxLineData,
-          GradeAData,
-      ]
+      ].concat(markranges)
   };
 
   // need some starting data for the animation to work it seems..
@@ -236,17 +255,15 @@
 
   function generate_mark_lines(days) {
     // Mark Line Generation
-    ChillaxLineData.data = [];
-    GradeAData.data = [];
-    GradeFData.data = [];
+    for(let range of markranges) {
+      range.data = [];
+    }
 
     for (var i = 1; i <= days; i++) {
-        var p = new DataPoint(i, Math.floor(i * max_xp*0.725 / days));
-        var pA = new DataPoint(i, Math.floor(i * max_xp*0.855 / days));
-        var pF = new DataPoint(i, Math.floor(i * max_xp*0.495 / days));
-        ChillaxLineData.data.push(p);
-        GradeAData.data.push(pA);
-        GradeFData.data.push(pF);
+        for (let range of markranges) {
+          var point = new DataPoint(i, Math.floor(i * max_xp*range.mark/100 / days))
+          range.data.push(point);
+        }
 
     }
   }

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -26,6 +26,9 @@ class MarkRangeTestModel(TenantTestCase):
 
 class MarkRangeTestManager(TenantTestCase):
     def setUp(self):
+        # clear default mark range variables
+        MarkRange.objects.all().delete()
+
         self.mr_50 = baker.make(MarkRange, minimum_mark=50.0)
 
     def test_get_range(self):

--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -7,7 +7,7 @@ among other issues
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
-from courses.models import Grade, Rank, Course, Block
+from courses.models import Grade, Rank, Course, Block, MarkRange
 from quest_manager.models import Quest, Category
 from badges.models import Badge, BadgeType, BadgeRarity
 from prerequisites.models import Prereq
@@ -21,6 +21,7 @@ def load_initial_tenant_data():
     create_site_config_object()
     create_initial_course()
     create_initial_blocks(user)
+    create_initial_markranges()
     create_initial_ranks()
     create_initial_grades()
     create_initial_badge_types()
@@ -53,6 +54,12 @@ def create_initial_course():
 
 def create_initial_blocks(user):
     Block.objects.create(block="Default", current_teacher=user)
+
+
+def create_initial_markranges():
+    MarkRange.objects.create(name="A", minimum_mark=85.5, color_light="#FFECB3", color_dark="#FFFF00")
+    MarkRange.objects.create(name="B", minimum_mark=72.5, color_light="#BEFFFA", color_dark="#337AB7")
+    MarkRange.objects.create(name="Pass", minimum_mark=49.5, color_light="#FFB3B3", color_dark="#FF0000")
 
 
 def create_initial_ranks():

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -1,6 +1,7 @@
 from django_tenants.test.cases import TenantTestCase
 
 from badges.models import BadgeRarity
+from courses.models import MarkRange
 
 
 class TenantInitializationTest(TenantTestCase):
@@ -16,3 +17,10 @@ class TenantInitializationTest(TenantTestCase):
     
     def test_only_default_rarities_created(self):
         self.assertEqual(BadgeRarity.objects.count(), 6)
+
+    def test_default_mark_ranges_created(self):
+        """ 
+            When a new tenant is created, the initialization script should create 3 default Markrange objects.
+        """ 
+        for name in ["A", "B", "Pass"]:
+            self.assertTrue(MarkRange.objects.filter(name=name).exists())


### PR DESCRIPTION
Todo:

 - [x] Chart line name match Mark Range name field
 - [x] Chart line color matches MarkRange color (both for dark theme and for light theme!)
 - [x] Only show on chart if mark range is Active "Active"
 - [x] Ensure default MarkRange data (in a new deck) make sense.

Only thing i didnt add are tests as i still dont know how to test the views when the graph is loaded via javascript. meaning i cant use assertContains to determine if mark labels are being properly rendered

![image](https://user-images.githubusercontent.com/39788517/172753296-977d0ad3-bc94-42db-a5ce-ad3399bec0f5.png)
![image](https://user-images.githubusercontent.com/39788517/172753258-0f544fdc-b672-47cf-b339-ad96f8f2a2a5.png)
![image](https://user-images.githubusercontent.com/39788517/172753273-a8a6d2b2-91e7-41b7-b085-514a02d56b8a.png)

