### PR TITLE
add link to campaign in quest detail view; closes #1070

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -1,6 +1,8 @@
 {% extends "quest_manager/base.html" %}
 {% load crispy_forms_tags %}
 
+{% block head_title %}Campaigns | {% endblock %}
+
 {% block heading_inner %} {{ object.title }} Campaign{% endblock %}
 
 {% block content %}

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -1,11 +1,26 @@
 
 <div class="media">
   <div class="media-left">
-      <img class="media-object icon-lg img-rounded" src="{{ category.get_icon_url }}" alt="icon" />
+    <img class="media-object icon-lg img-rounded" src="{{ category.get_icon_url }}" alt="icon" />
   </div>
-  <div class="media-body">
-    <p>Number of quests in this campaign: {{ category.quest_count }}</p>
-    <p>Total XP available: {{ category.xp_sum }}</p>
+</div>
+
+<div id="category-info-{{category.id}}" class="panel panel-primary panel-top">
+  <div class="panel-heading">
+    <h3 class="panel-title">Campaign Info</h3>
+  </div>
+  <div class="panel-body">
+
+    <div class="row">
+      <div class="col-sm-6">
+        <ul class="list-unstyled">
+          <li>Quests in this campaign: {{ category.quest_count }}</li>
+          <li>Total XP available: {{ category.xp_sum }}</li>
+          <li>Active: {{category.active }}</li>
+        </ul>
+      </div>
+    </div>
+
   </div>
 </div>
 

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -1,4 +1,4 @@
-{% extends "courses/base.html" %}
+{% extends "quest_manager/base.html" %}
 
 {% block head_title %}Campaigns | {% endblock %}
 {% block head %}{% endblock %}
@@ -6,7 +6,7 @@
 {% block content_first %}{% endblock %}
 {% block heading_inner %}Campaigns
 {% if request.user.is_staff %}
-  <a class="btn btn-primary" href="{% url 'quest_manager:category_create' %}" role="button">New</a>
+  <a class="btn btn-primary" href="{% url 'quest_manager:category_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
 {% endif %}
 {% endblock %}
 

--- a/src/quest_manager/templates/quest_manager/quest_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/quest_detail_content.html
@@ -19,7 +19,7 @@
         <ul class="list-unstyled">
           <li><h4>XP: {{quest.xp}}{% if quest.xp_can_be_entered_by_students %}+ <small>(student entered)</small>{% endif %}
           </h4></li>
-          <li>Campaign: {% if quest.campaign %}{{ quest.campaign }} {% else %}-{% endif %}</li>
+          <li>Campaign: {% if quest.campaign %}{% if user.is_staff %}<a href="{% url 'quests:category_detail' quest.campaign.id %}">{{ quest.campaign }}</a>{% else %}{{ quest.campaign }}{% endif %}{% else %}-{% endif %}</li>
           <li>Tags: {{ quest.tags.all|join:", " }}</li>
           <li>Expiry: {{quest.date_expired}}</li>
         </ul>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/179640225-8a5ed911-6cf8-414d-9609-2c3a44d915c5.png)
campaign detail view now accessible through a hyperlink in quest detail views, finally
there's still no link to the campaign list, maybe beside/in place of the "quest drafts" button in the sidebar?