### PR TITLE
Wrap INTERNAL_IPS getter inside try/except

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -773,11 +773,14 @@ if DEBUG:
     # Solves an issue where django-debug-toolbar is not showing when running inside a docker container
     # See: https://gist.github.com/douglasmiranda/9de51aaba14543851ca3#gistcomment-2916867
     # get ip address for docker host
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    for ip in ips:
-        # replace last octet in IP with .1
-        ip = '{}.1'.format(ip.rsplit('.', 1)[0])
-        INTERNAL_IPS.append(ip)
+    try:
+        hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+        for ip in ips:
+            # replace last octet in IP with .1
+            ip = '{}.1'.format(ip.rsplit('.', 1)[0])
+            INTERNAL_IPS.append(ip)
+    except (socket.gaierror, socket.herror, socket.timeout) as exc:
+        print(f"Error resolving hostname: {exc}. Defaulting to {INTERNAL_IPS} hosts.")
 
     # DEBUG TOOLBAR
     MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/

### What?

Simple fix to prevent the `runserver` from failing

### Why?

On some machines you will randomly get this error (ie macOS)

```python
Traceback (most recent call last):
  File "/Users/user/Sources/github.com/bytedeck/bytedeck/./src/manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/user/.local/share/virtualenvs/bytedeck/lib/python3.9/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/Users/user/.local/share/virtualenvs/bytedeck/lib/python3.9/site-packages/django/core/management/__init__.py", line 363, in execute
    settings.INSTALLED_APPS
  File "/Users/user/.local/share/virtualenvs/bytedeck/lib/python3.9/site-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/Users/user/.local/share/virtualenvs/bytedeck/lib/python3.9/site-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/Users/user/.local/share/virtualenvs/bytedeck/lib/python3.9/site-packages/django/conf/__init__.py", line 170, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/opt/homebrew/Cellar/python@3.9/3.9.17_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/user/Sources/github.com/bytedeck/bytedeck/src/hackerspace_online/local_settings.py", line 4, in <module>
    from .settings import *
  File "/Users/user/Sources/github.com/bytedeck/bytedeck/src/hackerspace_online/settings.py", line 775, in <module>
    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```

### How?

The error is harmless and only occurs when we are only developing so just ignore the exception when it happens

### Testing?
### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
