### PR TITLE
fix badge type sidebar button highlight; closes #1020

### DIFF
--- a/src/badges/urls.py
+++ b/src/badges/urls.py
@@ -8,6 +8,7 @@ app_name = 'badges'
 
 urlpatterns = [
     path('', views.badge_list, name='list'),
+    path('list/', views.badge_list, name='badge_list'),
     path('create/', views.badge_create, name='badge_create'),
     path('<int:badge_id>', views.detail, name='badge_detail'),
     url(r'^(?P<pk>[0-9]+)/edit/$', views.BadgeUpdate.as_view(), name='badge_update'),

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -40,8 +40,8 @@
       {% if request.user.is_staff %}
         <div class="clearfix">
           <a id="achievements-menu"
-          class="list-group-item left-side {% if '/achievements/' in request.path_info %}active{% endif %}"
-          href="{% url 'badges:list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
+          class="list-group-item left-side {% if '/achievements/list' in request.path_info %}active{% endif %}"
+          href="{% url 'badges:badge_list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
           <a title="Badge Types" class="list-group-item right-side text-center
           {% if 'achievements/types/' in request.path_info %}active{% endif %}"
           href="{% url 'badges:badge_types' %}"><i class="fa fa-certificate fa-fw"></i></a>


### PR DESCRIPTION
Badge type list view button on the sidebar should now highlight properly when active.
![image](https://user-images.githubusercontent.com/105619909/173466804-6da62a21-87a7-4841-b23f-8185b197fd6b.png)
(dark view makes this harder than usual to see, screenshot of another proper depiction included below)
![image](https://user-images.githubusercontent.com/105619909/173466869-04ae487f-0867-4d88-8274-f9379fd0ccb0.png)
