### PR TITLE
Feat: Added Middleware to silence PermissionDenied errors; Closes: #1044

### DIFF
--- a/src/hackerspace_online/middleware.py
+++ b/src/hackerspace_online/middleware.py
@@ -1,4 +1,6 @@
 from django.db import connections
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import render
 
 
 class ForceDebugCursorMiddleware:
@@ -10,3 +12,23 @@ class ForceDebugCursorMiddleware:
         connections['default'].force_debug_cursor = True
         response = self.get_response(request)
         return response
+
+
+# https://stackoverflow.com/a/68797100
+class PermissionDeniedErrorHandler:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, exception):
+        # This is the method that responsible for the safe-exception handling
+        if isinstance(exception, PermissionDenied):
+            return render(
+                request=request,
+                template_name="403.html",
+                status=403
+            )
+        return None

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -211,6 +211,8 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',  # used by django-date-time-widget
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+
+    'hackerspace_online.middleware.PermissionDeniedErrorHandler',
 ]
 
 DB_LOGS_ENABLED = env('DB_LOGS_ENABLED', default=False)


### PR DESCRIPTION
## Permission denied error
culprit of this error was just: ```django.contrib.auth.mixins.UserPassesTestMixin.test_func``` overriden in the url's cbv
ie: 
```
Forbidden (Permission denied): /quests/list/all
<CONSOLE ERROR HERE>
```
Then the cbv assocciated with ```/quests/list/all``` overrides the  ```django.contrib.auth.mixins.UserPassesTestMixin.test_func``` 
```
class ProfileList(NonPublicOnlyViewMixin, UserPassesTestMixin, ListView):

   def test_func(self):
          return self.request.user.is_staff
```

The fix for this was just adding a middleware to silence to error message. This doesnt remove the Forbidden (Permission denied) print though

## Not found message
Not found messages just appear when you try to get the reverse of a page that doesnt exist. That error shows up in the flatpages CRUD delete test
```
flatpage = random flatpage
self.client.post(reverse('utilities:flatpage_delete', kwargs={'pk': flatpage.pk}))

# WILL MAKE THE NOT FOUND MESSAGE APPEAR
self.assert404URL(flatpage.get_absolute_url())
```
