### PR TITLE
Fixed pg-admin being on separate docker network from database

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -89,6 +89,8 @@ services:
         condition: service_healthy
     ports:
       - "8080:80"
+    networks:
+      - backend-network
 
 volumes:
   postgres_data:


### PR DESCRIPTION
### What?
There was an issue where the pg-admin service was unable to access the postgres database.
### Why?
The pg-admin container was previously unusable in its state. These changes should make it easier for future maintainers to inspect the database.
### How?
The problem with pg-admin was due to the pg-admin container not having a docker network specified. This resulted in it being on the bytedeck_default network, while the database was on the bytedeck_backend network. This made them unable to communicate. The "networks" section was added to the docker-compose.override.yml file to fix this issue:
```yml
...
pg-admin:
    image: dpage/pgadmin4
    environment:
      PGADMIN_DEFAULT_EMAIL: admin@admin.com
      PGADMIN_DEFAULT_PASSWORD: password
    depends_on:
      db:
        condition: service_healthy
    ports:
      - "8080:80"
    networks:  ### HERE
      - backend-network
...
```
### Testing?
To test the pg-admin container functionality, run through the "**Advanced / Optional: Inspecting the database with pgadmin4**" steps as defined in CONTRIBUTING.md.
### Screenshots (if front end is affected)
Although this wasn't a frontend issue, I feel that attaching a screenshot of the issue is appropriate:
![pgadmin-issue](https://github.com/bytedeck/bytedeck/assets/11304586/55acd0a1-4646-4b09-ad04-83d45e7fe3aa)
### Anything Else?
The pg-admin service seemed very confusing to use. Maybe some additional documentation should be added on how to perform common database inspection tasks (i.e. generate ER diagram, view create table statements, enter queries, etc)?
### Review request
@tylerecouture
