### PR TITLE
fix #1416

### DIFF
--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -4,7 +4,6 @@
 
 {% block head %}
     <!-- need these loaded first for date-time picker and summernote widgets to work -->
-    <script src="{% static 'js/bootstrap-datetimepicker.js' %}"></script>
     {{ form.media }}
 {% endblock %}
 
@@ -104,11 +103,9 @@
     }
 
     // https://stackoverflow.com/a/42453540
-    $('body').on('focus',".datetimepickerinput", function(){
-        backup = {"showClose": true, "showClear": true, "showTodayButton": true, "format": "YYYY-MM-DD"};
-        data = cached_datepicker_data ? cached_datepicker_data : backup;
-        $(this).datetimepicker(data);
-    });
+    $("body").on("DOMNodeInserted", function (e) {
+        $("[data-dp-config]:not([disabled])").djangoDatetimePicker();
+    })
 
     function RemoveForm(index) {
         var fieldContainer = document.getElementById(`form-${index}-container`);


### PR DESCRIPTION
### What?
This is fix for a bug reported in https://github.com/bytedeck/bytedeck/issues/1416 where on create new semester form, the calendar does not pop up when clicking on the calendar icon for dates after the first excluded day.

### Why?
This bug was reported in https://github.com/bytedeck/bytedeck/issues/1416
### How?
Quick and dirty fix, instead of binding on `focus` event for `datetimepickerinput` input element, bind to `DOMNodeInserted` event and call `djangoDatetimePicker` function from `django-bootstrap-datepicker-plus` app to do the "proper" datepicker initialization.

### Testing?

manually :)

### Screenshots (if front end is affected)

![calendar](https://github.com/bytedeck/bytedeck/assets/144783/af67f286-168b-4bf2-a106-9a5de4cba8c8)

### Anything Else?
Closes #1416 
### Review request
@tylerecouture
