### PR TITLE
object too long (53+ combined chars) name + XP value no longer fails map generation; Closes #929

### DIFF
--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -554,7 +554,13 @@ class CytoScape(models.Model):
 
     @staticmethod
     def generate_label(obj):
-        max_len = 44  # max label length in characters
+        # set max label length in characters
+        # object labels with large xp values require a shorter name length so all values when combined comply with max label length
+        if hasattr(obj, 'xp'):
+            max_len = 46 - len(str(obj.xp))
+        else:
+            max_len = 44
+
         post = ""
         pre = ""
         if type(obj) is Badge:


### PR DESCRIPTION
### What?
This is a fix for a bug in map generation where objects with long names and xp values (greater than 53 characters combined, or length 50 (max length) name and 4+ digit xp count) would raise a DataError when maps containing them were generated.

### Why?
Long names and XP values are very feasible in some contexts, but even disregarding that, end users should not be able to raise uncaught/managed errors in general site use.

### How?
Previously, map objects had their labels truncated through a flat 44 character limit on names, which would not account for xp values above 3 characters long after label formatting had been applied. To remedy this, map labels now have their maximum name lengths dynamically set based on the amount of xp associated with the quest.

previous max_length set:
`max_len = 44`

new set:
```
        if hasattr(obj, 'xp'):
            max_len = 47 - len(str(obj.xp))
        else:
            max_len = 44
```

### Testing?
a new test, test_generate_map__long_name_xp() has been created to test for this edge case with a quest whose name is the maximum, 50 characters, and the xp value is 10,000,000 (more than will ever reasonably be used)

### Screenshots (if front end is affected)
Map containing truncated name and egregiously large XP count:
![image](https://github.com/bytedeck/bytedeck/assets/105619909/8119f83c-70fc-474b-bd86-e94af0c75ceb)

### Review request
@tylerecouture
