### PR TITLE
Fixed duplicate quest list IDs across quests and submissions

### DIFF
--- a/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
+++ b/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
@@ -24,8 +24,14 @@ function collapseRow($expandedRow, $table) {
   $expandedRow.next().find('td').addClass('collapsing');
   const $detailViewRow = $expandedRow.next();
   const expanded_row_html_id = $expandedRow.attr("id");
-  const expanded_quest_id = parseInt(expanded_row_html_id.match(/\d+$/)[0], 10);
-  const $expanded_hiddenDIV = $detailViewRow.find("#collapse-quest-" + expanded_quest_id);
+  const expanded_object_id = parseInt(expanded_row_html_id.match(/\d+$/)[0], 10);
+  let $expanded_hiddenDIV;
+  // find rows matching "collapse-quest-<id>" or "collapse-submission-<id>"
+  if (expanded_row_html_id.includes("quest")) {
+    $expanded_hiddenDIV = $detailViewRow.find(`#collapse-quest-${expanded_object_id}`);
+  } else {
+    $expanded_hiddenDIV = $detailViewRow.find(`#collapse-submission-${expanded_object_id}`);
+  }
 
   $expanded_hiddenDIV.slideUp(function() {
     // After animation complete, hide the div and append it back to its original parent
@@ -46,10 +52,16 @@ $(document).ready(function () {
     $table.bootstrapTable();
 
     $table.on('expand-row.bs.table', function (e, index, row, $detail) {
-      // Get the row's html id, then extract the last digit (quest id) from it
+      // Get the row's html id, then extract the last digit (quest or submission id) from it
       const row_html_id = row._id;
-      const quest_id = parseInt(row_html_id.match(/\d+$/)[0], 10);
-      const $hiddenDIV = $("#collapse-quest-" + quest_id);
+      const object_id = parseInt(row_html_id.match(/\d+$/)[0], 10);
+      let $hiddenDIV;
+      // find elements matching "collapse-quest-<id>" or "collapse-submission-<id>"
+      if (row_html_id.includes("quest")) {
+        $hiddenDIV = $(`#collapse-quest-${object_id}`);
+      } else {
+        $hiddenDIV = $(`#collapse-submission-${object_id}`);
+      }
 
       // Save the original parent of the hidden div for later use
       $hiddenDIV.data('originalParent', $hiddenDIV.parent());

--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -23,7 +23,7 @@
                           // quest/sub id is number at end of html_id
                           var id = parseInt(html_id.match(/\d+$/)[0], 10);
 
-                          var preview_content_selector = "#preview-content-" + id;
+                          var preview_content_selector = `#preview-quest-${id}, #preview-submission-${id}`;
 
                           $(preview_content_selector).html(jsonData[id]);
                       });
@@ -89,7 +89,7 @@
                   var ajax_url = "{% url 'quests:ajax_quest_root' %}" + id + "/";
               }
 
-              var preview_content_selector = "#preview-content-" + id;
+              var preview_content_selector = `#preview-quest-${id}, #preview-submission-${id}`;
               var hidden_selector = "#status-icon-" + id;
 
               $.ajax({

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -84,7 +84,7 @@
               {% else %}default{% endif %}"
       role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
       <ul class="list-group">
-        <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
+        <li id="preview-quest-{{q.id}}" class="list-group-item list-group-item-buttons">
             <p>
               <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
               &nbsp;Loading content...

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -37,9 +37,9 @@
           {% else %}default{% endif %}"
           role="tab"
           aria-expanded="{% if s.id == active_id %}true{% else %}false{% endif %}"
-          aria-controls="collapse-quest-{{s.id}}"
+          aria-controls="collapse-submission-{{s.id}}"
           {% comment %} ID makes the ajax_content_loading.html file populate detailed content {% endcomment %}
-          id="heading-quest-{{s.id}}"
+          id="heading-submission-{{s.id}}"
         >
           <td class="col-sm-1 col-xs-2 col-icon">
             <img class="img-responsive panel-title-img img-rounded" src="{{ s.quest.get_icon_url }}" alt="icon"/>
@@ -79,12 +79,12 @@
         ajax_content_loading.html inserts quest content here.
         If the content hasn't been retrieved yet from the server, a loading icon is displayed.
       {% endcomment %}
-      <div style="display: none" id="collapse-quest-{{s.id}}"
+      <div style="display: none" id="collapse-submission-{{s.id}}"
         class="{% if object.sticky %}info
               {% elif s.do_not_grant_xp %}muted
               {% else %}default{% endif %}"
-        role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
-        <ul id="preview-content-{{s.id}}" class="list-group">
+        role="tabpanel" aria-labelledby="heading-submission-{{s.id}}">
+        <ul id="preview-submission-{{s.id}}" class="list-group">
           <li class="list-group-item list-group-item-buttons">
               <p>
                 <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -79,7 +79,7 @@
             {% endif %}"
       role="tabpanel" aria-labelledby="heading-quest-{{q.id}}">
       <ul class="list-group">
-        <li id="preview-content-{{q.id}}" class="list-group-item list-group-item-buttons">
+        <li id="preview-quest-{{q.id}}" class="list-group-item list-group-item-buttons">
             <p>
               <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
               &nbsp;Loading content...

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -36,9 +36,9 @@
         {% else %}default{% endif %}"
         role="tab"
         aria-expanded="{% if s.id == active_id %}true{% else %}false{% endif %}"
-        aria-controls="collapse-quest-{{s.id}}"
+        aria-controls="collapse-submission-{{s.id}}"
         {% comment %} ID makes the ajax_content_loading.html file populate detailed content {% endcomment %}
-        id="heading-quest-{{s.id}}"
+        id="heading-submission-{{s.id}}"
       >
         <td class="col-sm-1 col-xs-2 col-icon">
           <img class="img-responsive panel-title-img img-rounded" src="{{ s.quest.get_icon_url }}" alt="icon"/>
@@ -76,13 +76,13 @@
         ajax_content_loading.html inserts quest content here.
         If the content hasn't been retrieved yet from the server, a loading icon is displayed.
       {% endcomment %}
-      <div style="display: none" id="collapse-quest-{{s.id}}"
+      <div style="display: none" id="collapse-submission-{{s.id}}"
         class="{% if s.is_awaiting_approval %}warning
                {% elif s.is_returned %}danger
                {% elif s.do_not_grant_xp %}muted
                {% else %}default{% endif %}"
-        role="tabpanel" aria-labelledby="heading-quest-{{s.id}}">
-        <ul id="preview-content-{{s.id}}" class="list-group" data-completed="{{completed}}" data-past="{{past}}">
+        role="tabpanel" aria-labelledby="heading-submission-{{s.id}}">
+        <ul id="preview-submission-{{s.id}}" class="list-group" data-completed="{{completed}}" data-past="{{past}}">
           <li class="list-group-item list-group-item-buttons">
               <p>
                 <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>


### PR DESCRIPTION
## What?
This issue occurred by some changes I mistakenly made in the bootstrap-table quest list. In the quest list, I changed some IDs. For example, I changed `heading-{{ [s.id](http://s.id) }}` to `heading-quest-{{ s.id }}`. I did this to match the other selectors in the other templates e.g. `heading-quest-{{ [q.id](http://q.id) }}`. But without realizing it, I created another bug! Since quests and submissions have different numberings for their IDs, their ID values can conflict. So due to my changes, the HTML ID values were conflicting across the tabs of the quest list. I noticed this after some strange HTML formatting issues were occurring, and it was a huge headache to discover the cause.

I’m going to give a quick refresher on how the quest list works. Each tab has an HTML table loaded into it, and each row in the table is a quest. It is important to note that each row in the “Available” tab represents a `Quest` object, while each row in the “In Progress”/”Completed” tabs are `QuestSubmission` objects. After the page loads, AJAX is used to insert all of the preview content into the quests. This content is inserted into a hidden DOM location, and whenever a quest is clicked, the preview content is inserted underneath the quest row. And when the preview content is collapsed, the content is sent back to the hidden location, and the quest goes back to its original look.

An example might make this issue easier to understand. Right now, while doing the Bytedeck orientation campaign, an HTML formatting bug can be triggered by this. If after completing the “Welcome to Bytedeck!” quest the student immediately submits the “Screenshots” quest, HTML formatting issues will be present if they collapse the submission as follows:

![duplicate_IDs_problem_bad_formatting](https://github.com/bytedeck/bytedeck/assets/11304586/f0f90528-6816-4ff3-abdf-708a4f29462a)

This is due to the duplicate IDs that appear in both the “Available” and “Completed” tabs. Since the “Screenshots” submission has an ID of “2” at this point, its elements will be labelled, for example, with the ID `collapse-quest-2`. But the “Bytedeck Class Contract” quest has an ID of 2, so it will label its elements using the same IDs. These IDs will then collide, since every quest list tab is rendered in the DOM simultaneously. This is problematic since the preview content for the submission will be inserted into the wrong spot. And although I’m not entirely certain about the specifics of the issues with the HTML formatting in this case, it has something to do with the fact that the preview content for the “Screenshots” quest is incorrectly inserted into where the “Create an Avatar” quest’s preview content is. Everything still mostly works, but the improper formatting causes the quick reply form to be hidden when the “Screenshots” quest submission is expanded.
The problematic IDs are as follows:

- `collapse-quest-{{s.id}}` and `collapse-quest-{{q.id}}`
- `heading-quest-{{s.id}}` and `heading-quest-{{q.id}}`
- `preview-content-{{s.id}}` and `preview-content-{{q.id}}`

## Why?
To ensure proper functioning of the quest list.

## How?
Instead of changing the IDs for submissions back to `collapse-{{s.id}}`, `heading-{{s.id}}`, etc, I changed them to `collapse-submission-{{s.id}}`, `heading-submission-{{s.id}}`, etc. This makes it easier to identify the elements as submissions for future reference.

## Testing?
Since this is a frontend problem, and since we currently have no way of testing our frontend JavaScript code, I did not write any tests for this.

Although I believe I have fully fixed this issue, and I haven't noticed any other issues, I wouldn't be surprised if the reviewer notices other issues after taking a look! Please let me know about any other potential issues you notice.

## Screenshots (if front end is affected)
The same screenshot as from earlier:

![duplicate_IDs_problem_bad_formatting](https://github.com/bytedeck/bytedeck/assets/11304586/85675ec0-6b2b-45ce-918c-b51d64fb1a87)

## Anything Else?
While working on this issue, I also discovered #1467. It is another highly related, yet separate issue. Please also take a look at it.

## Review request
@tylerecouture
