### PR TITLE
Feat: Map create form uses DAL widget; Closes #1141

### DIFF
--- a/src/djcytoscape/forms.py
+++ b/src/djcytoscape/forms.py
@@ -1,15 +1,87 @@
 from django import forms
-from django.contrib.contenttypes.models import ContentType
+
 from djcytoscape.models import CytoScape
 
+from dal import autocomplete
 
-class GenerateQuestMapForm(forms.Form):
 
-    content_types = ContentType.objects.filter(CytoScape.ALLOWED_INITIAL_CONTENT_TYPES)
-    scapes = CytoScape.objects.all()
+def get_model_options():
+    """ 
+        provides ContentTypes that are part of CytoScape.ALLOWED_INITIAL_CONTENT_TYPES
+        formatted for autocomplete.Select2GenericForeignKeyModelField use
 
-    name = forms.CharField(max_length=50, required=False,
-                           help_text="If not provided, the initial quest's name will be used")
-    initial_content_type = forms.ModelChoiceField(queryset=content_types, label='Initial Object Type', required=True)
-    initial_object_id = forms.IntegerField(required=True, label='Initial Object ID')
-    scape = forms.ModelChoiceField(queryset=scapes, label='Parent Quest Map', required=False)
+        from prerequisites.forms:
+            Can't always dynamically load this list due to accessing contenttypes too early
+            So instead provide a hard coded list which is checked during testing to ensure it matches
+            what the dynamically loaded list would have produced
+    """
+    from quest_manager.models import Quest
+    from badges.models import Badge
+    from courses.models import Rank
+
+    models = [Quest, Rank, Badge]
+    return [(model, model.dal_autocomplete_search_fields()) for model in models]
+
+
+class GenerateQuestMapForm(autocomplete.FutureModelForm):
+
+    class Meta:
+        model = CytoScape
+        fields = [
+            'name',
+            'initial_content_object',
+            'parent_scape',
+        ]
+   
+    name = forms.CharField(max_length=50, required=False, help_text="If not provided, the initial quest's name will be used")
+    
+    initial_content_object = autocomplete.Select2GenericForeignKeyModelField(
+        label="Initial Object",
+        required=True,
+        model_choice=get_model_options(), 
+    )
+
+    parent_scape = forms.ModelChoiceField(
+        label='Parent Quest Map', 
+        required=False,
+        queryset=CytoScape.objects.all(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.autobreak = kwargs.pop('autobreak', None)
+        super().__init__(*args, **kwargs)
+
+        # force initial set it here since initial_content_object doesn't seem to accept manual initial values
+        # if statement since UpdateView seems to work with initial, so we use that instead
+        if not self.initial.get('initial_content_object'):
+            self.initial['initial_content_object'] = kwargs['initial'].get('initial_content_object')
+
+        self.fields['initial_content_object'].widget.attrs['data-placeholder'] = 'Type to search'
+
+    def save(self, **kwargs):
+        obj = self.cleaned_data['initial_content_object']
+        name = self.cleaned_data['name'] or str(obj)
+        parent_scape = self.cleaned_data['parent_scape']
+
+        return CytoScape.generate_map(initial_object=obj, name=name, parent_scape=parent_scape, autobreak=self.autobreak)
+
+
+class QuestMapForm(GenerateQuestMapForm, forms.ModelForm):
+    """  Only used when updating Cytoscape map"""
+
+    class Meta(GenerateQuestMapForm.Meta):
+        fields = [
+            *GenerateQuestMapForm.Meta.fields,
+            'is_the_primary_scape',
+            'autobreak',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # prevent recursive maps
+        self.fields['parent_scape'].queryset = self.fields['parent_scape'].queryset.exclude(id=self.instance.id)
+    
+    # save with ModelForm default instead of CytoScape.generate_map()
+    def save(self, **kwargs):
+        return super(forms.ModelForm, self).save(**kwargs)

--- a/src/djcytoscape/templates/djcytoscape/cytoscape_form.html
+++ b/src/djcytoscape/templates/djcytoscape/cytoscape_form.html
@@ -1,13 +1,20 @@
 {% extends "djcytoscape/base.html" %}
 {% load crispy_forms_tags %}
 {% block heading_inner %}Update Quest Map{% endblock%}
+
+{% block head %}
+  {{ form.media }}
+{% endblock %}
+
 {% block content %}
 
-<form action="" method="post">{% csrf_token %}
+<form action="" method="post">
+    {% csrf_token %}
     <a href="{% url 'maps:index' %}" role="button" class="btn btn-danger">Cancel</a>
     <input type="submit" value="Update" class="btn btn-success"/>
     {{ form|crispy }}
     <a href="{% url 'maps:index' %}" role="button" class="btn btn-danger">Cancel</a>
     <input type="submit" value="Update" class="btn btn-success"/>
 </form>
+
 {% endblock %}

--- a/src/djcytoscape/templates/djcytoscape/generate_new_form.html
+++ b/src/djcytoscape/templates/djcytoscape/generate_new_form.html
@@ -1,19 +1,25 @@
 {% extends "djcytoscape/base.html" %}
 {% load crispy_forms_tags %}
 {% block heading_inner %}Generate a New Quest Map{% endblock%}
+
+{% block head %}
+  {{ form.media }}
+{% endblock %}
+
 {% block content %}
+
     {% if interlink %}
         <p>This quest map doesn't exist yet, but you can create it here.  Students who attempt to click the link that
         took you here will see a Page not found (404) error page until the map is created.</p>
 
         <p>Additional settings can be edited after the map has been generated.</p>
     {% endif %}
+    
     <form action="" method="post">
-    {% csrf_token %}
-    {{ form|crispy }}
-    <input type="submit" value="Generate a new Map starting from this Quest" class="btn btn-success"/>
-    <a href="{% url 'maps:index' %}" role="button" class="btn btn-danger">Cancel</a>
-</form>
+        {% csrf_token %}
+        {{ form|crispy }}
+        <input type="submit" value="Generate a new Map starting from this object." class="btn btn-success"/>
+        <a href="{% url 'maps:index' %}" role="button" class="btn btn-danger">Cancel</a>
+    </form>
+
 {% endblock %}
-
-

--- a/src/djcytoscape/urls.py
+++ b/src/djcytoscape/urls.py
@@ -6,8 +6,8 @@ app_name = 'djcytoscape'
 urlpatterns = [
     url(r'^$', views.index, name='index'),
 
-    url(r'^generate/(?P<quest_id>[0-9]+)/(?P<scape_id>[0-9]+)$', views.generate_map, name='generate_map'),
-    url(r'^generate/$', views.generate_map, name='generate_unseeded'),
+    url(r'^generate/(?P<quest_id>[0-9]+)/(?P<scape_id>[0-9]+)$', views.ScapeGenerateMap.as_view(), name='generate_map'),
+    url(r'^generate/$', views.ScapeGenerateMap.as_view(), name='generate_unseeded'),
     url(r'^primary/$', views.primary, name='primary'),
 
     url(r'^(?P<scape_id>[0-9]+)/$', views.quest_map, name='quest_map'),

--- a/src/djcytoscape/urls_dal.py
+++ b/src/djcytoscape/urls_dal.py
@@ -1,0 +1,20 @@
+from djcytoscape.forms import GenerateQuestMapForm
+
+""" 
+    this is necessary since dal autocomplete.Select2GenericForeignKeyModelField calls its reverse urls without namespaces in mind
+
+    so when putting GenerateQuestMapForm.as_urls() in djcytoscape.urls it would appear as:
+    >> 'djcytoscape:generate_quest_map_form_url_14312347247'
+    instead of (which Select2GenericForeignKeyModelField widget would use):
+    >> 'generate_quest_map_form_url_14312347247'
+
+    since
+    >> 'djcytoscape:generate_quest_map_form_url_14312347247' != 'generate_quest_map_form_url_14312347247'
+    you will get a NoReverseMatch error
+
+    for more info check comments
+    https://stackoverflow.com/questions/72588677/django-autocomplete-light-generic-foreign-key-invalid-view-function
+"""
+
+urlpatterns = []
+urlpatterns.extend(GenerateQuestMapForm.as_urls())

--- a/src/hackerspace_online/urls.py
+++ b/src/hackerspace_online/urls.py
@@ -47,6 +47,7 @@ urlpatterns += [
     url(r'^achievements/', AchievementRedirectView.as_view()),
     url(r'^badges/', include('badges.urls', namespace='badges')),
     url(r'^maps/', include('djcytoscape.urls', namespace='maps')),
+    url(r'^maps/dal/', include('djcytoscape.urls_dal')),
     url(r'^portfolios/', include('portfolios.urls', namespace='portfolios')),
     url(r'^utilities/', include('utilities.urls', namespace='utilities')),
     url(r'^config/', include('siteconfig.urls', namespace='config')),


### PR DESCRIPTION
Ended up using the same DAL widget as prereq, ran into the same problems described in #1153 (except its 3 obj per model)

Also converted generate_map fbv to ScapeGenerateMap cbv

ScapeGenerateMapView:
![image](https://user-images.githubusercontent.com/39788517/184795277-ba94b8d2-4d6b-4d2f-b4ee-0a203d51c3e2.png)
Update View:
![image](https://user-images.githubusercontent.com/39788517/184795088-a425f28f-f507-4f55-b4f4-33cf745e982a.png)
