### PR TITLE
Fix typo in contributing.md at database inspection with pgadmin4 steps 2, 5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Using pgadmin4 we can inspect the postgres database's schemas and tables (helpfu
 2. Log in:
    - url: [localhost:8080](http://localhost:8080)
    - email: admin@admin.com
-   - password: password  (or whatever you changed this to in you `.env` file)
+   - password: password  (or whatever you changed this to in your `.env` file)
 3. Click "Add New Server"
 4. Give it any Name you want
 5. In the Connection tab set:
@@ -125,7 +125,7 @@ Using pgadmin4 we can inspect the postgres database's schemas and tables (helpfu
    - Port: 5432
    - Maintenance database: postgres
    - Username: postgres
-   - Password: Change.Me!  (or whatever you change the db password to in you `.env` file)
+   - Password: Change.Me!  (or whatever you change the db password to in your `.env` file)
 6. Hit Save
 7. At the top left expand the Servers tree to find the database, and explore!
 8. You'll probably want to look at Schemas > (pick a schema) > Tables


### PR DESCRIPTION
### What?
Corrected grammar used in steps 2 and 5 of the CONTRIBUTING.MD file's instructions for inspecting databases via pgadmin4 (lines 120, 128)

### Why?
Proper grammar is important in documentation for high-standard projects such as Bytedeck

### How?
In both instances (lines 120, 128), the line "(or whatever you change the db password to in you `.env` file)" has been corrected to "(or whatever you change the db password to in **your** `.env` file)"

### Testing?
As this is purely a change in documentation, no explicit tests have been made. No new conflicts or test failures have arisen from the implementation of this change (as you'd expect/hope).

### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/c96d7b37-44fb-4ef1-8ac5-407d0dcfa631)

### Anything Else?
Notably, the capitalization of these two lines differ. No change has been made to that in this pull request, but it may warrant remediation in future iterations of this pull request/future PRs.

### Review request
@tylerecouture
