### PR TITLE
Fixed missing closing brace for pluralization

### DIFF
--- a/src/quest_manager/templates/quest_manager/preview_content_quests_avail.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_quests_avail.html
@@ -17,7 +17,7 @@
       <li>Repeatable: {% if q.max_repeats == 0 %}no
              {% else %}
                {% if q.max_repeats == -1 %} Unlimited
-               {% else %} {{q.max_repeats}} time{{q.max_repeats|pluralize} max
+               {% else %} {{q.max_repeats}} time{{q.max_repeats|pluralize}} max
                {% endif %}
                {% if q.hours_between_repeats > 0 %}
                - every {{ q.hours_between_repeats}} hrs


### PR DESCRIPTION
### What?
This fixes a small issue which exposed front-end code. It had to do with adding an "s" to the end of a word if a quest was repeatable more than once e.g. "repeatable 1 time" vs "repeatable 6 times".
### Why?
This will add to the overall polish of the website. Front-end code should not be exposed like this.
### How?
To fix this, all I had to do was add a closing brace to the code in preview_content_quests_avail.html.
### Testing?
I set the number of allowed repeats for one of the default quests to ensure that this issue was fixed. There didn't appear to be any exposed front-end code.

This issue seems much to simple to write a dedicated unit test for.
### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/11304586/ff6699a5-158d-47ea-ac6c-fd3ad8115654)

### Anything Else?
In the future, there might be some kind of test we could add to prevent this? Maybe something that scans each Django template file to ensure it contains valid code?
### Review request
@tylerecouture
