### PR TITLE
Automatically fix ordinals on error

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -1,6 +1,5 @@
 import uuid
 import json
-import logging
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -12,7 +11,6 @@ from django.db.models.functions import Greatest
 # from django.templatetags.static import static
 from django.urls import reverse
 from django.utils import timezone, datetime_safe
-from django.forms import model_to_dict
 
 from siteconfig.models import SiteConfig
 
@@ -24,8 +22,6 @@ from tags.models import TagsModelMixin
 
 # from django.contrib.contenttypes.models import ContentType
 # from django.contrib.contenttypes import generic
-
-logger = logging.getLogger(__name__)
 
 
 class Category(IsAPrereqMixin, models.Model):
@@ -961,13 +957,9 @@ class QuestSubmission(models.Model):
     def _fix_ordinal(self):
         # NOTE: There is a rare bug that we are unable to reproduce as of the moment where a QuestSubmission has the same ordinal.
         # This is just a temporary hack where it will automatically fix the incorrect ordinal
+        # See issue for context: https://github.com/bytedeck/bytedeck/issues/1260
         broken_ordinal_start = self.ordinal - 1
         submissions = QuestSubmission.objects.filter(quest=self.quest, user=self.user, ordinal__gte=self.ordinal - 1).order_by('time_completed')
-        logger.debug(
-            "This method should rarely be called. Anomalies found: {submissions}".format(
-                submissions=[f"{model_to_dict(submission)}" for submission in submissions]
-            )
-        )
 
         for submission in submissions:
             submission.ordinal = broken_ordinal_start

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -410,6 +410,10 @@ class SubmissionTestModel(TenantTestCase):
         third_sub.ordinal = second_sub.ordinal
         third_sub.save()
 
+        # Assert that MultipleObjectsReturned is raised now since we now have 2 records with the same ordinal
+        with self.assertRaises(QuestSubmission.MultipleObjectsReturned):
+            QuestSubmission.objects.get(quest=repeat_quest, user=self.student, ordinal=second_sub.ordinal)
+
         fourth_sub.ordinal = old_third_submission_ordinal
         fourth_sub.save()
 

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from unittest.mock import MagicMock
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -414,9 +415,14 @@ class SubmissionTestModel(TenantTestCase):
 
         self.assertEqual(second_sub.ordinal, third_sub.ordinal)
 
+        # Mock fhe _fix_ordinal so we can test that it was called.
+        # See SO solution: https://stackoverflow.com/a/50970342
+        fourth_sub._fix_ordinal = MagicMock(side_effect=fourth_sub._fix_ordinal)
+
         # This should fix the ordinals
-        # self.assertEqual(fourth_sub.get_previous(), QuestSubmission.objects.get(pk=third_sub.pk))
         self.assertEqual(fourth_sub.get_previous(), QuestSubmission.objects.get(pk=third_sub.pk))
+        self.assertTrue(fourth_sub._fix_ordinal.called)
+        self.assertEqual(fourth_sub._fix_ordinal.call_count, 1)
 
         third_sub.refresh_from_db()
         self.assertEqual(third_sub.ordinal, old_third_submission_ordinal)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Temporary hack to fix incorrect ordinals
### Why?
### How?
### Testing?
### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
