### PR TITLE
Refactored status icons column in quest list; Closes #1407

### DIFF
--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -92,9 +92,6 @@
               var preview_content_selector = "#preview-content-" + id;
               var hidden_selector = "#status-icon-" + id;
 
-              //console.log(preview_content_selector);
-              //console.log(ajax_url);
-
               $.ajax({
                   type: "POST",
                   url: ajax_url,
@@ -104,26 +101,6 @@
                   success: function (data) {
                       //console.log(data)
                       $(preview_content_selector).html(data.quest_info_html);
-
-                      // Quest status icons
-                      if (data.is_prerequisite) {
-                          $(hidden_selector).append("<i title='Prerequisite: completing this will cause additional quests to become available' class='icon-spacing fa fa-fw fa-share-alt'></i>");
-                      }
-                      else {
-                          $(hidden_selector).append("<i class='icon-spacing fa fa-fw'></i>");
-                      }
-                      if (data.is_repeatable) {
-                          $(hidden_selector).append("<i title='Repeat: this quest is repeatable' class='icon-spacing fa fa-fw fa-undo'></i>");
-                      }
-                      else {
-                          $(hidden_selector).append("<i class='icon-spacing fa fa-fw'></i>");
-                      }
-                      if (data.is_hidden) {
-                          $(hidden_selector).append("<i title='Hidden: this quest is on your hidden list' class='icon-spacing fa fa-fw fa-eye-slash'></i>");
-                      }
-                      else {
-                          $(hidden_selector).append("<i class='icon-spacing fa fa-fw'></i>");
-                      }
 
                       $('div.pack').pack()
                   },

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -50,8 +50,13 @@
           </td>
           <td class="col-sm-1 col-xs-2 text-center">{{q.xp}}{% if q.xp_can_be_entered_by_students %}+{% endif %}</td>
           <td class="col-sm-2 text-center hidden-xs"><small>{% if q.campaign %}{{q.campaign}}{% endif %}</small></td>
-          <td class="col-sm-1 text-center hidden-xs"><small>{{ q.tags.all|join:", "|default:"-" }}</small></td>
-          <td id="status-icon-{{q.id}}" class="col-xs-2 hidden-xs text-muted"></td>
+          <td class="col-sm-2 text-center hidden-xs"><small>{{ q.tags.all|join:", "|default:"-" }}</small></td>
+          <td id="status-icon-{{q.id}}" class="col-sm-1 hidden-xs text-muted">
+            {% if q.max_repeats != 0 %}<i title='Repeat: this quest is repeatable' class='icon-spacing fa fa-fw fa-undo'></i>
+            {% else %}<i class='icon-spacing fa fa-fw'></i>{% endif %}
+            {% if q.blocking %}<i title='Blocking: all other quests are unavailable until you complete this one.' class='icon-spacing fa fa-fw fa-exclamation-triangle'></i>
+            {% else %}<i class='icon-spacing fa fa-fw'></i>{% endif %}
+          </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -43,7 +43,7 @@
         <td class="col-sm-1 col-xs-2 col-icon">
           <img class="img-responsive panel-title-img img-rounded" src="{{ s.quest.get_icon_url }}" alt="icon"/>
         </td>
-        <td class="col-sm-5 col-xs-8">{{s.quest_name}}</td>
+        <td class="col-sm-4 col-xs-8">{{s.quest_name}}</td>
         <td class="col-sm-1 col-xs-2 text-center">
           {% if s.do_not_grant_xp %}<span title="Skipped quests do not grant XP">0*</span>
           {% elif s.quest.xp_can_be_entered_by_students %}<span title="XP requested by student">{{s.xp_requested}}*</span>
@@ -53,7 +53,7 @@
         <td class="col-sm-2 text-center hidden-xs"><small>
           {{ s.quest.campaign|default:"-" }}
         </small></td>
-        <td class="col-sm-1 text-center hidden-xs"><small>{{ s.quest.tags.all|join:", "|default:"-" }}</small></td>
+        <td class="col-sm-2 text-center hidden-xs"><small>{{ s.quest.tags.all|join:", "|default:"-" }}</small></td>
         <td class="col-sm-3 hidden-xs">
           {% include "quest_manager/snippets/submitted_status.html" %}
         </td>

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -510,18 +510,12 @@ def ajax_quest_info(request, quest_id=None):
 
         if quest_id:
             quest = get_object_or_404(Quest, pk=quest_id)
-            is_hidden = request.user.profile.is_quest_hidden(quest)
-            is_repeatable = quest.is_repeatable()
-            is_prerequisite = quest.is_used_prereq()
 
             template = "quest_manager/preview_content_quests_avail.html"
             quest_info_html = render_to_string(template, {"q": quest}, request=request)
 
             data = {
-                "quest_info_html": quest_info_html,
-                "is_hidden": is_hidden,
-                "is_repeatable": is_repeatable,
-                "is_prerequisite": is_prerequisite,
+                "quest_info_html": quest_info_html
             }
 
             # JsonResponse new in Django 1.7 is equivalent to:


### PR DESCRIPTION
### What?
As per #1407, the status icons column in the quest list had some strange behaviors, such as sometimes showing the same icon multiple times.

 The other icons (Prerequisite and Hidden) are no longer displayed. Blocking quests were given the [fa-exclamation-triangle](https://fontawesome.com/v4/icon/exclamation-triangle) font-awesome icon.

### Why?
This column provides useful insight to students and teachers, and it should work properly.

### How?
Django templating is now used to display the icons rather than JavaScript (which was used previously).

```html
<td id="status-icon-{{q.id}}" class="col-sm-1 hidden-xs text-muted">
  {% if q.max_repeats != 0 %}<i title='Repeat: this quest is repeatable' class='icon-spacing fa fa-fw fa-undo'></i>
  {% else %}<i class='icon-spacing fa fa-fw'></i>{% endif %}
  {% if q.blocking %}<i title='Blocking: all other quests are unavailable until you complete this one.' class='icon-spacing fa fa-fw fa-exclamation-triangle'></i>
  {% else %}<i class='icon-spacing fa fa-fw'></i>{% endif %}
</td>
```

The old JavaScript code was also removed.

### Testing?
Only manual clickthrough testing was done. I tried making quests repeatable, and setting them to be blocking, as the icons showed up accordingly. 

### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/11304586/9717f9cb-3804-4ac9-82ea-fba52cd87342)
![image](https://github.com/bytedeck/bytedeck/assets/11304586/34280dbd-8733-4da9-8a54-d041556f1886)

### Anything Else?


### Review request
@tylerecouture
