### PR TITLE
Removed extra "S" in quest detail tags display

### DIFF
--- a/src/quest_manager/templates/quest_manager/quest_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/quest_detail_content.html
@@ -22,9 +22,9 @@
           </h4></li>
           <li>Campaign: {% if quest.campaign %}{% if user.is_staff %}<a href="{% url 'quests:category_detail' quest.campaign.id %}">{{ quest.campaign }}</a>{% else %}{{ quest.campaign }}{% endif %}{% else %}-{% endif %}</li>
           {% if request.user.is_staff %}
-          <li>{% tag_name %}s: {% with quest as object %}{% include 'tags/snippets/tag-list.html' %}{% endwith %}</li>
+          <li>{% tag_name %}: {% with quest as object %}{% include 'tags/snippets/tag-list.html' %}{% endwith %}</li>
           {% else %}
-          <li>{% tag_name %}s: {% with quest as object %}{% include 'tags/snippets/tag-list.html' with user_obj=request.user %}{% endwith %}</li>
+          <li>{% tag_name %}: {% with quest as object %}{% include 'tags/snippets/tag-list.html' with user_obj=request.user %}{% endwith %}</li>
           {% endif %}
         </ul>
       </div>


### PR DESCRIPTION
Currently, there exists an extra "S" in the quest detail view. This is a small change that removes it.
![image](https://user-images.githubusercontent.com/105619909/186791909-bdee5a39-28ea-4660-9380-8d76727d6468.png)
