### PR TITLE
move period out of footer hyperlink; closes #1055

### DIFF
--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -4,7 +4,7 @@
         <div class='row'>
             <div class='col-sm-6'>
                 <p class='text-muted'>Want to contact us? Visit our 
-                    <a href="https://github.com/bytedeck/bytedeck/discussions">discussion page.</a></p>
+                    <a href="https://github.com/bytedeck/bytedeck/discussions">discussion page</a>.</p>
                 <a href="http://creativecommons.org/licenses/by/3.0/deed.en_US">
                     <img class="pull-left" src="{% static 'img/by-sa.svg' %}"
                          alt="Creative Commons Attribution-ShareAlike Logo"/>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/179652559-edc09849-a44e-4803-be6d-578fbe052a88.png)
![image](https://user-images.githubusercontent.com/105619909/179652583-985fdebb-43da-4423-9fad-db91b1ccdae6.png)
period is now excluded from link in footer