### PR TITLE
My groups button does not display when redundant; Closes #1395

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -857,11 +857,14 @@ def approvals(request, quest_id=None):
 
     quick_reply_form = SubmissionQuickReplyForm(request.POST or None)
 
-    show_all_blocks_button = False
+    # Header button that toggles displaying all quest approvals or only those from groups assigned to the current user
+    show_all_blocks_button = True
 
-    # Display My groups / All buttons when Block objects are assigned to atleast two different users / teachers
-    if len(Block.objects.grouped_teachers_blocks().keys()) > 1:
-        show_all_blocks_button = True
+    grouped_blocks = Block.objects.grouped_teachers_blocks()
+    teachers = grouped_blocks.keys()
+    # If there is only one user with assigned blocks AND that user is the current user, the header button is redundant and isn't displayed
+    if len(teachers) == 1 and list(teachers)[0] == request.user.id:
+        show_all_blocks_button = False
 
     context = {
         "heading": "Quest Approval",


### PR DESCRIPTION
### What?
The My Groups/All header button on the quest approvals page no longer displays when the current user is the only user with assigned blocks (groups)

### Why?
When the current user is the only one with any assigned blocks, toggling between "My groups" and "All groups" is redundant, and so the button becomes useless clutter which shouldn't be rendered.

### How?
Logic controlling when this button renders has been changed. 
Prior to this change, the only criteria for rendering this button was if more than one user had assigned blocks, but that would leave cases where only one user who wasn't the current user had assigned blocks uncovered. 

### Testing?
Tests for the prior rendering logic existed, and have been condensed into a single test for the three possible use cases:
- there is only one user with assigned blocks, but it isn't the current user (button is rendered)
- there are multiple users with assigned blocks (button is rendered)
- there is only one user with assigned blocks and it is the current user (not rendered)

### Screenshots (if front end is affected)
approvals page when button not rendered
![image](https://github.com/bytedeck/bytedeck/assets/105619909/c85ed28e-c2ff-4458-9361-25b8e32724a5)

approvals page when button rendered
![image](https://github.com/bytedeck/bytedeck/assets/105619909/00289c64-2f64-412a-8f10-f557c2ab1732)

### Anything Else?
The button is currently rendered when there are ZERO blocks assigned to ANY user. If this isn't desired, a simple change can be made to fix this. 

### Review request
@tylerecouture
