### PR TITLE
Remove print statements in test modules

### DIFF
--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -534,7 +534,6 @@ class RankModelTest(TenantTestCase):
         self.rank = baker.make(Rank, name="TestRank", xp=0)
 
     def test_rank_creation(self):
-        print(Rank.objects.all())
         self.assertIsInstance(self.rank, Rank)
         self.assertEqual(str(self.rank), self.rank.name)
 
@@ -547,6 +546,5 @@ class RankModelTest(TenantTestCase):
         self.assertEqual(self.rank.get_icon_url(), SiteConfig.get().get_default_icon_url())
         self.rank.icon = 'test.png'
         self.rank.save()
-        print(self.rank.icon, self.rank.icon.url)
 
         self.assertEqual(self.rank.get_icon_url(), self.rank.icon.url)

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -88,7 +88,6 @@ class NotificationTasksTests(TenantTestCase):
         self.assertEqual(type(email), EmailMultiAlternatives)
         self.assertEqual(email.to, [self.test_student1.email])
         # Default deck short name is "Deck"
-        print(email.subject)
         self.assertEqual(email.subject, "Deck Notifications")
 
         # https://stackoverflow.com/questions/62958111/how-to-display-html-content-of-an-emailmultialternatives-mail-object


### PR DESCRIPTION
### What?
Certain test modules have had lingering print statements that gum up your terminal when you run a test suite. This is a PR to remove some obvious ones

### Why?
Because they should've been removed before their corresponding features were implemented in the first place!

### How?
Lines featuring obviously non-useful print statements have been deleted.

### Anything Else?
There's an additional print statement made in signals.py located in the announcements app, but it might have utility I'm not aware of. Any advice on whether or not to remove it would be appreciated! (currently on line 79 in announcements/signals.py)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/032bc2c7-d9c9-40bf-bea8-70417213a6b1)
 
### Review request
@tylerecouture
