### PR TITLE
Public tenant email: verified OR all

### DIFF
--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -26,10 +26,12 @@ from django_tenants.utils import tenant_context, schema_context, get_public_sche
 
 from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
 from siteconfig.models import SiteConfig
-from tenant.models import Tenant, TenantDomain
-from tenant.forms import TenantBaseForm
-from tenant.utils import generate_schema_name
-from tenant.tasks import send_email_message
+
+from .models import Tenant, TenantDomain
+from .forms import TenantBaseForm
+from .utils import generate_schema_name
+from .tasks import send_email_message
+
 
 User = get_user_model()
 
@@ -140,7 +142,7 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
     delete_selected_confirmation_template = 'admin/tenant/tenant/delete_selected_confirmation.html'
     delete_confirmation_template = 'admin/tenant/tenant/delete_confirmation.html'
 
-    actions = ['message_selected', 'enable_google_signin', 'disable_google_signin']
+    actions = ['message_unverified', 'message_verified', 'enable_google_signin', 'disable_google_signin']
 
     @admin.display(description="owner full name")
     def owner_full_name_text(self, obj):
@@ -361,10 +363,19 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
 
         return self.render_delete_form(request, context)
 
-    @admin.action(description="Send an email message to all owners for the selected tenant(s)")
-    def message_selected(self, request, queryset):
+    @admin.action(description="Send an email message to *all* owners for the selected tenant(s)")
+    def message_unverified(modeladmin, request, queryset):
+        """Send an email message to *all* owners for selected tenant(s)."""
+        return modeladmin.message_selected(request, queryset, verified=False)
+
+    @admin.action(description="Send an email message to *verified* only owners for the selected tenant(s)")
+    def message_verified(modeladmin, request, queryset):
+        """Send an email message to *verified* only owners for selected tenant(s)."""
+        return modeladmin.message_selected(request, queryset, verified=True)
+
+    def message_selected(modeladmin, request, queryset, verified=True):
         """
-        Send an email message to all owners for selected tenant(s).
+        Send an email message to either *all* or *verified* only owners for selected tenant(s).
 
         This action first displays an intermediate page which shows compose message form and
         a list of all recipients.
@@ -372,7 +383,7 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         Next, it send email message to all selected users and redirects back to the change list.
         """
         # get a list of selected tenant(s), excluding public schema
-        objects = self.model.objects.filter(
+        objects = modeladmin.model.objects.filter(
             pk__in=[str(x) for x in request.POST.getlist(helpers.ACTION_CHECKBOX_NAME)]
         ).exclude(schema_name=get_public_schema_name())
 
@@ -386,9 +397,11 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
                 # get the full name of the user, or if none is supplied will return the username
                 full_name_or_username = owner.get_full_name() or owner.username
 
-                # get the email address, but only primary and verified
                 email = ""
-                for primary_email_address in EmailAddress.objects.filter(user=owner, primary=True, verified=True):
+                for primary_email_address in EmailAddress.objects.filter(user=owner):
+                    # get the email address, but only primary and verified
+                    if verified and not (primary_email_address.verified and primary_email_address.primary):
+                        continue
                     # make sure it's primary email for real
                     if primary_email_address.email == user_email(owner):
                         email = owner.email
@@ -399,7 +412,7 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         # Create a message informing the user that the recipients were not found
         # and return a redirect to the admin index page.
         if not len(recipient_list):
-            self.message_user(request, "No recipients found.", messages.WARNING)
+            modeladmin.message_user(request, "No recipients found.", messages.WARNING)
             # return None to display the change list page again.
             return None
 
@@ -423,7 +436,7 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
                 )
 
                 # show alert that everything is cool
-                self.message_user(request, "%s users emailed successfully!" % len(recipient_list), messages.SUCCESS)
+                modeladmin.message_user(request, "%s users emailed successfully!" % len(recipient_list), messages.SUCCESS)
 
                 # return None to display the change list page again.
                 return None
@@ -437,23 +450,23 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         # AdminForm is not usually used directly by developers, but can be used by libraries that want to
         # extend the forms within the Django Admin.
         adminform = helpers.AdminForm(form, [(None, {"fields": form.base_fields})], {})
-        media = self.media + adminform.media
+        media = modeladmin.media + adminform.media
 
-        request.current_app = self.admin_site.name
+        request.current_app = modeladmin.admin_site.name
 
         # we need to create a template of intermediate page with form
         return TemplateResponse(
             request,
             "admin/tenant/tenant/message_selected_compose.html",
             context={
-                **self.admin_site.each_context(request),
+                **modeladmin.admin_site.each_context(request),
                 "title": "Write your message here",
                 "adminform": adminform,
                 "subtitle": None,
                 "recipient_list": recipient_list,
                 "queryset": objects,
                 # building proper breadcrumb in admin
-                "opts": self.model._meta,
+                "opts": modeladmin.model._meta,
                 "DEFAULT_FROM_EMAIL": settings.DEFAULT_FROM_EMAIL,
                 "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
                 "media": media,

--- a/src/tenant/templates/admin/tenant/tenant/message_selected_compose.html
+++ b/src/tenant/templates/admin/tenant/tenant/message_selected_compose.html
@@ -80,7 +80,7 @@
             {% for obj in queryset %}
                 <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
             {% endfor %}
-            <input type="hidden" name="action" value="message_selected" />
+            <input type="hidden" name="action" value="{{ request.POST.action|default:"message_verified" }}" />
             <input type="hidden" name="post" value="yes">
             <ul>
                 <li class="grp-float-left"><a href="." class="grp-button grp-cancel-link">{% trans "No, take me back" %}</a></li>

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -586,7 +586,21 @@ class TenantAdminActionsTest(TenantTestCase):
             )
             self.extra_tenant.save()
 
-        # update "owner" and add missing email address
+        # update "owner" and add *unverified* email address
+        with tenant_context(self.tenant):
+            config = SiteConfig.get()
+            if config.deck_owner is not None and not config.deck_owner.email:
+                # using different name/email to test fallback feature
+                config.deck_owner.first_name = "Jane"
+                config.deck_owner.last_name = "Doe"
+                config.deck_owner.save()
+                # add *unverified* email address (done via allauth)
+                email_address = EmailAddress.objects.add_email(
+                    request=None, user=config.deck_owner, email="jane@doe.com")
+                email_address.set_as_primary()
+                email_address.save()
+
+        # update "owner" and add *verified* email address
         with tenant_context(self.extra_tenant):
             config = SiteConfig.get()
             if config.deck_owner is not None and not config.deck_owner.email:
@@ -609,9 +623,97 @@ class TenantAdminActionsTest(TenantTestCase):
     def tearDown(self):
         app.conf.task_always_eager = self.old_celery_always_eager
 
-    def test_model_admin_send_email_message_action(self):
+    def test_model_admin_message_unverified_action(self):
         """
-        The send_email_message action on public tenant sends emails to selected tenant "owners".
+        The message_unverified action on public tenant sends emails to selected tenant "owners",
+        using both *verified* and *unverified* email addresses.
+        """
+        # first case, access /admin/tenant/ page as anonymous user
+        # should returns 302 (login required)
+        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
+        self.assertEqual(response.status_code, 302)
+
+        self.client.force_login(self.superuser)
+
+        # second case, access /admin/tenant/ page as authenticated superuser
+        # should returns 200 (ok)
+        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
+        self.assertEqual(response.status_code, 200)
+
+        # third case, select tenants and execute "message_unverified" action
+        # should returns 200 (intermediate page)
+        action_data = {
+            # trying to send message on multiple tenants (public, test and extra),
+            # one is *verified* (extra), other not (tenant)
+            ACTION_CHECKBOX_NAME: [self.public_tenant.pk, self.tenant.pk, self.extra_tenant.pk],
+            "action": "message_unverified",
+            "index": 0,
+        }
+        response = self.client.post(
+            reverse("admin:{}_{}_changelist".format("tenant", "tenant")), action_data
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, TemplateResponse)
+        self.assertContains(
+            response, "Send email to multiple users"
+        )
+        self.assertContains(response, "<h1>Write your message here</h1>")
+        # two objects were selected (tenant and extra)
+        self.assertContains(response, ACTION_CHECKBOX_NAME, count=2)
+
+        # fourth case, complete "intermediate" page/form
+        # should returns 302 (redirect back to "changelist" page)
+        compose_confirmation_data = {
+            ACTION_CHECKBOX_NAME: [self.public_tenant.pk, self.tenant.pk, self.extra_tenant.pk],
+            "action": "message_unverified",
+            # submit intermediate form (subject and message)
+            "subject": "Greetings from a TenantAdmin action",
+            "message": "Lorem ipsum dolor sit amet..",
+            # click "confirmation" button
+            "post": "yes",  # confirm form
+        }
+        response = self.client.post(
+            reverse("admin:{}_{}_changelist".format("tenant", "tenant")), compose_confirmation_data
+        )
+        self.assertEqual(response.status_code, 302)
+        # check mailbox after submitting form
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Greetings from a TenantAdmin action")
+        # expecting to see recipients in BCC list
+        self.assertEqual(mail.outbox[0].to, [settings.DEFAULT_FROM_EMAIL])
+        # two objects were selected (tenant and extra), and both are valid recipient
+        self.assertIn(
+            f"{self.tenant.name} - Jane Doe <jane@doe.com>", mail.outbox[0].bcc,
+        )
+        self.assertIn(
+            f"{self.extra_tenant.name} - John Doe <john@doe.com>", mail.outbox[0].bcc,
+        )
+
+        # fifth case, without any *verified* recipiets
+        # should returns 200 (intermediate page)
+        action_data = {
+            # trying to send message on multiple tenants (public and tenant),
+            # but without any *verified* recipients
+            ACTION_CHECKBOX_NAME: [self.public_tenant.pk, self.tenant.pk],
+            "action": "message_unverified",
+            "index": 0,
+        }
+        response = self.client.post(
+            reverse("admin:{}_{}_changelist".format("tenant", "tenant")), action_data
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, TemplateResponse)
+        self.assertContains(
+            response, "Send email to multiple users"
+        )
+        self.assertContains(response, "<h1>Write your message here</h1>")
+        # one *unverified* object was selected (tenant)
+        self.assertContains(response, ACTION_CHECKBOX_NAME, count=1)
+
+    def test_model_admin_message_verified_action(self):
+        """
+        The message_verified action on public tenant sends emails to selected tenant "owners",
+        using *verified* only email addresses.
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
@@ -631,7 +733,7 @@ class TenantAdminActionsTest(TenantTestCase):
             # trying to send message on multiple tenants (public, test and extra),
             # but only one is legit (extra)
             ACTION_CHECKBOX_NAME: [self.public_tenant.pk, self.tenant.pk, self.extra_tenant.pk],
-            "action": "message_selected",
+            "action": "message_verified",
             "index": 0,
         }
         response = self.client.post(
@@ -650,7 +752,7 @@ class TenantAdminActionsTest(TenantTestCase):
         # should returns 302 (redirect back to "changelist" page)
         compose_confirmation_data = {
             ACTION_CHECKBOX_NAME: [self.public_tenant.pk, self.tenant.pk, self.extra_tenant.pk],
-            "action": "message_selected",
+            "action": "message_verified",
             # submit intermediate form (subject and message)
             "subject": "Greetings from a TenantAdmin action",
             "message": "Lorem ipsum dolor sit amet..",
@@ -667,7 +769,9 @@ class TenantAdminActionsTest(TenantTestCase):
         # expecting to see recipients in BCC list
         self.assertEqual(mail.outbox[0].to, [settings.DEFAULT_FROM_EMAIL])
         # two objects were selected (test and extra), but only one valid recipient
-        self.assertEqual(mail.outbox[0].bcc, ["extra - John Doe <john@doe.com>"])
+        self.assertEqual(mail.outbox[0].bcc, [
+            f"{self.extra_tenant.name} - John Doe <john@doe.com>",
+        ])
 
         # fifth case, no recipients found
         # should returns 302 (redirect back to "changelist" page) and show error message
@@ -675,7 +779,7 @@ class TenantAdminActionsTest(TenantTestCase):
             # trying to send message on multiple tenants (public and test),
             # but without any valid recipients
             ACTION_CHECKBOX_NAME: [self.public_tenant.pk, self.tenant.pk],
-            "action": "message_selected",
+            "action": "message_verified",
             "index": 0,
         }
         url = reverse("admin:{}_{}_changelist".format("tenant", "tenant"))


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
This PR is for feature requested in https://github.com/bytedeck/bytedeck/issues/1504 where website administrators can selectively compose and send email to *ALL* tenant owners (not just verified emails).

### Why?

At the moment administrators can send messages to verified owners *only* (verified means email address was verified and set as primary), ignoring everyone else.

### How?

Previosly written `message_selected` admin action was *patched* to support both workflows, ie. it can be used to send email messages either to *verified* users or to *all* (by default to *verified* only). 

Call `message_selected` method with `verified` param set to `True` (default) to limit recipients to verified only, or pass `False` to remove this limitation.

New admin action introduced: `message_unverified` as name states it's for sending messages to *all* (both verified and unverified) owners.

### Testing?

Yes, both `message_verified` and `message_unverified` admin actions are covered with tests.

### Screenshots (if front end is affected)

![Screenshot 2023-11-02 at 15 14 11](https://github.com/bytedeck/bytedeck/assets/144783/581e414d-c434-4cbf-932a-db90216aa40e)

### Anything Else?

Closes #1504 

### Review request
@tylerecouture
