### PR TITLE
sidebar no longer improperly highlights badges button when types are selected; closes #1020

### DIFF
--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -40,7 +40,7 @@
       {% if request.user.is_staff %}
         <div class="clearfix">
           <a id="badges-menu"
-          class="list-group-item left-side {% if '/badges/' in request.path_info %}active{% endif %}"
+          class="list-group-item left-side {% if '/badges/' in request.path_info and not '/types/' in request.path_info %}active{% endif %}"
           href="{% url 'badges:list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
           <a title="Badge Types" class="list-group-item right-side text-center
           {% if 'badges/types/' in request.path_info %}active{% endif %}"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/180915921-31cc8f92-f383-419b-99fd-f4c9bb687d5a.png)
the "badges" button in the sidebar no longer completely highlights when only types are selected.