### PR TITLE
fix: safe widget is stripping some html tags (closes #1340)

### DIFF
--- a/src/bytedeck_summernote/css_sanitizer.py
+++ b/src/bytedeck_summernote/css_sanitizer.py
@@ -1,0 +1,13 @@
+import html as htmllib
+
+from bleach import css_sanitizer
+
+
+class CSSSanitizer(css_sanitizer.CSSSanitizer):
+    """Override default `bleach.css_sanitizer.CSSSanitizer` class (mandatory for ByteDeck project)"""
+
+    def sanitize_css(self, style):
+        """
+        Override `sanitize_css` method, unescape styles before sanitization (fix #1340)
+        """
+        return super().sanitize_css(htmllib.unescape(style))

--- a/src/bytedeck_summernote/settings.py
+++ b/src/bytedeck_summernote/settings.py
@@ -1,0 +1,15 @@
+ALLOWED_TAGS = [
+    'a', 'div', 'p', 'span', 'img', 'em', 'i', 'li', 'ol', 'ul', 'strong', 'br',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'table', 'tbody', 'thead', 'tr', 'td',
+    'abbr', 'acronym', 'b', 'blockquote', 'code', 'strike', 'u', 'sup', 'sub',
+]
+
+STYLES = [
+    'background-color', 'font-size', 'line-height', 'color', 'font-family'
+]
+
+ATTRIBUTES = {
+    '*': ['style', 'align', 'title', ],
+    'a': ['href', ],
+}

--- a/src/bytedeck_summernote/settings.py
+++ b/src/bytedeck_summernote/settings.py
@@ -1,15 +1,67 @@
-ALLOWED_TAGS = [
-    'a', 'div', 'p', 'span', 'img', 'em', 'i', 'li', 'ol', 'ul', 'strong', 'br',
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    'table', 'tbody', 'thead', 'tr', 'td',
-    'abbr', 'acronym', 'b', 'blockquote', 'code', 'strike', 'u', 'sup', 'sub',
+from django_summernote.settings import ALLOWED_TAGS, STYLES
+
+# Extend a list of allowed tags (mandatory for ByteDeck project),
+ALLOWED_TAGS += [
+    # allow extra tags, fix #1340
+    "pre",
+    "kbd",
+    "var",
+    "mark",
+    "small",
+    "ins",
+    "del",
+    "font",
+    "iframe",
+    "hr",
+    # MathML (mandatory for ByteDeck project)
+    "math",
+    "maction",
+    "menclose",
+    "merror",
+    "mfenced",
+    "mfrac",
+    "mglyph",
+    "mi",
+    "mlabeledtr",
+    "mmultiscripts",
+    "mn",
+    "mo",
+    "mover",
+    "mpadded",
+    "mphantom",
+    "mroot",
+    "mrow",
+    "ms",
+    "mspace",
+    "msqrt",
+    "mstyle",
+    "msub",
+    "msup",
+    "msubsup",
+    "mtable",
+    "mtd",
+    "mtext",
+    "mtr",
+    "munder",
+    "munderover",
+    "none",
+    "mprescripts",
+    "semantics",
+    "annotation",
+    "annotation-xml",
 ]
 
-STYLES = [
-    'background-color', 'font-size', 'line-height', 'color', 'font-family'
+# Extend a list of allowed CSS properties (mandatory for ByteDeck project),
+STYLES += [
+    # allow extra styles, fix #1340
+    "float",
+    "height",
+    "list-style",
+    "list-style-type",
+    "margin-left",
+    "margin-right",
+    "text-align",
+    "text-decoration",
+    "text-indent",
+    "width",
 ]
-
-ATTRIBUTES = {
-    '*': ['style', 'align', 'title', ],
-    'a': ['href', ],
-}

--- a/src/bytedeck_summernote/tests/test_css_sanitizier.py
+++ b/src/bytedeck_summernote/tests/test_css_sanitizier.py
@@ -1,0 +1,23 @@
+from bleach import clean  # noqa
+from django_tenants.test.cases import TenantTestCase
+
+
+class TestCSSSanitizer(TenantTestCase):
+    """ByteDeck's CSSSanitizer implementation, fixes various issues"""
+
+    def test_sanitize_css(self):
+        """The sanitizer should not strip/remove escaped CSS values."""
+        from bytedeck_summernote.css_sanitizer import CSSSanitizer
+        from bytedeck_summernote.settings import STYLES
+
+        css_sanitizer = CSSSanitizer(allowed_css_properties=STYLES)
+
+        escaped_css_values = """<p>Lorem ipsum<span style="font-family: &quot;Comic Sans MS&quot;;">dolor</span> sit amet</p>"""
+        expected = """<p>Lorem ipsum<span style='font-family: "Comic Sans MS";'>dolor</span> sit amet</p>"""
+
+        assert (
+            clean(
+                escaped_css_values, tags=["p", "span"], attributes={"span": ["style"]}, css_sanitizer=css_sanitizer
+            )
+            == expected
+        )

--- a/src/bytedeck_summernote/widgets.py
+++ b/src/bytedeck_summernote/widgets.py
@@ -100,7 +100,7 @@ class ByteDeckSummernoteSafeWidgetMixin:
         value = super().value_from_datadict(data, files, name)
         # HTML escaping done with "bleach" library
         return bleach.clean(
-            value,
+            value or "",
             tags=ALLOWED_TAGS,
             # skip attributes sanitization (always allowed), fix #1340
             attributes=allow_any_attributes,

--- a/src/bytedeck_summernote/widgets.py
+++ b/src/bytedeck_summernote/widgets.py
@@ -84,7 +84,7 @@ class ByteDeckSummernoteSafeWidgetMixin:
 
     def value_from_datadict(self, data, files, name):
         """Override default `value_from_datadict` method to fix injection vulnerability"""
-        from django_summernote.settings import ALLOWED_TAGS, ATTRIBUTES, STYLES
+        from bytedeck_summernote.settings import ALLOWED_TAGS, ATTRIBUTES, STYLES
 
         value = super().value_from_datadict(data, files, name)
         # HTML escaping done with "bleach" library

--- a/src/bytedeck_summernote/widgets.py
+++ b/src/bytedeck_summernote/widgets.py
@@ -88,22 +88,14 @@ class ByteDeckSummernoteSafeWidgetMixin:
         """Override default `value_from_datadict` method to fix injection vulnerability"""
         from bytedeck_summernote.settings import ALLOWED_TAGS, STYLES
 
-        def allow_any_attributes(tag, name, value):
-            """
-            Sanitizing text (attributes) fragments.
-
-            For reference https://bleach.readthedocs.io/en/latest/clean.html#using-functions
-
-            """
-            return True  # Allowed attribute?
-
         value = super().value_from_datadict(data, files, name)
         # HTML escaping done with "bleach" library
         return bleach.clean(
             value or "",
             tags=ALLOWED_TAGS,
             # skip attributes sanitization (always allowed), fix #1340
-            attributes=allow_any_attributes,
+            # for reference https://bleach.readthedocs.io/en/latest/clean.html#using-functions
+            attributes=lambda tag, name, value: True,
             # improved CSS sanitization, fix #1340
             css_sanitizer=CSSSanitizer(allowed_css_properties=STYLES),
         )


### PR DESCRIPTION
### What?

Fixes issue with so-called "safe" widget is stripping/escaping some html tags entered in codeview 

### Why?

See https://github.com/bytedeck/bytedeck/issues/1340

Closes #1340 

### How?

It's a bug in upstream "django_summernote" package, but I fixed it in bytedeck's version, see diffs

### Testing?

Manually, yes.

### Screenshots (if front end is affected)

![makesummernotegreatagain](https://user-images.githubusercontent.com/144783/233617567-b92e5c12-69da-4f38-b67e-fd9cb419d7f7.gif)

### Anything Else?

Q: WTF you just did?
A: Upstream "django_summernote" has an issue, they didn't updated their list of ALLOWED_TAGS and STYLES for years, it was out-of-sync with the version of SummerNote Editor they use. I fixed it locally.

### Review request
@tylerecouture
