### PR TITLE
Fix email verification link when you create new deck

### DIFF
--- a/src/hackerspace_online/adapter.py
+++ b/src/hackerspace_online/adapter.py
@@ -8,6 +8,7 @@ from allauth.account.models import EmailAddress
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.utils import build_absolute_uri
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django_tenants.utils import get_tenant_model
 
 User = get_user_model()
 
@@ -28,9 +29,12 @@ class CustomAccountAdapter(DefaultAccountAdapter):
         """
         # clear the ``Site`` object cache
         Site.objects.clear_cache()
-        url = reverse("account_confirm_email", args=[emailconfirmation.key])
-        ret = build_absolute_uri(request=None, location=url)
-        return ret
+
+        # get current tenant object...
+        tenant = get_tenant_model().get()
+        # ...and use it to build absolute uri
+        location = ''.join((tenant.get_root_url(), reverse("account_confirm_email", args=[emailconfirmation.key])))
+        return build_absolute_uri(request=None, location=location)
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):

--- a/src/hackerspace_online/adapter.py
+++ b/src/hackerspace_online/adapter.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.shortcuts import redirect
 from django.urls import reverse
 
@@ -25,6 +26,8 @@ class CustomAccountAdapter(DefaultAccountAdapter):
         confirmations are sent outside of the request context `request`
         can be `None` here.
         """
+        # clear the ``Site`` object cache
+        Site.objects.clear_cache()
         url = reverse("account_confirm_email", args=[emailconfirmation.key])
         ret = build_absolute_uri(request=None, location=url)
         return ret

--- a/src/hackerspace_online/adapter.py
+++ b/src/hackerspace_online/adapter.py
@@ -1,10 +1,12 @@
+from django.contrib.auth import get_user_model
+from django.shortcuts import redirect
+from django.urls import reverse
+
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.models import EmailAddress
 from allauth.exceptions import ImmediateHttpResponse
-
+from allauth.utils import build_absolute_uri
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from django.contrib.auth import get_user_model
-from django.shortcuts import redirect
 
 User = get_user_model()
 
@@ -14,6 +16,18 @@ class CustomAccountAdapter(DefaultAccountAdapter):
     def clean_username(self, username, shallow=False):
         username = super().clean_username(username, shallow)
         return username.lower()
+
+    def get_email_confirmation_url(self, request, emailconfirmation):
+        """
+        Constructs the email confirmation (activation) url.
+
+        *Note* that if you have architected your system such that email
+        confirmations are sent outside of the request context `request`
+        can be `None` here.
+        """
+        url = reverse("account_confirm_email", args=[emailconfirmation.key])
+        ret = build_absolute_uri(request=None, location=url)
+        return ret
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -136,6 +136,8 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertIn("Please Confirm Your E-mail Address", mail.outbox[0].subject)
         # expecting to see john.doe@example.com as recipient
         self.assertEqual(mail.outbox[0].to, ['john.doe@example.com'])
+        # expecting to see correct domain name in confirmation link
+        self.assertIn('http://default.localhost/accounts/confirm-email/', mail.outbox[0].body)
 
         owner = SiteConfig.get().deck_owner or None
         self.assertEqual(owner.get_full_name(), "John Doe")  # should be equal and prove the case

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.shortcuts import reverse
 from django.test import RequestFactory
 
+from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name
@@ -136,8 +137,11 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertIn("Please Confirm Your E-mail Address", mail.outbox[0].subject)
         # expecting to see john.doe@example.com as recipient
         self.assertEqual(mail.outbox[0].to, ['john.doe@example.com'])
-        # expecting to see correct domain name in confirmation link
-        self.assertIn('http://default.localhost/accounts/confirm-email/', mail.outbox[0].body)
+        # expecting to see correct domain name in confirmation link and make sure link is correct
+        email_address = EmailAddress.objects.get(email="john.doe@example.com")
+        key = EmailConfirmationHMAC(email_address).key
+        confirmation_link = "".join(["http://default.localhost:8000", reverse("account_confirm_email", args=[key])])
+        self.assertIn(confirmation_link, mail.outbox[0].body)
 
         owner = SiteConfig.get().deck_owner or None
         self.assertEqual(owner.get_full_name(), "John Doe")  # should be equal and prove the case

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -3,13 +3,15 @@ import functools
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.sites.models import Site
 from django.db import connection
-from django.http import Http404
+from django.http import Http404, HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.generic.edit import CreateView
 from django.urls import reverse_lazy
 
 from django_tenants.utils import get_public_schema_name
 from django_tenants.utils import tenant_context
+
+from siteconfig.models import SiteConfig
 
 from .forms import TenantForm
 from .models import Tenant
@@ -57,14 +59,12 @@ class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
 
     def form_valid(self, form):
         """ Copy the tenant name to the schema_name and the domain_url fields."""
-        from siteconfig.models import SiteConfig
-
         # TODO: this is duplication of code in admin.py.  Move this into the Tenant model?  Perhaps as a pre-save hook?
         form.instance.schema_name = form.instance.name.replace('-', '_')
         form.instance.domain_url = f'{form.instance.name}.{Site.objects.get(id=1).domain}'
 
         # save the form and get the response (HttpResponseRedirect)
-        response = super().form_valid(form)
+        self.object = form.save()
 
         # saved object (tenant) can be accessed via `object` attribute
         cleaned_data = form.cleaned_data
@@ -76,21 +76,40 @@ class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
             owner.last_name = cleaned_data['last_name']
             owner.save()
 
-            # save email address...
+            # save email address
             email = cleaned_data['email']
             owner.email = email
             owner.save()
 
-            # ...and send email confirmation message
-            from allauth.account.utils import send_email_confirmation
-            send_email_confirmation(
-                request=self.request,
-                user=owner,
-                signup=False,
-                email=owner.email,
-            )
+            response = HttpResponseRedirect(self.get_success_url())
 
         return response
+
+    def post(self, request, *args, **kwargs):
+        """
+        Handle POST requests: instantiate a form instance with the passed
+        POST variables and then check if it's valid.
+        """
+        self.object = None
+
+        form = self.get_form()
+        if form.is_valid():
+            # get the response (HttpResponseRedirect)...
+            response = self.form_valid(form)
+            # ...and send email confirmation message
+            with tenant_context(self.object):
+                owner = SiteConfig.get().deck_owner
+                from allauth.account.utils import send_email_confirmation
+                send_email_confirmation(
+                    request=request,
+                    user=owner,
+                    signup=False,
+                    email=owner.email,
+                )
+
+            return response
+        else:
+            return self.form_invalid(form)
 
     def get_success_url(self):
         """ Redirect to the newly created tenant."""

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -64,7 +64,7 @@ class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
         form.instance.domain_url = f'{form.instance.name}.{Site.objects.get(id=1).domain}'
 
         # save the form and get the response (HttpResponseRedirect)
-        self.object = form.save()
+        response = super().form_valid(form)
 
         # saved object (tenant) can be accessed via `object` attribute
         cleaned_data = form.cleaned_data
@@ -81,7 +81,7 @@ class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
             owner.email = email
             owner.save()
 
-            response = HttpResponseRedirect(self.get_success_url())
+            return HttpResponseRedirect(self.get_success_url())
 
         return response
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
This is fix for a bug reported in #1490 where when you create new deck the link that is sent  uses bytedeck.com/ as a base instead of newdeckname.bytedeck.com/ so the link is bad.

### Why?

This bug was reported in #1490 

### How?

Simple, but viable solution: 

* modify `CustomAccountAdapter` class by overriding `get_email_confirmation_url` method to use current `Site` object to build absolute url (protocol + domain + path) instead of `request` object, this is can be done by calling `allauth.utils.build_absoulute_uri` function with `request` set to `None`.

### Testing?
Yes, PR includes test to check that the verification link contains correct domain name.

### Screenshots (if front end is affected)

![url](https://github.com/bytedeck/bytedeck/assets/144783/d107e1af-9ee1-45fb-ba55-e547f7232c94)

### Anything Else?

Closes #1490 

### Review request
@tylerecouture
