### PR TITLE
Feat: Added flake8 pre-commit hook; Closes #1075

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 exclude = 
-    migrations,
-    __pycache__,
+	*/migrations/*, 
+	*/__pycache__/*,
     
 #max-complexity = 12
 max-line-length = 150
@@ -12,6 +12,4 @@ max-line-length = 150
 # W503 line break before binary operator
 # E126 continuation line over-indented for hanging indent
 # W293 blank line contains whitespace
-ignore = W291, E216, W504, W503, E126, W293
-
-
+ignore = W291, E216, W504, W503, E126, W293,

--- a/.git-template/hooks/pre-commit
+++ b/.git-template/hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#!/bin/sh
+#!/usr/bin/env bash
+
+ARGS=(hook-impl --config=.pre-commit-config.yaml --hook-type=pre-commit)
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ARGS+=(--hook-dir "$HERE" -- "$@")
+
+if command -v pre-commit > /dev/null; then
+    exec pre-commit "${ARGS[@]}"
+else
+    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
+    exit 1
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+    -   repo: https://github.com/PyCQA/flake8
+        rev: 4.0.1
+        hooks:
+        -   id: flake8
+            additional_dependencies: [mccabe, pycodestyle, pyflakes] 
+        

--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ Using pgadmin4 we can inspect the postgres database's schemas and tables (helpfu
 For full details on code contributions, please see [CONTRIBUTING.md](https://github.com/bytedeck/bytedeck/blob/develop/CONTRIBUTING.md)
 
 1. Move into your cloned directory. `cd ~/Developer/bytedeck`
-2. Add the upstream remote (if it doesn't already exist): `git remote add upstream git@github.com:bytedeck/bytedeck.git`
-3. Pull in changes from the upstream master: `git pull upstream develop` (in case anything has changed since you cloned it)
+2. Initialize pre-commit hooks: `git init --template=.git-template`
+3. Add the upstream remote (if it doesn't already exist): `git remote add upstream git@github.com:bytedeck/bytedeck.git`
+4. Pull in changes from the upstream master: `git pull upstream develop` (in case anything has changed since you cloned it)
 5. Create a new branch with a name specific to the issue or feature or bug you will be working on: `git checkout -b yourbranchname`
 6. Write code!
 7. Before committing, make sure to run tests and linting locally (this will save you the annoyance of having to clean up lots of little "oops typo!" commits).  Note that the `--failfast` and `--parallel` modes are optional and used to speed up the tests.  `--failfast` will quit as soon as one test fails, and `--parallel` will run tests in multiple processes (however if a test fails, the output might not be helpful, and you might need to run the tests again without this option to get more info on the failing test):   
@@ -186,8 +187,8 @@ For full details on code contributions, please see [CONTRIBUTING.md](https://git
 12. Select your recently pushed branch and create a pull request (you should see a button for this)
 ![image](https://user-images.githubusercontent.com/10604391/125674000-d02eb7a0-b85d-4c8f-b8dd-2b144e274f7d.png)
 
-10. Complete pull request.
-11. Start work on another feature by checking out the develop branch again: `git checkout develop`
-12. Start again at Step 3 and repeat!
+13. Complete pull request.
+14. Start work on another feature by checking out the develop branch again: `git checkout develop`
+15. Start again at Step 4 and repeat!
 
 If you make mistakes during the commit process, or want to change or edit commits, [here's a great guide](http://sethrobertson.github.io/GitFixUm/fixup.html).

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ coveralls  # includes coverage
 names
 namegenerator
 tblib
+pre-commit


### PR DESCRIPTION
previous branch: #1098
(had to make new branch since commits got screwed up)

### Should work with linux users now. 

Problem was that linux couldnt use the previous 'shebang' line in the pre-commit file, using ``#!/bin/bash`` fixes it. The fix works with my windows machine and ubuntu virtual machine