### PR TITLE
fix: handle "menuitem" links, closes #1397

### DIFF
--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -103,7 +103,8 @@
       // _blank added for comments automatically in python when they are created, so this probabyl only still necessary
       // for in quest/announcement links
       //
-      // exclude dummy (.menuitem) CSS class, fix #1397
+      // exclude dummy (.menuitem) CSS class because these urls will set their own "target" attribute and
+      // should be left untouched
       $("a[href^='http://']:not('.menuitem')").attr("target","_blank");
       $("a[href^='https://']:not('.menuitem')").attr("target","_blank");
       $("a[href^='/media/']").attr("target","_blank");

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -102,8 +102,10 @@
       // Ensure external links and media open in new tabs by adding target="_blank".
       // _blank added for comments automatically in python when they are created, so this probabyl only still necessary
       // for in quest/announcement links
-      $("a[href^='http://']").attr("target","_blank");
-      $("a[href^='https://']").attr("target","_blank");
+      //
+      // exclude dummy (.menuitem) CSS class, fix #1397
+      $("a[href^='http://']:not('.menuitem')").attr("target","_blank");
+      $("a[href^='https://']:not('.menuitem')").attr("target","_blank");
       $("a[href^='/media/']").attr("target","_blank");
 
       // Enable allowfullscreen on responsive iframes

--- a/src/utilities/models.py
+++ b/src/utilities/models.py
@@ -80,7 +80,6 @@ class MenuItem(models.Model):
 
     def __str__(self):
         target = 'target="_blank"' if self.open_link_in_new_tab else ''
-        # append dummy (.menuitem) CSS class, fix #1397
         return '<a href="{}" {} class="menuitem">' \
                '<i class="fa fa-fw fa-{}"></i>&nbsp;&nbsp;{}' \
                '</a>'.format(self.url, target, self.fa_icon, self.label)

--- a/src/utilities/models.py
+++ b/src/utilities/models.py
@@ -80,6 +80,7 @@ class MenuItem(models.Model):
 
     def __str__(self):
         target = 'target="_blank"' if self.open_link_in_new_tab else ''
-        return '<a href="{}" {}>' \
+        # append dummy (.menuitem) CSS class, fix #1397
+        return '<a href="{}" {} class="menuitem">' \
                '<i class="fa fa-fw fa-{}"></i>&nbsp;&nbsp;{}' \
                '</a>'.format(self.url, target, self.fa_icon, self.label)


### PR DESCRIPTION
### What?
This is fix for a bug reported in https://github.com/bytedeck/bytedeck/issues/1397 where if you set a non-relative link to NOT "open in a new tab" it will still open in a new tab. The option works for relative urls such as `/courses/ranks/` but not for full urls `https://hackerspace.bytedeck.com/courses/ranks/`.

### Why?

This bug was reported in https://github.com/bytedeck/bytedeck/issues/1397

### How?

Quick and dirty fix, where a dummy CSS class was added to distinguish menu links from other links (see [utilities/models.py](https://github.com/bytedeck/bytedeck/pull/1456/commits/a8107d4bc461571f83fed4d9944d63bc8f65d452#diff-e54977f4110713a908cd1bba953065e78bacc6a0692de962b8af772b7a52f7fcR84)), and then these "special" links are excluded from altering as it currently done (see [templates/javascript.html](https://github.com/bytedeck/bytedeck/pull/1456/commits/a8107d4bc461571f83fed4d9944d63bc8f65d452#diff-1812463e491cd4e367a9e3a74f3d0866f999bec3e2cc9c1301cfd806d462d9a4R106))

### Testing?
Manually :)
### Screenshots (if front end is affected)
Nope
### Anything Else?

Dummy CSS class: `menuitem`

Closes #1397 

### Review request
@tylerecouture
