### PR TITLE
add quest count to campaign list and detail view; closes #1086

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -46,11 +46,19 @@ class Category(IsAPrereqMixin, models.Model):
             return self.icon.url
         else:
             return SiteConfig.get().get_default_icon_url()
+    
+    def current_quests(self):
+        """ Returns a queryset containing every currently available quest in this campaign."""
+        return self.quest_set.all().visible().not_archived()
+
+    def quest_count(self):
+        """ Returns the total number of quests available in this campaign."""
+        return self.current_quests().count()
 
     def xp_sum(self):
         """ Returns the total XP available from completing all visible quests in this campaign.
         Repeating quests are only counted once."""
-        return self.quest_set.all().visible().not_archived().aggregate(Sum('xp'))['xp__sum']
+        return self.current_quests().aggregate(Sum('xp'))['xp__sum']
 
     def condition_met_as_prerequisite(self, user, num_required=1):
         """

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -4,7 +4,8 @@
     <img class="media-object icon-lg img-rounded" src="{{ category.get_icon_url }}" alt="icon" />
   </div>
   <div class="media-body">
-    <p>Total XP available in this campaign: {{ category.xp_sum }}</p>
+    <p>Number of quests in this campaign: {{ category.quest_count }}</p>
+    <p>Total XP available: {{ category.xp_sum }}</p>
   </div>
 </div>
 

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -15,6 +15,8 @@
   <tr>
     <th>Title</th>
     <th>Icon</th>
+    <th># of Quests</th>
+    <th>XP Available</th>
     <th>Active</th>
     <th>Action</th>
   </tr>
@@ -22,6 +24,8 @@
   <tr>
     <td>{{ object.title }}</td>
     <td>{% if object.icon %}<img class="img-responsive panel-title-img img-rounded" src="{{ object.icon.url }}">{% endif %}</td>
+    <td>{{ object.quest_count }}</td>
+    <td>{{ object.xp_sum }}</td>
     <td>{{ object.active }}</td>
     <td>
       <a class="btn btn-info" href="{% url 'quests:category_detail' object.id %}" role="button" title="View Details: view the content of this campaign.">

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -59,19 +59,45 @@ class CategoryTestModel(TenantTestCase):  # aka Campaigns
 
     def test_category_url(self):
         self.assertEqual(self.client.get(self.category.get_absolute_url(), follow=True).status_code, 200)
+    
+    def test_current_quests(self):
+        """ Test that the queryset of all quests in a campaign is returned correctly """
+
+        # assert that the current campaign has no quests
+        self.assertEqual(self.category.current_quests().count(), 0)
+
+        # create some quests as part of the test campaign, some are invalid and won't be included
+        baker.make(Quest, campaign=self.category)  # included in queryset
+        baker.make(Quest, campaign=self.category)  # included in queryset
+        baker.make(Quest, campaign=self.category, visible_to_students=False)  # NOT included in queryset because not visible
+        baker.make(Quest, campaign=self.category, archived=True)  # NOT included in queryset because archived
+        baker.make(Quest)  # NOT included in queryset because in a different campaign
+
+        # assert that the current campaign has 2 valid quests after additions
+        self.assertEqual(self.category.current_quests().count(), 2)
 
     def test_xp_sum(self):
         """ Test that the XP sum of all quests in a campaign is returned correctly """
 
         # create some quests as part of the test campaign
-        baker.make(Quest, campaign=self.category, xp=1)  # included in sum
-        baker.make(Quest, campaign=self.category, xp=2)  # included in sum
-        baker.make(Quest, xp=4)  # NOT included in sum because n a different campaign
-        baker.make(Quest, visible_to_students=False, xp=8)  # NOT included in sum becuase not visible
-        baker.make(Quest, archived=True, xp=16)  # NOT included in sum becase archived
+        baker.make(Quest, campaign=self.category, xp=1)
+        baker.make(Quest, campaign=self.category, xp=2)
 
         # check that the XP sum is correct
         self.assertEqual(self.category.xp_sum(), 3)
+
+    def test_quest_count(self):
+        """ Test that the number of all quests in a campaign is returned correctly """
+
+        # assert that the current campaign has no quests
+        self.assertEqual(self.category.quest_count(), 0)
+
+        # create some quests as a part of the test campaign
+        baker.make(Quest, campaign=self.category)
+        baker.make(Quest, campaign=self.category)
+
+        # check that the quest count is correct after additions
+        self.assertEqual(self.category.quest_count(), 2)
 
 
 class CommonDataTestModel(TenantTestCase):


### PR DESCRIPTION
campaign list view now displays number of quests.
![image](https://user-images.githubusercontent.com/105619909/179337074-662a6545-6770-4154-b0ae-bb9adbd368af.png)
campaign detail view has also been updated accordingly:
![image](https://user-images.githubusercontent.com/105619909/179337096-78f50d8f-25a3-48e3-a5e1-a1a373fe7bd3.png)
