### PR TITLE
Default submission replies and quick replies use <p> tags; closes #1235

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -733,7 +733,8 @@ def approve(request, submission_id):
             comment_new = Comment.objects.create_comment(
                 user=request.user,
                 path=origin_path,
-                text=comment_text + comment_text_addition,
+                # wrap comment text in <p> tag so default submission replies and quick replies are formatted correctly
+                text=f"<p>{comment_text}</p>{comment_text_addition}",
                 target=submission,
             )
 


### PR DESCRIPTION
### What?
Small fix to wrap all quick reply and default submission text with p tags to format them correctly

### Why?
without p tags, quick reply and default reply comments won't be formatted correctly,  which creates visual inconsistencies between comments on submissions.

### How?
previously, submission comments created through the quick reply form (and those without body text on the normal approval form) were made directly with the `comment_text` variable, which is an unformatted string. This update wraps that `comment_text `variable in a p tag as a part of an fstring, which formats the text properly when rendered to a template.

Previously:
`text=comment_text + comment_text_addition,`

With <p> tag wrapping in fstring:
`text=f"<p>{comment_text}</p>{comment_text_addition}",`
(`comment_text_addition` is already formatted with the correct template tags, so not necessary to wrap it as well)

### Testing?
N/A, small templating adjustment

### Screenshots (if front end is affected)
(from top to bottom)

- correctly formatted submission reply with default text (through full submission reply form)
- correctly formatted quick reply form comment 
- non-formatted quick reply form comment (made prior to change)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/c576c31f-bf97-46f5-a182-627316233444)

### Review request
@tylerecouture
