### PR TITLE
Added Docstring and Renamed 'ajax' quest_manager View

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from django.http import JsonResponse
 
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
@@ -1602,6 +1603,88 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(before_delete_count - 1, after_delete_count)
 
 
+class AjaxSubmissionCountTest(ViewTestUtilsMixin, TenantTestCase):
+    """ Tests for:
+    def ajax_submission_count(request, quest_id=None)
+
+    via
+
+    url(r'^ajax/$', views.ajax_submission_count, name='ajax_submission_count'),
+    """
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+        self.test_student = User.objects.create_user('test_student', password="password")
+        self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
+        self.quest = baker.make(Quest, name="Test Quest")
+        # put the student in a course in the active semester
+        teacher_block = baker.make('courses.Block', current_teacher=self.test_teacher)
+        baker.make('courses.CourseStudent', block=teacher_block,
+                   user=self.test_student, semester=SiteConfig.get().active_semester)
+
+    def test_get_returns_404(self):
+        """ This view is only accessible by an ajax POST request """
+        self.client.force_login(self.test_teacher)
+        self.assert404('quests:ajax_submission_count')
+
+    def test_non_ajax_post_returns_404(self):
+        """ This view is only accessible by an ajax POST request """
+        self.client.force_login(self.test_teacher)
+        response = self.client.post(
+            reverse('quests:ajax_submission_count')
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_student_access_granted(self):
+        """ The current behavior is that students can access the view.
+        This test acknowledges that behavior."""
+        self.client.force_login(self.test_student)
+        response = self.client.post(
+            reverse('quests:ajax_submission_count'),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_ajax_returns_json(self):
+        self.client.force_login(self.test_teacher)
+        response = self.client.post(
+            reverse('quests:ajax_submission_count'),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(type(response), JsonResponse)
+
+    def test_ajax_returns_correct_count(self):
+        """ Should return the number of pending submissions for the quest"""
+        self.client.force_login(self.test_teacher)
+        # only submissions that are "completed" but not "approved" should be counted
+        submissions = [
+            baker.make(QuestSubmission, is_completed=True, is_approved=False),
+            baker.make(QuestSubmission, is_completed=True, is_approved=False),
+            baker.make(QuestSubmission, is_completed=False, is_approved=False),
+            baker.make(QuestSubmission, is_completed=False, is_approved=False),
+            baker.make(QuestSubmission, is_completed=True, is_approved=True),
+            baker.make(QuestSubmission, is_completed=False, is_approved=True),
+        ]
+        for sub in submissions:
+            sub.semester = SiteConfig.get().active_semester
+            sub.user = self.test_student
+            sub.quest = self.quest
+            sub.save()
+
+        response = self.client.post(
+            reverse('quests:ajax_submission_count'),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.json()['count'], 2)
+
+
 class AjaxQuestInfoTest(ViewTestUtilsMixin, TenantTestCase):
 
     """Tests for:
@@ -1640,7 +1723,6 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, TenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        from django.http import JsonResponse
         self.assertEqual(type(response), JsonResponse)
 
         # Same without a quest ID:
@@ -1651,7 +1733,6 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, TenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        from django.http import JsonResponse
         self.assertEqual(type(response), JsonResponse)
 
 
@@ -1692,7 +1773,6 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, TenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        from django.http import JsonResponse
         self.assertEqual(type(response), JsonResponse)
 
         # includes the submission in context as s
@@ -1747,7 +1827,6 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, TenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        from django.http import JsonResponse
         self.assertEqual(type(response), JsonResponse)
 
         # Check context variables

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     # url(r'^create/$', views.quest_create, name='quest_create'),
 
     # Ajax
-    url(r'^ajax/$', views.ajax, name='ajax'),
+    url(r'^ajax/$', views.ajax_submission_count, name='ajax_submission_count'),
     url(r'^ajax_flag/$', views.ajax_flag, name='ajax_flag'),
     url(r'^ajax_quest_info/(?P<quest_id>[0-9]+)/$', views.ajax_quest_info, name='ajax_quest_info'),
     url(r'^ajax_quest_info/$', views.ajax_quest_info, name='ajax_quest_root'),

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1324,17 +1324,15 @@ def submission(request, submission_id=None, quest_id=None):
 
 @non_public_only_view
 @login_required
-def ajax(request):
+def ajax_submission_count(request):
+    """Returns the number of submissions awaiting approval for the current user
+    This is used to update the number beside the "Approvals" button in the navbar"""
     if request.is_ajax() and request.method == "POST":
         submission_count = QuestSubmission.objects.all_awaiting_approval(
             teacher=request.user
         ).count()
-        sub_data = {
-            "count": submission_count,
-        }
-        json_data = json.dumps(sub_data)
 
-        return HttpResponse(json_data, content_type="application/json")
+        return JsonResponse(data={"count": submission_count})
     else:
         raise Http404
 

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -31,7 +31,7 @@
       //Update quests awaiting approval badge
       $.ajax({
         type: "POST",
-        url: "{% url 'quests:ajax' %}",
+        url: "{% url 'quests:ajax_submission_count' %}",
         data: {
           csrfmiddlewaretoken: "{{ csrf_token }}",
         },


### PR DESCRIPTION
### What?
While trying to understand the various views in the `quest_manager` app, I kept coming across the `ajax` function and wondering what it was for. Eventually I decided to take the time to understand what it did, as it could have been important, and I discovered that it allows the teacher to see how many submissions are currently in their marking inbox. The only location I could find that it was being used was in `src/templates/javascript.html`. Since I was very confused about the naming, I ended up spending a few minutes writing a docstring for it and giving it a new name.

### Why?
As mentioned above, I found this function very confusing! I think that my changes will improve the readability of this project's code.

### How?
Here is what the function looks like now:

```py
@non_public_only_view
@login_required
def ajax_submission_count(request):
    """Returns the number of submissions awaiting approval for the current user
    This is used to update the number beside the "Approvals" button in the navbar"""
    if request.is_ajax() and request.method == "POST":
        submission_count = QuestSubmission.objects.all_awaiting_approval(
            teacher=request.user
        ).count()

        return JsonResponse(data={"count": submission_count})
    else:
        raise Http404
```

### Testing?
Yes. It looks like this function didn't have tests previously, so this should increase coverage. I mostly followed the format of other tests for AJAX functions. I ensure get and non-ajax requests are rejected, and that it returns the expected result when accessed in the proper way.

### Screenshots (if front end is affected)
### Anything Else?
Unlike some other views that are used by staff, this view has the `@login_required` decorator, rather than the `@staff_member_required` decorator. I wasn't sure if this was intentional, so I didn't change it, but let me know if I should! I'm sure this function doesn't pose any sort of security risk if students can access it, other than possibly telling them that they have zero submissions awaiting their approval?

### Review request
@tylerecouture
