### PR TITLE
fix(ajax_content_loading): fix whitespace

### DIFF
--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -107,22 +107,22 @@
 
                       // Quest status icons
                       if (data.is_prerequisite) {
-                          $(hidden_selector).append("<i title='Prerequisite: completing this will cause additional quests to become available' class='fa fa-fw fa-share-alt'></i> ");
+                          $(hidden_selector).append("<i title='Prerequisite: completing this will cause additional quests to become available' class='fa fa-fw fa-share-alt'></i>");
                       }
                       else {
-                          $(hidden_selector).append("<i class='fa fa-fw'></i> ");
+                          $(hidden_selector).append("<i class='fa fa-fw'></i>");
                       }
                       if (data.is_repeatable) {
-                          $(hidden_selector).append("<i title='Repeat: this quest is repeatable' class='fa fa-fw fa-undo'></i> ");
+                          $(hidden_selector).append("<i title='Repeat: this quest is repeatable' class='fa fa-fw fa-undo'></i>");
                       }
                       else {
-                          $(hidden_selector).append("<i class='fa fa-fw'></i> ");
+                          $(hidden_selector).append("<i class='fa fa-fw'></i>");
                       }
                       if (data.is_hidden) {
-                          $(hidden_selector).append("<i title='Hidden: this quest is on your hidden list' class='fa fa-fw fa-eye-slash'></i> ");
+                          $(hidden_selector).append("<i title='Hidden: this quest is on your hidden list' class='fa fa-fw fa-eye-slash'></i>");
                       }
                       else {
-                          $(hidden_selector).append("<i class='fa fa-fw'></i> ");
+                          $(hidden_selector).append("<i class='fa fa-fw'></i>");
                       }
 
                       $('div.pack').pack()

--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -107,22 +107,22 @@
 
                       // Quest status icons
                       if (data.is_prerequisite) {
-                          $(hidden_selector).append("<i title='Prerequisite: completing this will cause additional quests to become available' class='fa fa-fw fa-share-alt'></i>");
+                          $(hidden_selector).append("<i title='Prerequisite: completing this will cause additional quests to become available' class='icon-spacing fa fa-fw fa-share-alt'></i>");
                       }
                       else {
-                          $(hidden_selector).append("<i class='fa fa-fw'></i>");
+                          $(hidden_selector).append("<i class='icon-spacing fa fa-fw'></i>");
                       }
                       if (data.is_repeatable) {
-                          $(hidden_selector).append("<i title='Repeat: this quest is repeatable' class='fa fa-fw fa-undo'></i>");
+                          $(hidden_selector).append("<i title='Repeat: this quest is repeatable' class='icon-spacing fa fa-fw fa-undo'></i>");
                       }
                       else {
-                          $(hidden_selector).append("<i class='fa fa-fw'></i>");
+                          $(hidden_selector).append("<i class='icon-spacing fa fa-fw'></i>");
                       }
                       if (data.is_hidden) {
-                          $(hidden_selector).append("<i title='Hidden: this quest is on your hidden list' class='fa fa-fw fa-eye-slash'></i>");
+                          $(hidden_selector).append("<i title='Hidden: this quest is on your hidden list' class='icon-spacing fa fa-fw fa-eye-slash'></i>");
                       }
                       else {
-                          $(hidden_selector).append("<i class='fa fa-fw'></i>");
+                          $(hidden_selector).append("<i class='icon-spacing fa fa-fw'></i>");
                       }
 
                       $('div.pack').pack()

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -512,6 +512,10 @@ td.notification-icons {
     padding-bottom: 0px !important;
 }
 
+.icon-spacing {
+    margin: 0 0.15rem;
+}
+
 /*td.notification-icons .fa {
   margin-top: 8px;
 }*/


### PR DESCRIPTION
FIX:
- removed redundant whitespace #L110, #L113, #L116, #L119, #L122, #L125

Removed whitespace between icons for the quests; this was tested with the new css class to space them out.