### PR TITLE
Feat: User specific Tag detail view; Closes #1125

### DIFF
--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -28,8 +28,11 @@
         </div>
         <div class="col-sm-6">
           <ul class="list-unstyled">
-            {% with badge as object %}
-            <li>Tags: {% include 'tags/snippets/tag-list.html' %}{% endwith %}<br></li>
+            {% if not request.user.is_staff %}
+            <li>Tags: {% include 'tags/snippets/tag-list.html' with object=badge user_obj=request.user %}<br></li>
+            {% else %}
+            <li>Tags: {% include 'tags/snippets/tag-list.html' with object=badge %}<br></li>
+            {% endif %}
             <li>Prerequisites: <a class="btn btn-info btn-xs" href="{% url 'badges:badge_prereqs_update' badge.id %}">Edit</a>
                   {% with badge as object %}{% include 'prerequisites/current_prereq_list.html' %}
                 

--- a/src/badges/templates/badges/snippets/badge_popover_content.html
+++ b/src/badges/templates/badges/snippets/badge_popover_content.html
@@ -8,9 +8,8 @@
 
 <p>Rarity: {{badge.get_rarity_icon|safe}} <small>{{badge.percent_of_active_users_granted_this|floatformat:1 }}% have earned this badge</small></p>
 
-{% with badge as object %}
-Tags: {% include 'tags/snippets/tag-list.html' %}
-{% endwith %}
+Tags: {% include 'tags/snippets/tag-list.html' with object=badge user_obj=user_obj %}
+POPOVER {{object.user}}
 
 Prerequisites:
 

--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -267,7 +267,7 @@
           {% for assertion in assertions %}
             {% with assertions_of_this_badge=assertion.get_duplicate_assertions badge=assertion.badge %}
             <span class="hidden-xs"> {# only use popover on wider screens #}
-              <a {% include 'badges/snippets/badge_popover.html' %} >
+              <a {% include 'badges/snippets/badge_popover.html' with user_obj=object.user %} >
                 {% include 'profile_manager/snippets/profile_badge.html' %}
               </a>
             </span>
@@ -301,7 +301,7 @@
 
       <div class="list-group">
         {% for tag, xp in tags %}
-          <a href="{% url 'tags:detail' pk=tag.pk %}" class="list-group-item list-group-item-packed">
+          <a href="{% url 'tags:detail_student' tag_pk=tag.pk user_pk=object.user.pk %}" class="list-group-item list-group-item-packed">
               <small>
                 {{tag|truncatechars:40}}
                 <span class="pull-right">{{xp}} XP</span>

--- a/src/quest_manager/templates/quest_manager/quest_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/quest_detail_content.html
@@ -20,7 +20,11 @@
           <li><h4>XP: {{quest.xp}}{% if quest.xp_can_be_entered_by_students %}+ <small>(student entered)</small>{% endif %}
           </h4></li>
           <li>Campaign: {% if quest.campaign %}{% if user.is_staff %}<a href="{% url 'quests:category_detail' quest.campaign.id %}">{{ quest.campaign }}</a>{% else %}{{ quest.campaign }}{% endif %}{% else %}-{% endif %}</li>
+          {% if request.user.is_staff %}
           <li>Tags: {% with quest as object %}{% include 'tags/snippets/tag-list.html' %}{% endwith %}</li>
+          {% else %}
+          <li>Tags: {% with quest as object %}{% include 'tags/snippets/tag-list.html' with user_obj=request.user %}{% endwith %}</li>
+          {% endif %}
         </ul>
       </div>
       <div class="col-sm-6">

--- a/src/tags/templates/tags/detail.html
+++ b/src/tags/templates/tags/detail.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block heading_inner %}
-    Tag: {{object.name}}
+    {{object.name}} Tag Details {% if user_obj %}for {{user_obj.username}}{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/tags/templates/tags/list.html
+++ b/src/tags/templates/tags/list.html
@@ -36,7 +36,7 @@
                 <tr>
                     <td>{{tag.name}}</td>
                     <td>
-                        <a class="btn btn-info" href="{% url 'tags:detail' tag.id %}" role="button" title="View page">
+                        <a class="btn btn-info" href="{% url 'tags:detail_staff' tag.id %}" role="button" title="View page">
                             <i class="fa fa-eye"></i>
                         </a>
         

--- a/src/tags/templates/tags/snippets/tag-list.html
+++ b/src/tags/templates/tags/snippets/tag-list.html
@@ -4,12 +4,24 @@
 <ul class='left-aligned'>
 {% if tags.count > 4 %}
     {% for tag in tags %}
-    <a href='{% url "tags:detail" tag.id %}'>{{ tag.name }}{% if not forloop.last %}, {% endif %}</a>
+
+    {% if user_obj %}
+    <a href='{% url "tags:detail_student" tag_pk=tag.id user_pk=user_obj.pk %}'>{{ tag.name }}{% if not forloop.last %}, {% endif %}</a>
+    {% else %}
+    <a href='{% url "tags:detail_staff" tag.id %}'>{{ tag.name }}{% if not forloop.last %}, {% endif %}</a>
+    {% endif %}
+
     {% empty %} None
     {% endfor %}
 {% else %}
     {% for tag in tags %}
-    <li><a href='{% url "tags:detail" tag.id %}'>{{ tag.name }}</a></li>
+
+    {% if user_obj %}
+    <li><a href='{% url "tags:detail_student" tag_pk=tag.id user_pk=user_obj.pk %}'>{{ tag.name }}</a></li>
+    {% else %}
+    <li><a href='{% url "tags:detail_staff" tag.id %}'>{{ tag.name }}</a></li>
+    {% endif %}
+
     {% empty %} <li>None</li>
     {% endfor %}
 {% endif %}

--- a/src/tags/urls.py
+++ b/src/tags/urls.py
@@ -12,7 +12,8 @@ urlpatterns = [
 
     path('', views.TagList.as_view(), name='list'),
     path('create/', views.TagCreate.as_view(), name='create'),
-    path('<int:pk>/', views.TagDetail.as_view(), name='detail'),
+    path('<int:pk>/', views.TagDetailStaff.as_view(), name='detail_staff'),
+    path('<int:tag_pk>/<int:user_pk>/', views.TagDetailStudent.as_view(), name='detail_student'),
     path('update/<int:pk>/', views.TagUpdate.as_view(), name='update'),
     path('delete/<int:pk>/', views.TagDelete.as_view(), name='delete'),
 ]

--- a/src/tags/views.py
+++ b/src/tags/views.py
@@ -1,5 +1,6 @@
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
+from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 from django.views.generic import DetailView
@@ -8,8 +9,8 @@ from django.views.generic.list import ListView
 
 from hackerspace_online.decorators import staff_member_required
 
-from badges.models import Badge
-from quest_manager.models import Quest
+from badges.models import Badge, BadgeAssertion
+from quest_manager.models import Quest, QuestSubmission
 
 from tags.forms import TagForm
 
@@ -37,20 +38,67 @@ from taggit.models import Tag
 
 #         return qs
 
+User = get_user_model()
+
 
 class TagList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
     model = Tag
     template_name = 'tags/list.html'
 
 
-class TagDetail(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
+class TagDetailMixin(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
     model = Tag
     template_name = 'tags/detail.html'
 
     def get_context_data(self, **kwargs):
-        kwargs['quests'] = Quest.objects.filter(tags__name=self.object.name)
-        kwargs['badges'] = Badge.objects.filter(tags__name=self.object.name)
+        kwargs['quests'] = self.get_quest_queryset()
+        kwargs['badges'] = self.get_badge_queryset()
+
         return super().get_context_data(**kwargs)
+
+
+class TagDetailStudent(TagDetailMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
+
+    def get_object(self):
+        pk = self.request.GET.get('tag_pk')
+        return Tag.objects.get(pk=pk)
+
+    def get_user_object(self):
+        pk = self.request.GET.get('user_pk')
+        return User.objects.get(pk=pk)
+
+    def get(self, *args, **kwargs):
+        self.request.GET = kwargs
+        self.object = self.get_object()
+        self.user = self.get_user_object()
+
+        return super().get(*args, **kwargs)
+
+    def get_quest_queryset(self):
+        # returns all quest objects related to tag and user
+        return QuestSubmission.objects.filter(
+                    user=self.user, quest__tags__name=self.object.name
+                ).order_by('quest__id').distinct('quest__id').select_related('quest').all()
+
+    def get_badge_queryset(self):
+        # returns all badge objects related to tag and user
+        return BadgeAssertion.objects.filter(
+                    user=self.user, badge__tags__name=self.object.name
+                ).order_by('badge__id').distinct('badge__id').select_related('badge').all()
+
+    def get_context_data(self, **kwargs):
+        kwargs['user_obj'] = self.user
+        return super().get_context_data(**kwargs) 
+
+
+@method_decorator(staff_member_required, name='dispatch')
+class TagDetailStaff(TagDetailMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
+
+    def get_quest_queryset(self):
+        return Quest.objects.filter(tags__name=self.object.name)
+
+    def get_badge_queryset(self):
+        return Badge.objects.filter(tags__name=self.object.name)
 
 
 @method_decorator(staff_member_required, name='dispatch')
@@ -88,7 +136,6 @@ class TagDelete(NonPublicOnlyViewMixin, DeleteView):
     success_url = reverse_lazy('tags:list')
 
     def get_context_data(self, **kwargs):
-        ctx = super().get_context_data(**kwargs).copy()
-        ctx['quests'] = Quest.objects.filter(tags__id=self.object.id)
-        ctx['badges'] = Badge.objects.filter(tags__id=self.object.id)
-        return ctx
+        kwargs['quests'] = Quest.objects.filter(tags__id=self.object.id)
+        kwargs['badges'] = Badge.objects.filter(tags__id=self.object.id)
+        return super().get_context_data(**kwargs)


### PR DESCRIPTION
 - [x] Instead of displaying all quests and badges for the tag, only shows those earned by the student

 - [x] no admin buttons obviously...

 - [x] make sure the page h1 title also indicates the username of the specific user (TAG1 Tag Details for Username)
 - im assuming youre talking about the heading_inner template tag
 
 - [x] link the Tags listed in a user profiles to these user specific Tag detail view
 - See pr #1124

 - [x] rest of the detail view should be the same as the existing detail view (consider moving common html into a template snippet, if you plan to use 2 different templates)