### PR TITLE
fix: add tag duplicate name/slug protection validator; Closes #1351

### DIFF
--- a/src/tags/forms.py
+++ b/src/tags/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.utils.text import slugify
 from django.core.validators import validate_slug
+from django.core.exceptions import ValidationError
 
 from taggit.models import Tag
 
@@ -17,6 +18,19 @@ class BootstrapTaggitSelect2Widget(TaggitSelect2Widget):
         }
 
 
+def validate_unique_slug(value):
+    """
+    Names that are not unique after being converted to a slug should be detected and rejected during validation
+    i.e 'TEST-TAG' should not be accepted if tag named 'test-tag' exists, because names will be identical after processing, breaking unique=true
+    """
+    # check all tag objects for a slug identical to inputted name after being slugified
+    duplicate_slug = Tag.objects.all().filter(slug=slugify(value))
+
+    if duplicate_slug.exists():
+        # if true, duplicate_slug is a 1-item queryset, calling .first() retrieves that item as a callable object
+        raise ValidationError(f"Tag name too similar to existing tag: {duplicate_slug.first()}")
+
+
 class TagForm(forms.ModelForm):
 
     class Meta:
@@ -25,13 +39,17 @@ class TagForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['name'].validators = [validate_slug]
+        self.fields['name'].validators = [validate_slug, validate_unique_slug]
         self.fields['name'].help_text = 'Tags cannot contain spaces, use hyphens to create multi-word-tags-like-this'
 
     def save(self, *args):
         # will be saved on super func, assuming commit=True
-        # save method override necessary since slug is unique=True, so we use unique name to generate a new slug to prevent possible duplicates
-        # without it, updating a tag and assigning it to an object will actually re-create the OLD tag and assign that instead...
-        self.instance.slug = slugify(self.cleaned_data['name'])
+        # save method override necessary since slug is unique=True, so we use unique name to generate a new slug to prevent duplicates
+        # slugify name upon saving to keep consistency among all tag object names
+
+        # save override necessary for update view to properly update tag slugs, assigning a tag with a changed name to an object will instead create
+        # a new tag with the OLD name because tag slug hasn't changed
+        self.instance.name = slugify(self.cleaned_data['name'])
+        self.instance.slug = self.instance.name
 
         return super().save(*args)

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -5,6 +5,8 @@ from django.core import signing
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
+from django.utils.text import slugify
+
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 
@@ -205,14 +207,17 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.client.force_login(self.test_teacher)
         self.client.post(reverse('tags:create'), data=form_data)
 
-        self.assertTrue(Tag.objects.filter(name=form_data['name']).exists())
+        self.assertTrue(Tag.objects.filter(name=slugify(form_data['name'])).exists())
 
     def test_CreateView__slug_validation(self):
         """
         Invalid slug names provided to Tag CreateView should be rejected
-        validator that must be passed (validate-slug):
-        https://docs.djangoproject.com/en/3.2/ref/validators/#validate-slug
+        validators that must be passed:
+        validate_slug https://docs.djangoproject.com/en/3.2/ref/validators/#validate-slug
+        validate_unique_slug (custom validator, located at tags.forms.validate_unique_slug)
         """
+
+        # login a teacher to create tags
         self.client.force_login(self.test_teacher)
 
         # post to create form with an invalid name to trigger validator 'validate_slug'
@@ -222,6 +227,13 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertContains(response, 'Enter a valid “slug” consisting of letters, numbers, underscores or hyphens.')
         self.assertFalse(Tag.objects.filter(name='invalid name').exists())
 
+        # post to create form with non-unique (after slugification) name to trigger validator 'validate_unique_slug'
+        response = self.client.post(reverse('tags:create'), data={'name': 'TEST-TAG'})
+
+        # assert object is not created and error message displayed
+        self.assertContains(response, 'Tag name too similar to existing tag: test-tag')
+        self.assertFalse(Tag.objects.filter(name='TEST-TAG').exists())
+
     def test_UpdateView(self):
         """Make sure update view can change name + update slug"""
         form_data = generate_form_data(model_form=TagForm)
@@ -230,7 +242,8 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.client.post(reverse('tags:update', args=[self.tag.pk]), data=form_data)
 
         tag = Tag.objects.get(pk=self.tag.pk)  # refresh object
-        self.assertEqual(form_data['name'], tag.name)
+        # Form data is set to lowercase as a part of form submission, final name/slug will be lowercase of what was entered
+        self.assertEqual(form_data['name'].lower(), tag.name)
         self.assertEqual(form_data['name'].lower(), tag.slug)
 
     def test_DeleteView(self):


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
This PR is the implementation of a new validator for tag creation that checks to make sure tags with unique names that would be accepted as unique, but after processing into slugs, would potentially become identical to existing tags, breaking the unique=true constraint and raising a duplicate key error.
 
### Why?
in production, no actual errors should be raised when preventable problems arise. Instead, they should be caught with appropriate error messages displayed so users can course-correct.

### How?
a new validator function has been defined in tags.forms and added to the name field of the tag form.

### Testing?
the slug validation test that had already existed for the name field, where the new validator has been implemented, has been expanded to include this new validator.

### Screenshots (if front end is affected)
error message when problem case occurs:
![image](https://github.com/bytedeck/bytedeck/assets/105619909/dbecdd74-98a6-42a5-9153-6c07fc96d582)

### Review request
@tylerecouture
