### PR TITLE
Feat: Close off django admin from users; Closes #1038

### DIFF
--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -221,7 +221,7 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
         # check if model data was changed
         self.assertTrue(User.objects.filter(email=form_data["email"]).exists())
 
-        # check if staff and superuser args were ignored
+        # check if staff args were ignored
         user_instance = User.objects.get(email=form_data["email"])
         self.assertFalse(user_instance.is_staff)
     

--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -2,7 +2,7 @@
 
     $(document).ready(function () {
 
-        {% if quests_available_page and request.user.is_superuser %}
+        {% if quests_available_page and request.user.is_staff %}
             // teacher on main quest page need to load all at once since individual ajax calls for each quest will
             // overwhelm or error out or something bad (i.e. doesn't work most of time)
             $.ajax({

--- a/src/templates/navbar-fixed-admin-snippet.html
+++ b/src/templates/navbar-fixed-admin-snippet.html
@@ -10,9 +10,11 @@
         <li class="dropdown-header">Custom Pages</li>
         <li><a href="{% url 'utilities:flatpage_list' %}"><i class="fa fa-list"></i>&nbsp;Pages</a></li>
         <li><a href="{% url 'utilities:flatpage_create' %}"><i class="fa fa-pencil-square-o"></i>&nbsp;Create Page</a></li>
+        {% if request.user.is_superuser %}
         <li role="separator" class="divider"></li>
         <li class="dropdown-header">Advanced</li>
-        <li><a href="/admin"><i class="fa fa-fw fa-database"></i>&nbsp;Site Administration</a></li>
+        <li><a href="/admin"><i class="fa fa-fw fa-database"></i>&nbsp;Django Admin</a></li>
+        {% endif %}
         <li role="separator" class="divider"></li>
         <li class="dropdown-header">ByteDeck</li>
         <li><a title="Ask a question, report a bug, or request a feature!" href="https://github.com/bytedeck/bytedeck/discussions"><i class="fa fa-fw fa-comments-o"></i>&nbsp;ByteDeck Forum</a></li>

--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -24,7 +24,7 @@ User = get_user_model()
 
 
 def load_initial_tenant_data():
-    create_superusers()
+    create_users()
     create_site_config_object()
     create_initial_course()
     create_initial_blocks()
@@ -76,7 +76,7 @@ def set_initial_icons(object_list):
             print(f"Couldn't open icon at {icon_file}")
 
 
-def create_superusers():
+def create_users():
     # BYTEDECK ADMIN
     User.objects.create_superuser(
         username=settings.TENANT_DEFAULT_ADMIN_USERNAME, 


### PR DESCRIPTION
 - [x] Default deck owner will NOT be a superuser (i.e. django admin access) instead they will only be is_staff=True
 - already done with issue #1059
 
  - [x] Ensure access to all views check for staff status (not superuser status)
  - see issue #1049 and its associated pr #1126
  
  - [x] Remove the "Advanced > Site Administration" button from the admin menu for all users except the admin user, and change the text to "Django Admin"
  
  admin
![image](https://user-images.githubusercontent.com/39788517/182978546-42f9d069-719e-4cf9-9791-a276aa433037.png)
owner
![image](https://user-images.githubusercontent.com/39788517/182978533-323cad6f-bb65-4940-94ce-a91cfa88c37a.png)
  
 - [x]  Ensure all tests are checking for staff status, not superuser status (unless there are any specific superuser tests?)
 - there were actually no tests that checked for superuser status (except initialization.py)