### PR TITLE
condensed badge/type creation buttons into a single btn-group; closes #1133

### DIFF
--- a/src/badges/templates/badges/list.html
+++ b/src/badges/templates/badges/list.html
@@ -4,8 +4,10 @@
 
 {% block heading_inner %}{{heading}}
 {% if request.user.is_staff %}
-  <a class="btn btn-primary" href="{% url 'badges:badge_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge</a>
-  <a class="btn btn-primary" href="{% url 'badges:badge_type_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge Type</a>
+  <div class="btn-group">
+    <a class="btn btn-primary" href="{% url 'badges:badge_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge</a>
+    <a class="btn btn-primary" href="{% url 'badges:badge_type_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create Badge Type</a>
+  </div>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105619909/187256454-52a9bb6c-9664-4e2b-a119-a30bce6b1bd5.png)
the badge/type creation submenu at the top of the badge list is now a part of a singular btn-group div, like the announcement submenu.