### PR TITLE
add sort order as heading in badgetype list view; closes #1021

### DIFF
--- a/src/badges/templates/badges/badgetype_list.html
+++ b/src/badges/templates/badges/badgetype_list.html
@@ -13,12 +13,14 @@
   <tr>
     <th>Title</th>
     <th>Icon</th>
+    <th>Sort Order</th>
     <th>Action</th>
   </tr>
   {% for object in object_list %}
   <tr>
     <td>{{ object.name }}</td>
     <td>{% if object.fa_icon %}<i class="fa {{ object.fa_icon }}"></i>{% endif %}</td>
+    <td>{{ object.sort_order }}</td>
     <td>
       <a class="btn btn-warning" href="{% url 'badges:badge_type_update' object.id %}" role="button" title="Edit this badge_type">
         <i class="fa fa-edit"></i>


### PR DESCRIPTION
Added sort order to the badge type list view as a header and content. 
![image](https://user-images.githubusercontent.com/105619909/173458205-a02308e6-a6c6-4880-8692-d26e1d1c0962.png)
Sort order for both badge type and badge list views is linked, so you can view and edit the ordering of badge types from the more convenient list view.
![image](https://user-images.githubusercontent.com/105619909/173458426-91ab2f1b-2f96-44b4-a1f8-bc40f9e9effa.png)
![image](https://user-images.githubusercontent.com/105619909/173458445-116fb6a9-241e-4a92-a6c8-8a3c2275ded8.png)
