### PR TITLE
Add student course count to semester list view; Closes #1205

### DIFF
--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -29,6 +29,7 @@
       <th>Last Day</th>
       <th>Total Days</th>
       <th># Excluded Dates</th>
+      <th># Students</th>
       <th>Closed</th>
       <!-- <th>Active</th> -->
       <th>Action</th>
@@ -41,6 +42,7 @@
       <td>{{ object.last_day }}</td>
       <td>{{ object.num_days }}</td>
       <td>{{ object.excludeddate_set.count }}</td>
+      <td>{{ object.coursestudent_set.count }}</td>
       <td>{{ object.closed }}</td>
       <!-- <td>{% if object == config.active_semester %}True{% else %}False{% endif %}</td> -->
       <td>


### PR DESCRIPTION
### What?
This is an additional column on the SemesterList view that tallies the number of coursestudent objects enrolled in any given semester

### Why?
This is a useful tool to gauge the prospective amount of students in any given term, and can be used to assign corresponding amounts of instructors, assistants, etc.

### How?
Similarly to the already implemented '# Excluded Dates' column, a relatedset template tag is used, with the .count method to convert that set to a raw number. Essentially, the number of coursestudent objects assigned to a given semester is counted.

### Testing?
N/A, in its current form, this update is just the implementation of a template tag, which aren't tested by ByteDeck testing conventions.

### Screenshots (if front end is affected)
New column with a student enrolled in 2 courses (explained further below)
![image](https://github.com/bytedeck/bytedeck/assets/105619909/db2ea9a5-2646-420c-8582-30fe294ff30a)


### Anything Else?
Currently, this column tallies CourseStudent objects related to any given Semester. This means the # Students count can include the same student MULTIPLE TIMES if they are enrolled in multiple courses during any given semester (i.e 1 user enrolled in class A and class B, both in semester july-2023, # Students column will read "2" despite only 1 student being a part of it). If this is NOT preferable, django template tag conventions would warrant the implementation of a python method or custom filter that takes a two-level relatedset and filters it via .distinct(), which would also warrant an accompanying test.

### Review request
@tylerecouture
