### PR TITLE
fix: make "figure" and "figcaption" safe again

### DIFF
--- a/src/bytedeck_summernote/settings.py
+++ b/src/bytedeck_summernote/settings.py
@@ -13,6 +13,8 @@ ALLOWED_TAGS += [
     "font",
     "iframe",
     "hr",
+    "figure",
+    "figcaption",
     # MathML (mandatory for ByteDeck project)
     "math",
     "maction",


### PR DESCRIPTION
### What?
make "figure" and "figcaption" safe again
### Why?
requested by @tylerecouture 
### How?
appending "figure" and "figcaption" to `settings.ALLOWED_TAGS` list
### Testing?
Nope
### Screenshots (if front end is affected)
No
### Anything Else?
Nope
### Review request
@tylerecouture
