### PR TITLE
temporary quest sort order fix; closes #1162

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -150,7 +150,11 @@ class XPItem(models.Model):
 
     class Meta:
         abstract = True
-        ordering = ["-sort_order", "-time_expired", "-date_expired", "name"]
+        # manual ordering of a quest queryset places quests with smaller sort_order values above larger ones by default
+        # as such, the original value for sort_order (-sort_order,) orders quests upside-down 
+        # the sort_order value in this list should be reverted to -sort_order once manually sorting is not necessary
+        # further information can be found here: https://github.com/bytedeck/bytedeck/pull/1179
+        ordering = ["sort_order", "-time_expired", "-date_expired", "name"]
 
     def __str__(self):
         return self.name
@@ -383,7 +387,7 @@ class QuestManager(models.Manager):
 
     def get_available_without_course(self, user):
         qs = self.get_active().get_conditions_met(user).available_without_course()
-        return qs.get_list_not_submitted_or_inprogress(user)
+        return qs.not_submitted_or_inprogress(user)
 
     def all_drafts(self, user):
         qs = self.get_queryset().filter(visible_to_students=False)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -24,6 +24,7 @@ from hackerspace_online.decorators import staff_member_required
 from badges.models import BadgeAssertion
 from comments.models import Comment, Document
 from courses.models import Block
+from quest_manager.models import XPItem
 from notifications.signals import notify
 from prerequisites.views import ObjectPrereqsFormView
 from siteconfig.models import SiteConfig
@@ -387,6 +388,12 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
             available_quests = Quest.objects.get_available(request.user, remove_hidden)
         else:
             available_quests = Quest.objects.get_available_without_course(request.user)
+    
+    # this logic is in place as a temporary fix to issue #1162 (https://github.com/bytedeck/bytedeck/issues/1162)
+    # once a solution is found for the root cause of this issue, this line should be deleted.
+    # likely stems from PR #1158 (https://github.com/bytedeck/bytedeck/pull/1158)
+    # proper quest ordering is pulled directly from the parent model XPItem's "ordering" meta value
+    available_quests = available_quests.order_by(*XPItem._meta.ordering)
 
     available_quests_count = len(available_quests) if type(available_quests) is list else available_quests.count()
 


### PR DESCRIPTION
this is a temporary fix for [issue #1162 ](https://github.com/bytedeck/bytedeck/issues/1162), along with a test that should be future-proofed for any other permanent solution to the issue along with a change to the class method used in get_available_without_course().

fixed quest ordering, with "expiry" value switched with a sort order display to demonstrate correct ordering:
![image](https://user-images.githubusercontent.com/105619909/186033146-19b8466c-932d-4cb5-8c52-6c7fbdfab470.png)
