### PR TITLE
Fixed quick reply forms not working after refactoring

### DIFF
--- a/src/quest_manager/templates/quest_manager/quest_approval.html
+++ b/src/quest_manager/templates/quest_manager/quest_approval.html
@@ -60,7 +60,8 @@
 {% block js %}
 <script>
 $( document ).ready(function() {
-    $('[id^=btn_quick_text]').on('click', function () {
+    // Attach the event to the document and delegate it to elements with ids starting with 'btn_quick_text'
+    $(document).on('click', '[id^=btn_quick_text]', function () {
         var msg = ' {{ quick_reply_text }} ';
         var textarea = $($(this).data('target')).find('textarea');
         textarea.val(textarea.val() + msg);

--- a/src/quest_manager/templates/quest_manager/snippets/flag_submissions_scripts.html
+++ b/src/quest_manager/templates/quest_manager/snippets/flag_submissions_scripts.html
@@ -2,7 +2,7 @@
 
     $(document).ready(function() {
         // Flag submissions via Ajax when button clicked:
-        $('.btn-flag-submission').on('click', function(event){
+        $(document).on('click', '.btn-flag-submission', function(event){
             event.preventDefault(); // prevent browser from reloading
             flag_submission(this);
         });

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -54,44 +54,47 @@
           <td class="col-sm-3 hidden-xs">
             {% include "quest_manager/submitted_time.html" %}
           </td>
-
-          {% comment %}
-            ### COLLAPSING CONTENT ###
-            This is the content that is hidden until the row is clicked.
-            ajax_content_loading.html inserts quest content here.
-            If the content hasn't been retrieved yet from the server, a loading icon is displayed.
-          {% endcomment %}
-          <span style="display: none" id="collapse-quest-{{s.id}}"
-            class="{% if object.sticky %}info
-                   {% elif s.do_not_grant_xp %}panel-muted
-                   {% else %}default{% endif %}"
-            role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
-            <ul id="preview-content-{{s.id}}" class="list-group">
-              <li class="list-group-item list-group-item-buttons">
-                  <p>
-                    <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-                    &nbsp;Loading content...
-                    <!-- preview_content_approvals.html via AJAX -->
-                  </p>
-              </li>
-            </ul>
-
-            <li class="list-group-item">
-              <form id="quick_reply{{s.id}}" method="POST" enctype="multipart/form-data"
-                    action="{% url 'quests:approve' s.id %}">{% csrf_token %}
-                {{ quick_reply_form | crispy }}
-                <div>
-                  {% include "quest_manager/submission_buttons_form.html" %}
-                  {% include "quest_manager/submission_buttons_other.html" %}
-                </div>
-              </form>
-            </li>
-          </span>
-
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    {% comment %} The hidden content needs to be in its own for loop.
+     Otherwise, additional formatting is applied to it that breaks the form. {% endcomment %}
+    {% for s in tab.submissions %}
+      {% comment %}
+        ### COLLAPSING CONTENT ###
+        This is the content that is hidden until the row is clicked.
+        ajax_content_loading.html inserts quest content here.
+        If the content hasn't been retrieved yet from the server, a loading icon is displayed.
+      {% endcomment %}
+      <div style="display: none" id="collapse-quest-{{s.id}}"
+        class="{% if object.sticky %}info
+              {% elif s.do_not_grant_xp %}panel-muted
+              {% else %}default{% endif %}"
+        role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
+        <ul id="preview-content-{{s.id}}" class="list-group">
+          <li class="list-group-item list-group-item-buttons">
+              <p>
+                <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+                &nbsp;Loading content...
+                <!-- preview_content_approvals.html via AJAX -->
+              </p>
+          </li>
+        </ul>
+
+        <li class="list-group-item">
+          <form id="quick_reply{{s.id}}" method="POST" enctype="multipart/form-data"
+                action="{% url 'quests:approve' s.id %}">{% csrf_token %}
+            {{ quick_reply_form | crispy }}
+            <div>
+              {% include "quest_manager/submission_buttons_form.html" %}
+              {% include "quest_manager/submission_buttons_other.html" %}
+            </div>
+          </form>
+        </li>
+      </div>
+    {% endfor %}
 
   {% with items=tab.submissions %}
     {% include "quest_manager/pagination_controls.html" %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -51,47 +51,50 @@
         <td class="col-sm-3 hidden-xs">
           {% include "quest_manager/submitted_time.html" %}
         </td>
-
-        {% comment %}
-          ### COLLAPSING CONTENT ###
-          This is the content that is hidden until the row is clicked.
-          ajax_content_loading.html inserts quest content here.
-          If the content hasn't been retrieved yet from the server, a loading icon is displayed.
-        {% endcomment %}
-        {% comment %} Lamma remove class="tab-warning" {% endcomment %}
-        <span style="display: none" id="collapse-quest-{{s.id}}"
-          class="{% if s.is_awaiting_approval %}warning
-                 {% elif s.is_returned %}danger
-                 {% elif s.do_not_grant_xp %}panel-muted
-                 {% else %}default{% endif %}"
-          role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
-          <ul id="preview-content-{{s.id}}" class="list-group" data-completed="{{completed}}" data-past="{{past}}">
-            <li class="list-group-item list-group-item-buttons">
-                <p>
-                  <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-                  &nbsp;Loading content...
-                  <!-- preview_content_submissions.html via AJAX -->
-                </p>
-            </li>
-          </ul>
-          <!-- will load a student quick reply form for submissions that have been returned or handed in -->
-          {% if s.is_returned or completed %}
-            <li class="list-group-item">
-              <form id="quick_reply{{s.id}}" method="POST" enctype="multipart/form-data"
-                    action="{% url 'quests:complete' s.id %}">{% csrf_token %}
-                {{ quick_reply_form | crispy }}
-                <div>
-                  {% include "quest_manager/submission_buttons_form_student.html" %}
-                </div>
-              </form>
-            </li>
-          {% endif %}
-        </span>
-
       </tr>
-    {% endfor %}
+      {% endfor %}
     </tbody>
   </table>
+
+  {% comment %} The hidden content needs to be in its own for loop.
+     Otherwise, additional formatting is applied to it that breaks the form. {% endcomment %}
+  {% for s in submissions%}
+      {% comment %}
+        ### COLLAPSING CONTENT ###
+        This is the content that is hidden until the row is clicked.
+        ajax_content_loading.html inserts quest content here.
+        If the content hasn't been retrieved yet from the server, a loading icon is displayed.
+      {% endcomment %}
+      {% comment %} Lamma remove class="tab-warning" {% endcomment %}
+      <div style="display: none" id="collapse-quest-{{s.id}}"
+        class="{% if s.is_awaiting_approval %}warning
+               {% elif s.is_returned %}danger
+               {% elif s.do_not_grant_xp %}panel-muted
+               {% else %}default{% endif %}"
+        role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
+        <ul id="preview-content-{{s.id}}" class="list-group" data-completed="{{completed}}" data-past="{{past}}">
+          <li class="list-group-item list-group-item-buttons">
+              <p>
+                <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+                &nbsp;Loading content...
+                <!-- preview_content_submissions.html via AJAX -->
+              </p>
+          </li>
+        </ul>
+        <!-- will load a student quick reply form for submissions that have been returned or handed in -->
+        {% if s.is_returned or completed %}
+          <li class="list-group-item">
+            <form id="quick_reply{{s.id}}" method="POST" enctype="multipart/form-data"
+                  action="{% url 'quests:complete' s.id %}">{% csrf_token %}
+              {{ quick_reply_form | crispy }}
+              <div>
+                {% include "quest_manager/submission_buttons_form_student.html" %}
+              </div>
+            </form>
+          </li>
+        {% endif %}
+      </div>
+  {% endfor %}
 
   {% with items=submissions %}
     {% include "quest_manager/pagination_controls.html" %}


### PR DESCRIPTION
### What?
After refactoring the quest lists to be bootstrap-tables, the quick reply forms were broken. 

### Why?
This seems to have been caused by formatting that the bootstrap-table does to any elements that are inside of it.

### How?
I fixed this by moving the hidden content outside of the table. It was placed in its own for loop:

```html
...
          <td class="col-sm-3 hidden-xs">
            {% include "quest_manager/submitted_time.html" %}
          </td>
        </tr>
        {% endfor %}
      </tbody>
    </table>

    {% comment %} The hidden content needs to be in its own for loop.
     Otherwise, additional formatting is applied to it that breaks the form. {% endcomment %}
    {% for s in tab.submissions %}
      {% comment %}
        ### COLLAPSING CONTENT ###
        This is the content that is hidden until the row is clicked.
        ajax_content_loading.html inserts quest content here.
        If the content hasn't been retrieved yet from the server, a loading icon is displayed.
      {% endcomment %}
      <div style="display: none" id="collapse-quest-{{s.id}}"
        class="{% if object.sticky %}info
              {% elif s.do_not_grant_xp %}panel-muted
              {% else %}default{% endif %}"
        role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
        <ul id="preview-content-{{s.id}}" class="list-group">
          <li class="list-group-item list-group-item-buttons">
              <p>
                <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
                &nbsp;Loading content...
                <!-- preview_content_approvals.html via AJAX -->
              </p>
          </li>
        </ul>

        <li class="list-group-item">
          <form id="quick_reply{{s.id}}" method="POST" enctype="multipart/form-data"
                action="{% url 'quests:approve' s.id %}">{% csrf_token %}
            {{ quick_reply_form | crispy }}
            <div>
              {% include "quest_manager/submission_buttons_form.html" %}
              {% include "quest_manager/submission_buttons_other.html" %}
            </div>
          </form>
        </li>
      </div>
    {% endfor %}
...
```

#### "Please read the submission instructions..." Button Problem❗
This was a difficult issue to debug. It was due to the fact that we are inserting content underneath table rows after the page has already loaded. So the event listener was only applied to the versions of the buttons, but not to the ones that were inserted into the page after it had already loaded. The solution was to apply the event listener to the page itself, and delegate it to any elements with the given ID. 

![image](https://github.com/bytedeck/bytedeck/assets/11304586/b220782d-2485-4ef4-9d56-1512d7314bac)

After fixing this issue, I was curious about other event listeners that might have this problem. So I searched for them with the regular expression `\$\([^)]*\)\s*\.on\s*\(['"]click`, and the flag button also had the same problem. It has also been fixed. I have also tried pressing each of the buttons, and they seem to work correctly.

### Testing?
<del>I am planning to write a test for this. I was trying something with selenium, but I can't seem to get it working. Here's what I've tried so far:</del>

❗Since this is an HTML formatting issue, testing would require a frontend testing framework, such as selenium. We've decided not to tackle this for now.

### Screenshots (if front end is affected)

The image below shows how the form was incorrectly closed.
![form_incorrectly_closed](https://github.com/bytedeck/bytedeck/assets/11304586/e05a74c4-4bad-4a43-bc7e-45eca97a68b3)

Here is what it looks like after the fix:
![image](https://github.com/bytedeck/bytedeck/assets/11304586/329ab8b9-8f44-4b8b-9265-ddd605a962fb)


### Anything Else?
<del>As mentioned in the "testing" section, I have been unable to write unit tests for this issue. I am still actively trying to use selenium to ensure that the quick reply functionality works correctly.</del>

Here is the Selenium testing code that I was working on, for future reference:

<details>

<summary>Attempt at Selenium multitenant unit test.</summary>

```py
from django.contrib.staticfiles.testing import StaticLiveServerTestCase
from selenium.webdriver.common.by import By
from selenium.webdriver.firefox.webdriver import WebDriver
from selenium.webdriver.firefox.options import Options as FirefoxOptions
options = FirefoxOptions()
options.add_argument("--headless")


class MySeleniumTests(StaticLiveServerTestCase, TenantTestCase):

    @classmethod
    def setUpClass(cls):
        super().setUpClass()
        cls.client = TenantClient(cls.tenant)
        cls.selenium = WebDriver(options=options)
        cls.selenium.implicitly_wait(1)

        cls.test_student = User.objects.create_user('test_student', password="password")
        # log in the student for all tests here
        cls.client.force_login(cls.test_student)

        cls.quest = baker.make(Quest, xp=5)
        cls.sub = baker.make(QuestSubmission, user=cls.test_student, quest=cls.quest)

        # Assign a unique domain URL to your tenant
        cls.tenant.domain_url = 'testtenant.localhost'
        cls.tenant.save()

    @classmethod
    def tearDownClass(cls):
        cls.selenium.quit()
        super().tearDownClass()

    def test_quickreply_submit_form(self):
        # self.selenium.get(f"{self.live_server_url}" + reverse('quests:inprogress'))
        # page_url = f"http://tenant.test.localhost:8000" + reverse('quests:inprogress')
        page_url = self.live_server_url.replace('localhost', self.tenant.domain_url) + reverse('quests:inprogress')
        print(f"page_url: {page_url}")
        self.selenium.get(page_url)
        print(self.selenium.page_source)
        page_source = self.selenium.page_source
        print(f"404 in page?: {page_source.find('404 Error: Page Not Found.')}")
        
        # find the form
        quick_reply_form = self.selenium.find_element(By.ID, "collapse-quest-0")
        self.assertInHTML("Quick Reply", quick_reply_form.text)
        # click the submit button
        # ...

        self.sub.refresh_from_db()
        self.assertTrue(self.sub.is_completed)
```

</details>

### Review request
@tylerecouture
