### PR TITLE
Feat: Custom decorator staff_member_required alternative; Closes #1049

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -32,21 +32,19 @@ class AnnouncementViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.ann_pk = self.test_announcement.pk
 
     def test_all_announcement_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to home page or admin  '''
+        ''' If not logged in then all views should redirect to login page '''
 
-        # go home
         self.assertRedirectsLogin('announcements:list')
         self.assertRedirectsLogin('announcements:archived')
         self.assertRedirectsLogin('announcements:list2')
         self.assertRedirectsLogin('announcements:comment', args=[1])
         self.assertRedirectsLogin('announcements:list', args=[1])
 
-        # go admin
-        self.assertRedirectsAdmin('announcements:create')
-        self.assertRedirectsAdmin('announcements:delete', args=[1])
-        self.assertRedirectsAdmin('announcements:update', args=[1])
-        self.assertRedirectsAdmin('announcements:copy', args=[1])
-        self.assertRedirectsAdmin('announcements:publish', args=[1])
+        self.assertRedirectsLogin('announcements:create')
+        self.assertRedirectsLogin('announcements:delete', args=[1])
+        self.assertRedirectsLogin('announcements:update', args=[1])
+        self.assertRedirectsLogin('announcements:copy', args=[1])
+        self.assertRedirectsLogin('announcements:publish', args=[1])
 
     def test_all_announcement_page_status_codes_for_students(self):
         # log in a student
@@ -58,9 +56,9 @@ class AnnouncementViewTests(ViewTestUtilsMixin, TenantTestCase):
         #     print(field, getattr(self.test_announcement, field.name))
 
         # students should have access to these:
-        self.assertEqual(self.client.get(reverse('announcements:list')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('announcements:list2')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('announcements:list', args=[self.ann_pk])).status_code, 200)
+        self.assert200('announcements:list')
+        self.assert200('announcements:list2')
+        self.assert200('announcements:list', args=[self.ann_pk])
 
         # Announcement from setup() should appear in the list
         self.assertContains(self.client.get(reverse('announcements:list')), self.test_announcement.title)
@@ -74,12 +72,12 @@ class AnnouncementViewTests(ViewTestUtilsMixin, TenantTestCase):
             expected_url=reverse('announcements:list', args=[self.ann_pk]),
         )
 
-        # These views should redirect to admin login
-        self.assertRedirectsAdmin('announcements:create')
-        self.assertRedirectsAdmin('announcements:delete', args=[1])
-        self.assertRedirectsAdmin('announcements:update', args=[1])
-        self.assertRedirectsAdmin('announcements:copy', args=[1])
-        self.assertRedirectsAdmin('announcements:publish', args=[1])
+        # Authenticated users that aren't staff should get permission denied 403
+        self.assert403('announcements:create')
+        self.assert403('announcements:delete', args=[1])
+        self.assert403('announcements:update', args=[1])
+        self.assert403('announcements:copy', args=[1])
+        self.assert403('announcements:publish', args=[1])
 
     def test_all_announcement_page_status_codes_for_teachers(self):
         # log in a teacher

--- a/src/announcements/views.py
+++ b/src/announcements/views.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.messages.views import SuccessMessageMixin
@@ -12,6 +11,8 @@ from django.urls.base import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
+
+from hackerspace_online.decorators import staff_member_required
 
 from comments.forms import CommentForm
 from comments.models import Comment

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -35,7 +35,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.test_assertion = baker.make(BadgeAssertion)
 
     def test_all_badge_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to home or admin page  '''
+        ''' If not logged in then all views should redirect to home  '''
         b_pk = self.test_badge.pk
         a_pk = self.test_assertion.pk
         s_pk = self.test_student1.pk
@@ -44,13 +44,13 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertRedirectsLogin('badges:badge_detail', args=[b_pk])
         self.assertRedirectsLogin('badges:badge_create')
 
-        self.assertRedirectsAdmin('badges:badge_update', args=[b_pk])
-        self.assertRedirectsAdmin('badges:badge_copy', args=[b_pk])
-        self.assertRedirectsAdmin('badges:badge_delete', args=[b_pk])
-        self.assertRedirectsAdmin('badges:grant', args=[b_pk, s_pk])
-        self.assertRedirectsAdmin('badges:bulk_grant_badge', args=[b_pk])
-        self.assertRedirectsAdmin('badges:bulk_grant')
-        self.assertRedirectsAdmin('badges:revoke', args=[a_pk])
+        self.assertRedirectsLogin('badges:badge_update', args=[b_pk])
+        self.assertRedirectsLogin('badges:badge_copy', args=[b_pk])
+        self.assertRedirectsLogin('badges:badge_delete', args=[b_pk])
+        self.assertRedirectsLogin('badges:grant', args=[b_pk, s_pk])
+        self.assertRedirectsLogin('badges:bulk_grant_badge', args=[b_pk])
+        self.assertRedirectsLogin('badges:bulk_grant')
+        self.assertRedirectsLogin('badges:revoke', args=[a_pk])
 
     def test_all_badge_page_status_codes_for_students(self):
 
@@ -65,18 +65,18 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert200('badges:list')
         self.assert200('badges:badge_detail', args=[b_pk])
 
-        # students shouldn't have access to these and should be redirected
+        # students shouldn't have access to these and should get permission denied 403
+        
+        self.assert403('badges:badge_create'),
+        self.assert403('badges:badge_update', args=[b_pk])
+        self.assert403('badges:badge_copy', args=[b_pk])
+        self.assert403('badges:badge_delete', args=[b_pk])
+        self.assert403('badges:grant', args=[b_pk, s_pk])
+        self.assert403('badges:bulk_grant_badge', args=[b_pk])
+        self.assert403('badges:bulk_grant')
+        self.assert403('badges:revoke', args=[s_pk])
 
-        self.assertRedirectsQuests('badges:badge_create', follow=True),
-        self.assertRedirectsAdmin('badges:badge_update', args=[b_pk])
-        self.assertRedirectsAdmin('badges:badge_copy', args=[b_pk])
-        self.assertRedirectsAdmin('badges:badge_delete', args=[b_pk])
-        self.assertRedirectsAdmin('badges:grant', args=[b_pk, s_pk])
-        self.assertRedirectsAdmin('badges:bulk_grant_badge', args=[b_pk])
-        self.assertRedirectsAdmin('badges:bulk_grant')
-        self.assertRedirectsAdmin('badges:revoke', args=[s_pk])
-
-        self.assertEqual(self.client.get(reverse('badges:badge_prereqs_update', args=[b_pk])).status_code, 302)
+        self.assertEqual(self.client.get(reverse('badges:badge_prereqs_update', args=[b_pk])).status_code, 403)
 
     def test_all_badge_page_status_codes_for_teachers(self):
         # log in a teacher
@@ -239,21 +239,21 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.badge_type = baker.make(BadgeType)
     
     def test_all_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
-        self.assertRedirectsAdmin('badges:badge_types')
-        self.assertRedirectsAdmin('badges:badge_type_create')
-        self.assertRedirectsAdmin('badges:badge_type_update', args=[1])
-        self.assertRedirectsAdmin('badges:badge_type_delete', args=[1])
+        ''' If not logged in then all views should redirect to login page '''
+        self.assertRedirectsLogin('badges:badge_types')
+        self.assertRedirectsLogin('badges:badge_type_create')
+        self.assertRedirectsLogin('badges:badge_type_update', args=[1])
+        self.assertRedirectsLogin('badges:badge_type_delete', args=[1])
     
     def test_all_page_status_codes_for_students(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
+        ''' If not logged in then all views should redirect to 403 '''
         self.client.force_login(self.test_student1)
 
         # Staff access only
-        self.assertRedirectsAdmin('badges:badge_types')
-        self.assertRedirectsAdmin('badges:badge_type_create')
-        self.assertRedirectsAdmin('badges:badge_type_update', args=[1])
-        self.assertRedirectsAdmin('badges:badge_type_delete', args=[1])
+        self.assert403('badges:badge_types')
+        self.assert403('badges:badge_type_create')
+        self.assert403('badges:badge_type_update', args=[1])
+        self.assert403('badges:badge_type_delete', args=[1])
     
     def test_BadgeTypeList_view(self):
         """ Admin should be able to view badge type list """

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -1,7 +1,6 @@
 import uuid
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
@@ -11,6 +10,8 @@ from django.utils.decorators import method_decorator
 from django.views.generic import RedirectView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
+
+from hackerspace_online.decorators import staff_member_required
 
 from notifications.signals import notify
 from prerequisites.views import ObjectPrereqsFormView
@@ -76,20 +77,8 @@ class BadgeUpdate(NonPublicOnlyViewMixin, UpdateView):
 
 
 @non_public_only_view
-@login_required
+@staff_member_required
 def badge_create(request):
-
-    # Using `@staff_member_required(login_url='/accounts/login/')` causes a RedirectCycleErrror.
-    # For example, a student that is already logged in tries to access this page,
-    # They will get redirect to `/accounts/login/?next=/badges/create/`.
-    # And since they are already logged in, they will be redirected to `/badges/create/`
-    # Causing again to redirect since they are not a staff.
-
-    # We could use `@staff_member_required(login_url='/')` but this breaks the tests
-    # which requires views to be redirected to /accounts/login
-    if request.user.is_active and not request.user.is_staff:
-        return redirect('quests:quests')
-
     form = BadgeForm(request.POST or None, request.FILES or None)
 
     if form.is_valid():

--- a/src/comments/views.py
+++ b/src/comments/views.py
@@ -1,11 +1,12 @@
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
 from django.shortcuts import (HttpResponseRedirect, get_object_or_404,
                               redirect, render)
+
+from hackerspace_online.decorators import staff_member_required
 
 from notifications.signals import notify
 from tenant.views import non_public_only_view

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -31,22 +31,22 @@ class RankViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.test_student1 = User.objects.create_user('test_student', password=self.test_password)
 
     def test_all_rank_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
+        ''' If not logged in then all views should redirect to login page '''
 
         self.assertRedirectsLogin('courses:ranks')
-        self.assertRedirectsAdmin('courses:rank_create')
-        self.assertRedirectsAdmin('courses:rank_update', args=[1])
-        self.assertRedirectsAdmin('courses:rank_delete', args=[1])
+        self.assertRedirectsLogin('courses:rank_create')
+        self.assertRedirectsLogin('courses:rank_update', args=[1])
+        self.assertRedirectsLogin('courses:rank_delete', args=[1])
 
     def test_all_rank_page_status_codes_for_students(self):
-        ''' If logged in as student then all views except ranks list view should redirect to home page or admin login '''
+        ''' If logged in as student then all views except ranks list view should redirect to login page '''
         self.client.force_login(self.test_student1)
         self.assert200('courses:ranks') 
 
         # staff access only
-        self.assertRedirectsAdmin('courses:rank_create')
-        self.assertRedirectsAdmin('courses:rank_update', args=[1])
-        self.assertRedirectsAdmin('courses:rank_delete', args=[1])
+        self.assert403('courses:rank_create')
+        self.assert403('courses:rank_update', args=[1])
+        self.assert403('courses:rank_delete', args=[1])
 
     def test_all_rank_page_status_codes_for_staff(self):
         ''' If logged in as staff then all views should return code 200 for successful retrieval of page '''
@@ -140,35 +140,35 @@ class CourseViewTests(ViewTestUtilsMixin, TenantTestCase):
         }
 
     def test_all_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
+        ''' If not logged in then all views should redirect to home page '''
         self.assertRedirectsLogin('courses:create')
-        self.assertRedirectsAdmin('courses:join', args=[1])
+        self.assertRedirectsLogin('courses:join', args=[1])
         self.assertRedirectsLogin('courses:ranks')
         self.assertRedirectsLogin('courses:my_marks')
         self.assertRedirectsLogin('courses:marks', args=[1])
-        self.assertRedirectsAdmin('courses:end_active_semester')
+        self.assertRedirectsLogin('courses:end_active_semester')
         self.assertRedirectsLogin('courses:ajax_progress_chart', args=[1])
 
-        self.assertRedirectsAdmin('courses:semester_list')
-        self.assertRedirectsAdmin('courses:semester_create')
-        self.assertRedirectsAdmin('courses:semester_update', args=[1])
+        self.assertRedirectsLogin('courses:semester_list')
+        self.assertRedirectsLogin('courses:semester_create')
+        self.assertRedirectsLogin('courses:semester_update', args=[1])
 
-        self.assertRedirectsAdmin('courses:block_list')
-        self.assertRedirectsAdmin('courses:block_create')
-        self.assertRedirectsAdmin('courses:block_update', args=[1])
-        self.assertRedirectsAdmin('courses:block_delete', args=[1])
+        self.assertRedirectsLogin('courses:block_list')
+        self.assertRedirectsLogin('courses:block_create')
+        self.assertRedirectsLogin('courses:block_update', args=[1])
+        self.assertRedirectsLogin('courses:block_delete', args=[1])
 
-        self.assertRedirectsAdmin('courses:course_list')
-        self.assertRedirectsAdmin('courses:course_create')
-        self.assertRedirectsAdmin('courses:course_update', args=[1])
-        self.assertRedirectsAdmin('courses:course_delete', args=[1])
+        self.assertRedirectsLogin('courses:course_list')
+        self.assertRedirectsLogin('courses:course_create')
+        self.assertRedirectsLogin('courses:course_update', args=[1])
+        self.assertRedirectsLogin('courses:course_delete', args=[1])
         # View from external package.  Need to override view with LoginRequiredMixin if we want to bother
         # self.assertRedirectsLogin('courses:mark_distribution_chart', args=[1])
 
         # Refer to rank specific tests for Rank CRUD views
 
     def test_all_page_status_codes_for_students(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
+        ''' If not logged in then all views should redirect to home page '''
         self.client.force_login(self.test_student1)
         self.assert200('courses:create')
         self.assert200('courses:ranks')
@@ -181,22 +181,22 @@ class CourseViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert404('courses:ajax_progress_chart', args=[self.test_student1.id])
 
         # Staff access only
-        self.assertRedirectsAdmin('courses:join', args=[self.test_student1.id])
-        self.assertRedirectsAdmin('courses:end_active_semester')
+        self.assert403('courses:join', args=[self.test_student1.id])
+        self.assert403('courses:end_active_semester')
 
-        self.assertRedirectsAdmin('courses:semester_list')
-        self.assertRedirectsAdmin('courses:semester_create')
-        self.assertRedirectsAdmin('courses:semester_update', args=[1])
+        self.assert403('courses:semester_list')
+        self.assert403('courses:semester_create')
+        self.assert403('courses:semester_update', args=[1])
 
-        self.assertRedirectsAdmin('courses:block_list')
-        self.assertRedirectsAdmin('courses:block_create')
-        self.assertRedirectsAdmin('courses:block_update', args=[1])
-        self.assertRedirectsAdmin('courses:block_delete', args=[1])
+        self.assert403('courses:block_list')
+        self.assert403('courses:block_create')
+        self.assert403('courses:block_update', args=[1])
+        self.assert403('courses:block_delete', args=[1])
 
-        self.assertRedirectsAdmin('courses:course_list')
-        self.assertRedirectsAdmin('courses:course_create')
-        self.assertRedirectsAdmin('courses:course_update', args=[1])
-        self.assertRedirectsAdmin('courses:course_delete', args=[1])
+        self.assert403('courses:course_list')
+        self.assert403('courses:course_create')
+        self.assert403('courses:course_update', args=[1])
+        self.assert403('courses:course_delete', args=[1])
 
         # Refer to rank specific tests for Rank CRUD views
 

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -1,7 +1,6 @@
 import json
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
@@ -12,6 +11,8 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
+
+from hackerspace_online.decorators import staff_member_required
 
 from announcements.models import Announcement
 from siteconfig.models import SiteConfig

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -39,12 +39,12 @@ class ViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertRedirectsLogin('djcytoscape:quest_map_interlink', args=[1, 1, 1])
 
         self.assertRedirectsLogin('djcytoscape:list')
-        self.assertRedirectsAdmin('djcytoscape:regenerate', args=[1])
-        self.assertRedirectsAdmin('djcytoscape:regenerate_all')
-        self.assertRedirectsAdmin('djcytoscape:generate_map', kwargs={'quest_id': 1, 'scape_id': 1})
-        self.assertRedirectsAdmin('djcytoscape:generate_unseeded')
-        self.assertRedirectsAdmin('djcytoscape:update', args=[1])
-        self.assertRedirectsAdmin('djcytoscape:delete', args=[1])
+        self.assertRedirectsLogin('djcytoscape:regenerate', args=[1])
+        self.assertRedirectsLogin('djcytoscape:regenerate_all')
+        self.assertRedirectsLogin('djcytoscape:generate_map', kwargs={'quest_id': 1, 'scape_id': 1})
+        self.assertRedirectsLogin('djcytoscape:generate_unseeded')
+        self.assertRedirectsLogin('djcytoscape:update', args=[1])
+        self.assertRedirectsLogin('djcytoscape:delete', args=[1])
 
     def test_all_page_status_codes_for_students(self):
         success = self.client.login(username=self.test_student1.username, password=self.test_password)
@@ -58,12 +58,12 @@ class ViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert200('djcytoscape:primary')
         self.assert200('djcytoscape:quest_map', args=[self.map.id])
 
-        self.assertRedirectsAdmin('djcytoscape:update', args=[self.map.id])
-        self.assertRedirectsAdmin('djcytoscape:delete', args=[self.map.id])
-        self.assertRedirectsAdmin('djcytoscape:regenerate', args=[self.map.id])
-        self.assertRedirectsAdmin('djcytoscape:regenerate_all')
-        self.assertRedirectsAdmin('djcytoscape:generate_map', kwargs={'quest_id': 1, 'scape_id': 1})
-        self.assertRedirectsAdmin('djcytoscape:generate_unseeded')
+        self.assert403('djcytoscape:update', args=[self.map.id])
+        self.assert403('djcytoscape:delete', args=[self.map.id])
+        self.assert403('djcytoscape:regenerate', args=[self.map.id])
+        self.assert403('djcytoscape:regenerate_all')
+        self.assert403('djcytoscape:generate_map', kwargs={'quest_id': 1, 'scape_id': 1})
+        self.assert403('djcytoscape:generate_unseeded')
 
     def test_all_page_status_codes_for_teachers(self):
         # log in a teacher

--- a/src/djcytoscape/views.py
+++ b/src/djcytoscape/views.py
@@ -1,5 +1,4 @@
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -11,6 +10,8 @@ from django.utils.decorators import method_decorator
 from django.views.generic import ListView
 from django.views.generic.edit import UpdateView, DeleteView
 from django.urls import reverse_lazy
+
+from hackerspace_online.decorators import staff_member_required
 
 from quest_manager.models import QuestSubmission, Quest
 from tenant.views import NonPublicOnlyViewMixin, non_public_only_view

--- a/src/hackerspace_online/decorators.py
+++ b/src/hackerspace_online/decorators.py
@@ -1,0 +1,27 @@
+from django.utils.decorators import method_decorator
+from django.contrib.auth import settings
+from django.shortcuts import render, redirect, reverse
+
+
+def staff_member_required(f):
+    """ 
+        Asserts if user is logged in and is_staff=True, if not redirects to 403 page or non admin login
+        functionally the same as django.decorator.staff_member_required but this redirects to 403 page
+    """
+    def wrapper(request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return redirect(f'{reverse(settings.LOGIN_URL)}?next={request.path}')
+
+        elif request.user.is_authenticated and request.user.is_staff:
+            return f(request, *args, **kwargs)
+
+        return render(request, '403.html', status=403)
+            
+    return wrapper
+
+    
+class StaffMemberRequiredMixin:
+
+    @method_decorator(staff_member_required)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -6,6 +6,7 @@ from django.shortcuts import reverse
 from model_bakery import baker
 
 import json
+import warnings
 
 
 def generate_form_data(model=None, model_form=None, **kwargs):
@@ -164,10 +165,14 @@ class ViewTestUtilsMixin():
     
     def assertRedirectsAdmin(self, url_name, *args, **kwargs):
         """
+        Redirection to django admin is now deprecated.
+        Use assertRedirectsLogin(self, url_name, *args, **kwargs) instead.
+
         Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the admin login page.
         with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
 
         """
+        warnings.warn("Redirection to django admin is now deprecated.\nUse assertRedirectsLogin(self, url_name, *args, **kwargs) instead...")
         self.assertRedirects(
             response=self.client.get(reverse(url_name, *args, **kwargs)),
             expected_url='{}?next={}'.format('/admin/login/', reverse(url_name, *args, **kwargs)),

--- a/src/prerequisites/views.py
+++ b/src/prerequisites/views.py
@@ -2,8 +2,9 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.utils.decorators import method_decorator
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib import messages
+
+from hackerspace_online.decorators import staff_member_required
 
 from tenant.views import NonPublicOnlyViewMixin
 from prerequisites.forms import PrereqFormInline, PrereqFormsetHelper

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -99,9 +99,9 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
         # viewing the profile of another student
         self.assertRedirectsQuests('profiles:profile_detail', args=[s2_pk])
 
-        self.assertEqual(self.client.get(reverse('profiles:comment_ban', args=[s_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('profiles:comment_ban_toggle', args=[s_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('profiles:xp_toggle', args=[s_pk])).status_code, 302)
+        self.assertEqual(self.client.get(reverse('profiles:comment_ban', args=[s_pk])).status_code, 403)
+        self.assertEqual(self.client.get(reverse('profiles:comment_ban_toggle', args=[s_pk])).status_code, 403)
+        self.assertEqual(self.client.get(reverse('profiles:xp_toggle', args=[s_pk])).status_code, 403)
         # self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
         self.assert404('profiles:profile_update', args=[s2_pk])
@@ -268,16 +268,16 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(user_instance.profile.is_TA, form_data["is_TA"])
 
     def test_password_change_status_code__anonymous(self):
-        self.assertRedirectsAdmin("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
-        self.assertRedirectsAdmin("profiles:change_password", kwargs={"pk": self.test_student1.pk})
-        self.assertRedirectsAdmin("profiles:change_password", kwargs={"pk": self.test_student2.pk})
+        self.assertRedirectsLogin("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
+        self.assertRedirectsLogin("profiles:change_password", kwargs={"pk": self.test_student1.pk})
+        self.assertRedirectsLogin("profiles:change_password", kwargs={"pk": self.test_student2.pk})
     
     def test_password_change_status_code__student(self):
         self.client.force_login(self.test_student1)
 
-        self.assertRedirectsAdmin("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
-        self.assertRedirectsAdmin("profiles:change_password", kwargs={"pk": self.test_student1.pk})
-        self.assertRedirectsAdmin("profiles:change_password", kwargs={"pk": self.test_student2.pk})
+        self.assert403("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
+        self.assert403("profiles:change_password", kwargs={"pk": self.test_student1.pk})
+        self.assert403("profiles:change_password", kwargs={"pk": self.test_student2.pk})
     
     def test_password_change_status_code__staff(self):
         self.client.force_login(self.test_teacher)

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -1,5 +1,4 @@
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import UserPassesTestMixin
@@ -10,6 +9,8 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import UpdateView, FormView
+
+from hackerspace_online.decorators import staff_member_required
 
 from .models import Profile
 from .forms import ProfileForm, UserForm
@@ -247,7 +248,7 @@ class PasswordReset(FormView):
 
 
 @non_public_only_view
-@staff_member_required(login_url='/')
+@staff_member_required
 def recalculate_current_xp(request):
     profiles_qs = Profile.objects.all_for_active_semester()
     for profile in profiles_qs:
@@ -268,7 +269,7 @@ def tour_complete(request):
 
 
 @non_public_only_view
-@staff_member_required(login_url='/')
+@staff_member_required
 def xp_toggle(request, profile_id):
     profile = get_object_or_404(Profile, id=profile_id)
     profile.not_earning_xp = not profile.not_earning_xp
@@ -277,13 +278,13 @@ def xp_toggle(request, profile_id):
 
 
 @non_public_only_view
-@staff_member_required(login_url='/')
+@staff_member_required
 def comment_ban_toggle(request, profile_id):
     return comment_ban(request, profile_id, toggle=True)
 
 
 @non_public_only_view
-@staff_member_required(login_url='/')
+@staff_member_required
 def comment_ban(request, profile_id, toggle=False):
     profile = get_object_or_404(Profile, id=profile_id)
     if toggle:

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -117,16 +117,16 @@ class QuestViewQuickTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(self.client.get(reverse('quests:quest_detail', args=[q_pk])).status_code, 200)
 
         #  students shouldn't have access to these and should be redirected to login
-        self.assertEqual(self.client.get(reverse('quests:submitted')).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:submitted_all')).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:returned')).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:approved')).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 302)
+        self.assertEqual(self.client.get(reverse('quests:submitted')).status_code, 403)
+        self.assertEqual(self.client.get(reverse('quests:submitted_all')).status_code, 403)
+        self.assertEqual(self.client.get(reverse('quests:returned')).status_code, 403)
+        self.assertEqual(self.client.get(reverse('quests:approved')).status_code, 403)
+        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 403)
         # self.assertEqual(self.client.get(reverse('quests:skipped')).status_code, 302)
         # self.assertEqual(self.client.get(reverse('quests:submitted_for_quest', args=[q_pk])).status_code, 302)
         # self.assertEqual(self.client.get(reverse('quests:returned_for_quest', args=[q_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:approved_for_quest', args=[q_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:approved_for_quest_all', args=[q_pk])).status_code, 302)
+        self.assertEqual(self.client.get(reverse('quests:approved_for_quest', args=[q_pk])).status_code, 403)
+        self.assertEqual(self.client.get(reverse('quests:approved_for_quest_all', args=[q_pk])).status_code, 403)
         # self.assertEqual(self.client.get(reverse('quests:skipped_for_quest', args=[q_pk])).status_code, 302)
 
         self.assertEqual(self.client.get(reverse('quests:start', args=[q2_pk])).status_code, 302)
@@ -134,7 +134,7 @@ class QuestViewQuickTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(self.client.get(reverse('quests:unhide', args=[q_pk])).status_code, 302)
         self.assertEqual(self.client.get(reverse('quests:skip_for_quest', args=[q_pk])).status_code, 404)
 
-        self.assertEqual(self.client.get(reverse('quests:quest_prereqs_update', args=[q_pk])).status_code, 302)
+        self.assertEqual(self.client.get(reverse('quests:quest_prereqs_update', args=[q_pk])).status_code, 403)
 
         # 403 for CRUD views:
         self.assertEqual(self.client.get(reverse('quests:quest_create')).status_code, 403)
@@ -312,14 +312,14 @@ class SubmissionViewTests(TenantTestCase):
         self.assertEqual(self.client.get(reverse('quests:submission_past', args=[s1_pk])).status_code, 200)
 
         # Students shouldn't have access to these
-        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 302)
+        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 403)
 
         # Student's own submission
         self.assertEqual(self.client.get(reverse('quests:skip', args=[s1_pk])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:approve', args=[s1_pk])).status_code, 302)
+        self.assertEqual(self.client.get(reverse('quests:approve', args=[s1_pk])).status_code, 403)
         self.assertEqual(self.client.get(reverse('quests:submission_past', args=[s1_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:flag', args=[s1_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:unflag', args=[s1_pk])).status_code, 302)
+        self.assertEqual(self.client.get(reverse('quests:flag', args=[s1_pk])).status_code, 403)
+        self.assertEqual(self.client.get(reverse('quests:unflag', args=[s1_pk])).status_code, 403)
         self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
 
         # Not this student's submission
@@ -1463,24 +1463,24 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         # self.category = baker.make('quests_manager.category', name="testcat")
 
     def test_all_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
+        ''' If not logged in then all views should redirect to home page '''
 
-        self.assertRedirectsAdmin('quests:categories')
-        self.assertRedirectsAdmin('quests:category_detail', kwargs={"pk": 1})
-        self.assertRedirectsAdmin('quests:category_create')
-        self.assertRedirectsAdmin('quests:category_update', args=[1])
-        self.assertRedirectsAdmin('quests:category_delete', args=[1])
+        self.assertRedirectsLogin('quests:categories')
+        self.assertRedirectsLogin('quests:category_detail', kwargs={"pk": 1})
+        self.assertRedirectsLogin('quests:category_create')
+        self.assertRedirectsLogin('quests:category_update', args=[1])
+        self.assertRedirectsLogin('quests:category_delete', args=[1])
 
     def test_all_page_status_codes_for_students(self):
-        ''' If not logged in then all views should redirect to home page or admin login '''
+        ''' If not logged in then all views should redirect to 403'''
         self.client.force_login(self.test_student1)
 
         # Staff access only
-        self.assertRedirectsAdmin('quests:categories')
-        self.assertRedirectsAdmin('quests:category_detail', kwargs={"pk": 1})
-        self.assertRedirectsAdmin('quests:category_create')
-        self.assertRedirectsAdmin('quests:category_update', args=[1])
-        self.assertRedirectsAdmin('quests:category_delete', args=[1])
+        self.assert403('quests:categories')
+        self.assert403('quests:category_detail', kwargs={"pk": 1})
+        self.assert403('quests:category_create')
+        self.assert403('quests:category_update', args=[1])
+        self.assert403('quests:category_delete', args=[1])
 
     def test_all_page_status_codes_for_staff(self):
         ''' If not logged in then all views should redirect to home page or admin login '''
@@ -2291,19 +2291,19 @@ class CommonDataViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.cqi = baker.make(CommonData)
 
     def test_page_status_code__anonymous(self):
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_list")
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_create")
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
+        self.assertRedirectsLogin("quest_manager:commonquestinfo_list")
+        self.assertRedirectsLogin("quest_manager:commonquestinfo_create")
+        self.assertRedirectsLogin("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
+        self.assertRedirectsLogin("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
 
     def test_page_status_code__student(self):
         stu = baker.make(User)
         self.client.force_login(stu)
 
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_list")
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_create")
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
-        self.assertRedirectsAdmin("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
+        self.assert403("quest_manager:commonquestinfo_list")
+        self.assert403("quest_manager:commonquestinfo_create")
+        self.assert403("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
+        self.assert403("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
 
     def test_page_status_code__teacher(self):
         self.client.force_login(self.teacher)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -7,7 +7,6 @@ from django.views.generic.list import ListView
 import numpy as np
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
@@ -19,6 +18,8 @@ from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
 from django.views.generic import DetailView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
+
+from hackerspace_online.decorators import staff_member_required
 
 from badges.models import BadgeAssertion
 from comments.models import Comment, Document

--- a/src/siteconfig/tests/test_views.py
+++ b/src/siteconfig/tests/test_views.py
@@ -30,23 +30,23 @@ class SiteConfigViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.config = SiteConfig.get()
         self.client = TenantClient(self.tenant)
 
-    def test_SiteConfigUpdateOwn(self):
-        """ SiteConfigUpdateOwn is an update view that sets the object to
-        this tenants SiteConfig singleton
-        """
+    def test_all_siteconfig_page_status_codes_for_anonymous(self):
+        self.assertRedirectsLogin('config:site_config_update', args=[self.config.get().id])
+        self.assertRedirectsLogin('config:site_config_update_own')
 
-        # requires staff member
-        self.assertRedirectsAdmin('config:site_config_update_own')
+    def test_all_siteconfig_page_status_codes_for_students(self):
+        student = baker.make(User)
+        self.client.force_login(student)
 
-        self.client.force_login(User.objects.create_user(username='staff_test', is_staff=True))
-        self.assert200('config:site_config_update_own')
+        self.assert403('config:site_config_update', args=[self.config.get().id])
+        self.assert403('config:site_config_update_own')
 
-    def test_SiteConfigUpdate(self):
-        # requires staff member
-        self.assertRedirectsAdmin('config:site_config_update', args=[self.config.get().id])
+    def test_all_siteconfig_page_status_codes_for_staff(self):
+        teacher = baker.make(User, is_staff=True)
+        self.client.force_login(teacher)
 
-        self.client.force_login(User.objects.create_user(username='staff_test', is_staff=True))
         self.assert200('config:site_config_update', args=[self.config.get().id])
+        self.assert200('config:site_config_update_own')
 
     def testSiteConfigUpdate_uses_newly_saved_cache_data(self):
 

--- a/src/siteconfig/views.py
+++ b/src/siteconfig/views.py
@@ -1,7 +1,8 @@
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.messages.views import SuccessMessageMixin
 from django.utils.decorators import method_decorator
 from django.views.generic.edit import UpdateView
+
+from hackerspace_online.decorators import staff_member_required
 
 from .models import SiteConfig
 from .forms import SiteConfigForm

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -54,9 +54,9 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
         """Make sure the all views are not accessible to anonymous users"""
         self.assert302('tags:list')
         self.assert302('tags:detail', args=[self.tag.pk])
-        self.assertRedirectsAdmin('tags:create')
-        self.assertRedirectsAdmin('tags:update', args=[self.tag.pk])
-        self.assertRedirectsAdmin('tags:delete', args=[self.tag.pk])
+        self.assertRedirectsLogin('tags:create')
+        self.assertRedirectsLogin('tags:update', args=[self.tag.pk])
+        self.assertRedirectsLogin('tags:delete', args=[self.tag.pk])
 
     def test_page_status_code__student(self):
         """Make sure the list/detail views are accessible students but create/update/delete are not"""
@@ -64,9 +64,9 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         self.assert200('tags:list')
         self.assert200('tags:detail', args=[self.tag.pk])
-        self.assertRedirectsAdmin('tags:create')
-        self.assertRedirectsAdmin('tags:update', args=[self.tag.pk])
-        self.assertRedirectsAdmin('tags:delete', args=[self.tag.pk])
+        self.assert403('tags:create')
+        self.assert403('tags:update', args=[self.tag.pk])
+        self.assert403('tags:delete', args=[self.tag.pk])
 
     def test_page_status_code__teacher(self):
         """Make sure the everything is accessible to teachers"""

--- a/src/tags/views.py
+++ b/src/tags/views.py
@@ -1,11 +1,12 @@
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.admin.views.decorators import staff_member_required
 
 from django.views.generic import DetailView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic.list import ListView
+
+from hackerspace_online.decorators import staff_member_required
 
 from badges.models import Badge
 from quest_manager.models import Quest

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -6,7 +6,6 @@ from django.db import connection
 from django.http import Http404
 from django.utils.decorators import method_decorator
 from django.views.generic.edit import CreateView
-
 from django_tenants.utils import get_public_schema_name
 
 from .forms import TenantForm

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -29,21 +29,21 @@ class MenuItemViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.test_student = User.objects.create_user('test_student', password=self.test_password)
 
     def test_all_page_status_codes_for_anonymous(self):
-        ''' If not logged in then all views should redirect to admin login '''
-        self.assertRedirectsAdmin('utilities:menu_items')
-        self.assertRedirectsAdmin('utilities:menu_item_create')
-        self.assertRedirectsAdmin('utilities:menu_item_update', args=[1])
-        self.assertRedirectsAdmin('utilities:menu_item_delete', args=[1])
+        ''' If not logged in then all views should redirect to login '''
+        self.assertRedirectsLogin('utilities:menu_items')
+        self.assertRedirectsLogin('utilities:menu_item_create')
+        self.assertRedirectsLogin('utilities:menu_item_update', args=[1])
+        self.assertRedirectsLogin('utilities:menu_item_delete', args=[1])
     
     def test_all_page_status_codes_for_students(self):
-        ''' If not logged in as admin then all views should redirect to admin login '''
+        ''' If not logged in as admin then all views should redirect to 403 '''
         self.client.force_login(self.test_student)
 
         # Staff access only
-        self.assertRedirectsAdmin('utilities:menu_items')
-        self.assertRedirectsAdmin('utilities:menu_item_create')
-        self.assertRedirectsAdmin('utilities:menu_item_update', args=[1])
-        self.assertRedirectsAdmin('utilities:menu_item_delete', args=[1])
+        self.assert403('utilities:menu_items')
+        self.assert403('utilities:menu_item_create')
+        self.assert403('utilities:menu_item_update', args=[1])
+        self.assert403('utilities:menu_item_delete', args=[1])
     
     def test_MenuItemList_view(self):
         ''' Admin should be able to view menu item list '''
@@ -196,13 +196,13 @@ class FlatPageViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert200('utilities:flatpage_list')
 
         # Staff only
-        self.assertRedirectsAdmin('utilities:flatpage_create')
-        self.assertRedirectsAdmin('utilities:flatpage_edit', args=[1])
-        self.assertRedirectsAdmin('utilities:flatpage_delete', args=[1])
+        self.assertRedirectsLogin('utilities:flatpage_create')
+        self.assertRedirectsLogin('utilities:flatpage_edit', args=[1])
+        self.assertRedirectsLogin('utilities:flatpage_delete', args=[1])
 
     def test_all_page_status_codes_for_students(self):
         """
-            Redirects to admin or returns 200 if user is is_staff=False
+            Redirects to 403 or returns 200 if user is is_staff=False
         """
         success = self.client.login(username=self.test_student1.username, password=self.test_password)
         self.assertTrue(success)
@@ -210,9 +210,9 @@ class FlatPageViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert200('utilities:flatpage_list')
 
         # Staff only
-        self.assertRedirectsAdmin('utilities:flatpage_create')
-        self.assertRedirectsAdmin('utilities:flatpage_edit', args=[1])
-        self.assertRedirectsAdmin('utilities:flatpage_delete', args=[1])
+        self.assert403('utilities:flatpage_create')
+        self.assert403('utilities:flatpage_edit', args=[1])
+        self.assert403('utilities:flatpage_delete', args=[1])
 
     def test_all_page_status_codes_for_staff(self):
         """ 

--- a/src/utilities/views.py
+++ b/src/utilities/views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render
 
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.models import Site
@@ -8,6 +7,8 @@ from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic.list import ListView
+
+from hackerspace_online.decorators import staff_member_required
 
 from .models import MenuItem, VideoResource
 from utilities.forms import MenuItemForm, VideoForm, CustomFlatpageForm


### PR DESCRIPTION
Added a decorator and CBV mixin called ``staff_member_required`` and ``StaffMemberRequiredMixin`` that is functionally the same as django.decorators version. But this returns a 403 for logged in, staff=False users, and redirects non logged in users to ``accounts_login`` page 

Didnt add tests for this since i replaced the views that used ``django.decorator.staff_member_required`` with our ``staff_member_required`` version, and those views already have tests