### PR TITLE
Fixed XP button not working on mobile devices; Closes #1283

### DIFF
--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -180,6 +180,20 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         self.assert404('courses:my_marks')
 
+    def test_student_view_marks_200_if_enabled(self):
+        """
+        Student marks page should be accessible if site admin has enabled it.
+        """
+        # Login a student
+        success = self.client.login(username=self.test_student1.username, password=self.test_password)
+        self.assertTrue(success)
+
+        config = SiteConfig.get()
+        config.display_marks_calculation = True
+        config.save()
+
+        self.assert200('courses:my_marks')
+
     def test_assert_correct_forms__not_staff(self):
         """
             test if non staff users have access to ProfileForm and not UserForm in ProfileView

--- a/src/templates/navbar-fixed.html
+++ b/src/templates/navbar-fixed.html
@@ -54,10 +54,11 @@
             <div class="visible-xs-inline navbar-mobile-xp-container">
                 <ul class="nav navbar-nav navbar-mobile-xp">
                     <li>
-                        {% comment %} # DISABLE MARKS {% endcomment %}
-                        {% comment %} <a href="{% url 'courses:marks' request.user.id %}" {% endcomment %}
-                        <a href="#" title="The Mark Calculations page is currently disabled, sorry!"
-                        class="navbar-text-large-container">XP:
+                        {% url 'courses:marks' request.user.id as marks_url %}
+                        <a
+                          href="{% if config.display_marks_calculation %} {{ marks_url }} {% else %}#{% endif %}"
+                          title="View your marks calculation"
+                           class="navbar-text-large-container">XP:
                             <span class="navbar-text-large"> {{ request.user.profile.xp_cached }}</span>
                         </a>
                     </li>


### PR DESCRIPTION
### What?
For my first issue, I opted to fix #1283.
### Why?
I was instructed to select a "good first issue" to complete. Beyond that, it is annoying for users if they are unable to use the site properly on their mobile devices, so this should help make this site more mobile-friendly.
### How?
This mainly involved slotting in commented-out code that already appeared in the `src/templates/navbar-fixed.html` file.

❗**Update**: Since there are essentially two versions of this code, I tried to maintain the same style that was used for the desktop XP button:
```html
{% else %}
<!-- Students XP & Rank -->
<li id="menu-xp" class="hidden-xs navbar-xp">
    {% url 'courses:marks' request.user.id as marks_url %}
    <a
      href="{% if config.display_marks_calculation %} {{ marks_url }} {% else %}#{% endif %}"
      title="View your marks calculation"
       class="navbar-text-large-container">XP:
        <span class="navbar-text-large"> {{ request.user.profile.xp_cached }}</span>
    </a>
</li>
{% endif %}
```

Notice that the `courses:marks` page for the user is put into a variable `marks_url`, which makes the code logic more simple underneath. And addressing Tylere's question, if `config.display_marks_calculation` is set to false, clicking the XP button will do nothing. Maybe it should also say "The marks page is disabled"? I'm not sure what the best solution is here, and I'm open to suggestions.

### Testing?
I added one simple test to ensure that if the user is logged in, and the `display_marks_calculation` site configuration option is set to true, the user can successfully access the "courses:my_marks" page.
### Screenshots (if front end is affected)
N/A
### Anything Else?

#### Refactoring This Frontend Code
This frontend code seems a bit bloated, basically having two duplicated versions for desktop and mobile. We could probably merge a lot of this into one version by, for example, using the Django templating functionality to control which CSS classes are activated (shouldn't the "@media" CSS tags do this anyways?). Merging these into one version would be very time-consuming, but might help in the long run.

#### Better Frontend Testing
In the future, it seems highly advisable that we start using selenium to test the site frontend. Using selenium, we could ensure that upon clicking the XP button, the user can successfully navigate to the marks page. I believe we could also control the screen size, allowing us to test that it still works with smaller screen sizes. 

Here is an example I found from [this tutorial](https://ordinarycoders.com/blog/article/testing-django-selenium). It tests that a user can successfully submit a form after pressing the enter key:

<details>

<summary>Selenium code example.</summary>

```py
from django.test import LiveServerTestCase
from selenium import webdriver
from selenium.webdriver.common.keys import Keys

# Create your tests here.
class PlayerFormTest(LiveServerTestCase):

  def testform(self):
    selenium = webdriver.Chrome()
    #Choose your url to visit
    selenium.get('http://127.0.0.1:8000/')
    #find the elements you need to submit form
    player_name = selenium.find_element_by_id('id_name')
    player_height = selenium.find_element_by_id('id_height')
    player_team = selenium.find_element_by_id('id_team')
    player_ppg = selenium.find_element_by_id('id_ppg')

    submit = selenium.find_element_by_id('submit_button')

    #populate the form with data
    player_name.send_keys('Lebron James')
    player_team.send_keys('Los Angeles Lakers')
    player_height.send_keys('6 feet 9 inches')
    player_ppg.send_keys('25.7')

    #submit form
    submit.send_keys(Keys.RETURN)

    #check result; page source looks at entire html document
    assert 'Lebron James' in selenium.page_source
 ```

</details>

### Review request
@tylerecouture
