### PR TITLE
iconless campaigns display 'no icon' text instead of blank; closes #1082

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -1,7 +1,7 @@
 
 <div class="media">
   <div class="media-left">
-    <img class="media-object icon-lg img-rounded" src="{{ category.get_icon_url }}" alt="icon" />
+      <img class="media-object icon-lg img-rounded" src="{{ category.get_icon_url }}" alt="icon" />
   </div>
   <div class="media-body">
     <p>Total XP available in this campaign: {{ category.xp_sum }}</p>

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -21,7 +21,7 @@
   {% for object in object_list %}
   <tr>
     <td>{{ object.title }}</td>
-    <td>{% if object.icon %}<img class="img-responsive panel-title-img img-rounded" src="{{ object.icon.url }}">{% endif %}</td>
+    <td><img class="img-responsive panel-title-img img-rounded" src="{{ object.get_icon_url }}"></td>
     <td>{{ object.active }}</td>
     <td>
       <a class="btn btn-info" href="{% url 'quests:category_detail' object.id %}" role="button" title="View Details: view the content of this campaign.">


### PR DESCRIPTION
campaigns with no icons appearing in list or detail views will now display "none" or "no icon" text respectively.
![image](https://user-images.githubusercontent.com/105619909/179337468-f6ecf5bc-d132-43de-a854-07ed673968cf.png)

![image](https://user-images.githubusercontent.com/105619909/179337456-add13301-3e1c-412c-8e3a-5b508a466c57.png)
