### PR TITLE
Campaign/Course pages now use their proper page icons; Closes #1132

### DIFF
--- a/src/courses/templates/courses/course_confirm_delete.html
+++ b/src/courses/templates/courses/course_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "courses/base.html" %}
 {% load crispy_forms_tags %}
 
-{% block heading_inner %} Delete Course {% endblock %}
+{% block heading %}<i class="fa fa-book pull-right"></i>{% block heading_inner %} Delete Course {% endblock %}{% endblock %}
 
 {% block content %}
 {% if not populated %}

--- a/src/courses/templates/courses/course_form.html
+++ b/src/courses/templates/courses/course_form.html
@@ -1,7 +1,7 @@
 {% extends "courses/base.html" %}
 {% load crispy_forms_tags %}
 
-{% block heading_inner %} {{ heading }} {% endblock %}
+{% block heading %}<i class="fa fa-book pull-right"></i>{% block heading_inner %} {{ heading }} {% endblock %}{% endblock %}
 
 {% block content %}
 <form method="post" enctype="multipart/form-data">{% csrf_token %}

--- a/src/courses/templates/courses/course_list.html
+++ b/src/courses/templates/courses/course_list.html
@@ -4,11 +4,11 @@
 {% block head %}{% endblock %}
 
 {% block content_first %}{% endblock %}
-{% block heading_inner %}Courses
+{% block heading %}<i class="fa fa-book pull-right"></i>{% block heading_inner %}Courses
 {% if request.user.is_staff %}
   <a class="btn btn-primary" href="{% url 'courses:course_create' %}" role="button">New</a>
 {% endif %}
-{% endblock %}
+{% endblock %}{% endblock %}
 
 {% block content %}
 <p>This page is visible to staff only.</p>

--- a/src/quest_manager/templates/quest_manager/category_confirm_delete.html
+++ b/src/quest_manager/templates/quest_manager/category_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "quest_manager/base.html" %}
 {% load crispy_forms_tags %}
 
-{% block heading_inner %}Delete Campaign {% endblock %}
+{% block heading %}<i class="fa fa-compass pull-right"></i>{% block heading_inner %}Delete Campaign {% endblock %}{% endblock %}
 
 {% block content %}
 <form action="" method="post">{% csrf_token %}

--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -3,7 +3,7 @@
 
 {% block head_title %}Campaigns | {% endblock %}
 
-{% block heading_inner %} {{ object.title }} Campaign{% endblock %}
+{% block heading %}<i class="fa fa-compass pull-right"></i>{% block heading_inner %} {{ object.title }} Campaign{% endblock %}{% endblock %}
 
 {% block content %}
     {% if request.user.is_staff %}

--- a/src/quest_manager/templates/quest_manager/category_form.html
+++ b/src/quest_manager/templates/quest_manager/category_form.html
@@ -1,7 +1,7 @@
 {% extends "courses/base.html" %}
 {% load crispy_forms_tags %}
 
-{% block heading_inner %} {{ heading }} {% endblock %}
+{% block heading %}<i class="fa fa-compass pull-right"></i>{% block heading_inner %} {{ heading }} {% endblock %}{% endblock %}
 
 {% block content %}
 <form method="post" enctype="multipart/form-data">{% csrf_token %}

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -4,11 +4,11 @@
 {% block head %}{% endblock %}
 
 {% block content_first %}{% endblock %}
-{% block heading_inner %}Campaigns
+{% block heading %}<i class="fa fa-compass pull-right"></i>{% block heading_inner %}Campaigns
 {% if request.user.is_staff %}
   <a class="btn btn-primary" href="{% url 'quest_manager:category_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
 {% endif %}
-{% endblock %}
+{% endblock %}{% endblock %}
 
 {% block content %}
 <p>This page is visible to staff only.</p>


### PR DESCRIPTION
### What?
Small frontend change to course/campaign view page icons to make them in-line with their intended icons.

### Why?
Differentiated page icons are useful for making site navigation more clear and easy to understand.

### How?
Header block overrides in the templates for each of the changed pages that include the correct icons have been added.

### Testing?
N/A, small template change

### Screenshots (if front end is affected)
New Campaign pages icon:
![image](https://github.com/bytedeck/bytedeck/assets/105619909/37184dee-2b62-4ee3-bac6-783f8fae9e81)

New Course pages icon:
![image](https://github.com/bytedeck/bytedeck/assets/105619909/abc8427d-6d4a-4e43-8efb-448cc5dcd92e)

### Anything Else?
### Review request
@tylerecouture
