### PR TITLE
sidebar doesn't highlight badge button when in badge types; closes #1020

### DIFF
--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -40,7 +40,7 @@
       {% if request.user.is_staff %}
         <div class="clearfix">
           <a id="badges-menu"
-          class="list-group-item left-side {% if '/badges/' in request.path_info %}active{% endif %}"
+          class="list-group-item left-side {% if '/badges/' in request.path_info and not '/badges/types' in request.path_info %}active{% endif %}"
           href="{% url 'badges:list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
           <a title="Badge Types" class="list-group-item right-side text-center
           {% if 'badges/types/' in request.path_info %}active{% endif %}"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/180914755-88cd572e-aff5-40b7-88b5-bd896e23cf79.png)
the sidebar no longer fully highlights the "badges" section when badge types are selected, similarly to the quest drafts button.