### PR TITLE
WIP: implement SummernoteInplaceSafeWidget

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -15,6 +15,7 @@ django-grappelli>=2.13.3,<2.14
 django-import-export>=2.0,<2.1
 #freeze tablib to 0.14.0 until django-import-export fixes its own dependencies
 # https://github.com/django-import-export/django-import-export/issues/1064
+bleach[css]>=5,<6
 tablib==0.14.0
 django-redis>=5.2.0,<5.3
 django-select2>=6.3.1,<6.4

--- a/src/announcements/admin.py
+++ b/src/announcements/admin.py
@@ -1,12 +1,12 @@
 from django.contrib import admin
 
-from django_summernote.admin import SummernoteModelAdmin
-
 from tenant.admin import NonPublicSchemaOnlyAdminAccessMixin
+from bytedeck_summernote.admin import ByteDeckSummernoteModelAdmin
+
 from .models import Announcement
 
 
-class AnnouncementAdmin(NonPublicSchemaOnlyAdminAccessMixin, SummernoteModelAdmin):
+class AnnouncementAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteModelAdmin):
     list_display = ('title', 'datetime_released',)
     list_filter = ['datetime_released']
     search_fields = ['title', 'content', ]

--- a/src/announcements/forms.py
+++ b/src/announcements/forms.py
@@ -4,7 +4,8 @@ from django import forms
 from django.utils import timezone
 
 from bootstrap_datepicker_plus.widgets import DateTimePickerInput
-from django_summernote.widgets import SummernoteInplaceWidget
+
+from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
 
 from .models import Announcement
 
@@ -26,7 +27,7 @@ class AnnouncementForm(forms.ModelForm):
         # > If you don't like <iframe>, then use inplace widget
         # > Or if you're using django-crispy-forms, please use this.
         widgets = {
-            'content': SummernoteInplaceWidget(),
+            'content': ByteDeckSummernoteSafeWidget(),
             'sticky_until': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
             'datetime_released': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
             'datetime_expires': DateTimePickerInput(format='%Y-%m-%d %H:%M'),

--- a/src/bytedeck_summernote/__init__.py
+++ b/src/bytedeck_summernote/__init__.py
@@ -1,0 +1,6 @@
+SUMMERNOTE_APPS = (
+    # third-party apps
+    "django_summernote",
+    # custom apps
+    "bytedeck_summernote",
+)

--- a/src/bytedeck_summernote/admin.py
+++ b/src/bytedeck_summernote/admin.py
@@ -1,0 +1,32 @@
+from django.db import models
+from django.contrib import admin
+from django.contrib.admin.options import InlineModelAdmin
+
+from .widgets import ByteDeckSummernoteAdvancedWidget, ByteDeckSummernoteSafeWidget
+
+
+class ByteDeckSummernoteModelAdminMixin:
+    summernote_fields = '__all__'
+
+    def formfield_for_dbfield(self, db_field, *args, **kwargs):
+        """Override `SummernoteModelAdminMixin` class by injecting customized version of SummernoteWidget(s)"""
+        from django_summernote.utils import get_config
+
+        summernote_widget = ByteDeckSummernoteAdvancedWidget if get_config()['iframe'] else ByteDeckSummernoteSafeWidget
+
+        if self.summernote_fields == '__all__':
+            if isinstance(db_field, models.TextField):
+                kwargs['widget'] = summernote_widget
+        else:
+            if db_field.name in self.summernote_fields:
+                kwargs['widget'] = summernote_widget
+
+        return super().formfield_for_dbfield(db_field, *args, **kwargs)
+
+
+class ByteDeckSummernoteInlineModelAdmin(ByteDeckSummernoteModelAdminMixin, InlineModelAdmin):
+    pass
+
+
+class ByteDeckSummernoteModelAdmin(ByteDeckSummernoteModelAdminMixin, admin.ModelAdmin):
+    pass

--- a/src/bytedeck_summernote/templates/bytedeck_summernote/LICENSE
+++ b/src/bytedeck_summernote/templates/bytedeck_summernote/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2013-2018 django-summernote contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/bytedeck_summernote/templates/bytedeck_summernote/widget_advanced.html
+++ b/src/bytedeck_summernote/templates/bytedeck_summernote/widget_advanced.html
@@ -1,0 +1,6 @@
+{% extends "django_summernote/widget_iframe.html" %}
+{% comment %}
+Start changes from source at https://github.com/summernote/django-summernote/blob/main/django_summernote/templates/django_summernote/widget_iframe.html
+
+Changes because: using "bytedeck_summernote" namespace
+{% endcomment %}

--- a/src/bytedeck_summernote/templates/bytedeck_summernote/widget_advanced_editor.html
+++ b/src/bytedeck_summernote/templates/bytedeck_summernote/widget_advanced_editor.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>django-summernote frame</title>
+        {% for url in css %}
+        <link href="{{ url }}" rel="stylesheet">{% endfor %}
+        {% for url in js %}
+        <script src="{{ url }}"></script>{% endfor %}
+        <style>
+        html, body {
+            margin: 0;
+        }
+        .note-editor {
+            margin-bottom: 0;
+        }
+        </style>
+    </head>
+    <body>
+        <div id="summernote"></div>
+    </body>
+{% comment %}
+Start changes from source at https://github.com/summernote/django-summernote/blob/main/django_summernote/templates/django_summernote/widget_iframe_editor.html
+
+Changes because: using "bytedeck_summernote" namespace
+{% endcomment %}
+    {% include "bytedeck_summernote/widget_common.html" with iframe=True %}
+{% comment %} End changes {% endcomment %}
+    <script>
+    initSummernote_{{ id_safe }}();
+    </script>
+</html>

--- a/src/bytedeck_summernote/templates/bytedeck_summernote/widget_common.html
+++ b/src/bytedeck_summernote/templates/bytedeck_summernote/widget_common.html
@@ -1,0 +1,170 @@
+<script>
+ function initSummernote_{{ id_safe }}() {
+     {{ config.jquery }}(document).ready(function($) {
+{% if iframe %}
+         var frameId = window.frameElement.id;
+         var id = frameId.substring(0, frameId.length - 7);  // without `_frame`
+         var iframe = window.parent.document.getElementById(frameId);
+         var origin = window.parent.document.getElementById(id);
+         var csrftoken = '{{ csrf_token }}';
+         var settings = window.parent.settings_{{ id_safe }};
+         var $sn = $('#summernote');
+         $(iframe).height(settings.height);
+{% else %}
+         var origin = window.document.getElementById('{{ id }}');
+         var csrftoken = getCookie('{{ CSRF_COOKIE_NAME }}');
+         var settings = {{ settings|safe }};
+         var $sn = $(origin);
+{% endif %}
+{% comment %} Start changes from source at https://github.com/summernote/django-summernote/blob/main/django_summernote/templates/django_summernote/widget_common.html
+
+Changes because: fix django-summernote/issues/465 issue, make it possible to use XSS protection for non-iframe widgets
+{% endcomment %}
+{% if iframe %}
+         $sn.html(origin.value);
+         $(origin).hide();
+{% endif %}
+{% comment %} End changes {% endcomment %}
+         var $nEditor, $nCodable, $nImageInput;
+
+         function recalcHeight(e) {
+             var nEditable = e.find('.note-editable');
+             var nEditor = $('.note-editor');
+             var height = parseInt(
+                 parseInt(settings.height)  // default
+                 - e.find('.note-toolbar').outerHeight()
+                 - e.find('.note-status-output').outerHeight()
+                 - e.find('.note-statusbar').outerHeight()
+                 - (nEditor.outerHeight() - nEditor.innerHeight())  // editor's border
+             );
+             nEditable.outerHeight(height);
+         }
+
+         var initEditor = function() {
+             $sn.summernote($.extend(settings, {
+{% if iframe %}
+                 disableResizeEditor: true,
+{% endif %}
+                 callbacks: {
+                     onInit: function() {
+                         $nEditor = $sn.next();
+                         $nCodable = $nEditor.find('.note-codable');
+                         recalcHeight($nEditor);
+
+{% if iframe %}
+                         // Resize again when the height of note-toolbar changed
+                         // This enhances calculation behaviors on Safari
+                         new ResizeSensor($nEditor.find('.note-toolbar'), function() {
+                             recalcHeight($nEditor);
+                         });
+                         // Add an event handler for fullscreen
+                         $nEditor.find('.btn-fullscreen').on('click', {editor: $nEditor}, function (e) {
+                             var $nEditor = e.data.editor;
+                             if ($nEditor.hasClass('fullscreen')) {
+                                 $(iframe).addClass('note-fullscreen');
+                             } else {
+                                 $(iframe).removeClass('note-fullscreen');
+                             }
+                         });
+{% else %}
+                         // Apply attributes with wrapper div
+                         var $wrap = $($nEditor).wrap(
+                             '<div class="summernote-div"></div>'
+                         ).parent();
+                         {% for k, v in attrs.items %}
+                         $wrap.attr('{{ k }}', '{{ v }}');
+                         {% endfor %}
+{% endif %}
+
+                         // Move dropdown dialog when it exceeds the bound of the editor
+                         $nEditor.find('.note-btn-group').on('shown.bs.dropdown', function () {
+                             var nDropdown = $(this).find(".dropdown-menu");
+                             var offset = nDropdown.offset();
+                             var width = nDropdown.width();
+
+                             var windowWidth = $(window).width();
+                             var margin = 15;
+
+                             if( offset.left + width + margin > windowWidth ) {
+                                 var left = windowWidth - width - offset.left - margin;
+                                 nDropdown.css("left", left + "px");
+                             }
+                         });
+                     },
+                     onBlur: function() {
+                         origin.value = $sn.summernote('code');
+                     },
+                     onBlurCodeview: function() {
+                         origin.value = $sn.summernote('code');
+                     },
+                     {% if not config.disable_attachment %}
+                     onImageUpload: function(files) {
+                         // custom attachment data
+                         var attachmentData = origin.dataset;
+                         $nImageInput = $nEditor.find('.note-image-input');
+                         $nImageInput.fileupload();
+                         var jqXHR = $nImageInput.fileupload('send',
+                                                             {
+                                                                 files: files,
+                                                                 formData: $.extend({csrfmiddlewaretoken: csrftoken}, attachmentData),
+                                                                 url: settings.url.upload_attachment,
+                         })
+                                                 .done(function (data, textStatus, jqXHR) {
+                                                     $.each(data.files, function (index, file) {
+                                                         $sn.summernote("insertImage", file.url);
+                                                     });
+                                                 })
+                                                 .fail(function (jqXHR, textStatus, errorThrown) {
+                                                     // if the error message from the server has any text in it, show it
+                                                     var msg = jqXHR.responseJSON;
+                                                     if (msg && msg.message) {
+                                                         alert(msg.message);
+                                                     }
+                                                     // otherwise, show something generic
+                                                     else {
+                                                         alert('Got an error while uploading images.');
+                                                     }
+                                                 });
+                         // Summernote will replace ImageInput when next the dialog opens.
+                         // But we have to reset it to prevent additional uploading by form itself.
+                         $nImageInput.replaceWith($nImageInput.val('').clone(true));
+                     }
+                     {% endif %}
+                 }
+             }));
+         };
+
+         // include summernote language pack, synchronously
+         $.ajax({url: settings.url.language, dataType: "script", complete: initEditor})
+
+         // For CodeMirror
+         $sn.on('summernote.codeview.toggled', function() {
+             var cmEditor = $nCodable.data('cmEditor');
+             if( cmEditor ) {
+                 cmEditor.on('blur', function() {
+                     origin.value = cmEditor.getValue();
+                 });
+             }
+         });
+
+{% if not iframe %}
+         // See https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
+         function getCookie(name) {
+             var cookieValue = null;
+             if (document.cookie && document.cookie != '') {
+                 var cookies = document.cookie.split(';');
+                 for (var i = 0; i < cookies.length; i++) {
+                     var cookie = jQuery.trim(cookies[i]);
+                     // Does this cookie string begin with the name we want?
+                     if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                         cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                         break;
+                     }
+                 }
+             }
+             return cookieValue;
+         }
+{% endif %}
+     });
+ }
+</script>

--- a/src/bytedeck_summernote/templates/bytedeck_summernote/widget_safe.html
+++ b/src/bytedeck_summernote/templates/bytedeck_summernote/widget_safe.html
@@ -1,0 +1,22 @@
+{% comment %}
+Start changes from source at https://github.com/summernote/django-summernote/blob/main/django_summernote/templates/django_summernote/widget_inplace.html
+
+Changes because: using "bytedeck_summernote" namespace
+{% endcomment %}
+{% include "bytedeck_summernote/widget_common.html" with iframe=False %}
+{% comment %} End changes {% endcomment %}
+<script>
+{% if config.lazy %}
+    if( __summernotes__ === undefined ) {
+        var __summernotes__ = new Array();
+        function initSummernote() {
+            for (i = 0, l = __summernotes__.length; i < l; ++i) {
+                __summernotes__[i]();
+            }
+        }
+    }
+    __summernotes__.push(initSummernote_{{ id_safe }});
+{% else %}
+    initSummernote_{{ id_safe }}();
+{% endif %}
+</script>

--- a/src/bytedeck_summernote/tests/test_admin.py
+++ b/src/bytedeck_summernote/tests/test_admin.py
@@ -1,0 +1,76 @@
+from django.db import models
+from django.apps import apps
+from django.contrib.admin.sites import AdminSite
+
+from django_tenants.test.cases import TenantTestCase
+
+
+class TestByteDeckSummernoteModelAdmin(TenantTestCase):
+
+    def setUp(self):
+        self.username = 'lqez'
+        self.password = 'ohmygoddess'
+        self.site = AdminSite()
+
+        self.app_config = apps.get_app_config('django_summernote')
+        self.app_config.update_config()
+        self.summernote_config = self.app_config.config
+
+    def test_admin_model(self):
+        from bytedeck_summernote.admin import ByteDeckSummernoteModelAdmin
+        from bytedeck_summernote.admin import ByteDeckSummernoteInlineModelAdmin
+        from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedWidget
+
+        class SimpleModel(models.Model):
+            foobar = models.TextField()
+
+        class SimpleModelAdmin(ByteDeckSummernoteModelAdmin):
+            pass
+
+        ma = SimpleModelAdmin(SimpleModel, self.site)
+
+        assert isinstance(
+            ma.get_form(None).base_fields['foobar'].widget,
+            ByteDeckSummernoteAdvancedWidget
+        )
+
+        class SimpleParentModel(models.Model):
+            foobar = models.TextField()
+
+        class SimpleModel2(models.Model):
+            foobar = models.TextField()
+            parent = models.ForeignKey(SimpleParentModel, on_delete=models.CASCADE)
+
+        class SimpleModelInline(ByteDeckSummernoteInlineModelAdmin):
+            model = SimpleModel2
+
+        class SimpleParentModelAdmin(ByteDeckSummernoteModelAdmin):
+            inlines = [SimpleModelInline]
+
+        ma = SimpleParentModelAdmin(SimpleParentModel, self.site)
+
+        assert isinstance(
+            ma.get_form(None).base_fields['foobar'].widget,
+            ByteDeckSummernoteAdvancedWidget
+        )
+
+    def test_admin_model_inplace(self):
+        from bytedeck_summernote.admin import ByteDeckSummernoteModelAdmin
+        from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
+
+        class SimpleModel3(models.Model):
+            foobar = models.TextField()
+
+        self.summernote_config['iframe'] = False
+
+        class SimpleModelAdmin(ByteDeckSummernoteModelAdmin):
+            pass
+
+        ma = SimpleModelAdmin(SimpleModel3, self.site)
+
+        assert isinstance(
+            ma.get_form(None).base_fields['foobar'].widget,
+            ByteDeckSummernoteSafeWidget
+        )
+
+        self.summernote_config['iframe'] = True

--- a/src/bytedeck_summernote/tests/test_views.py
+++ b/src/bytedeck_summernote/tests/test_views.py
@@ -1,0 +1,16 @@
+from django.urls import reverse
+
+from django_tenants.test.cases import TenantTestCase
+from django_tenants.test.client import TenantClient
+
+
+class TestByteDeckSummernoteView(TenantTestCase):
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+
+    def test_url(self):
+        url = reverse('bytedeck_summernote-editor', kwargs={'id': 'foobar'})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)

--- a/src/bytedeck_summernote/tests/test_widgets.py
+++ b/src/bytedeck_summernote/tests/test_widgets.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+
+from django_tenants.test.cases import TenantTestCase
+
+
+class TestByteDeckSummernoteWidget(TenantTestCase):
+
+    def test_widget(self):
+        from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedWidget
+
+        widget = ByteDeckSummernoteAdvancedWidget()
+        html = widget.render(
+            'foobar', 'lorem ipsum', attrs={'id': 'id_foobar'}
+        )
+        url = reverse('bytedeck_summernote-editor', kwargs={'id': 'id_foobar'})
+
+        assert url in html
+        assert 'id="id_foobar"' in html
+
+    def test_widget_inplace(self):
+        from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
+
+        widget = ByteDeckSummernoteSafeWidget()
+
+        html = widget.render(
+            'foobar', 'lorem ipsum', attrs={'id': 'id_foobar'}
+        )
+
+        assert 'summernote' in html
+
+        illegal_tags = '<script>alert("Hello")</script>'
+        value = widget.value_from_datadict({"foobar": illegal_tags}, {}, "foobar")
+
+        self.assertEqual(value, '&lt;script&gt;alert("Hello")&lt;/script&gt;')

--- a/src/bytedeck_summernote/urls.py
+++ b/src/bytedeck_summernote/urls.py
@@ -1,0 +1,13 @@
+"""Override `SummernoteEditor` class to use customized template file"""
+
+from django.urls import path
+
+from django_summernote.urls import urlpatterns as summernote_patterns
+
+from .views import ByteDeckSummernoteEditor
+
+urlpatterns = [
+    path('editor/<id>/', ByteDeckSummernoteEditor.as_view(), name='bytedeck_summernote-editor'),
+]
+
+urlpatterns += summernote_patterns

--- a/src/bytedeck_summernote/views.py
+++ b/src/bytedeck_summernote/views.py
@@ -1,0 +1,8 @@
+from django_summernote.views import SummernoteEditor
+
+
+class ByteDeckSummernoteEditor(SummernoteEditor):
+    """
+    Override `SummernoteEditor` class to use customized template file
+    """
+    template_name = 'bytedeck_summernote/widget_advanced_editor.html'

--- a/src/bytedeck_summernote/widgets.py
+++ b/src/bytedeck_summernote/widgets.py
@@ -1,0 +1,94 @@
+import html as htmllib
+import json
+import bleach
+
+from django.urls import reverse
+from django.conf import settings as django_settings
+from django.forms.utils import flatatt
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+from bleach.css_sanitizer import CSSSanitizer
+from django_summernote.widgets import SummernoteWidget, SummernoteInplaceWidget
+from django_summernote.utils import get_config
+
+
+class ByteDeckSummernoteAdvancedWidget(SummernoteWidget):
+
+    def render(self, name, value, attrs=None, **kwargs):
+        """Override default `render` method to use customized template file"""
+        summernote_settings = self.summernote_settings()
+        summernote_settings.update(self.attrs.get('summernote', {}))
+
+        # XSS protection for CodeView (mandatory for ByteDeck project)
+        summernote_settings.update({
+            'codeviewFilter': True,  # set this to true to filter entities.
+            'codeviewIframeFilter': True,
+        })
+
+        html = super(SummernoteWidget, self).render(name, value, attrs=attrs, **kwargs)
+        context = {
+            'id': attrs['id'],
+            'id_safe': attrs['id'].replace('-', '_'),
+            'flat_attrs': flatatt(self.final_attr(attrs)),
+            'settings': json.dumps(summernote_settings),
+            # using customized url here...
+            'src': reverse('bytedeck_summernote-editor', kwargs={'id': attrs['id']}),
+
+            # Width and height have to be pulled out to create an iframe with correct size
+            'width': summernote_settings['width'],
+            'height': summernote_settings['height'],
+        }
+
+        # using customized template here...
+        html += render_to_string('bytedeck_summernote/widget_advanced.html', context)
+        return mark_safe(html)
+
+
+class ByteDeckSummernoteSafeWidget(SummernoteInplaceWidget):
+
+    def render(self, name, value, attrs=None, **kwargs):
+        """Override default `render` method to use customized template file"""
+        summernote_settings = self.summernote_settings()
+        summernote_settings.update(self.attrs.get('summernote', {}))
+
+        # XSS protection for CodeView (mandatory for ByteDeck project)
+        summernote_settings.update({
+            'codeviewFilter': True,  # set this to true to filter entities.
+            'codeviewIframeFilter': True,
+        })
+
+        html = super(SummernoteInplaceWidget, self).render(name, value, attrs=attrs, **kwargs)
+        context = {
+            'id': attrs['id'],
+            'id_safe': attrs['id'].replace('-', '_'),
+            'attrs': self.final_attr(attrs),
+            'config': get_config(),
+            'settings': json.dumps(summernote_settings),
+            'CSRF_COOKIE_NAME': django_settings.CSRF_COOKIE_NAME,
+        }
+
+        # using customized template here...
+        html += render_to_string('bytedeck_summernote/widget_safe.html', context)
+        return mark_safe(html)
+
+    def value_from_datadict(self, data, files, name):
+        """Override default `value_from_datadict` method to fix injection vulnerability"""
+        from django_summernote.settings import ALLOWED_TAGS, ATTRIBUTES, STYLES
+        from django_summernote.utils import get_config
+
+        config = get_config()
+        value = data.get(name, None)
+
+        if value in config['empty']:
+            return None
+
+        # HTML escaping done with "bleach" library
+        value = bleach.clean(
+            htmllib.unescape(value) if value else "",
+            tags=ALLOWED_TAGS,
+            attributes=ATTRIBUTES,
+            css_sanitizer=CSSSanitizer(allowed_css_properties=STYLES),
+        )
+
+        return value

--- a/src/comments/forms.py
+++ b/src/comments/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from django_summernote.widgets import SummernoteWidget
+from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedWidget
 
 
 # class CommentForm(forms.ModelForm):
@@ -17,7 +17,7 @@ class CommentForm(forms.Form):
         super(CommentForm, self).__init__(*args, **kwargs)
         # do some more stuff after the object has been created
         if self.wysiwyg:
-            self.fields['comment_text'].widget = SummernoteWidget()
+            self.fields['comment_text'].widget = ByteDeckSummernoteAdvancedWidget()
         else:
             self.fields['comment_text'].widget = forms.Textarea(attrs={'rows': 2})
 

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -100,7 +100,10 @@ TENANT_APPS = (
     'django_celery_beat',
 
     'hackerspace_online',
+
+    # https://github.com/summernote/django-summernote
     'django_summernote',
+    'bytedeck_summernote',
 
     'taggit',
 
@@ -152,6 +155,7 @@ INSTALLED_APPS = (
 
     # https://github.com/summernote/django-summernote
     'django_summernote',
+    'bytedeck_summernote',
 
     # https://pypi.org/project/django-recaptcha/
     'captcha',
@@ -618,7 +622,6 @@ SUMMERNOTE_CONFIG = {
             # You have to include theme file in 'css' or 'css_for_inplace' before using it.
             'theme': 'monokai',
         },
-
     },
 
     # Need authentication while uploading attachments.

--- a/src/hackerspace_online/urls.py
+++ b/src/hackerspace_online/urls.py
@@ -51,11 +51,11 @@ urlpatterns += [
     url(r'^utilities/', include('utilities.urls', namespace='utilities')),
     url(r'^config/', include('siteconfig.urls', namespace='config')),
     url(r'^decks/', include('tenant.urls', namespace='decks')),
+    # bytedeck summernote
+    url(r'^summernote/', include('bytedeck_summernote.urls')),
 
     url(r'^tags/', include('tags.urls', namespace='tags')),
 
-    # summer_note
-    url(r'^summernote/', include('django_summernote.urls')),
     # allauth
     url(r'^accounts/password/reset/$',
         views.CustomPasswordResetView.as_view(),

--- a/src/portfolios/forms.py
+++ b/src/portfolios/forms.py
@@ -1,8 +1,10 @@
-from bootstrap_datepicker_plus.widgets import DatePickerInput
 from django import forms
-from django_summernote.widgets import SummernoteInplaceWidget
 
-from portfolios.models import Portfolio, Artwork
+from bootstrap_datepicker_plus.widgets import DatePickerInput
+
+from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
+
+from .models import Portfolio, Artwork
 
 
 class PortfolioForm(forms.ModelForm):
@@ -10,7 +12,7 @@ class PortfolioForm(forms.ModelForm):
         model = Portfolio
         fields = ['description', 'listed_locally', 'listed_publicly', ]
         widgets = {
-            'description': SummernoteInplaceWidget(),
+            'description': ByteDeckSummernoteSafeWidget(),
         }
 
 

--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -6,13 +6,14 @@ from django.contrib.contenttypes.models import ContentType
 
 from import_export import resources
 from import_export.fields import Field
-from django_summernote.admin import SummernoteModelAdmin
 from import_export.admin import ImportExportActionModelAdmin, ExportActionMixin
 
 from prerequisites.models import Prereq
 from prerequisites.admin import PrereqInline
 from badges.models import Badge
 from tenant.admin import NonPublicSchemaOnlyAdminAccessMixin
+from bytedeck_summernote.admin import ByteDeckSummernoteModelAdmin
+
 from .signals import tidy_html
 from .models import Quest, Category, QuestSubmission, CommonData
 
@@ -57,7 +58,7 @@ class FeedbackAdmin(admin.ModelAdmin):
 # class TaggedItemInline(GenericTabularInline):
 #     model = TaggedItem
 
-class CommonDataAdmin(NonPublicSchemaOnlyAdminAccessMixin, SummernoteModelAdmin):
+class CommonDataAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteModelAdmin):
     pass
 
 
@@ -165,7 +166,7 @@ class QuestResource(resources.ModelResource):
                 self.generate_campaign(parent_quest, data_dict)
 
 
-class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, SummernoteModelAdmin, ImportExportActionModelAdmin):  # use SummenoteModelAdmin
+class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteModelAdmin, ImportExportActionModelAdmin):  # use SummenoteModelAdmin
     resource_class = QuestResource
     list_display = ('id', 'name', 'xp', 'archived', 'visible_to_students', 'blocking', 'sort_order', 'max_repeats', 'date_expired',
                     'editor', 'specific_teacher_to_notify', 'common_data', 'campaign')

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,4 +1,3 @@
-
 from datetime import date
 
 from django import forms
@@ -8,12 +7,13 @@ from bootstrap_datepicker_plus.widgets import DatePickerInput, TimePickerInput
 from crispy_forms.bootstrap import Accordion, AccordionGroup
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Layout
-from django_summernote.widgets import SummernoteInplaceWidget
 from django_select2.forms import ModelSelect2MultipleWidget, ModelSelect2Widget
+
+from badges.models import Badge
+from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
+from utilities.fields import RestrictedFileFormField
 from tags.forms import BootstrapTaggitSelect2Widget
 
-from utilities.fields import RestrictedFileFormField
-from badges.models import Badge
 from .models import Category, Quest, CommonData
 
 
@@ -81,9 +81,9 @@ class QuestForm(forms.ModelForm):
         }
 
         widgets = {
-            'instructions': SummernoteInplaceWidget(),
-            'submission_details': SummernoteInplaceWidget(),
-            'instructor_notes': SummernoteInplaceWidget(),
+            'instructions': ByteDeckSummernoteSafeWidget(),
+            'submission_details': ByteDeckSummernoteSafeWidget(),
+            'instructor_notes': ByteDeckSummernoteSafeWidget(),
 
             'date_available': DatePickerInput(format='%Y-%m-%d'),
 
@@ -211,7 +211,7 @@ class TAQuestForm(QuestForm):
 
 
 class SubmissionForm(forms.Form):
-    comment_text = forms.CharField(label='', required=False, widget=SummernoteInplaceWidget())
+    comment_text = forms.CharField(label='', required=False, widget=ByteDeckSummernoteSafeWidget())
 
     attachments = RestrictedFileFormField(required=False,
                                           max_upload_size=16777216,
@@ -278,5 +278,5 @@ class CommonDataForm(forms.ModelForm):
         model = CommonData
         fields = "__all__"
         widgets = {
-            "instructions": SummernoteInplaceWidget()
+            "instructions": ByteDeckSummernoteSafeWidget()
         }

--- a/src/utilities/admin.py
+++ b/src/utilities/admin.py
@@ -1,13 +1,14 @@
 from django.contrib import admin
-from django_summernote.admin import SummernoteModelAdmin
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.flatpages.admin import FlatPageAdmin
 
 from tenant.admin import NonPublicSchemaOnlyAdminAccessMixin
-from utilities.models import ImageResource, MenuItem, VideoResource
+from bytedeck_summernote.admin import ByteDeckSummernoteModelAdmin
+
+from .models import ImageResource, MenuItem, VideoResource
 
 
-class FlatPageAdmin2(FlatPageAdmin, SummernoteModelAdmin):
+class FlatPageAdmin2(FlatPageAdmin, ByteDeckSummernoteModelAdmin):
     list_display = ('url', 'title', 'registration_required',)
     summernote_fields = ('content',)
 

--- a/src/utilities/forms.py
+++ b/src/utilities/forms.py
@@ -2,9 +2,10 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.flatpages.forms import FlatpageForm
-from django_summernote.widgets import SummernoteInplaceWidget
 
-from utilities.models import VideoResource, MenuItem
+from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
+
+from .models import VideoResource, MenuItem
 
 
 class FutureModelForm(forms.ModelForm):
@@ -140,7 +141,7 @@ class CustomFlatpageForm(FlatpageForm):
         exclude = ('enable_comments', 'template_name',)
 
         widgets = {
-            'content': SummernoteInplaceWidget(),
+            'content': ByteDeckSummernoteSafeWidget(),
 
             # https://code.djangoproject.com/ticket/24453
             'sites': forms.MultipleHiddenInput(),


### PR DESCRIPTION
### What?

I've implemented `ByteDeckSummernoteInplaceWidget` class as substitute for `SummernoteInplaceWidget` from `django-summernote`

### Why?

See https://github.com/bytedeck/bytedeck/issues/1302

### How?

append `bytedeck_summernote` right after `django_summernote` in INSTALLED_APPS
```python
INSTALLED_APPS = [
...
'django_summernote',
'bytedeck_summernote',
]
```

update urls.py, replace `django_summernote.urls` with `bytedeck_summernote.urls`:

```python
urlpatterns += [
...
    # bytedeck summernote
    url(r'^summernote/', include('bytedeck_summernote.urls')),
]
```

Replace imports:
```python
from django_summernote.widgets import SummernoteInplaceWidget, SummernoteWidget

# and
from django_summernote.admin import SummernoteModelAdmin, SummernoteInlineModelAdmin
```
with

```python
from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget, ByteDeckSummernoteAdvancedWidget

# and
from bytedeck_summernote.admin import ByteDeckSummernoteModelAdmin, ByteDeckSummernoteInlineModelAdmin

```

### Testing?
Yes
### Screenshots (if front end is affected)

![summernoteinplacewidget](https://user-images.githubusercontent.com/144783/227222795-4dd2477a-2ae1-4d0f-a439-e672fc79dd67.gif)

### Anything Else?

fork django-summernote under your project/company account, name the fork as bytedeck-summernote or django-summernote-bytedeck

### Review request
@tylerecouture
