### PR TITLE
feature: custom middleware to handle RequestDataTooBig exception

### DIFF
--- a/src/hackerspace_online/middleware.py
+++ b/src/hackerspace_online/middleware.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from django.db import connections
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.core.exceptions import RequestDataTooBig
+from django.template.defaultfilters import filesizeformat
 
 
 class ForceDebugCursorMiddleware:
@@ -19,6 +21,7 @@ class RequestDataTooBigMiddleware:
     """
     Custom middleware to handle requests that exceed the settings.DATA_UPLOAD_MAX_MEMORY_SIZE
     """
+
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -32,9 +35,16 @@ class RequestDataTooBigMiddleware:
         except RequestDataTooBig:
             # if the size of the request (excluding any file uploads) exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.
 
+            msg = (
+                "This requests exceeds the maximum size of {}. This is likely caused by"
+                " one of the text fields contains too much data, either from text (including whitespace)"
+                " or a large data URI (an image or other data encoded as text).".format(
+                    filesizeformat(settings.DATA_UPLOAD_MAX_MEMORY_SIZE)
+                )
+            )
+
             # generate a more sensible response and redirect back
-            messages.add_message(
-                request, messages.ERROR, "The size of the request is too large. Please reduce its size and try again.")
+            messages.add_message(request, messages.ERROR, msg)
             return HttpResponseRedirect(request.build_absolute_uri())
 
         # ...as if nothing has happened

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -224,6 +224,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',  # used by django-date-time-widget
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'hackerspace_online.middleware.RequestDataTooBigMiddleware',  # after MessageMiddleware
 ]
 
 DB_LOGS_ENABLED = env('DB_LOGS_ENABLED', default=False)

--- a/src/hackerspace_online/tests/test_middleware.py
+++ b/src/hackerspace_online/tests/test_middleware.py
@@ -1,64 +1,107 @@
-from io import BytesIO
-from unittest.mock import patch
+from functools import wraps
 
-from django.test import TestCase, RequestFactory, override_settings
+from django.conf import settings
+from django.urls import reverse, path
+from django.contrib.messages import get_messages
+from django.test import override_settings
 from django.http import HttpResponse
 
-from hackerspace_online.middleware import RequestDataTooBigMiddleware
+from django_tenants.test.cases import TenantTestCase
+from django_tenants.test.client import TenantClient
+
+from hackerspace_online.urls import urlpatterns as hackerspace_urlpatterns
+
+
+def without_requestdatatoobig_middleware(func):
+    """
+    Decorator for disabling hackerspace_online.middleware.RequestDataTooBigMiddleware, for testing purpose.
+    """
+    middleware = list(settings.MIDDLEWARE[:])
+    middleware.remove("hackerspace_online.middleware.RequestDataTooBigMiddleware")
+
+    @wraps(func)
+    def _wrapped(*args, **kwargs):
+        with override_settings(MIDDLEWARE=middleware):
+            return func(*args, **kwargs)
+
+    return _wrapped
 
 
 def get_response_empty(request):
-    """Returns an empty response, for testing purpose"""
+    """ returns an empty response, for testing purpose """
+
+    # trying to process post and files, RequestDataTooBig exception will raises if
+    # request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.
+    request._load_post_and_files()
     return HttpResponse()
 
 
-class RequestDataTooBigMiddlewareTestCase(TestCase):
+urlpatterns = [
+    path("empty", get_response_empty, name="empty"),
+] + hackerspace_urlpatterns
+
+
+class RequestDataTooBigMiddlewareTestCase(TenantTestCase):
     """
     Various tests for `hackerspace_online.middleware.RequestDataTooBigMiddleware` class
     """
 
     def setUp(self):
-        self.rf = RequestFactory()
+        self.client = TenantClient(self.tenant)
 
+        # make sure RequestDataTooBig middleware is enabled for a testing purpose
+        self.old_MIDDLEWARE = settings.MIDDLEWARE
+        middleware_class = "hackerspace_online.middleware.RequestDataTooBigMiddleware"
+        if middleware_class not in settings.MIDDLEWARE:
+            settings.MIDDLEWARE = list(settings.MIDDLEWARE) + [middleware_class]
+
+    def tearDown(self):
+        settings.MIDDLEWARE = self.old_MIDDLEWARE
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=2621440, ROOT_URLCONF=__name__)
     def test_default(self):
         """
         By default request should pass through middleware as-is, without exceptions.
         """
-        data = b"""{"orson": "wells"}"""  # request data
+        data = {"orson": "wells"}  # request data
 
-        mw = RequestDataTooBigMiddleware(get_response_empty)
-        request = self.rf.request(
-            **{
-                "wsgi.input": BytesIO(data),
-                "CONTENT_LENGTH": len(data),
-            }
-        )
-
-        # should receive an empty response as if nothing has happened
-        response = mw(request)
+        response = self.client.post(reverse("empty"), data=data)
+        # should receive an empty response (ok) as if nothing has happened
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"")
 
-    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=2, ALLOWED_HOSTS="*")
-    @patch("hackerspace_online.middleware.messages.add_message")
-    def test_request_data_too_big_exception(self, mock_add_message):
+    @without_requestdatatoobig_middleware
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=8, ROOT_URLCONF=__name__)
+    def test_request_data_too_big_exception_without_requestdatatoobig_middleware(self):
+        """
+        Somehow request data exceeds the settings.DATA_UPLOAD_MAX_MEMORY_SIZE limit,
+        that raises `RequestDataTooBig` exception.
+
+        Returns BadRequest (400), because `RequestDataTooBig` exception is not handled properly.
+        """
+        data = {"orson": "wells"}  # request data
+
+        response = self.client.post(reverse("empty"), data=data)
+        # should receive an bad request error (400) as request exceeds the limit.
+        self.assertEqual(response.status_code, 400)
+        # check for messages on a response that has no context
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 0)  # nothing, cuz not handled properly
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=8, ROOT_URLCONF=__name__)
+    def test_request_data_too_big_exception_with_requestdatatoobig_middleware(self):
         """
         Somehow request data exceeds the settings.DATA_UPLOAD_MAX_MEMORY_SIZE limit,
         that raises `RequestDataTooBig` exception.
 
         Custom middleware should handle exception gracefully.
         """
-        data = b"""{"orson": "wells"}"""  # request data
+        data = {"orson": "wells"}  # request data
 
-        mw = RequestDataTooBigMiddleware(get_response_empty)
-        request = self.rf.request(
-            **{
-                "wsgi.input": BytesIO(data),
-                "CONTENT_LENGTH": len(data),
-            }
-        )
-
-        # should redirect back with error message
-        response = mw(request)
+        response = self.client.post(reverse("empty"), data=data)
+        # should redirect back with error message (via django.contrib.messages framework)
         self.assertEqual(response.status_code, 302)
-        mock_add_message.assert_called
+        # check for messages on a response that has no context
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)  # bingo!
+        self.assertIn("requests exceeds the maximum size", str(messages[0]))

--- a/src/hackerspace_online/tests/test_middleware.py
+++ b/src/hackerspace_online/tests/test_middleware.py
@@ -1,0 +1,64 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory, override_settings
+from django.http import HttpResponse
+
+from hackerspace_online.middleware import RequestDataTooBigMiddleware
+
+
+def get_response_empty(request):
+    """Returns an empty response, for testing purpose"""
+    return HttpResponse()
+
+
+class RequestDataTooBigMiddlewareTestCase(TestCase):
+    """
+    Various tests for `hackerspace_online.middleware.RequestDataTooBigMiddleware` class
+    """
+
+    def setUp(self):
+        self.rf = RequestFactory()
+
+    def test_default(self):
+        """
+        By default request should pass through middleware as-is, without exceptions.
+        """
+        data = b"""{"orson": "wells"}"""  # request data
+
+        mw = RequestDataTooBigMiddleware(get_response_empty)
+        request = self.rf.request(
+            **{
+                "wsgi.input": BytesIO(data),
+                "CONTENT_LENGTH": len(data),
+            }
+        )
+
+        # should receive an empty response as if nothing has happened
+        response = mw(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=2, ALLOWED_HOSTS="*")
+    @patch("hackerspace_online.middleware.messages.add_message")
+    def test_request_data_too_big_exception(self, mock_add_message):
+        """
+        Somehow request data exceeds the settings.DATA_UPLOAD_MAX_MEMORY_SIZE limit,
+        that raises `RequestDataTooBig` exception.
+
+        Custom middleware should handle exception gracefully.
+        """
+        data = b"""{"orson": "wells"}"""  # request data
+
+        mw = RequestDataTooBigMiddleware(get_response_empty)
+        request = self.rf.request(
+            **{
+                "wsgi.input": BytesIO(data),
+                "CONTENT_LENGTH": len(data),
+            }
+        )
+
+        # should redirect back with error message
+        response = mw(request)
+        self.assertEqual(response.status_code, 302)
+        mock_add_message.assert_called


### PR DESCRIPTION
### What?

This is fix for a bug reported in https://github.com/bytedeck/bytedeck/issues/1350 when request body exceeded `settings.DATA_UPLOAD_MAX_MEMORY_SIZE` and exception (server side error) raises, we need to handle this error by providing user feedback instead of just an error page.

### Why?

This bug was reported in https://github.com/bytedeck/bytedeck/issues/1350

### How?

Solved by introducing new middleware class `RequestDataTooBigMiddleware` (see [hackerspace_online/middleware.py](https://github.com/bytedeck/bytedeck/pull/1455/files#diff-0b2510ac5d32351730fabc8ba7d04f062a98292a3e6919b770f7f703697d0ed3)). This custom middleware can handle requests that exceed the `DATA_UPLOAD_MAX_MEMORY_SIZE` setting, by catching `RequestDataTooBig` exception, it generates a more user friendly error message (not just server error as it was before), see screenshot bellow.

`RequestDataTooBigMiddleware` depends on `django.contrib.messages` module, and must be installed after `MessageMiddleware` middleware:
```python
MIDDLEWARE = [
    ...
    'django.contrib.messages.middleware.MessageMiddleware',
    'hackerspace_online.middleware.RequestDataTooBigMiddleware',  # after MessageMiddleware
]

```

### Testing?
Yes, and they are self explanatory.

### Screenshots (if front end is affected)
![Screenshot 2023-08-07 at 1 05 14 PM](https://github.com/bytedeck/bytedeck/assets/144783/591b4341-13a5-40c3-9836-8f7be96f16ee)

### Anything Else?

Closes #1350 

### Review request
@tylerecouture
