### PR TITLE
Badges without sort orders no longer break profile views when accessed; Closes #1432

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -271,7 +271,7 @@ class BadgeAssertionManager(models.Manager):
         https://docs.djangoproject.com/en/1.10/ref/models/querysets/#distinct
         """
         qs = self.get_queryset(False).get_user(user).order_by('badge_id').distinct('badge_id')
-        sorted_qs = sorted(qs, key=lambda x: x.badge.sort_order)
+        sorted_qs = sorted(qs, key=lambda x: x.badge.sort_order or 0)  # sort_order defaults to 0 if not set
         return sorted_qs
 
     def badge_assertions_dict_items(self, user):

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -149,22 +149,32 @@ class BadgeAssertionManagerTest(TenantTestCase):
         self.assertNotIn(user3, qs)
 
     def test_all_for_user_distinct(self):
-        """ Test that BadgeAssertion.objects.all_for_user_distinct() returns a queryset of BadgeAssertions
-        that are distinct on the badge, and sorted by badge.sort_order"""
+        """
+        BadgeAssertion.objects.all_for_user_distinct() returns a queryset of BadgeAssertions assigned to a user
+        that are distinct by badge, and sorted by badge.sort_order
 
-        badge1 = baker.make(Badge, sort_order=2)
+        Badge objects without a defined sort_order value should default to sort_order = 0
+        """
+
+        # create badges to assign to user
+        badge1 = baker.make(Badge)  # sort order should default to 0 when not set
         badge2 = baker.make(Badge, sort_order=1)
+        badge3 = baker.make(Badge, sort_order=2)
 
         # give the student two of badge1
         badge_assertion = baker.make(BadgeAssertion, user=self.student, badge=badge1)
-        baker.make(BadgeAssertion, user=self.student, badge=badge1)
-        # and one of badge2
+        baker.make(BadgeAssertion, user=self.student, badge=badge1)  # should not be returned by all_for_user_distinct so not stored in a variable
+
+        # one of badge2
         badge_assertion2 = baker.make(BadgeAssertion, user=self.student, badge=badge2)
 
-        # this should only return two, not the duplicate badge_assertion of badge1
+        # and one of badge3
+        badge_assertion3 = baker.make(BadgeAssertion, user=self.student, badge=badge3)
+
+        # this should only return three, not the duplicate badge_assertion of badge1
         # and they should be sorted by badge.sort_order
         qs = BadgeAssertion.objects.all_for_user_distinct(user=self.student)
-        self.assertQuerysetEqual(qs, [badge_assertion2, badge_assertion])
+        self.assertQuerysetEqual(qs, [badge_assertion, badge_assertion2, badge_assertion3])
 
 
 class BadgeAssertionTestModel(TenantTestCase):


### PR DESCRIPTION
### What?
This is a small addition to the BadgeAssertionManager's all_for_user_distinct() method that defaults a badge's sort_order to 0 if none is provided.

### Why?
Without this, when the all_for_user_distinct() method sorts its queryset of badges using each badge's sort_order value, a TypeError error is raised when it tries to sort by a value that doesn't exist

### How?
As stated in the [issue briefing](https://github.com/bytedeck/bytedeck/issues/1432), `lambda x: x.badge.sort_order or 0` is used to default a badge's sort_order value to 0 if none exists when sorting.

### Testing?
the `test_all_for_user_distinct()` test has been expanded to assert badges with no sort_order value are handled without error and sorted correctly via their new sort_order value of 0.

### Review request
@tylerecouture
