### PR TITLE
Fix: extend list of permitted "javascript" mimetypes aa06649 

### DIFF
--- a/src/siteconfig/models.py
+++ b/src/siteconfig/models.py
@@ -236,7 +236,8 @@ class SiteConfig(models.Model):
             This feature also has the potential of making your deck unusable. Use at your own risk.",
     )
     custom_javascript = RestrictedFileField(
-        null=True, blank=True, content_types=['application/x-javascript'], max_upload_size=512000,
+        null=True, blank=True, content_types=[
+            'application/x-javascript', 'application/javascript', 'text/javascript'], max_upload_size=512000,
         help_text="WARNING: This custom JavaScript file can be used to completely override how the front end of your deck functions. \
             This feature also has the potential of making your deck unusable. Use at your own risk.",
     )


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Extending list of permitted mimetypes for `custom_javascript` file uploads

### Why?

See https://github.com/bytedeck/bytedeck/issues/1365#issuecomment-1572740175

### How?

See diffs

### Testing?

Yes
### Screenshots (if front end is affected)

Nope
### Anything Else?
Nope
### Review request
@tylerecouture
