### PR TITLE
tests: filterable QuerySetSequence in GFK Select Field/Widget

### DIFF
--- a/src/utilities/tests/test_widgets.py
+++ b/src/utilities/tests/test_widgets.py
@@ -4,6 +4,7 @@ import string
 import collections
 
 from django import forms
+from django.db.models import Q
 from django.core import signing
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
@@ -134,6 +135,21 @@ class TestGFKSelect2Widget(TenantTestCase):
         widget = GFKSelect2Widget(
             queryset=QuerySetSequence(Group.objects.all()), search_fields={'auth': {'group': ['name__icontains']}})
         group = Group.objects.last()
+        result = widget.filter_queryset(group.name)
+        assert result.exists()
+
+    def test_queryset_is_filterable(self):
+        group = self.groups[0]
+
+        queryset = QuerySetSequence(Group.objects.filter(~Q(name__icontains=group.name)))
+        widget = GFKSelect2Widget(
+            queryset=queryset, search_fields={'auth': {'group': ['name__icontains']}})
+        result = widget.filter_queryset(group.name)
+        assert not result.exists()
+
+        queryset = QuerySetSequence(Group.objects.filter(Q(name__icontains=group.name)))
+        widget = GFKSelect2Widget(
+            queryset=queryset, search_fields={'auth': {'group': ['name__icontains']}})
         result = widget.filter_queryset(group.name)
         assert result.exists()
 

--- a/src/utilities/widgets.py
+++ b/src/utilities/widgets.py
@@ -97,7 +97,7 @@ class GFKSelect2Mixin:
                 or_queries = [Q(**{orm_lookup: term}) for orm_lookup in search_fields]
                 select |= reduce(operator.or_, or_queries)
 
-            queryset_models.append(model.objects.filter(select))
+            queryset_models.append(qs.filter(select))
 
         # Aggregate querysets
         return QuerySetSequence(*queryset_models)


### PR DESCRIPTION
### What?
This is fix for a bug reported in #1472 that there is no way to filter the querysets included in a `QuerySetSequence` for our `GFKChoiceField`.

### Why?
This bug was reported in #1472
### How?
Quick and dirty fix, see [utilities/widgets.py](https://github.com/bytedeck/bytedeck/pull/1481/commits/5268056aada0d402c0e47426ef77359fc3887c41#diff-c4caff1c56921182fde27c25c76ab9ee7845fe41739f9cb4a13349953f7d7acfR100), speaking shortly I found and fixed bug in `filter_queryset` method that didn't used existing queryset (with all previously applied filtering and custom queries), but instead initialized completely new one.

### Testing?
Yes
### Screenshots (if front end is affected)
None
### Anything Else?
Closes #1472 
### Review request
@tylerecouture
