### PR TITLE
make campaign detail view accessible to students; closes #1178

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -6,19 +6,23 @@
 {% block heading_inner %} {{ object.title }} Campaign{% endblock %}
 
 {% block content %}
-    <div class="pull-right">
-        <a class="btn btn-warning" href="{% url 'quests:category_update' object.id %}" role="button"
-            title = "Edit this campaign" >
-        <i class="fa fa-edit"></i>
-        </a>
-        <a class="btn btn-danger" href="{% url 'quests:category_delete' object.id %}" role="button"
-            title = "Delete this campaign" >
-        <i class="fa fa-trash-o"></i>
-        </a>
-    </div>
-
-    {% with object as category %}
-        {% include "quest_manager/category_detail_content.html" %}
-    {% endwith %}
-
+    {% if request.user.is_staff %}
+        <div class="pull-right">
+            <a class="btn btn-warning" href="{% url 'quests:category_update' object.id %}" role="button"
+                title = "Edit this campaign" >
+            <i class="fa fa-edit"></i>
+            </a>
+            <a class="btn btn-danger" href="{% url 'quests:category_delete' object.id %}" role="button"
+                title = "Delete this campaign" >
+            <i class="fa fa-trash-o"></i>
+            </a>
+        </div>
+    {% endif %}
+    {% if object.active or request.user.is_staff %}
+        {% with object as category %}
+            {% include "quest_manager/category_detail_content.html" %}
+        {% endwith %}
+    {% else %}
+        <p>The campaign you're trying to reach is currently unavailable. Please contact your teacher if this comes as a surprise.</p>
+    {% endif %}
 {% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-{% if category.quest_set.all %}
+{% if category_displayed_quests %}
   <div class="row panel-heading">
     <div class="col-sm-1 col-xs-2 col-icon"></div>
     <div class="col-sm-5 col-xs-8">Quest</div>
@@ -34,7 +34,7 @@
   <div class="panel-group panel-group-packed" id="accordion-available"
     role="tablist" aria-multiselectable="true">
 
-  {% for q in category.quest_set.all %}
+  {% for q in category_displayed_quests %}
 
     <div class="panel accordian
       {% if not q.visible_to_students %}panel-danger


### PR DESCRIPTION
students can now access campaign detail view, but won't see edit/delete buttons or inactive quests.
![image](https://user-images.githubusercontent.com/105619909/187009660-712ce0c2-365f-48d0-ab85-9399c617f8aa.png)
old links to campaigns that have been made inactive will display the following:
![image](https://user-images.githubusercontent.com/105619909/187009674-ad783c40-ddd7-4ebc-b5f9-d6f84462710e.png)
