### PR TITLE
fix broken badge/type creation links in pr #1094

### DIFF
--- a/src/badges/templates/badges/list.html
+++ b/src/badges/templates/badges/list.html
@@ -4,8 +4,8 @@
 
 {% block heading_inner %}{{heading}}
 {% if request.user.is_staff %}
-  <a class="btn btn-primary" href="% url 'badges:badge_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge</a>
-  <a class="btn btn-primary" href="% url 'badges:badge_type_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge Type</a>
+  <a class="btn btn-primary" href="{% url 'badges:badge_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge</a>
+  <a class="btn btn-primary" href="{% url 'badges:badge_type_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge Type</a>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
This is a little embarrassing. 
In the last PR involving updated badge/type creation buttons being updated, the buttons had improperly formatted href values that caused them to break. This is a fix to that.
