### PR TITLE
Do not return None when creating a new quest submission

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -779,25 +779,21 @@ class QuestSubmissionManager(models.Manager):
         return quest.is_repeat_available(user)
 
     def create_submission(self, user, quest):
-        # this logic should probably be removed from this location?
-        # When would I want to return None that isn't already handled?
-        if self.not_submitted_or_inprogress(user, quest):
-            last_submission = self.last_submission(user, quest)
-            if last_submission:
-                ordinal = last_submission.ordinal + 1
-            else:
-                ordinal = 1
+        last_submission = self.last_submission(user, quest)
 
-            new_submission = QuestSubmission(
-                quest=quest,
-                user=user,
-                ordinal=ordinal,
-                semester_id=SiteConfig.get().active_semester.pk,
-            )
-            new_submission.save()
-            return new_submission
+        if last_submission:
+            ordinal = last_submission.ordinal + 1
         else:
-            return None
+            ordinal = 1
+
+        new_submission = QuestSubmission(
+            quest=quest,
+            user=user,
+            ordinal=ordinal,
+            semester_id=SiteConfig.get().active_semester.pk,
+        )
+        new_submission.save()
+        return new_submission
 
     def calculate_xp(self, user):
         """


### PR DESCRIPTION
Closes #1225

I looked at the stack trace and the error only happens when `QuestSubmission.objects.create_submission(request.user, quest)` returns `None` as I tried to manually call `redirect(None)` from the shell and got the same error.
