### PR TITLE
Fixed issue with content not loading in approvals tab

### DIFF
--- a/src/quest_manager/templates/quest_manager/ajax_content_loading.html
+++ b/src/quest_manager/templates/quest_manager/ajax_content_loading.html
@@ -62,6 +62,7 @@
         }
         else if (window.location.href.indexOf("/approvals/") > -1) {
             is_approval = true;
+            tab_id = "#tab-submitted";
             if (window.location.href.indexOf("/submitted/") > -1) {
                 tab_id = "#tab-submitted";
             }

--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -12,12 +12,13 @@ while each row in the “In Progress”/”Completed” tabs are QuestSubmission
 
 After the page loads, AJAX is used to insert all of the preview content into the quests.
 Several AJAX endpoints can be used depending on the tab. This is handled in
-`ajax_content_loading.html`.
+`ajax_content_loading.html`. A whole bunch of conditions are used to ensure content
+is only loaded into the currently active tab.
 
 This content is inserted into a hidden DOM location, and whenever a quest is clicked,
 the preview content is inserted underneath the quest row. And when the preview content
-is collapsed, the content is sent back to the hidden location, and the quest goes back
-to its original look.
+is collapsed, the content is sent back to the hidden location, and the quest row goes
+back to its original look.
 -->
 
 {% extends "quest_manager/base.html" %}


### PR DESCRIPTION
### What?
In my last PR (#1473), I introduced a change to ensure quest content is only loaded for the currently active quest tab. I added several conditionals to make it only select quest list rows that were in the DIV for the current tab. This is done by looking at the browser URL to see what page the student is currently on.

Unfortunately, I missed one page URL. When a teacher first clicks the "Quest Approvals" button, they are brought to the "Submitted" tab. But the URL item `/submitted/` is not present in the page address. Because of this, the detailed content wouldn't load while in this state. This is a bit hard to explain. Here are examples of the URLs I'm talking about:
- `http://hackerspace.localhost:8000/quests/approvals/`: Problematic URL. Present after clicking "Quest Approvals" button.
- `http://hackerspace.localhost:8000/quests/approvals/submitted/`: Content successfully loaded. Present after clicking "Submitted" tab. I'm not sure why there are two different URLs for this tab?
- `http://hackerspace.localhost:8000/quests/approvals/returned/`: Content successfully loaded. Present after clicking "Returned" tab.
- and so on...

### Why?
### How?
To fix this issue, I changed the `ajax_content_loading.html` script to use the default selector of `#tab-submitted` if `/approvals/` is present in the URL. And if `/submitted/`,  `/returned/`, `/approved/`, or `/flagged/` are also present, the selector is changed accordingly.

### Testing?
I've manually gone through every quest list tab to ensure the detailed content is loaded correctly. However, I'm not sure how to activate the "Past Courses" tab, so I haven't been able to test it. So although there is a condition to ensure the `#past_submissions` selector is used if `/past/` is present in the URL, I haven't tested this.

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
