### PR TITLE
dropdown menus for sidebar buttons; closes #1010

### DIFF
--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -17,20 +17,30 @@
 
   {#    Group Menus #}
   <div class="nav list-group hidden-xs sidebar-menu" id="lg-menu-main">
-    <div class="clearfix">
+    <div class="clearfix dropdown">
      <a id="quests-menu" class="list-group-item left-side
         {% if '/quests/' in request.path_info and not '/approvals/' in request.path_info and not '/inprogress/' in request.path_info and not '/drafts/' in request.path_info%}active{% endif %}"
        href="{% url 'quests:quests' %}"><i class="fa fa-shield fa-fw"></i>&nbsp; Quests</a>
-    {% if request.user.is_staff %}
-     <a title="Jump to your Drafts quest list." class="list-group-item right-side text-center
-      {% if 'quests/drafts/' in request.path_info %}active{% endif %}"
-      href="{% url 'quests:drafts' %}"><i class="fa fa-shield fa-flip-horizontal"></i></a>
-     {% else %}
-     <a title="Jump to your In Progress quest list." class="list-group-item right-side text-center
-       {% if 'quests/inprogress/' in request.path_info %}active{% endif %}"
-        href="{% url 'quests:inprogress' %}"><i class="fa fa-shield fa-flip-horizontal"></i></a>
-     {% endif %}
 
+      <div id="dropdown-button-wrapper"> <!-- isolates dropdown button highlight -->
+        <a id="quests-menu-dropdown" 
+          class="list-group-item right-side dropdown-toggle text-center" 
+          data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+          <i class="fa fa-ellipsis-v fa-fw"></i></a>
+        <ul class="dropdown-menu dropdown-menu-right">
+          {% if request.user.is_staff %}
+            <li><a href="{% url 'quests:categories' %}"><i class="fa fa-compass fa-fw"></i>&nbsp; Campaigns</a></li>
+            <li role="separator" class="divider"></li>
+            <li><a href="{% url 'quests:drafts' %}"><i class="fa fa-shield fa-flip-horizontal fa-fw"></i>&nbsp; Draft Quests</a></li>
+            <li role="separator" class="divider"></li>
+            <li><a href="{% url 'quests:commonquestinfo_list' %}"><i class="fa fa-shield fa-flip-horizontal fa-fw"></i>&nbsp; Common Quest Info</a></li>
+          {% else %}
+            <li><a href="{% url 'quests:inprogress' %}"><i class="fa fa-shield fa-flip-horizontal fa-fw"></i>&nbsp; In Progress</a></li>
+            <li role="separator" class="divider"></li>
+            <li><a href="{% url 'quests:completed' %}"><i class="fa fa-shield fa-flip-horizontal fa-fw"></i>&nbsp; Completed</a></li>
+          {% endif %}
+        </ul>
+      </div>
     </div>
 {#    <a id="quests-menu" class="list-group-item#}
 {#        {% if '/quests/' in request.path_info and not '/approvals/' in request.path_info %}active{% endif %}"#}
@@ -38,13 +48,22 @@
 {#      <i class="fa fa-shield fa-fw"></i>&nbsp; Quests#}
 {#    </a>#}
       {% if request.user.is_staff %}
-        <div class="clearfix">
-          <a id="badges-menu"
-          class="list-group-item left-side {% if '/badges/' in request.path_info and not '/types/' in request.path_info %}active{% endif %}"
-          href="{% url 'badges:list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
-          <a title="Badge Types" class="list-group-item right-side text-center
-          {% if 'badges/types/' in request.path_info %}active{% endif %}"
-          href="{% url 'badges:badge_types' %}"><i class="fa fa-certificate fa-fw"></i></a>
+        <div class="clearfix dropdown">
+            <a id="badges-menu"
+              class="list-group-item left-side {% if '/badges/' in request.path_info and not '/types/' in request.path_info %}active{% endif %}"
+              href="{% url 'badges:list' %}"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badges</a>
+
+            <div id="dropdown-button-wrapper"> <!-- isolates dropdown button highlight -->
+              <a id="badges-menu-dropdown" 
+                class="list-group-item right-side dropdown-toggle text-center" 
+                data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                <i class="fa fa-ellipsis-v fa-fw"></i></a>
+              <ul class="dropdown-menu dropdown-menu-right">
+                <li><a href="#"><i class="fa fa-certificate fa-fw"></i>&nbsp; Badge Types</a></li>
+                <!-- don't forget to add dividers when adding more menu items
+                <li role="separator" class="divider"></li> -->
+              </ul>
+            </div>
         </div>
       {% else %}
         <a id="badges-menu"


### PR DESCRIPTION
sidebar buttons now have dropdown menus to make larger portions of the site more accessible.
![image](https://user-images.githubusercontent.com/105619909/183004443-05009eb5-0429-4a51-801f-5c2f6917cb83.png)
dropdown menus vary depending on whether or not the user is a staff member or not.
![image](https://user-images.githubusercontent.com/105619909/183004525-4386ac4b-15f1-46da-b07a-01cd0b74df61.png)
![image](https://user-images.githubusercontent.com/105619909/183005536-b0837a5f-2563-4873-86a0-8bc5e615bcc4.png)
