### PR TITLE
Bump build pipeline version to ubuntu-latest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,10 +2,10 @@ name: Build and Tests
 
 on: [push, pull_request]
 
-jobs: 
+jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Copy sample environment variables

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Lint with Flake8
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fixed the github workflow

### Why?

So builds can run

### How?

By updating the ubuntu version https://github.com/orgs/community/discussions/31587

Github release an article about deprecating `ubuntu-18.04` https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

### Testing?

### Screenshots (if front end is affected)
### Anything Else?

I think it should be alright using `ubuntu-latest` since we are running a docker container within Github's container

### Review request
@tylerecouture
