### PR TITLE
refactor quest map list view; closes #1040

### DIFF
--- a/src/badges/templates/badges/badgetype_list.html
+++ b/src/badges/templates/badges/badgetype_list.html
@@ -5,7 +5,7 @@
 
 {% block content_first %}{% endblock %}
 {% block heading_inner %}Badge Types
-  <a class="btn btn-primary" href="% url 'badges:badge_type_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
+  <a class="btn btn-primary" href="{% url 'badges:badge_type_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
 {% endblock %}
 
 {% block content %}

--- a/src/djcytoscape/templates/djcytoscape/cytoscape_confirm_delete.html
+++ b/src/djcytoscape/templates/djcytoscape/cytoscape_confirm_delete.html
@@ -1,9 +1,15 @@
 {% extends "djcytoscape/base.html" %}
 
-{% block content %}
+{% block heading_inner %}Delete Map {% endblock %}
 
+{% block content %}
 <form action="" method="post">{% csrf_token %}
-    <p>Are you sure you want to delete "{{ object }}"?</p>
-    <input type="submit" value="Confirm" />
+  <p>Are you sure you want to delete this map?<p>
+  <div class="well">
+    <p>Map Name: {{ object.name }}</p>
+    <p>Map ID: {{ object.id }}</p>
+  </div>
+  <a href="{% url 'djcytoscape:list' %}" role="button" class="btn btn-info">Cancel</a>
+  <input type="submit" value="Delete" class="btn btn-danger" />
 </form>
 {% endblock %}

--- a/src/djcytoscape/templates/djcytoscape/cytoscape_form.html
+++ b/src/djcytoscape/templates/djcytoscape/cytoscape_form.html
@@ -6,10 +6,8 @@
 <form action="" method="post">{% csrf_token %}
     <a href="{% url 'maps:index' %}" role="button" class="btn btn-danger">Cancel</a>
     <input type="submit" value="Update" class="btn btn-success"/>
-    <a href="/admin/djcytoscape/cytoscape/{{object.id}}/" role="button" class="btn btn-default">via Admin</a>
     {{ form|crispy }}
     <a href="{% url 'maps:index' %}" role="button" class="btn btn-danger">Cancel</a>
     <input type="submit" value="Update" class="btn btn-success"/>
-    <a href="/admin/djcytoscape/cytoscape/{{object.id}}/" role="button" class="btn btn-default">via Admin</a>
 </form>
 {% endblock %}

--- a/src/djcytoscape/templates/djcytoscape/cytoscape_list.html
+++ b/src/djcytoscape/templates/djcytoscape/cytoscape_list.html
@@ -1,28 +1,39 @@
 {% extends "djcytoscape/base.html" %}
 {% load static %}
-{% block heading_inner %}Quest Maps{% endblock%}
+
+{% block content_first %}{% endblock %}
+{% block heading_inner %}Quest Maps
+  {% if request.user.is_staff %}
+    <a class="btn btn-primary" href="{% url 'djcytoscape:generate_unseeded' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
+    <a class="btn btn-primary" href="{% url 'djcytoscape:regenerate_all' %}" role="button"
+    title = "Recalculate ALL Maps.  This may take a few moments." ><i class="fa fa-refresh"></i></a>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
-    {% if user.is_staff %}
-        <p>
-            <a class="btn btn-primary" href="{% url 'djcytoscape:regenerate_all' %}" role="button"
-              title = "Recalculate ALL Maps.  This may take a few moments." >
-              <i class="fa fa-refresh"></i>
-            </a>
-            <a class="btn btn-success" href="{% url 'djcytoscape:generate_unseeded' %}" role="button"
-              title = "Create a new Map." >
-              <i class="fa fa-map-signs"></i>
-            </a>
-        </p>
-    {%  endif %}
-
-  <ul>
-      {% for scape in object_list %}
-      <li>{{ scape.name }}  :  generated on {{ scape.last_regeneration }}
-        <a href="{% url "djcytoscape:quest_map" scape.id %}">view</a>
-      <a href="{% url "djcytoscape:update" scape.id %}">edit</a>
-      <a href="{% url "djcytoscape:delete" scape.id %}">delete</a>
-      </li>
-      {% endfor %}
-  </ul>
-
-{%  endblock %}
+<table class="table table-striped">
+  <tr>
+    <th>Map Name</th>
+    <th>Generated On</th>
+    {% if request.user.is_staff %}
+      <th>Action</th>
+    {% endif %} 
+  </tr>
+  {% for scape in object_list %}
+  <tr>
+    <td><a href="{% url 'djcytoscape:quest_map' scape.id %}">{{ scape.name }}</a></td>
+    <td>{{ scape.last_regeneration }}</td>
+    {% if request.user.is_staff %}
+      <td>
+          <a class="btn btn-warning" href="{% url 'djcytoscape:update' scape.id %}" role="button" title="Edit this map.">
+            <i class="fa fa-edit"></i>
+          </a>
+          <a class="btn btn-danger" href="{% url 'djcytoscape:delete' scape.id %}" role="button" title="Delete this map.">
+            <i class="fa fa-trash-o"></i>
+          </a>
+      </td>
+    {% endif %}
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/src/djcytoscape/templates/djcytoscape/quest_map.html
+++ b/src/djcytoscape/templates/djcytoscape/quest_map.html
@@ -5,52 +5,48 @@
   <link rel="stylesheet" href="{% static 'djcytoscape/css/djcytoscape.css' %}">
 {% endblock %}
 {% endblock %}
+
 {% block heading_inner %}{{ scape.name }} Quest Map
+  <span><small>Generated On: {{ scape.last_regeneration }}</small></span>
 {% if personalized_user %}
     <br><small>of <a href="{% url 'profiles:profile_detail' personalized_user.profile.id %}">{{personalized_user}}</a>, {{ personalized_user.profile}}</small>
 {%endif %}
 {% endblock%}
+
 {% block content %}
-    {% if user.is_staff %}
-        <p>
-            <a class="btn btn-primary" href="{% url 'djcytoscape:regenerate_all' %}" role="button"
-              title = "Recalculate ALL Maps.  This may take a few moments." >
-              <i class="fa fa-refresh"></i>
-            </a>
-            <a class="btn btn-success" href="{% url 'djcytoscape:regenerate' scape.id %}" role="button"
-              title = "Recalculate this Map." >
-              <i class="fa fa-undo"></i>
-            </a>
-            <a class="btn btn-default" href="{% url 'djcytoscape:list' %}" role="button"
-              title = "List all maps" >
-              <i class="fa fa-list-ul"></i>
-            </a>
-            <a class="btn btn-warning" href="{% url 'djcytoscape:update' scape.id %}" role="button"
-              title = "Edit the Map" >
-              <i class="fa fa-edit"></i>
-            </a>
-            <a class="btn btn-danger" href="{% url 'djcytoscape:delete' scape.id %}" role="button"
-              title = "Delete this Map" >
-              <i class="fa fa-trash-o"></i>
-            </a>
-        &nbsp;&nbsp;&nbsp;Generated on {{ scape.last_regeneration }}
-        </p>
-
-    {%  endif %}
-
-    <p id="fullscreen" class="pull-right">
-      <a id="btn-print" role="button" class="btn btn-default">Print <i class="fa fa-print"></i></a>
+  {% if user.is_staff %}
+    <div class="pull-right">
+      &nbsp;<a id="btn-print" role="button" class="btn btn-default">Print <i class="fa fa-print"></i></a>
       <a id="btn-fullscreen" role="button" class="btn btn-default">Fullscreen <i class="fa fa-arrows-alt"></i></a>
-    </p>
+      <a class="btn btn-default" href="{% url 'djcytoscape:list' %}" role="button"
+        title = "List all maps"><i class="fa fa-list-ul"></i></a>
+      <a class="btn btn-primary" href="{% url 'djcytoscape:regenerate_all' %}" role="button"
+        title = "Recalculate ALL Maps.  This may take a few moments." >
+        <i class="fa fa-refresh"></i>
+      </a>
+      <a class="btn btn-success" href="{% url 'djcytoscape:regenerate' scape.id %}" role="button"
+        title = "Recalculate this Map." >
+        <i class="fa fa-undo"></i>
+      </a>
+      <a class="btn btn-warning" href="{% url 'djcytoscape:update' scape.id %}" role="button"
+        title = "Edit the Map" >
+        <i class="fa fa-edit"></i>
+      </a>
+      <a class="btn btn-danger" href="{% url 'djcytoscape:delete' scape.id %}" role="button"
+        title = "Delete this Map" >
+        <i class="fa fa-trash-o"></i>
+      </a>
+    </div>
+  {%  endif %}
 
-    <p>Click on a quest to go to it.  A blue quest or badge will take you to a connected map.
-      Some quests are available based on your Rank; see the <a href="{% url 'courses:ranks' %}">Ranks page</a>
-      to view the Rank-based maps.</p>
+  <p>Click on a quest to go to it.  A blue quest or badge will take you to a connected map.
+    Some quests are available based on your Rank; see the <a href="{% url 'courses:ranks' %}">Ranks page</a>
+    to view the Rank-based maps.</p>
 
-    {% if scape.parent_scape %}
-        <p>Back to <a href="{{ scape.parent_scape.get_absolute_url }}">{{ scape.parent_scape }} Quest Map</a></p>
-    {% endif %}
-    <div id="cy"></div>
+  {% if scape.parent_scape %}
+    <p>Back to <a href="{{ scape.parent_scape.get_absolute_url }}">{{ scape.parent_scape }} Quest Map</a></p>
+  {% endif %}
+  <div id="cy"></div>
 
 {% endblock %}
 {% block js %}

--- a/src/djcytoscape/views.py
+++ b/src/djcytoscape/views.py
@@ -23,6 +23,7 @@ from .tasks import regenerate_all_maps
 User = get_user_model()
 
 
+@method_decorator(staff_member_required, name='dispatch')
 class ScapeUpdate(NonPublicOnlyViewMixin, UpdateView):
     model = CytoScape
     fields = [
@@ -38,6 +39,7 @@ class ScapeUpdate(NonPublicOnlyViewMixin, UpdateView):
         return super(ScapeUpdate, self).dispatch(*args, **kwargs)
 
 
+@method_decorator(staff_member_required, name='dispatch')
 class ScapeDelete(NonPublicOnlyViewMixin, DeleteView):
     model = CytoScape
     success_url = reverse_lazy('djcytoscape:list')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/183231813-e355bada-a4f8-4b1f-9278-7bd08fad63f5.png)
Quest map list view now looks better than garbage. In addition, the confirm delete view for quest maps has been updated.
![image](https://user-images.githubusercontent.com/105619909/183231970-48d04052-123d-43d2-87ea-c0bd00ba736c.png)
The button to access the maps list has been made public, removing create/edit/delete functions for non-staff users.
![image](https://user-images.githubusercontent.com/105619909/183231985-5acd9316-a9a5-4fb3-a880-c429deb4af85.png)
![image](https://user-images.githubusercontent.com/105619909/183232004-73979a28-ccdd-41a6-829c-a45365b66c8f.png)
