### PR TITLE
Added proper sorting to status column; Closes #1406

### DIFF
--- a/src/quest_manager/templates/quest_manager/snippets/submission_status_timestamp.html
+++ b/src/quest_manager/templates/quest_manager/snippets/submission_status_timestamp.html
@@ -1,0 +1,17 @@
+{% comment %} Hidden column to allow sorting by time since quest completion {% endcomment %}
+{% comment %} Uses same logic defined in `quest_manager/snippets/submitted_status.html` for getting the submission time {% endcomment %}
+{% if s.is_approved %}
+  {{s.time_approved|date:"U"}}
+{% elif s.is_awaiting_approval %}
+  {{s.time_completed|date:"U"}}
+{% elif s.is_returned %}
+  {% if s.time_returned %}
+    {{s.time_returned|date:"U"}}
+  {% else %}
+    {% comment %} If this quest was returned an unknown time ago, assume it was a very long time ago {% endcomment %}
+    0
+  {% endif %}
+{% else %}
+  {% comment %} If the quest is currently in progress, get the timestamp for now {% endcomment %}
+  {% now "U" %}
+{% endif %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -23,7 +23,10 @@
         <th class="col-sm-1 col-xs-2" data-field="xp" data-sortable="true">XP</th>
         <th class="col-sm-1 hidden-xs" data-field="group_name" data-sortable="true">{% group_name %}</th>
         <th class="col-sm-2 col-xs-3 hidden-xs" data-field="user" data-sortable="true">User</th>
-        <th class="col-sm-3 hidden-xs" data-field="status" data-sortable="true">Status</th>
+        <!-- Uses `status_timestamps` for sorting the status column by the submission time -->
+        <th class="col-sm-3 hidden-xs" data-field="status" data-sortable="true" data-sort-name="status_timestamps">Status</th>
+        <th data-field="status_timestamps" data-switchable="false" data-visible="false"></th>
+        <!-- End sorting group -->
       </tr>
     </thead>
     <tbody class="panel-group panel-group-packed" role="tablist" aria-multiselectable="true">
@@ -57,6 +60,11 @@
           <td class="col-sm-3 hidden-xs">
             {% include "quest_manager/snippets/submitted_status.html" %}
           </td>
+          <!-- `status_timestamps` -->
+          <td>
+            {% include "quest_manager/snippets/submission_status_timestamp.html" %}
+          </td>
+          <!-- end `status_timestamps` -->
         </tr>
         {% endfor %}
       </tbody>

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -21,7 +21,10 @@
         <th class="col-sm-1 text-right col-xs-2" data-field="xp" data-sortable="true">XP</th>
         <th class="col-sm-2 text-right hidden-xs" data-field="campaign" data-sortable="true">Campaign</th>
         <th class="col-sm-1 text-center hidden-xs" data-field="tags" data-sortable="true">{{ config.custom_name_for_tag }}s</th>
-        <th class="col-sm-3 hidden-xs" data-field="status" data-sortable="true">Status</th>
+        <!-- Uses `status_timestamps` for sorting the status column by the submission time -->
+        <th class="col-sm-3 hidden-xs" data-field="status" data-sortable="true" data-sort-name="status_timestamps">Status</th>
+        <th data-field="status_timestamps" data-switchable="false" data-visible="false"></th>
+        <!-- End sorting group -->
       </tr>
     </thead>
     <tbody role="tablist" aria-multiselectable="true">
@@ -54,6 +57,11 @@
         <td class="col-sm-3 hidden-xs">
           {% include "quest_manager/snippets/submitted_status.html" %}
         </td>
+        <!-- `status_timestamps` -->
+        <td>
+          {% include "quest_manager/snippets/submission_status_timestamp.html" %}
+        </td>
+        <!-- end `status_timestamps` -->
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## What?
Previously, in the `/quests/completed/`, `/quests/inprogress/`, and `/quests/approvals/` pages, the status column was not sorted correctly, defaulting to alphabetic sorting. The column is now sorted by the time since the user submitted their quest.

## Why?
Sorting by submission time should make the site easier for students and admins to manage their quests. Namely, it should allow admins to more easily keep track of which quests were submitted a long time ago and should be addressed.

## How?
This was done by adding a new hidden column to the quest list table. The new column holds the timestamp for when the quest was submitted. This essentially involved the code shown below:

`quest_manager/tab_quest_submission.html`
```html
<!-- Uses `status_timestamps` for sorting the status column by the submission time -->
        <th class="col-sm-3 hidden-xs" data-field="status" data-sortable="true" data-sort-name="status_timestamps">Status</th>
        <th data-field="status_timestamps" data-switchable="false" data-visible="false"></th>
        <!-- End sorting group -->
```

`quest_manager/snippets/submission_status_timestamp.html`
```html
{% comment %} Hidden column to allow sorting by time since quest completion {% endcomment %}
{% if s.is_approved %}
  {{s.time_approved|date:"U"}}
{% elif s.is_awaiting_approval %}
  {{s.time_completed|date:"U"}}
{% elif s.is_returned %}
  {% if s.time_returned %}
    {{s.time_returned|date:"U"}}
  {% else %}
    {% comment %} If this quest was returned an unknown time ago, assume it was a very long time ago {% endcomment %}
    0
  {% endif %}
{% else %}
  {% comment %} If the quest is currently in progress, get the timestamp for now {% endcomment %}
  {% now "U" %}
{% endif %}
```

As you can see, I created a new snippet to keep track of the logic for getting the timestamp. It uses the same logic that was defined in `quest_manager/snippets/submitted_status.html` for getting the submission time. This was done to reduce the repetition of code. But since this snippet is small and relatively simple, moving it into each file and thereby repeating it would also be a good option.

## Testing?
I spent time trying the sorting on different tabs with quests having different submission statuses. They all seemed to sort correctly. 

## Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/11304586/d9587148-2c39-482b-8f91-e28c33e73573)
![image](https://github.com/bytedeck/bytedeck/assets/11304586/e132dd22-2260-499d-8163-29fd5fee3a1c)

## Anything Else?
## Review request
@tylerecouture
