### PR TITLE
change achievements url to badges and redirect old links; closes #997

### DIFF
--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
+from django.views.generic import RedirectView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 
@@ -16,6 +17,11 @@ from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 
 from .forms import BadgeAssertionForm, BadgeForm, BulkBadgeAssertionForm
 from .models import Badge, BadgeAssertion, BadgeType
+
+
+class AchievementRedirectView(NonPublicOnlyViewMixin, LoginRequiredMixin, RedirectView):
+    def dispatch(self, request):
+        return redirect(request.path_info.replace("achievements", "badges", 1))
 
 
 @non_public_only_view
@@ -70,8 +76,8 @@ def badge_create(request):
 
     # Using `@staff_member_required(login_url='/accounts/login/')` causes a RedirectCycleErrror.
     # For example, a student that is already logged in tries to access this page,
-    # They will get redirect to `/accounts/login/?next=/achievements/create/`.
-    # And since they are already logged in, they will be redirected to `/achievements/create/`
+    # They will get redirect to `/accounts/login/?next=/badges/create/`.
+    # And since they are already logged in, they will be redirected to `/badges/create/`
     # Causing again to redirect since they are not a staff.
 
     # We could use `@staff_member_required(login_url='/')` but this breaks the tests
@@ -85,7 +91,7 @@ def badge_create(request):
         form.save()
         return redirect('badges:list')
     context = {
-        "heading": "Create New Achievment",
+        "heading": "Create New Badge",
         "form": form,
         "submit_btn_value": "Create",
     }

--- a/src/hackerspace_online/tests/test_views.py
+++ b/src/hackerspace_online/tests/test_views.py
@@ -83,3 +83,15 @@ class ViewsTest(ViewTestUtilsMixin, TenantTestCase):
 
     def test_password_reset_view(self):
         self.assert200('account_reset_password')
+    
+    def test_achievements_redirect_to_badges_views(self):
+        # log in a teacher
+        staff_user = User.objects.create_user(username="test_staff_user", password="password", is_staff=True)
+        self.client.force_login(staff_user)
+
+        # assert (most) relevant badge views are redirected to from old urls
+        self.assertRedirects(self.client.get('/achievements/'), reverse('badges:list'))
+        self.assertRedirects(self.client.get('/achievements/create/'), reverse('badges:badge_create'))
+        self.assertRedirects(self.client.get('/achievements/1'), reverse('badges:badge_detail', args=[1]))
+        self.assertRedirects(self.client.get('/achievements/1/edit/'), reverse('badges:badge_update', args=[1]))
+        self.assertRedirects(self.client.get('/achievements/1/delete/'), reverse('badges:badge_delete', args=[1]))

--- a/src/hackerspace_online/urls.py
+++ b/src/hackerspace_online/urls.py
@@ -19,6 +19,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include
 
+from badges.views import AchievementRedirectView
 from hackerspace_online import views
 from siteconfig.models import SiteConfig
 
@@ -43,7 +44,8 @@ urlpatterns += [
     url(r'^comments/', include('comments.urls', namespace='comments')),
     url(r'^notifications/', include('notifications.urls', namespace='notifications')),
     url(r'^courses/', include('courses.urls', namespace='courses')),
-    url(r'^achievements/', include('badges.urls', namespace='badges')),
+    url(r'^achievements/', AchievementRedirectView.as_view()),
+    url(r'^badges/', include('badges.urls', namespace='badges')),
     url(r'^maps/', include('djcytoscape.urls', namespace='maps')),
     url(r'^portfolios/', include('portfolios.urls', namespace='portfolios')),
     url(r'^utilities/', include('utilities.urls', namespace='utilities')),

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -39,16 +39,16 @@
 {#    </a>#}
       {% if request.user.is_staff %}
         <div class="clearfix">
-          <a id="achievements-menu"
-          class="list-group-item left-side {% if '/achievements/list' in request.path_info %}active{% endif %}"
-          href="{% url 'badges:badge_list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
+          <a id="badges-menu"
+          class="list-group-item left-side {% if '/badges/' in request.path_info %}active{% endif %}"
+          href="{% url 'badges:list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
           <a title="Badge Types" class="list-group-item right-side text-center
-          {% if 'achievements/types/' in request.path_info %}active{% endif %}"
+          {% if 'badges/types/' in request.path_info %}active{% endif %}"
           href="{% url 'badges:badge_types' %}"><i class="fa fa-certificate fa-fw"></i></a>
         </div>
       {% else %}
-        <a id="achievements-menu"
-        class="list-group-item {% if '/achievements/' in request.path_info %}active{% endif %}"
+        <a id="badges-menu"
+        class="list-group-item {% if '/badges/' in request.path_info %}active{% endif %}"
         href="{% url 'badges:list' %}">
         <i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
       {% endif %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/173704413-2027e71d-69d5-4042-a923-81aa81d978c2.png)
"achievements" in url path to get to badge views has been changed to "badges".
links that go to "achievements" at any point will instead redirect to the badge list view.