### PR TITLE
Replace block terminology with custom name for group; Closes #1393

### DIFF
--- a/src/quest_manager/templates/quest_manager/quest_approval.html
+++ b/src/quest_manager/templates/quest_manager/quest_approval.html
@@ -13,7 +13,7 @@
       {% if show_all_blocks_button %}
         <div class="btn-group">
             <a href="{% url 'quests:submitted' %}"
-               class="btn {% if current_teacher_only %}btn-primary{% else %}btn-default{% endif %}">My blocks</a>
+               class="btn {% if current_teacher_only %}btn-primary{% else %}btn-default{% endif %}">My {{ config.custom_name_for_group|lower }}s</a>
             <a href="{% url 'quests:submitted_all' %}"
                class="btn {% if not current_teacher_only %}btn-primary{% else %}btn-default{% endif %}">All</a>
         </div>

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -90,8 +90,8 @@
   {% endwith %}
 
 {% elif user.block_set.count == 0 %}
-  <p>You are not assigned as the teacher for any blocks yet.</p>
-  <a class="btn btn-info" href="{% url 'courses:block_list' %}">Join a block</a>
+  <p>You are not assigned as the teacher for any {{ config.custom_name_for_group|lower }}s yet.</p>
+  <a class="btn btn-info" href="{% url 'courses:block_list' %}">Join a {{ config.custom_name_for_group|lower }}</a>
 {% else %}
   <p>None.</p>
 {% endif %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2297,13 +2297,13 @@ class ApprovalsViewTest(ViewTestUtilsMixin, TenantTestCase):
         """ Approved submissions of only this specific quest, regardless of teacher """
 
     def test_approvals_all_buttons_does_not_exist(self):
-        """ My blocks should not be rendered when there is only one teacher"""
+        """ My groups should not be rendered when there is only one teacher"""
 
         response = self.client.get(reverse('quests:approvals'))
-        self.assertNotContains(response, 'My blocks')
+        self.assertNotContains(response, 'My groups')
 
     def test_approval_all_button_exists(self):
-        """ My blocks button should not be rendered """
+        """ My groups button should not be rendered """
 
         baker.make('courses.Block', name='A', current_teacher=self.current_teacher)
         baker.make('courses.Block', name='B', current_teacher=self.current_teacher)
@@ -2313,7 +2313,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, TenantTestCase):
         baker.make('courses.Block', name='D', current_teacher=another_teacher)
 
         response = self.client.get(reverse('quests:approvals'))
-        self.assertContains(response, 'My blocks')
+        self.assertContains(response, 'My groups')
 
 
 class Is_staff_or_TA_test(TenantTestCase):

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -859,7 +859,7 @@ def approvals(request, quest_id=None):
 
     show_all_blocks_button = False
 
-    # Display My Blocks / All buttons when Block objects are assigned to atleast two different users / teachers
+    # Display My groups / All buttons when Block objects are assigned to atleast two different users / teachers
     if len(Block.objects.grouped_teachers_blocks().keys()) > 1:
         show_all_blocks_button = True
 


### PR DESCRIPTION
### What?
This is a small fix to make use of the group custom label set in siteconfig, replacing 3 instances of the non-flexible term 'block'.

### Why?
'Block' is an outdated term that doesn't conform to Bytedeck's goal of customizable context through custom label setting.

### How?
These problem instances of 'block' have been replaced with the config.custom_name_for_group template tag.

### Testing?
Previously existing tests for the "my blocks" button have been refactored to assert the new custom label default, "my groups"

### Screenshots (if front end is affected)
New Instances of the custom label:
![image](https://github.com/bytedeck/bytedeck/assets/105619909/9d5f2e56-58e2-4c08-8195-6568d6262981)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/3856b6de-4d9b-4788-8245-df006107e1b8)

### Review request
@tylerecouture
