### PR TITLE
Fix: return httpresponseredirect instead of raise; Closes #1446

### DIFF
--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -64,6 +64,12 @@ class NotificationViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(self.client.get(reverse('notifications:list')).status_code, 200)
         self.assertEqual(self.client.get(reverse('notifications:list_unread')).status_code, 200)
 
+        # Bad id notification read request should redirect to list view
+        self.assertRedirects(
+            response=self.client.get(reverse('notifications:read', args=[999])),
+            expected_url=reverse('notifications:list'),
+        )
+
         self.assertRedirects(
             response=self.client.get(reverse('notifications:read_all')),
             expected_url=reverse('notifications:list'),

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
@@ -73,9 +74,11 @@ def read(request, id):
                 return HttpResponseRedirect(reverse('notifications:list'))
         else:
             raise Http404
-    except:  # noqa
-        # TODO deal with this bare exception
-        raise HttpResponseRedirect(reverse('notifications:list'))
+
+    # If this view is accessed with an id argument that doesn't match an existing notification, redirect to list view and display error message
+    except Notification.DoesNotExist:
+        messages.error(request, "This notification doesn't exist or has been deleted.")
+        return HttpResponseRedirect(reverse('notifications:list'))
 
 
 @non_public_only_view


### PR DESCRIPTION
### What?
small fix to change the way an httpresponseredirect is accessed upon exception in notification views, all redirects should be returned, not raised.
 
### Why?
raising a redirect such as httpresponseredirect will result in an error, make sure to return redirects.

### How?
changed "raise" to "return", plus the exception condition was specified to be "notification.doesnotexist", so it won't catch other errors we would want to have raised incase of any other site-breaking conditions.

### Testing?
a test to assert accessing the notification "read" view with a non-existent notification id  redirects to the notification list has been created

### Screenshots (if front end is affected)
N/A

### Anything Else?
Is there anything specific about this issue I should be addressing? The redirect happens upon exception of a try/except block, if there's a specific, re-creatable issue at play here, would there be any error message that should be displayed?

### Review request
@tylerecouture
