### PR TITLE
feat: add_possessive filter + default

### DIFF
--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -1,7 +1,8 @@
 {% extends "profile_manager/base.html" %}
 {% load utility_tags %}
+{% load filters %}
 
-{% block heading_inner %}{{ object.get_preferred_name }}'s Profile
+{% block heading_inner %}{{ object.get_preferred_name|default:"<<no name>>"|add_possessive }} Profile
     <div class="btn-group" role="group">
       <a class="btn btn-info" title="Edit your Profile"
         href="{% url 'profiles:profile_update' object.id %}"

--- a/src/utilities/templatetags/filters.py
+++ b/src/utilities/templatetags/filters.py
@@ -1,0 +1,18 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def add_possessive(string):
+    """
+    Possessivizes names to include either a 's or an ' depending on if the name ends in a "s".
+    """
+    if string[-2:] == "'s" or string[-2:] == "’s":
+        return string
+    elif string[-1:] == "s":
+        return f"{string}'"
+    else:
+        return f"{string}'s"

--- a/src/utilities/tests/test_templatetags_filters.py
+++ b/src/utilities/tests/test_templatetags_filters.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.template import Template, Context
+
+
+class PossessiveFilterTest(TestCase):
+    def test_possessive_filter(self):
+        template = Template("{% load filters %}{{ name|add_possessive }}")
+
+        # Test a name that ends with "s"
+        context = Context({"name": "James"})
+        output = template.render(context)
+        self.assertEqual(output, "James&#x27;")
+
+        # Test a name that ends with "'s"
+        context = Context({"name": "John's"})
+        output = template.render(context)
+        self.assertEqual(output, "John&#x27;s")
+
+        # Test a name that ends with "’s"
+        context = Context({"name": "Andrés’s"})
+        output = template.render(context)
+        self.assertEqual(output, "Andrés’s")
+
+        # Test a name that doesn't end with "s", "'s", or "’s"
+        context = Context({"name": "Mary"})
+        output = template.render(context)
+        self.assertEqual(output, "Mary&#x27;s")


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/

### What?
- Adds correct possessives to names, as well as providing a default fallback of <<no name>> if the user decides to no longer have a name...
### Why?
- To have correct (objectively) possessives as well as providing a fallback for no name cases.
### How?
- by adding a custom filter for possessives called add_possessive and adding a default fallback (this is a filter builtin to django)
### Testing?
- There is a test added for this new filter in utilities/templatetags/tests, the file is called test_templatetags_filters.py, when making the commit all tests have passed regarding this.
### Screenshots (if front end is affected)
![Screenshot from 2023-05-09 15-10-40](https://github.com/bytedeck/bytedeck/assets/37005919/3528f886-59e9-4b39-8fc6-d49e33b74617)
![Screenshot from 2023-05-09 15-13-38](https://github.com/bytedeck/bytedeck/assets/37005919/a7af1332-7b56-42e8-b930-ce4862e40f93)
![Screenshot from 2023-05-09 15-14-14](https://github.com/bytedeck/bytedeck/assets/37005919/81a5f4c1-0543-46b8-96d5-fbae3e7cec8c)

### Review request
@tylerecouture
