### PR TITLE
Fix: deck_owner no longer superuser; Closes: #1059

### DIFF
--- a/src/siteconfig/tests/test_models.py
+++ b/src/siteconfig/tests/test_models.py
@@ -13,6 +13,7 @@ from model_bakery import baker
 
 from siteconfig.models import SiteConfig, get_default_deck_owner
 
+
 User = get_user_model()
 
 
@@ -123,7 +124,7 @@ class SiteConfigModelTest(TenantTestCase):
             Test if get_deck_owner either gets an already created owner user or creates one
         """ 
         # owner already exists since tenantSetup runs initialization.py
-        owner_user = User.objects.get(username=settings.TENANT_DEFAULT_OWNER_USERNAME, is_superuser=True, is_staff=True)
+        owner_user = User.objects.get(username=settings.TENANT_DEFAULT_OWNER_USERNAME, is_staff=True)
         old_owner_pk = owner_user.pk
 
         # if non_admin_staff_qs.exists()

--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -44,17 +44,20 @@ def create_superusers():
         password=settings.TENANT_DEFAULT_ADMIN_PASSWORD
     )
     # OWNER OF THE DECK
-    # get_or_create IS HERE BECAUSE siteconfig.models.get_default_deck_owner() will run before this file (initialization.py)
+    # update_or_create IS HERE BECAUSE siteconfig.models.get_default_deck_owner() will run before this file (initialization.py)
     # although siteconfig.models.get_default_deck_owner() will not run before this every time based on manual testing
-    owner, _ = User.objects.get_or_create(username=settings.TENANT_DEFAULT_OWNER_USERNAME)
 
-    # set owner vars since siteconfig.models.get_deck_owner() wont set all vars and/or has not created model yet
-    owner.email = 'owner@example.com'
-    owner.set_password(settings.TENANT_DEFAULT_OWNER_PASSWORD)
-    owner.is_superuser = True
-    owner.is_staff = True
+    owner, _ = User.objects.update_or_create(
+        username=settings.TENANT_DEFAULT_OWNER_USERNAME, 
+        defaults={
+            "email": 'owner@example.com',
+            "is_superuser": False,
+            "is_staff": True,
+        },
+    )
+    owner.set_password(settings.TENANT_DEFAULT_OWNER_PASSWORD,)
     owner.save()
-        
+
 
 def create_site_config_object():
     """ Create the single SiteConfig object for this tenant """

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -7,6 +7,9 @@ from courses.models import MarkRange
 from utilities.models import MenuItem
 
 
+User = get_user_model()
+
+
 class TenantInitializationTest(TenantTestCase):
 
     def test_default_badge_rarities_created(self):
@@ -31,26 +34,34 @@ class TenantInitializationTest(TenantTestCase):
     def test_default_menu_items_created(self):
         self.assertTrue(MenuItem.objects.filter(label="Ranks List").exists())
 
-    def test_superusers_created(self):
+    def test_admin_created(self):
         """ 
-            Check if superusers are created, and username/password is correct
+            Check if admin superuser is created upon initialization
         """ 
-        User = get_user_model()
+        username = "admin"
+        password = settings.TENANT_DEFAULT_ADMIN_PASSWORD
 
-        usernames = ['admin', 'owner']
-        passwords = [settings.TENANT_DEFAULT_ADMIN_PASSWORD, settings.TENANT_DEFAULT_OWNER_PASSWORD]
-        accounts = {usernames[i]: passwords[i] for i in range(len(usernames))}
+        user = User.objects.filter(username=username).first()
+        self.assertTrue(user is not None)
 
-        for username, password in accounts.items():
-            
-            # Check if in DB
-            user = User.objects.filter(username=username).first()
-            self.assertTrue(user is not None)
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
 
-            # Check if superusers and is_staff
-            self.assertTrue(user.is_superuser)
-            self.assertTrue(user.is_staff)
-            
-            # Check if can login
-            success = self.client.login(username=username, password=password)
-            self.assertTrue(success)
+        success = self.client.login(username=username, password=password)
+        self.assertTrue(success)
+
+    def test_owner_created(self):
+        """ 
+            Check if deck_owner is created upon initialization
+        """ 
+        username = "owner"
+        password = settings.TENANT_DEFAULT_OWNER_PASSWORD
+
+        user = User.objects.filter(username=username).first()
+        self.assertTrue(user is not None)
+
+        self.assertTrue(user.is_staff)
+        self.assertFalse(user.is_superuser)
+
+        success = self.client.login(username=username, password=password)
+        self.assertTrue(success)


### PR DESCRIPTION
cant put password in ```defaults``` so
```
owner.set_password(settings.TENANT_DEFAULT_OWNER_PASSWORD,)
owner.save()
```
is neccessary