### PR TITLE
add github contact link in website footer; closes #542

### DIFF
--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -3,6 +3,8 @@
     <div class='container-fluid'>
         <div class='row'>
             <div class='col-sm-6'>
+                <p class='text-muted'>Want to contact us? Visit our 
+                    <a href="https://github.com/bytedeck/bytedeck/discussions">discussion page.</a></p>
                 <a href="http://creativecommons.org/licenses/by/3.0/deed.en_US">
                     <img class="pull-left" src="{% static 'img/by-sa.svg' %}"
                          alt="Creative Commons Attribution-ShareAlike Logo"/>


### PR DESCRIPTION
added a link to the github discussions page in website footer. currently need a github account to leave any comments or participate in discussions, however.

![image](https://user-images.githubusercontent.com/105619909/174199107-7432a1a7-595f-43ad-b65a-a242863fb9a9.png)

