### PR TITLE
Added FILE_MIME_TYPES Constant and Set Default content_type for RestrictedFileField to 'All'

### DIFF
--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -10,6 +10,40 @@ from queryset_sequence import QuerySetSequence
 from .widgets import GFKSelect2Widget
 
 
+# common file MIME types to be uploaded by users
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types
+
+IMAGE_MIME_TYPES = [
+    'image/jpeg',  # JPEG images
+    'image/png',   # PNG images
+    'image/gif',   # GIF images
+    'image/webp',  # WEBP images
+    'image/tiff',  # TIFF images
+    'image/bmp',   # BMP images
+    'image/svg+xml'  # SVG vector images
+]
+
+VIDEO_MIME_TYPES = [
+    'video/mp4',   # MP4 videos
+    'video/webm',  # WebM videos
+    'video/ogg',   # OGG videos
+    'video/quicktime',  # MOV videos
+    'video/x-msvideo',  # AVI videos
+    'video/x-ms-wmv',  # WMV videos
+    'video/mpeg',  # MPEG videos
+    'video/3gpp',  # 3GP videos
+    'video/3gpp2',  # 3G2 videos
+    'video/x-flv',  # FLV videos
+    'video/x-m4v'  # M4V videos
+]
+
+FILE_MIME_TYPES = {
+    'image': IMAGE_MIME_TYPES,
+    'video': VIDEO_MIME_TYPES,
+    'media': IMAGE_MIME_TYPES + VIDEO_MIME_TYPES
+}
+
+
 class GFKChoiceIterator(ModelChoiceIterator):
 
     def __iter__(self):

--- a/src/utilities/models.py
+++ b/src/utilities/models.py
@@ -21,7 +21,7 @@ class RestrictedFileField(models.FileField):
     """
 
     def __init__(self, **kwargs):
-        self.content_types = kwargs.pop("content_types", ["text/css"])
+        self.content_types = kwargs.pop("content_types", "All")
         self.max_upload_size = kwargs.pop("max_upload_size", 512000)
 
         super().__init__(**kwargs)

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -6,7 +6,8 @@ from django.core.exceptions import ValidationError
 from django_tenants.test.cases import TenantTestCase
 from queryset_sequence import QuerySetSequence
 
-from utilities.fields import GFKChoiceField
+from utilities.fields import GFKChoiceField, RestrictedFileFormField
+from utilities.models import RestrictedFileField
 
 
 User = get_user_model()
@@ -57,3 +58,33 @@ class GFKChoiceFieldTest(TenantTestCase):
 
         self.assertEqual(f.clean(self._ct_pk(self.user2)).get_full_name(), "Jane Doe")
         self.assertEqual(f.clean(self._ct_pk(self.group1)).name, "Editors")
+
+
+class RestrictedFileFieldTest(TenantTestCase):
+    def setUp(self):
+        self.default_file_field = RestrictedFileField()
+        self.image_file_field = RestrictedFileField(content_types=['image/jpeg', 'image/png'])
+
+    def test_content_type(self):
+        "Ensure the default content type is 'All', and that the content type can be set correctly."
+
+        # ensure default content type is 'All'
+        self.assertEqual(self.default_file_field.content_types, 'All')
+
+        # ensure content type is set correctly
+        self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])
+
+
+class RestrictedFileFormFieldTest(TenantTestCase):
+    def setUp(self):
+        self.default_file_field = RestrictedFileFormField()
+        self.image_file_field = RestrictedFileFormField(content_types=['image/jpeg', 'image/png'])
+
+    def test_content_type(self):
+        "Ensure the default content type is 'All', and that the content type can be set correctly."
+
+        # ensure default content type is 'All'
+        self.assertEqual(self.default_file_field.content_types, 'All')
+
+        # ensure content type is set correctly
+        self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])


### PR DESCRIPTION
### What?
I changed the default content_type for `RestrictedFileField` to 'All'. This is the same as for `RestrictedFileFormField`, which already had this default setting. This doesn't break anything, since content_type was already set manually everywhere `RestrictedFileField` is used.

I also added a `FILE_MIME_TYPES` constant in utilities/fields.py`.

### Why?
We are planning to use the `RestrictedFileField` and `RestrictedFileFormField` for the quest question models and forms. These changes will give us a smoother development process.

### How?

```py
class RestrictedFileField(models.FileField):
    ...
    def __init__(self, **kwargs):
        self.content_types = kwargs.pop("content_types", "All")
        ...
```

The `FILE_MIME_TYPES` constant was added to `utilities/fields.py` as follows:
```py
# common file MIME types to be uploaded by users
# https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types

IMAGE_MIME_TYPES = [
    'image/jpeg',  # JPEG images
    'image/png',   # PNG images
    'image/gif',   # GIF images
    'image/webp',  # WEBP images
    'image/tiff',  # TIFF images
    'image/bmp',   # BMP images
    'image/svg+xml'  # SVG vector images
]

VIDEO_MIME_TYPES = [
    'video/mp4',   # MP4 videos
    'video/webm',  # WebM videos
    'video/ogg',   # OGG videos
    'video/quicktime',  # MOV videos
    'video/x-msvideo',  # AVI videos
    'video/x-ms-wmv',  # WMV videos
    'video/mpeg',  # MPEG videos
    'video/3gpp',  # 3GP videos
    'video/3gpp2',  # 3G2 videos
    'video/x-flv',  # FLV videos
    'video/x-m4v'  # M4V videos
]

FILE_MIME_TYPES = {
    'image': IMAGE_MIME_TYPES,
    'video': VIDEO_MIME_TYPES,
    'media': IMAGE_MIME_TYPES + VIDEO_MIME_TYPES
}
```
### Testing?
I added a few simple tests for the content types of `RestrictedFileField` and `RestrictedFileFormField`. 

```py
class RestrictedFileFieldTest(TenantTestCase):
    def setUp(self):
        self.default_file_field = RestrictedFileField()
        self.image_file_field = RestrictedFileField(content_types=['image/jpeg', 'image/png'])

    def test_content_type(self):
        "Ensure the default content type is 'All', and that the content type can be set correctly."

        # ensure default content type is 'All'
        self.assertEqual(self.default_file_field.content_types, 'All')

        # ensure content type is set correctly
        self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])


class RestrictedFileFormFieldTest(TenantTestCase):
    def setUp(self):
        self.default_file_field = RestrictedFileFormField()
        self.image_file_field = RestrictedFileFormField(content_types=['image/jpeg', 'image/png'])

    def test_content_type(self):
        "Ensure the default content type is 'All', and that the content type can be set correctly."

        # ensure default content type is 'All'
        self.assertEqual(self.default_file_field.content_types, 'All')

        # ensure content type is set correctly
        self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])
```

### Screenshots (if front end is affected)
Nope.

### Anything Else?
It would be pretty cool, and possibly extremely useful to test the submission of real files using these fields. For example, we could try submitting a small jpeg file using a RestrictedFileField that only accepts video, ensuring our checks actually work. I tried searching for a test like this in the project, but I couldn't find anything similar.

### Review request
@tylerecouture
