### PR TITLE
Feat: CommonData CRUD; Closes #1072

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -15,7 +15,7 @@ from tags.forms import BootstrapTaggitSelect2Widget
 
 from utilities.fields import RestrictedFileFormField
 from badges.models import Badge
-from .models import Category, Quest
+from .models import Category, Quest, CommonData
 
 
 class BadgeLabel:
@@ -106,6 +106,9 @@ class QuestForm(forms.ModelForm):
         super(QuestForm, self).__init__(*args, **kwargs)
 
         self.fields['date_available'].initial = date.today().strftime('%Y-%m-%d'),
+
+        self.fields['common_data'].label = 'Common Quest Info'
+        self.fields['common_data'].queryset = CommonData.objects.filter(active=True)
 
         cancel_btn = '<a href="{{ cancel_url }}" role="button" class="btn btn-danger">Cancel</a> '
         submit_btn = '<input type="submit" value="{{ submit_btn_value }}" class="btn btn-success"/> '
@@ -265,3 +268,13 @@ class SubmissionQuickReplyForm(forms.Form):
     def __init__(self, *args, **kwds):
         super(SubmissionQuickReplyForm, self).__init__(*args, **kwds)
         self.fields['award'].queryset = Badge.objects.all_manually_granted()
+
+
+class CommonDataForm(forms.ModelForm):
+
+    class Meta:
+        model = CommonData
+        fields = "__all__"
+        widgets = {
+            "instructions": SummernoteInplaceWidget()
+        }

--- a/src/quest_manager/templates/quest_manager/common_quest_info_delete.html
+++ b/src/quest_manager/templates/quest_manager/common_quest_info_delete.html
@@ -1,0 +1,17 @@
+{% extends "quest_manager/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block head_title%} Confirm Deletion | {% endblock%}
+
+{% block heading_inner %}Delete Common Quest Info: {{object.title}}{% endblock %}
+
+{% block content %}
+    <form action="" method="post">
+        {% csrf_token %}
+
+        <p>Are you sure you want to delete Common Quest Info - {{object.title}}?</a><p>
+
+        <a href="{% url 'quest_manager:commonquestinfo_list' %}" role="button" class="btn btn-info">Cancel</a>
+        <input type="submit" value="Delete" class="btn btn-danger"/>
+    </form>
+{% endblock %} 

--- a/src/quest_manager/templates/quest_manager/common_quest_info_form.html
+++ b/src/quest_manager/templates/quest_manager/common_quest_info_form.html
@@ -1,0 +1,24 @@
+{% extends "quest_manager/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block head_title%} Common Quest Info |{% endblock%}
+
+{% block head %}
+    {{ form.media }}
+{% endblock %}
+
+{% block heading_inner %}{{ heading }}{% endblock %}
+
+{% block content %}
+    <div>
+        <form action="" method="post">
+            {% csrf_token %}
+
+            {{ form|crispy }}
+
+            <a href="{% url 'quest_manager:commonquestinfo_list' %}" role="button" class="btn btn-danger">Cancel</a>
+            <input type="submit" value="Submit" class="btn btn-success"/>
+        </form>
+
+    </div>
+{% endblock %} 

--- a/src/quest_manager/templates/quest_manager/common_quest_info_list.html
+++ b/src/quest_manager/templates/quest_manager/common_quest_info_list.html
@@ -1,0 +1,44 @@
+{% extends "quest_manager/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block head_title %}Common Quest Info | {% endblock %}
+
+{% block heading_inner %}
+    Common Quest Info
+
+    <a class="btn btn-primary" href="{% url 'quest_manager:commonquestinfo_create' %}" role="button">New</a>
+{% endblock %}
+
+{% block content %}
+    <table class="table table-striped">
+        <thead class="thead-light">
+            <tr class="row">
+                <th class="col-sm-5" scope="col">Title</th>
+                <th class="col-sm-5" scope="col">Active</th>
+                <th class="col-sm-2" scope="col">Action</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for object in object_list %}
+                <tr class="row">
+                    <td class="class-sm">
+                        {{object.title}}
+                    </td>
+                    <td class="class-sm">
+                        {{object.active}}
+                    </td>
+                    <td class="class-sm">
+                        <a class="btn btn-warning" href="{% url 'quest_manager:commonquestinfo_update' pk=object.pk %}" role="button" title="Edit this page">
+                            <i class="fa fa-edit"></i>
+                        </a>
+                        <a class="btn btn-danger" href="{% url 'quest_manager:commonquestinfo_delete' pk=object.pk %}" role="button" title="Delete this page">
+                            <i class="fa fa-trash-o"></i>
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+{% endblock %} 

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -20,9 +20,9 @@ from django_tenants.test.client import TenantClient
 from mock import patch
 from model_bakery import baker
 
-from hackerspace_online.tests.utils import ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ViewTestUtilsMixin, generate_form_data
 from notifications.models import Notification
-from quest_manager.models import Category, Quest, QuestSubmission
+from quest_manager.models import Category, Quest, QuestSubmission, CommonData
 from quest_manager.views import is_staff_or_TA
 from siteconfig.models import SiteConfig
 
@@ -56,7 +56,7 @@ class AutocompleteViewTests(ViewTestUtilsMixin, TenantTestCase):
 
     def test_commondata_autocomplete_view(self):
         """ Make sure autocomplete view for this model is accessible and not throwing errors"""
-        response = self.client.get(reverse('quests:commondata_autocomplete'))
+        response = self.client.get(reverse('quests:commonquestinfo_autocomplete'))
         self.assertEqual(response.status_code, 200)
 
     # TODO: Campaign Autocomplete <-- why doesn't this work?  should be same as above tests!!!
@@ -2280,3 +2280,92 @@ class Is_staff_or_TA_test(TenantTestCase):
     def test_is_staff_or_TA__anonymous(self):
         """ Anonymous user returns False"""
         self.assertFalse(is_staff_or_TA(AnonymousUser()))
+
+
+class CommonDataViewTest(ViewTestUtilsMixin, TenantTestCase):
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+        self.teacher = baker.make(User, is_staff=True)
+
+        self.cqi = baker.make(CommonData)
+
+    def test_page_status_code__anonymous(self):
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_list")
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_create")
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
+
+    def test_page_status_code__student(self):
+        stu = baker.make(User)
+        self.client.force_login(stu)
+
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_list")
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_create")
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
+        self.assertRedirectsAdmin("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
+
+    def test_page_status_code__teacher(self):
+        self.client.force_login(self.teacher)
+        
+        self.assert200("quest_manager:commonquestinfo_list")
+        self.assert200("quest_manager:commonquestinfo_create")
+        self.assert200("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
+        self.assert200("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
+
+    def test_CommonDataList_view(self):
+        """
+            Test if CommonData displays all CQI obj
+        """
+        baker.make(CommonData, _quantity=5)
+        self.client.force_login(self.teacher)
+        
+        response = self.client.get(reverse("quest_manager:commonquestinfo_list"))
+        object_list = response.context["object_list"]
+
+        self.assertEqual(CommonData.objects.count(), len(object_list))
+
+        for model_obj, ctx_obj in zip(CommonData.objects.all(), object_list):
+            self.assertEqual(model_obj.pk, ctx_obj.pk)
+
+    def test_CommonDataCreate_view(self):
+        """ 
+            Test if CQI can be created using CreateView via form_data
+        """ 
+        self.client.force_login(self.teacher)
+
+        response = self.client.post(reverse("quest_manager:commonquestinfo_create"), data=generate_form_data(CommonData))
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(CommonData.objects.count(), 2)
+
+    def test_CommonDataUpdate_view(self):
+        """ 
+            Test if CQI can be updated using UpdateView via form_data
+        """ 
+        self.client.force_login(self.teacher)
+        old = baker.make(CommonData, title="old title")
+
+        response = self.client.post(
+            reverse("quest_manager:commonquestinfo_update", args=[old.pk]), 
+            data=generate_form_data(CommonData, title="new title", instructions=old.instructions)
+        )
+        self.assertEqual(response.status_code, 302)
+
+        new = CommonData.objects.filter(pk=old.pk).first()
+        self.assertTrue(new)
+        self.assertNotEqual(new.title, old.title)
+        self.assertEqual(new.instructions, old.instructions)
+
+    def test_CommonDataDelete_view(self):
+        """ 
+            Test if CQI can be deleted using DeleteView
+        """ 
+        obj = baker.make(CommonData)
+        self.assertNotEqual(CommonData.objects.count(), 1)
+        self.client.force_login(self.teacher)
+
+        response = self.client.post(reverse("quest_manager:commonquestinfo_delete", args=[obj.pk]))
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(CommonData.objects.count(), 1)

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -105,5 +105,10 @@ urlpatterns = [
     path('campaigns/autocomplete/', ModelAutocomplete.as_view(model=Category), name='category_autocomplete'),
 
     # Common Data
-    path('commondata/autocomplete/', ModelAutocomplete.as_view(model=CommonData), name='commondata_autocomplete'),
+    path('common-quest-info/autocomplete/', ModelAutocomplete.as_view(model=CommonData), name='commonquestinfo_autocomplete'),
+
+    path('common-quest-info/list/', views.CommonDataListView.as_view(), name='commonquestinfo_list'),
+    path('common-quest-info/create/', views.CommonDataCreateView.as_view(), name='commonquestinfo_create'),
+    path('common-quest-info/update/<pk>/', views.CommonDataUpdateView.as_view(), name='commonquestinfo_update'),
+    path('common-quest-info/delete/<pk>/', views.CommonDataDeleteView.as_view(), name='commonquestinfo_delete'),
 ]

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -29,8 +29,8 @@ from siteconfig.models import SiteConfig
 from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 
 from .forms import (QuestForm, SubmissionForm, SubmissionFormCustomXP, SubmissionFormStaff,
-                    SubmissionQuickReplyForm, TAQuestForm)
-from .models import Quest, QuestSubmission, Category
+                    SubmissionQuickReplyForm, TAQuestForm, CommonDataForm)
+from .models import Quest, QuestSubmission, Category, CommonData
 
 User = get_user_model()
 
@@ -223,6 +223,50 @@ class QuestSubmissionSummary(DetailView, UserPassesTestMixin):
         context['percent_returned'] = percent_returned
 
         return context
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class CommonDataListView(ListView):
+    model = CommonData
+    template_name = "quest_manager/common_quest_info_list.html"
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class CommonDataCreateView(CreateView):
+    model = CommonData
+    form_class = CommonDataForm
+    template_name = "quest_manager/common_quest_info_form.html"
+    success_url = reverse_lazy("quest_manager:commonquestinfo_list")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['heading'] = "Create Common Quest Info"
+        context['submit_btn_value'] = "Create"
+        return context
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class CommonDataUpdateView(UpdateView):
+    model = CommonData
+    form_class = CommonDataForm
+    template_name = "quest_manager/common_quest_info_form.html"
+    success_url = reverse_lazy("quest_manager:commonquestinfo_list")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['heading'] = "Update Common Quest Info"
+        context['submit_btn_value'] = "Update"
+        return context
+
+    def get_success_url(self):
+        return self.request.GET.get('next', self.success_url)
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class CommonDataDeleteView(DeleteView):
+    model = CommonData
+    template_name = "quest_manager/common_quest_info_delete.html"
+    success_url = reverse_lazy("quest_manager:commonquestinfo_list")
 
 
 @non_public_only_view

--- a/src/templates/common_data.html
+++ b/src/templates/common_data.html
@@ -1,7 +1,7 @@
       <div id="quest-common-{{ q.id }}" class="panel panel-primary panel-top">
         <div class="panel-heading">
           <h3 class="panel-title">{{ q.common_data.title }}<br>
-            <small>General Info (<a href="/admin/quest_manager/commondata/{{q.common_data.id}}/change/">edit</a>)</small>
+            <small>General Info (<a href="{% url 'quest_manager:commonquestinfo_update' pk=q.common_data.id %}?next={{request.get_full_path}}">edit</a>)</small>
           </h3>
         </div>
         <div class="panel-body">


### PR DESCRIPTION
Moved to different branch since i didnt want to revert all renames (orignal pr is #1103)

Renamed url of commondata to commonquestinfo
Added CRUD views + tests for CommonQuestInfo

NOTE:
I haven't added a proper way to get into the crud views yet since it relies on https://github.com/bytedeck/bytedeck/issues/1010 which hasn't been PR'ed yet