### PR TITLE
Fix error creating maps with already "in use" initial objects

### DIFF
--- a/src/djcytoscape/forms.py
+++ b/src/djcytoscape/forms.py
@@ -32,7 +32,8 @@ class CytoscapeGFKChoiceField(AllowedGFKChoiceField):
             # do not use Quest, Rank or Badge as an initial object,
             # if it is already an intitial object for another map
             queryset_models.append(
-                model.objects.exclude(
+                # use existing queryset, with all previously applied filtering and custom queries
+                qs.exclude(
                     pk__in=CytoScape.objects.filter(
                         initial_content_type=ContentType.objects.get_for_model(model),
                     ).values_list('initial_object_id', flat=True)

--- a/src/djcytoscape/forms.py
+++ b/src/djcytoscape/forms.py
@@ -21,12 +21,16 @@ class CytoscapeGFKChoiceField(AllowedGFKChoiceField):
     """
 
     def __init__(self, *args, **kwargs):
+        # Initialize the new instance of CytoscapeGFKChoiceField,
+        # inherits features and methods from AllowedGFKChoiceField.
         super().__init__(*args, **kwargs)
 
         queryset_models = []
+        # get previously initialized "queryset" class attribute and apply custom filtering
         for qs in self.queryset.get_querysets():
             model = qs.model
-            # Do not use Quest, Rank or Badge as an initial object, if it is already an intitial object for another map
+            # do not use Quest, Rank or Badge as an initial object,
+            # if it is already an intitial object for another map
             queryset_models.append(
                 model.objects.exclude(
                     pk__in=CytoScape.objects.filter(
@@ -34,7 +38,7 @@ class CytoscapeGFKChoiceField(AllowedGFKChoiceField):
                     ).values_list('initial_object_id', flat=True)
                 )
             )
-        # Aggregate querysets
+        # aggregate querysets
         self.queryset = QuerySetSequence(*queryset_models)
 
     def get_allowed_model_classes(self):

--- a/src/djcytoscape/forms.py
+++ b/src/djcytoscape/forms.py
@@ -20,14 +20,11 @@ class CytoscapeGFKChoiceField(AllowedGFKChoiceField):
         what the dynamically loaded list would have produced
     """
 
-    def __init__(self, *args, **kwargs):
-        # Initialize the new instance of CytoscapeGFKChoiceField,
-        # inherits features and methods from AllowedGFKChoiceField.
-        super().__init__(*args, **kwargs)
-
+    def overridden_querysetsequence(self, querysetsequence: QuerySetSequence) -> QuerySetSequence:
+        """Apply custom filtering and returns overridden QuerySetSequence instance"""
         queryset_models = []
-        # get previously initialized "queryset" class attribute and apply custom filtering
-        for qs in self.queryset.get_querysets():
+        # get previously initialized "querysetsequence" and apply custom filtering
+        for qs in querysetsequence.get_querysets():
             model = qs.model
             # do not use Quest, Rank or Badge as an initial object,
             # if it is already an intitial object for another map
@@ -40,7 +37,7 @@ class CytoscapeGFKChoiceField(AllowedGFKChoiceField):
                 )
             )
         # aggregate querysets
-        self.queryset = QuerySetSequence(*queryset_models)
+        return QuerySetSequence(*queryset_models)
 
     def get_allowed_model_classes(self):
         model_classes = [

--- a/src/djcytoscape/tests/test_fields.py
+++ b/src/djcytoscape/tests/test_fields.py
@@ -8,12 +8,26 @@ from djcytoscape.models import CytoScape
 class CytoscapeGFKChoiceFieldTest(TenantTestCase):
 
     def test_queryset(self):
+        """ Quick test to see if the hardcoded model list is equal to CytoScape.ALLOWED_INITIAL_CONTENT_TYPES """
         from djcytoscape.forms import CytoscapeGFKChoiceField
 
-        """ Quick test to see if the hardcoded model list is equal to CytoScape.ALLOWED_INITIAL_CONTENT_TYPES """
         dynamically_loaded_models = [
             ct.model_class() for ct in ContentType.objects.filter(CytoScape.ALLOWED_INITIAL_CONTENT_TYPES)]
 
         f = CytoscapeGFKChoiceField()
 
         self.assertEqual(dynamically_loaded_models, [qs.model for qs in f.queryset.get_querysets()])
+
+    def test_queryset_is_filterable(self):
+        from djcytoscape.forms import CytoscapeGFKChoiceField
+
+        content_type = ContentType.objects.filter(CytoScape.ALLOWED_INITIAL_CONTENT_TYPES).first()
+        obj = content_type.model_class().objects.first()
+
+        f = CytoscapeGFKChoiceField()
+        self.assertIn(obj, [o for qs in f.queryset.get_querysets() for o in qs])
+
+        CytoScape.generate_map(obj, "test")
+
+        f = CytoscapeGFKChoiceField()
+        self.assertNotIn(obj, [o for qs in f.queryset.get_querysets() for o in qs])

--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -174,7 +174,10 @@ class AllowedGFKChoiceField(GFKChoiceField):
             # django_content_type (e.g. sqlite)
             pass
 
-        super().__init__(QuerySetSequence(*[x.objects.all() for x in model_classes]), *args, **kwargs)
+        querysetsequence = self.overridden_querysetsequence(
+            QuerySetSequence(*[x.objects.all() for x in model_classes])
+        )
+        super().__init__(querysetsequence, *args, **kwargs)
 
         search_fields = {}
         for qs in self.queryset.get_querysets():
@@ -190,6 +193,14 @@ class AllowedGFKChoiceField(GFKChoiceField):
         raise NotImplementedError(
             '%s, must implement "get_allowed_model_classes" method.' % self.__class__.__name__
         )
+
+    def overridden_querysetsequence(self, querysetsequence: QuerySetSequence) -> QuerySetSequence:
+        """
+        Returns overridden QuerySetSequence instance.
+
+        Called inside __init__(), subclass should override for any actions to run.
+        """
+        return querysetsequence
 
 
 # http://stackoverflow.com/questions/2472422/django-file-upload-size-limit


### PR DESCRIPTION
### What?
This is fix for a bug reported in #1370, when creating a new map object through the create view, selecting a `Quest`, `Rank` or `Badge` as an initial object that is already an initial object for another map throws an error.

### Why?
When the bug #1370 was reported, there where no way to filter the querysets included in a `QuerysetSequence` for our `GFKChoiceField` (and all its subclasses). It was impossible to filter out (exclude) already used initial objects, so they were available in autocomplete list of our select2 widget even after being used in creating of other maps.

### How?

Simple, yet viable solution:

* modify `AllowedGFKChoiceField` class, to make it possible to run any actions on `QuerySetSequence` instance without overridding `.__init__()` instance method of subclasses, see [src/utilities/fields.py](https://github.com/bytedeck/bytedeck/pull/1485/commits/30668c797d8d40ef94cb451f157266f1a03bfc12#diff-8d3fdc182c6a97b6c31fb8f2e8ab62a22d94c4dc16b8482520373d3ba5e1f193R197)
* modify `CytoscapeGFKChoiceField` class by *overriding* `overridden_querysetsequence` method, applying custom filtering on `QuerySetSequence` instance to exclude `Quest`, `Rank` or `Badge` from querysets, if it is already an intitial object for another map, see [src/djcytoscape/forms.py](https://github.com/bytedeck/bytedeck/pull/1485/commits/30668c797d8d40ef94cb451f157266f1a03bfc12#diff-2d6c4aeb937381eeb696ddb646e4a16ff79ca0c739d0321fdb0097f2a0ee2030R23)

The [patch](https://github.com/bytedeck/bytedeck/pull/1481/commits/5268056aada0d402c0e47426ef77359fc3887c41) made it possible to use (preserve) custom querysets, not just return *all* existing objects as it was discovered by reporter. This PR goes further and fix `IntegrityError` reported in #1370, by excluding individual objects from querysets "on-a-fly" based on defined rules, next time you load the "generate new map" page and try to type in autocompletion field, you will see that all previously used "initial objects" are gone from the list.

### Testing?
Yes, PR includes test to check that the `overridden_querysetsence` method does custom filtering as described above.

### Screenshots (if front end is affected)

![exclude](https://github.com/bytedeck/bytedeck/assets/144783/ed2270d0-2481-449e-b1a3-bcbbff2da680)

### Anything Else?
Closes #1370 
### Review request
@tylerecouture
