### PR TITLE
all list menus now use the same drop-down menu; closes #1133

### DIFF
--- a/src/announcements/templates/announcements/list.html
+++ b/src/announcements/templates/announcements/list.html
@@ -48,16 +48,16 @@
         </span>
         <!-- </a> -->
 
-        <div class="dropdown announcement-dropdown pull-right">
-          <a class="dropdown-toggle" type="button" id="announcement-dropdown-id" data-toggle="dropdown"
+        <div class="dropdown list-submenu-dropdown pull-right">
+          <a class="dropdown-toggle" type="button" id="list-submenu-dropdown-id" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false">
             <i class="fa fa-fw fa-ellipsis-v"></i>
           </a>
-          <ul class="dropdown-menu" aria-labelledby="announcement-dropdown-id">
+          <ul class="dropdown-menu" aria-labelledby="list-submenu-dropdown-id">
             {% if request.user.is_staff %}
-            <li class="announcement--delete"><a href="{% url 'announcements:delete' object.id %}">Delete</a></li>
-            <li class="announcement--edit"><a href="{% url 'announcements:update' object.id %}">Edit</a></li>
-            <li class="announcement--copy"><a href="{% url 'announcements:copy' object.id %}">Copy</a></li>
+            <li class="list-submenu-action"><a href="{% url 'announcements:delete' object.id %}">Delete</a></li>
+            <li class="list-submenu-action"><a href="{% url 'announcements:update' object.id %}">Edit</a></li>
+            <li class="list-submenu-action"><a href="{% url 'announcements:copy' object.id %}">Copy</a></li>
             {% if object.draft %}
               <li><a href="{% url 'announcements:publish' object.id %}" title="Publish and broadcast this announcement to students.">Publish</a></li>
             {% endif %}
@@ -160,20 +160,8 @@
       $(e.trigger).attr('title', 'Copied').tooltip('fixTitle').tooltip('show');
       $(e.trigger).attr('title', 'Copy permalink').tooltip('fixTitle');
     });
-
-    // https://stackoverflow.com/a/37406402/3788603
-    $('.announcement-dropdown .dropdown-toggle').click(function(e) {
-      e.stopPropagation();
-      $('.announcement-dropdown.open').removeClass('open');
-      $(this).closest('.dropdown').toggleClass('open');
-    });
-
-    $('.announcement--delete, .announcement--edit, .announcement--copy').click(function(e) {
-      e.stopPropagation();
-      $('.announcement-dropdown.open').removeClass('open');
-      $(this).closest('.dropdown').toggleClass('open');
-    });
-
-
   </script>
 {% endblock %}
+
+<!-- prevents dropdown button from triggering click events in parent div -->
+{% include "list_view_dropdown_fix.html" %}

--- a/src/badges/templates/badges/badgetype_list.html
+++ b/src/badges/templates/badges/badgetype_list.html
@@ -14,7 +14,9 @@
     <th>Title</th>
     <th>Icon</th>
     <th>Sort Order</th>
-    <th>Action</th>
+    <!-- empty header exists to extend header table to full length of object list table -->
+    <!-- header table coloring won't fill space completely otherwise -->
+    <th></th>
   </tr>
   {% for object in object_list %}
   <tr>
@@ -22,12 +24,16 @@
     <td>{% if object.fa_icon %}<i class="fa {{ object.fa_icon }}"></i>{% endif %}</td>
     <td>{{ object.sort_order }}</td>
     <td>
-      <a class="btn btn-warning" href="{% url 'badges:badge_type_update' object.id %}" role="button" title="Edit this badge_type">
-        <i class="fa fa-edit"></i>
-      </a>
-      <a class="btn btn-danger" href="{% url 'badges:badge_type_delete' object.id %}" role="button" title="Delete this badge type">
-        <i class="fa fa-trash-o"></i>
-      </a>
+      <div class="dropdown list-submenu-dropdown pull-right">
+        <a class="dropdown-toggle" type="button" id="list-submenu-dropdown-id" data-toggle="dropdown"
+          aria-haspopup="true" aria-expanded="false">
+          <i class="fa fa-fw fa-ellipsis-v"></i>
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="list-submenu-dropdown-id">
+          <li><a href="{% url 'badges:badge_type_delete' object.id %}">Delete</a></li>
+          <li><a href="{% url 'badges:badge_type_update' object.id %}">Edit</a></li>
+        </ul>
+      </div>
     </td>
   </tr>
   {% endfor %}

--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -9,14 +9,6 @@
     {% endif %}
 
     {% if  request.user.is_staff or request.user == q.editor %}
-        <a class="btn btn-warning" href="{% url 'quests:quest_update' q.id %}" role="button"
-          title = "Edit the quest" >
-          <i class="fa fa-edit"></i>
-        </a>
-        <a class="btn btn-primary" href="{% url 'quests:quest_copy' q.id %}" role="button"
-          title = "Create a copy of this quest" >
-          <i class="fa fa-copy"></i>
-        </a>
         <a class="btn btn-default" href="{% url 'quests:approved_for_quest' q.id %}" role="button"
           title = "View past submissions of this quest" >
           <i class="fa fa-folder-open-o"></i>
@@ -25,10 +17,20 @@
           title="View summary data for this quest" >
           <i class="fa fa-fw fa-bar-chart"></i>
         </a>
-        <a class="btn btn-danger" href="{% url 'quests:quest_delete' q.id %}" role="button"
-          title = "Delete this quest" >
-          <i class="fa fa-trash-o"></i>
-        </a>
+        {% if not '/quests/ajax_quest_info/' in request.path_info %} <!-- these buttons shouldn't load if the quest is being previewed -->
+          <a class="btn btn-danger" href="{% url 'quests:quest_delete' q.id %}" role="button"
+            title = "Delete this quest" >
+            <i class="fa fa-trash-o"></i>
+          </a>
+          <a class="btn btn-warning" href="{% url 'quests:quest_update' q.id %}" role="button"
+            title = "Edit the quest" >
+            <i class="fa fa-edit"></i>
+          </a>
+          <a class="btn btn-primary" href="{% url 'quests:quest_copy' q.id %}" role="button"
+            title = "Create a copy of this quest" >
+            <i class="fa fa-copy"></i>
+          </a>
+        {% endif %}
 
     {% else %}
 

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -25,70 +25,9 @@
 </div>
 
 {% if category_displayed_quests %}
-  <div class="row panel-heading">
-    <div class="col-sm-1 col-xs-2 col-icon"></div>
-    <div class="col-sm-5 col-xs-8">Quest</div>
-    <div class="col-sm-1 col-xs-2 text-right">XP</div>
-    <div class="col-sm-2 hidden-xs"><!-- status_icons --></div>
-  </div>
-  <div class="panel-group panel-group-packed" id="accordion-available"
-    role="tablist" aria-multiselectable="true">
-
-  {% for q in category_displayed_quests %}
-
-    <div class="panel accordian
-      {% if not q.visible_to_students %}panel-danger
-      {% elif q.expired %}panel-warning
-      {% else %}panel-default
-      {% endif %}
-      {% if q.id == active_q_id %} active {% endif %}">
-      <div class="panel-heading accordian accordian-trigger panel-heading-tall
-        {% if q.id == active_q_id %} active {% endif %}"
-        role="tab"
-        id="heading-quest-{{q.id}}"
-        aria-expanded="{% if q.id == active_q_id %}true{% else %}false{% endif %}"
-        aria-controls="collapse-quest-{{q.id}}"
-        data-parent="#accordion-available" data-toggle="collapse"
-        data-target="#collapse-quest-{{q.id}}">
-
-        <div class="row">
-          <h4 class="panel-title">
-            <!-- COLUMNS -->
-            <div class="col-sm-1 col-xs-2 col-icon">
-              <img class="img-responsive panel-title-img img-rounded"
-                src="{{ q.get_icon_url }}" alt="icon"/>
-            </div>
-            <div class="col-sm-5 col-xs-8">{{q.name}}</div>
-            <div class="col-sm-1 col-xs-2 text-right">{{q.xp}}</div>
-            <div class="col-sm-2 hidden-xs text-center"><small>
-            </small></div>
-            <div id="status-icon-{{q.id}}" class="col-xs-2 hidden-xs text-muted"></div>
-
-          </h4>
-        </div> <!-- row -->
-      </div> <!-- accordian section heading -->
-
-      <div id="collapse-quest-{{q.id}}"
-        class="panel-collapse collapse {% if q.id == active_q_id %} in {% endif %}"
-        role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
-        <ul class="list-group">
-          <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
-              <p>
-                <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-                &nbsp;Loading content...
-                <!-- preview_content_quests_avail.html via AJAX -->
-              </p>
-          </li>
-        </ul>
-      </div> <!-- accordian panel-collapse -->
-
-
-    </div> <!-- accordian -->
-
-  {% endfor %} <!-- for each quest -->
-
-  </div> <!-- accordian panel group -->
-
+  {% with category_displayed_quests as available_quests %}
+    {% include "quest_manager/tab_quests_available.html" %}
+  {% endwith %}
 {% else %}
   <p>There are no quests in this campaign.</p>
 {% endif %}

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -18,7 +18,9 @@
     <th># of Quests</th>
     <th>XP Available</th>
     <th>Active</th>
-    <th>Action</th>
+    <!-- empty header exists to extend header table to full length of object list table -->
+    <!-- header table coloring won't fill space completely otherwise -->
+    <th></th>
   </tr>
   {% for object in object_list %}
   <tr>
@@ -32,12 +34,16 @@
       <a class="btn btn-info" href="{% url 'quests:category_detail' object.id %}" role="button" title="View Details: view the content of this campaign.">
        <i class="fa fa-fw fa-info-circle"></i>
       </a>
-      <a class="btn btn-warning" href="{% url 'quests:category_update' object.id %}" role="button" title="Edit this campaign">
-        <i class="fa fa-edit"></i>
-      </a>
-      <a class="btn btn-danger" href="{% url 'quests:category_delete' object.id %}" role="button" title="Delete this campaign">
-        <i class="fa fa-trash-o"></i>
-      </a>
+      <div class="dropdown list-submenu-dropdown pull-right">
+        <a class="dropdown-toggle" type="button" id="list-submenu-dropdown-id" data-toggle="dropdown"
+          aria-haspopup="true" aria-expanded="false">
+          <i class="fa fa-fw fa-ellipsis-v"></i>
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="list-submenu-dropdown-id">
+          <li class="list-submenu-action"><a href="{% url 'quests:category_delete' object.id %}">Delete</a></li>
+          <li class="list-submenu-action"><a href="{% url 'quests:category_update' object.id %}">Edit</a></li>
+        </ul>
+      </div>
     </td>
   </tr>
   {% endfor %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -13,7 +13,10 @@
     <div class="col-sm-1 col-xs-2 col-icon"></div>
     <div class="col-sm-5 col-xs-8">Quest</div>
     <div class="col-sm-1 col-xs-2 text-right">XP</div>
-    <div class="col-sm-2 hidden-xs text-center">Campaign</div>
+    <!-- don't need to label campaigns if accessing from a campaign detail view -->
+    {% if not '/quests/campaigns/' in request.path_info %}
+      <div class="col-sm-2 hidden-xs text-center">Campaign</div>
+    {% endif %}
     <div class="col-sm-1 hidden-xs text-center">Expiry</div>
     <div class="col-sm-2 hidden-xs"><!-- status_icons --></div>
   </div>
@@ -48,9 +51,12 @@
               {% if q.editor %}<br><small>Editor: {{ q.editor.username }} - {{ q.editor.profile }}</small>{% endif %}
             </div>
             <div class="col-sm-1 col-xs-2 text-right">{{q.xp}}{% if q.xp_can_be_entered_by_students %}+{% endif %}</div>
-            <div class="col-sm-2 hidden-xs text-center"><small>
-              {% if q.campaign %}{{q.campaign}}{% endif %}
-            </small></div>
+            <!-- don't need to label campaigns if accessing from a campaign detail view -->
+            {% if not '/quests/campaigns/' in request.path_info %}
+              <div class="col-sm-2 hidden-xs text-center"><small>
+                {% if q.campaign %}{{q.campaign}}{% endif %}
+              </small></div>
+            {% endif %}
             <div class="col-sm-1 hidden-xs text-right"><small>
               {% if q.date_expired %}{{q.date_expired}}<br>{% endif %}
               {% if q.time_expired %}{{q.time_expired}}
@@ -58,7 +64,20 @@
               {% endif %}
             </small></div>
             <div id="status-icon-{{q.id}}" class="col-xs-2 hidden-xs text-muted"></div>
-
+            <!-- edit/delete/copy submenu -->
+            {% if  request.user.is_staff or request.user == q.editor %}
+              <div class="dropdown list-submenu-dropdown col-sm-1 hidden-xs pull-right">
+                <a class="dropdown-toggle" type="button" id="quest-dropdown-id" data-toggle="dropdown"
+                  aria-haspopup="true" aria-expanded="false">
+                  <i class="fa fa-fw fa-ellipsis-v"></i>
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="quest-dropdown-id">
+                  <li class="list-submenu-action"><a href="{% url 'quests:quest_delete' q.id %}">Delete</a></li>
+                  <li class="list-submenu-action"><a href="{% url 'quests:quest_update' q.id %}">Edit</a></li>
+                  <li class="list-submenu-action"><a href="{% url 'quests:quest_copy' q.id %}">Copy</a></li>
+                </ul>
+              </div>
+            {% endif %}
           </h4>
         </div> <!-- row -->
       </div> <!-- accordian section heading -->
@@ -87,3 +106,6 @@
 {% else %}
   <p>No quests are available.</p>
 {% endif %}
+
+<!-- prevents dropdown button from triggering click events in parent div -->
+{% include "list_view_dropdown_fix.html" %}

--- a/src/static/css/custom.css
+++ b/src/static/css/custom.css
@@ -156,6 +156,13 @@ a.list-group-item-muted {
     border-color: #ddd;
 }
 
+/*************** Lists *******************/
+
+/* color for list view dropdown buttons across the site */
+.list-submenu-dropdown a{
+    color: #777;
+}
+
 /***********Submission ********************************/
 
 /***********ACCORDIAN COMMENTS *******************************/
@@ -180,15 +187,10 @@ a.list-group-item-muted {
     color: #555;
 }
 
-/* COMMENT and annoucnement higlights */
+/* COMMENT and announcement highlights */
 
 @keyframes temporaryHighlight {
     0% { background:  gold}
     50% { background: gold }
     100% { background: inherit }
-}
-
-/* Announcement menu button */
-.announcement-dropdown a{
-    color: #777;
 }

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -338,6 +338,19 @@ ol > ol > ol {
     list-style-type: lower-roman;
 }
 
+/* style used for list view dropdown buttons across site */
+.list-submenu-dropdown {
+    margin-left: 15px;
+}
+
+/* SEE THEME SPECIFIC STYLESHEET For color */
+.list-submenu-dropdown a{
+    text-shadow: none;
+}
+
+.list-submenu-dropdown a:hover {
+    color: black;
+}
 
 /************ BADGES/Achievements **********************/
 .panel-body-badge {
@@ -418,19 +431,6 @@ ol > ol > ol {
 }
 
 /************ ANNOUNCEMENT *******************/
-
-.announcement-dropdown {
-    margin-left: 15px;
-}
-
-/* SEE THEME SPECIFIC STYLESHEET For color */
-.announcement-dropdown a{
-    text-shadow: none;
-}
-
-.announcement-dropdown a:hover {
-    color: black;
-}
 
 .announcement-content {
     overflow-wrap: break-word;

--- a/src/static/css/custom_slate.css
+++ b/src/static/css/custom_slate.css
@@ -213,6 +213,13 @@ a.list-group-item-muted {
   border-color: #2B669A;*/
 }
 
+/*************** Lists *******************/
+
+/* color for list view dropdown buttons across the site */
+.list-submenu-dropdown a{
+  color: rgb(200, 200, 200);
+}
+
 /***********ACCORDIAN COMMENTS *******************************/
 
 /************ TABS *****************************************/
@@ -283,15 +290,10 @@ input, textarea {
     color: #c8c8c8 !important;
 }
 
-/* COMMENT and annoucnement higlights */
+/* COMMENT and announcement highlights */
 
 @keyframes temporaryHighlight {
   0% { background:  black}
   50% { background:  black}
   100% { background: inherit }
-}
-
-/* Announcement menu button */
-.announcement-dropdown a{
-    color: rgb(200, 200, 200);
 }

--- a/src/templates/list_view_dropdown_fix.html
+++ b/src/templates/list_view_dropdown_fix.html
@@ -1,0 +1,11 @@
+{% block js %}
+  <script>
+    // this code stops click events in the parent div of a pressed submenu element
+    // solution adapted from https://stackoverflow.com/a/37406402/3788603
+    $('.list-submenu-dropdown .dropdown-toggle, .list-submenu-action').click(function(e) {
+      e.stopPropagation();
+      $('.list-submenu-dropdown.open').removeClass('open');
+      $(this).closest('.dropdown').toggleClass('open');
+    });
+  </script>
+{% endblock %}


### PR DESCRIPTION
all list views now use the same styling as announcements for their edit/delete controls.
![image](https://user-images.githubusercontent.com/105619909/187804960-64dd527e-f300-437d-9cd2-dd92fb9a49bd.png)
![image](https://user-images.githubusercontent.com/105619909/187804979-a61cc2b0-a286-407f-b247-05c752858d5e.png)
in addition, consolidated category detail and available quest views for a more DRY end-result.
announcement dropdown button css class refactored to represent all list views accurately, and javascript that prevents click events in parent divs of dropdown buttons made into importable separate script.