### PR TITLE
fix: slug validation on tag creation and tag deletion info; Closes #1282

### DIFF
--- a/src/tags/forms.py
+++ b/src/tags/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.utils.text import slugify
+from django.core.validators import validate_slug
 
 from taggit.models import Tag
 
@@ -22,9 +23,15 @@ class TagForm(forms.ModelForm):
         model = Tag
         fields = ['name']
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['name'].validators = [validate_slug]
+        self.fields['name'].help_text = 'Tags cannot contain spaces, use hyphens to create multi-word-tags-like-this'
+
     def save(self, *args):
         # will be saved on super func, assuming commit=True
-        # necessary since slug is unique=True, so we use unique name to generate a new slug to prevent possible duplicates
+        # save method override necessary since slug is unique=True, so we use unique name to generate a new slug to prevent possible duplicates
+        # without it, updating a tag and assigning it to an object will actually re-create the OLD tag and assign that instead...
         self.instance.slug = slugify(self.cleaned_data['name'])
 
         return super().save(*args)

--- a/src/tags/templates/tags/snippets/related-xp-item.html
+++ b/src/tags/templates/tags/snippets/related-xp-item.html
@@ -5,7 +5,6 @@
         <div class="panel-body">
             <ul>
                 {% if view == 'staff' %}
-
                     {% for quest in quests %}
                         <li><a href="{{ quest.get_absolute_url }}">{{ quest }} ({{ quest.xp }} XP)</a></li>
                     {% empty %}

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -207,6 +207,21 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         self.assertTrue(Tag.objects.filter(name=form_data['name']).exists())
 
+    def test_CreateView__slug_validation(self):
+        """
+        Invalid slug names provided to Tag CreateView should be rejected
+        validator that must be passed (validate-slug):
+        https://docs.djangoproject.com/en/3.2/ref/validators/#validate-slug
+        """
+        self.client.force_login(self.test_teacher)
+
+        # post to create form with an invalid name to trigger validator 'validate_slug'
+        response = self.client.post(reverse('tags:create'), data={'name': 'invalid name'})
+
+        # assert object is not created and error message displayed
+        self.assertContains(response, 'Enter a valid “slug” consisting of letters, numbers, underscores or hyphens.')
+        self.assertFalse(Tag.objects.filter(name='invalid name').exists())
+
     def test_UpdateView(self):
         """Make sure update view can change name + update slug"""
         form_data = generate_form_data(model_form=TagForm)

--- a/src/tags/views.py
+++ b/src/tags/views.py
@@ -198,6 +198,7 @@ class TagDelete(NonPublicOnlyViewMixin, DeleteView):
     success_url = reverse_lazy('tags:list')
 
     def get_context_data(self, **kwargs):
+        kwargs['view'] = 'staff'
         kwargs['quests'] = Quest.objects.filter(tags__id=self.object.id)
         kwargs['badges'] = Badge.objects.filter(tags__id=self.object.id)
         return super().get_context_data(**kwargs)


### PR DESCRIPTION
### What?
This is a fix for the tag create/delete views that remedies two issues:
- The tag create view would not validate tag names properly, causing duplicate tags to be created when accessed through any other view/form
- The tag delete view would not display related quest/badge information on the confirmation page

### Why?
both of these are unintended bugs that create problems when encountered that are severe enough to warrant remediation:
- duplicate tags cause bloat and unintentional inconsistencies in tag organization
- incomplete information regarding the deletion of tags could lead to tags being deleted by mistake

### How?
a form field validator was added in a newly created __init__ method for the tag form.
additionally, a missing context variable was added to the tag delete view that was preventing information from being displayed.

### Testing?
a test for name validation during tag creation has been implemented.

### Screenshots (if front end is affected)
new tag create view with implemented help text and visible validation failure
![image](https://github.com/bytedeck/bytedeck/assets/105619909/7f85d104-5e82-493a-9a7b-6a6e18156de4)

delete view confirmation prior to fix (missing one related quest)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/ba8e6ca0-67ac-4364-bec9-c8c25913b960)

delete view confirmation after fix (no assignations changed)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/d0ac1370-6b10-47d0-bc2e-44e2037e8ef4)

### Review request
@tylerecouture
