### PR TITLE
Set login session expiry to 8 weeks

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -497,6 +497,7 @@ SILENCED_SYSTEM_CHECKS += ['captcha.recaptcha_test_key_error']
 
 
 # AUTHENTICATION ##################################################
+SESSION_COOKIE_AGE = env("SESSION_COOKIE_AGE", default=int(60 * 60 * 24 * 7 * 8))  # 8 Weeks
 
 AUTHENTICATION_BACKENDS = (
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

I've added a fix that made the `Remember Me?` checkbox not work as it relies on the `SESSION_COOKIE_AGE`.

### Why?

These changes complete the requirements for issue #1298 

### How?

django-allauth uses the builtin `SESSION_COOKIE_AGE` of Django and uses that variable for setting the expiry of a cookie. Previously, since it is unset, it would just set it to `0`.

You can take a look at their implementation here: https://github.com/pennersr/django-allauth/blob/99b67e8db3795ff1ebc5eb27b4a843f7c2c39591/allauth/account/forms.py#L206-L207

### Testing?

Added a test that the session automatically expires depending on the value of `SESSION_COOKIE_AGE`.

It's quite hard to use seconds during tests since there might be some discrepancies as to when was the `User.last_login` set and when was the session's expiry is set.

### Screenshots (if front end is affected)

<!-- https://user-images.githubusercontent.com/10972027/227072790-aa7973b9-fc61-453a-b6d4-ee7a54d7c18a.mp4 -->


First part is leaving the `Remember me` unchecked and closing the browser automatically logged them out.

Second part is checking the `Remember me` and closing the browser still leaves them logged in.

Tested on Firefox

https://user-images.githubusercontent.com/10972027/227086943-b9771777-6ee9-4b79-be8a-c5b925542b8a.mp4


### Anything Else?
### Review request
@tylerecouture
