### PR TITLE
Added detailed description of quest list tabs to top of quests.html template

### DIFF
--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -5,6 +5,19 @@
     > completed (tab_quests_submission.html)
     > past courses (tab_quests_submission.html)
     > drafts (tab_quests_available.html)
+
+Each tab has an HTML table loaded into it, and each row in the table is a quest.
+It is important to note that each row in the “Available” tab represents a Quest object,
+while each row in the “In Progress”/”Completed” tabs are QuestSubmission objects.
+
+After the page loads, AJAX is used to insert all of the preview content into the quests.
+Several AJAX endpoints can be used depending on the tab. This is handled in
+`ajax_content_loading.html`.
+
+This content is inserted into a hidden DOM location, and whenever a quest is clicked,
+the preview content is inserted underneath the quest row. And when the preview content
+is collapsed, the content is sent back to the hidden location, and the quest goes back
+to its original look.
 -->
 
 {% extends "quest_manager/base.html" %}


### PR DESCRIPTION
### What?
In PR #1466, I gave a detailed description of how the quest list works, and in particular, how the site manages having multiple tabs of quest lists. I added a revised version of this description to the top of the `quests.html` template.

### Why?
This should make it easier for future developers to understand how the quest lists work.

### How?
### Testing?
### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
