### PR TITLE
Fixed Quest List Bugs: Duplicate IDs, Border Styling, Infinite Loading Indicator

### DIFF
--- a/src/quest_manager/static/quest_manager/css/bootstrap-table-accordion.css
+++ b/src/quest_manager/static/quest_manager/css/bootstrap-table-accordion.css
@@ -13,6 +13,10 @@
   border-bottom-width: 2px !important;
 }
 
+.accordian-table {
+  border: transparent;
+}
+
 /* Remove unnecessary transparent border to prevent gaps in row borders */
 .bootstrap-table .table.table-no-bordered > tbody > tr > td,
 .bootstrap-table .table.table-no-bordered > thead > tr > th {
@@ -56,6 +60,7 @@
   background-repeat: repeat-x;
 }
 
+/* ##################################### */
 
 /*============================================
 =            Detailed View Styles            =
@@ -81,12 +86,6 @@
 .detail-view .list-group-item:last-child {
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
-  border-bottom-color: #337ab7;
-}
-
-.detail-view .list-group-item {
-  border-left-color: #337ab7;
-  border-right-color: #337ab7;
 }
 
 .detail-view .list-group {
@@ -113,8 +112,9 @@
 
 /* Updating border-color based on class */
 /* Specify the colors for each class */
-.accordian-table > tbody > tr {
-  --accordian-table-border-color: transparent;
+.accordian-table > tbody > tr,
+.accordian-table > tbody > tr > .collapsing {
+  --accordian-table-border-color: transparent !important;
 }
 
 .accordian-table > tbody > tr > .default {
@@ -123,7 +123,7 @@
 }
 
 .accordian-table > tbody > tr > .muted {
-  --accordian-table-border-color: #333;
+  --accordian-table-border-color: transparent;
 }
 
 .accordian-table > tbody > tr > .warning {

--- a/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
+++ b/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
@@ -26,29 +26,29 @@ $(document).ready(function () {
       var row_html_id = row._id;
       var quest_id = parseInt(row_html_id.match(/\d+$/)[0], 10);
 
-      // Get the hidden span element
-      var $hiddenSpan = $("#collapse-quest-" + quest_id);
+      // Get the hidden div element
+      var $hiddenDIV = $("#collapse-quest-" + quest_id);
 
       $detail.html('<div class="detail-container" style="display:none;"></div>');
-      // Add all classes from the hidden span to the tr.detail-view element
-      $detail.addClass($hiddenSpan.attr('class'));
+      // Add all classes from the hidden div to the tr.detail-view element
+      $detail.addClass($hiddenDIV.attr('class'));
 
       // Get the detail container div
       var $detailContainer = $detail.find('div.detail-container');
 
       // Create a function to update the row's content
       var updateContent = function () {
-        var detailContent = $hiddenSpan.html();
+        var detailContent = $hiddenDIV.html();
         $detailContainer.html(detailContent);
       };
 
       // Update the row's content initially
       updateContent();
 
-      // Create an observer that updates the row's content when the span's content changes
+      // Create an observer that updates the row's content when the div's content changes
       // This is activated when the ajax script updates the quest content
       var observer = new MutationObserver(updateContent);
-      observer.observe($hiddenSpan[0], { childList: true, subtree: true });
+      observer.observe($hiddenDIV[0], { childList: true, subtree: true });
 
       // When the row is expanded, slide down the detail container
       $detailContainer.slideDown();
@@ -58,6 +58,9 @@ $(document).ready(function () {
       // If the row is already expanded, collapse it
       if ($tr.next().is('tr.detail-view')) {
         $tr.removeClass('active');
+        // Add a class to the row before it starts collapsing
+        var $detailViewRow = $tr.next();
+        $detailViewRow.find('td').addClass('collapsing');
         // send slideUp callback to collapseRow. This causes the currently expanded row to collapse
         $tr.next().find('div.detail-container').slideUp(function () {
           $table.bootstrapTable('collapseRow', $tr.data('index'));
@@ -68,6 +71,8 @@ $(document).ready(function () {
         $table.find('tr.active').each(function () {
           var $expandedRow = $(this);
           $expandedRow.removeClass('active');
+          // Add a class to the row before it starts collapsing
+          $expandedRow.next().find('td').addClass('collapsing');
           $expandedRow.next().find('div.detail-container').slideUp(function () {
             $table.bootstrapTable('collapseRow', $expandedRow.data('index'));
           });

--- a/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
+++ b/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
@@ -11,76 +11,73 @@
     - Adding "active" and "collapse" classes to rows when they are expanded or collapsed
 
 */
-$(document).ready(function () {
-  // Changed from id selector to class selector to target all tables with the class '.accordian-table'
-  var $tables = $('.accordian-table');
 
+/**
+     * Collapses the provided row, animates the collapse, moves the content back to its original location,
+     * and updates the Bootstrap table to reflect the row's collapsed state.
+     *
+     * @param {JQuery} $expandedRow - The row to collapse. Should be a JQuery object.
+     * @param {JQuery} $table - The Bootstrap table in which the row is located. Should be a JQuery object.
+     */
+function collapseRow($expandedRow, $table) {
+  $expandedRow.removeClass('active');
+  $expandedRow.next().find('td').addClass('collapsing');
+  const $detailViewRow = $expandedRow.next();
+  const expanded_row_html_id = $expandedRow.attr("id");
+  const expanded_quest_id = parseInt(expanded_row_html_id.match(/\d+$/)[0], 10);
+  const $expanded_hiddenDIV = $detailViewRow.find("#collapse-quest-" + expanded_quest_id);
+
+  $expanded_hiddenDIV.slideUp(function() {
+    // After animation complete, hide the div and append it back to its original parent
+    $expanded_hiddenDIV.hide().appendTo($expanded_hiddenDIV.data('originalParent'));
+    $table.bootstrapTable('collapseRow', $expandedRow.data('index'));
+  });
+}
+
+$(document).ready(function () {
+  // class selector to target all tables with the class '.accordian-table'
+  const $tables = $('.accordian-table');
+
+  // For each table, initialize the Bootstrap Table and add event listeners for expanding/collapsing rows
   $tables.each(function() {
-    var $table = $(this);
+    const $table = $(this);
 
     // Initialize the Bootstrap Table
     $table.bootstrapTable();
 
     $table.on('expand-row.bs.table', function (e, index, row, $detail) {
       // Get the row's html id, then extract the last digit (quest id) from it
-      var row_html_id = row._id;
-      var quest_id = parseInt(row_html_id.match(/\d+$/)[0], 10);
+      const row_html_id = row._id;
+      const quest_id = parseInt(row_html_id.match(/\d+$/)[0], 10);
+      const $hiddenDIV = $("#collapse-quest-" + quest_id);
 
-      // Get the hidden div element
-      var $hiddenDIV = $("#collapse-quest-" + quest_id);
+      // Save the original parent of the hidden div for later use
+      $hiddenDIV.data('originalParent', $hiddenDIV.parent());
 
-      $detail.html('<div class="detail-container" style="display:none;"></div>');
-      // Add all classes from the hidden div to the tr.detail-view element
+      // The primary change is here: instead of copying the content, we're moving it
+      $hiddenDIV.appendTo($detail);
+
+      // Add all classes from the hidden div to the detail element
       $detail.addClass($hiddenDIV.attr('class'));
 
-      // Get the detail container div
-      var $detailContainer = $detail.find('div.detail-container');
-
-      // Create a function to update the row's content
-      var updateContent = function () {
-        var detailContent = $hiddenDIV.html();
-        $detailContainer.html(detailContent);
-      };
-
-      // Update the row's content initially
-      updateContent();
-
-      // Create an observer that updates the row's content when the div's content changes
-      // This is activated when the ajax script updates the quest content
-      var observer = new MutationObserver(updateContent);
-      observer.observe($hiddenDIV[0], { childList: true, subtree: true });
-
-      // When the row is expanded, slide down the detail container
-      $detailContainer.slideDown();
+      // Start animation for expanding
+      // .hide() sets display to none, and slideDown() does animation before setting display to block
+      $hiddenDIV.hide().slideDown();
     });
 
-    $table.on("click-row.bs.table", function (e, row, $tr) {
-      // If the row is already expanded, collapse it
+    $table.on('click-row.bs.table', function (e, row, $tr) {
+      // If the clicked row is already expanded, collapse it
       if ($tr.next().is('tr.detail-view')) {
-        $tr.removeClass('active');
-        // Add a class to the row before it starts collapsing
-        var $detailViewRow = $tr.next();
-        $detailViewRow.find('td').addClass('collapsing');
-        // send slideUp callback to collapseRow. This causes the currently expanded row to collapse
-        $tr.next().find('div.detail-container').slideUp(function () {
-          $table.bootstrapTable('collapseRow', $tr.data('index'));
-        });
-        // If the row is collapsed, expand it
+        collapseRow($tr, $table);
+      // If the clicked row is collapsed, expand it
       } else {
         // Collapse all other expanded rows
         $table.find('tr.active').each(function () {
-          var $expandedRow = $(this);
-          $expandedRow.removeClass('active');
-          // Add a class to the row before it starts collapsing
-          $expandedRow.next().find('td').addClass('collapsing');
-          $expandedRow.next().find('div.detail-container').slideUp(function () {
-            $table.bootstrapTable('collapseRow', $expandedRow.data('index'));
-          });
+          const $expandedRow = $(this);
+          collapseRow($expandedRow, $table);
         });
 
-        // Expand the row
         $table.bootstrapTable('expandRow', $tr.data('index'));
-        // And mark it as expanded
         $tr.addClass('active');
       }
     });

--- a/src/quest_manager/templates/quest_manager/base.html
+++ b/src/quest_manager/templates/quest_manager/base.html
@@ -11,4 +11,11 @@
 {% block heading %}<i class="fa fa-shield pull-right"></i>{% block heading_inner %}{% endblock%}{% endblock %}
 
 {% block content %}{% endblock %}
-{% block js %}{% endblock %}
+{% block js %}
+    {% comment %} ### Import Bootstrap Table JS ### {% endcomment %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.18.3/bootstrap-table.min.js"
+            integrity="sha384-H2wFlf4pp5vxYPba0+XWp9zlTzEKO5Syk7ZZlbgOgZqj5GWvazhyWvq9zHs0INqj"
+            crossorigin="anonymous"></script>
+
+    <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}"></script>
+{% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -26,3 +26,9 @@
         <p>The campaign you're trying to reach is currently unavailable. Please contact your teacher if this comes as a surprise.</p>
     {% endif %}
 {% endblock %}
+
+{% block js%}
+  {{ block.super }}
+
+  {% include "quest_manager/ajax_content_loading.html" %}
+{% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -65,35 +65,35 @@
           <td class="col-sm-1 col-xs-2 text-center">{{q.xp}}</td>
           <td class="col-sm-1 hidden-xs text-center"><small>{{ q.tags.all|join:", "|default:"-" }}</small></td>
           <td id="status-icon-{{q.id}}" class="col-xs-2 hidden-xs text-muted"></td>
-
-          {% comment %}
-            ### COLLAPSING CONTENT ###
-            This is the content that is hidden until the row is clicked.
-            ajax_content_loading.html inserts quest content here.
-            If the content hasn't been retrieved yet from the server, a loading icon is displayed.
-          {% endcomment %}
-          <span style="display: none" id="collapse-quest-{{q.id}}"
-            class="{% if not q.visible_to_students %}danger
-                   {% elif q.expired %}warning
-                   {% else %}default{% endif %}"
-            role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
-            <ul class="list-group">
-              <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
-                  <p>
-                    <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-                    &nbsp;Loading content...
-                    <!-- preview_content_quests_avail.html via AJAX -->
-                  </p>
-              </li>
-            </ul>
-          </span> <!-- accordian panel-collapse -->
-
-
         </tr> <!-- accordian -->
 
       {% endfor %} <!-- for each quest -->
     </tbody>
   </table>
+
+  {% for q in category_displayed_quests %}
+    {% comment %}
+      ### COLLAPSING CONTENT ###
+      This is the content that is hidden until the row is clicked.
+      ajax_content_loading.html inserts quest content here.
+      If the content hasn't been retrieved yet from the server, a loading icon is displayed.
+    {% endcomment %}
+    <div style="display: none" id="collapse-quest-{{q.id}}"
+      class="{% if not q.visible_to_students %}danger
+              {% elif q.expired %}warning
+              {% else %}default{% endif %}"
+      role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
+      <ul class="list-group">
+        <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
+            <p>
+              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+              &nbsp;Loading content...
+              <!-- preview_content_quests_avail.html via AJAX -->
+            </p>
+        </li>
+      </ul>
+    </div> <!-- accordian panel-collapse -->
+  {% endfor %} <!-- for each quest -->
 
 {% else %}
   <p>There are no quests in this campaign.</p>

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -98,14 +98,3 @@
 {% else %}
   <p>There are no quests in this campaign.</p>
 {% endif %}
-
-{% block js %}
-  {% include "quest_manager/ajax_content_loading.html" %}
-
-  {% comment %} ### Import Bootstrap Table JS ### {% endcomment %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.18.3/bootstrap-table.min.js"
-  integrity="sha384-H2wFlf4pp5vxYPba0+XWp9zlTzEKO5Syk7ZZlbgOgZqj5GWvazhyWvq9zHs0INqj"
-  crossorigin="anonymous"></script>
-
-  <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}"></script>
-{% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -57,9 +57,3 @@
 </table>
 
 {% endblock %}
-
-{% block js %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.18.3/bootstrap-table.min.js"
-  integrity="sha384-H2wFlf4pp5vxYPba0+XWp9zlTzEKO5Syk7ZZlbgOgZqj5GWvazhyWvq9zHs0INqj"
-  crossorigin="anonymous"></script>
-{% endblock %}

--- a/src/quest_manager/templates/quest_manager/quest_approval.html
+++ b/src/quest_manager/templates/quest_manager/quest_approval.html
@@ -58,6 +58,9 @@
 {% endblock %}
 
 {% block js %}
+
+{{ block.super }}
+
 <script>
 $( document ).ready(function() {
     // Attach the event to the document and delegate it to elements with ids starting with 'btn_quick_text'
@@ -74,12 +77,5 @@ $( document ).ready(function() {
 {% include "quest_manager/ajax_content_loading.html" %}
 
 {% include "quest_manager/snippets/flag_submissions_scripts.html" %}
-
-{% comment %} ### Import Bootstrap Table JS ### {% endcomment %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.18.3/bootstrap-table.min.js"
-integrity="sha384-H2wFlf4pp5vxYPba0+XWp9zlTzEKO5Syk7ZZlbgOgZqj5GWvazhyWvq9zHs0INqj"
-crossorigin="anonymous"></script>
-
-<script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}"></script>
 
 {% endblock %}

--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -117,15 +117,11 @@
 {% endblock %}
 
 {% block js %}
+  {% comment %} Include from quest_manager/base.html {% endcomment %}
+  {{ block.super }}
+
   {% with quests_available_page=True %}
     {% include "quest_manager/ajax_content_loading.html" %}
   {% endwith %}
-
-  {% comment %} ### Import Bootstrap Table JS ### {% endcomment %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.18.3/bootstrap-table.min.js"
-          integrity="sha384-H2wFlf4pp5vxYPba0+XWp9zlTzEKO5Syk7ZZlbgOgZqj5GWvazhyWvq9zHs0INqj"
-          crossorigin="anonymous"></script>
-
-  <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}"></script>
 
 {% endblock %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -30,7 +30,7 @@
       {% for s in tab.submissions %}
         <tr class="accordian-trigger panel-title
           {% if object.sticky %}info
-          {% elif s.do_not_grant_xp %}panel-muted
+          {% elif s.do_not_grant_xp %}panel-muted muted
           {% else %}default{% endif %}"
           role="tab"
           aria-expanded="{% if s.id == active_id %}true{% else %}false{% endif %}"
@@ -73,7 +73,7 @@
       {% endcomment %}
       <div style="display: none" id="collapse-quest-{{s.id}}"
         class="{% if object.sticky %}info
-              {% elif s.do_not_grant_xp %}panel-muted
+              {% elif s.do_not_grant_xp %}muted
               {% else %}default{% endif %}"
         role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
         <ul id="preview-content-{{s.id}}" class="list-group">

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -48,31 +48,34 @@
           <td class="col-sm-2 text-center hidden-xs"><small>{% if q.campaign %}{{q.campaign}}{% endif %}</small></td>
           <td class="col-sm-1 text-center hidden-xs"><small>{{ q.tags.all|join:", "|default:"-" }}</small></td>
           <td id="status-icon-{{q.id}}" class="col-xs-2 hidden-xs text-muted"></td>
-          {% comment %}
-            ### COLLAPSING CONTENT ###
-            This is the content that is hidden until the row is clicked.
-            ajax_content_loading.html inserts quest content here.
-            If the content hasn't been retrieved yet from the server, a loading icon is displayed.
-          {% endcomment %}
-          <span style="display: none" id="collapse-quest-{{q.id}}"
-            class="{% if not q.visible_to_students %}danger
-                   {% elif q.expired %}warning
-                   {% else %}default{% endif %}"
-            role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
-            <ul class="list-group">
-              <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
-                  <p>
-                    <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-                    &nbsp;Loading content...
-                    <!-- preview_content_quests_avail.html via AJAX -->
-                  </p>
-              </li>
-            </ul>
-          </span>
         </tr>
       {% endfor %}
     </tbody>
   </table>
+
+  {% for q in available_quests %}
+    {% comment %}
+      ### COLLAPSING CONTENT ###
+      This is the content that is hidden until the row is clicked.
+      ajax_content_loading.html inserts quest content here.
+      If the content hasn't been retrieved yet from the server, a loading icon is displayed.
+    {% endcomment %}
+    <div style="display: none" id="collapse-quest-{{q.id}}"
+      class="{% if not q.visible_to_students %}danger
+              {% elif q.expired %}warning
+              {% else %}default{% endif %}"
+      role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
+      <ul class="list-group">
+        <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
+            <p>
+              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+              &nbsp;Loading content...
+              <!-- preview_content_quests_avail.html via AJAX -->
+            </p>
+        </li>
+      </ul>
+    </div>
+  {% endfor %}
 {% else %}
   <p>No quests are available.</p>
 {% endif %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -29,7 +29,7 @@
       <tr class="accordian-trigger panel-title
         {% if s.is_awaiting_approval %}warning
         {% elif s.is_returned %}danger
-        {% elif s.do_not_grant_xp %}panel-muted
+        {% elif s.do_not_grant_xp %}panel-muted muted
         {% else %}default{% endif %}"
         role="tab"
         aria-expanded="{% if s.id == active_id %}true{% else %}false{% endif %}"
@@ -68,11 +68,10 @@
         ajax_content_loading.html inserts quest content here.
         If the content hasn't been retrieved yet from the server, a loading icon is displayed.
       {% endcomment %}
-      {% comment %} Lamma remove class="tab-warning" {% endcomment %}
       <div style="display: none" id="collapse-quest-{{s.id}}"
         class="{% if s.is_awaiting_approval %}warning
                {% elif s.is_returned %}danger
-               {% elif s.do_not_grant_xp %}panel-muted
+               {% elif s.do_not_grant_xp %}muted
                {% else %}default{% endif %}"
         role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
         <ul id="preview-content-{{s.id}}" class="list-group" data-completed="{{completed}}" data-past="{{past}}">


### PR DESCRIPTION
## What?
There were still a few major issues with the bootstrap-table quest lists that needed to be worked out. These included:

- **Duplicate IDs**: When a quest was clicked and the detailed content was shown, the content was duplicated from another source. Since the HTML DOM elements contained IDs (which are supposed to be kept unique), the JavaScript code wasn’t sure which elements to target. As a result, it would simply target elements that were closer to the top of the tree. This resulted in several issues, including the loading indicator being shown forever.
- **Reduce JavaScript Includes**: Some JavaScript includes (bootstrap-table.min.js and bootstrap-table-accordion.js) were done multiple times in multiple files, so they were moved to base.html.
- **Bad Table Styling**: Some table styles related to borders were improved.

## Why?
These issues would reduce user satisfaction and make the project more difficult to maintain in the long term.

## How?

### Expand/Collapse JavaScript Refactoring
Perhaps the biggest change was to the bootstrap-table-accordion.js, which is responsible for handling expanding/collapsing of quest list rows when the user clicks them. Previously, when content was being inserted underneath a quest row, it was duplicated from a hidden DIV element that existed elsewhere on the page. The hidden DIV was meant to hold the content while the row was collapsed, allowing for the ajax_content_loading.html script to load content while a row was still collapsed.

This duplication of HTML code resulted in unexpected issues, such as the element IDs existing in more than one place. This created several problems, such as the loading indicator being displayed forever if a row was expanded before it had its content inserted, then had its content inserted before being collapsed/expanded again. The reason was that the ajax_content_loading.html script would target the duplicated element. It would insert the content into the duplicated code that was inserted underneath the row, rather than in the original hidden DIV element.

The solution to this was to "move" the hidden DIV underneath the row, rather than duplicate it. This greatly simplified the expanding/collapsing process. Not implementing it this way in the first place was a definite oversight on my part.

### Table Border Styling Fixed for Muted and Collapsed Rows, and Table in Mobile View (#1403 and #1409)
I made some changes to the bootstrap-table-accordion CSS. Firstly, the border around the table in the mobile view is removed. Second, the border is made invisible while a table row is collapsing. And third, the border was removed around the "muted" expanded rows.

```css
/* Fixes #1409 */
.accordian-table {
  border: transparent;
}
.accordian-table > tbody > tr,
.accordian-table > tbody > tr > .collapsing {
  --accordian-table-border-color: transparent !important;
}
/* Fixes #1403 */
.accordian-table > tbody > tr > .muted {
  --accordian-table-border-color: transparent;
}
```

### JavaScript Includes Moved to `quest_manager/base.html`
Since several of the templates in the quest_manager app make use of the bootstrap-table library, I moved the script includes to `quest_manager/base.html`:
```html
{% block js %}
    {% comment %} ### Import Bootstrap Table JS ### {% endcomment %}
    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.18.3/bootstrap-table.min.js"
            integrity="sha384-H2wFlf4pp5vxYPba0+XWp9zlTzEKO5Syk7ZZlbgOgZqj5GWvazhyWvq9zHs0INqj"
            crossorigin="anonymous"></script>

    <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}"></script>
{% endblock %}
```

Since other scripts included the `ajax_content_loading.html` script in their JS blocks, I had to use the `{{ block.super }}` tag in some of the templates, such as here in `quest.html`:
```
{% block js %}
  {% comment %} Include from quest_manager/base.html {% endcomment %}
  {{ block.super }}

  {% with quests_available_page=True %}
    {% include "quest_manager/ajax_content_loading.html" %}
  {% endwith %}

{% endblock %}
```

## Testing?
I spent time clicking through the various options that were previously broken, such as the quick reply form, the "Please read submission instruction more carefully..." button, the flag button, etc.

It would also be helpful if the reviewer checked out these changes to make sure nothing is broken.

## Screenshots (if front end is affected)

<details>

<summary>Top Border Fixed in Mobile View</summary>

![image](https://github.com/bytedeck/bytedeck/assets/11304586/f698615d-dc19-4499-a13c-a15c162b492b)

</details>

<details>

<summary>Expanded content for muted rows is no longer muted</summary>

![image](https://github.com/bytedeck/bytedeck/assets/11304586/63ef1d45-fc7f-4f88-a66b-1661366421e0)

![image](https://github.com/bytedeck/bytedeck/assets/11304586/bfa45c39-6727-4215-a86b-10f1e92f6e6e)


</details>

<details>

<summary>While a row is collapsing, the border is removed</summary>

![image](https://github.com/bytedeck/bytedeck/assets/11304586/3ad1f3cb-d407-45ab-9fa8-07c985d0e0b3)


</details>

## Anything Else?
I looked into fixing #1407, but I'm not sure if it is still issue. I'm also not entirely sure of the intended behavior. Based on the code and comments in `quest_manager/ajax_content_loading.html`, it looks like the hidden labels are only meant to show up in the quests available tab? But some comments seem to indicate that they should also show up in the quest approvals tab, They do show up in the quests available tab for me, but not in the approvals tab. I may need a bit longer to investigate this.

## Review request
@tylerecouture 