### PR TITLE
Add daily task for invalidating profile cache

### DIFF
--- a/src/hackerspace_online/celery.py
+++ b/src/hackerspace_online/celery.py
@@ -3,6 +3,7 @@ import os
 from django.conf import settings
 
 from tenant_schemas_celery.app import CeleryApp
+from celery.schedules import crontab
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hackerspace_online.settings')
@@ -17,6 +18,22 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+# This is the default schedule for celery beat
+# We can add more schedules here or by using the admin interface
+# See https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html
+#
+# If we need to remove a schedule, we can do so by using the admin interface
+# We just need to ensure that it is not listed in the database since it will
+# always attempt to run a schedule that is listed in the database even if
+# it is not listed here or the name of the task is changed.
+app.conf.beat_schedule = {
+    "Invalidate Profile Cache for all schemas daily task": {
+        "task": "profile_manager.tasks.invalidate_profile_cache_in_all_schemas",
+        "schedule": crontab(minute=0, hour=0),
+    }
+}
 
 
 # @app.task(bind=True)

--- a/src/profile_manager/tasks.py
+++ b/src/profile_manager/tasks.py
@@ -1,0 +1,25 @@
+from hackerspace_online.celery import app
+
+from django_tenants.utils import tenant_context, get_tenant_model
+from .models import Profile
+
+
+@app.task(name="profile_manager.tasks.invalidate_profile_cache_in_all_schemas")
+def invalidate_profile_cache_in_all_schemas():
+    """
+    Recalculate the xp of all profiles for all schemas
+    """
+    for tenant in get_tenant_model().objects.exclude(schema_name="public"):
+        with tenant_context(tenant):
+            invalidate_profile_cache_on_schema.delay()
+
+
+@app.task(name="profile_manager.tasks.invalidate_profile_cache_on_schema")
+def invalidate_profile_cache_on_schema():
+    """
+    Recalculate the xp of all profiles for a schema
+    """
+
+    profiles_qs = Profile.objects.all_for_active_semester()
+    for profile in profiles_qs:
+        profile.xp_invalidate_cache()

--- a/src/profile_manager/tests/test_tasks.py
+++ b/src/profile_manager/tests/test_tasks.py
@@ -1,0 +1,53 @@
+from django.contrib.auth import get_user_model
+
+from django_tenants.test.cases import TenantTestCase
+
+from profile_manager.tasks import invalidate_profile_cache_in_all_schemas
+from profile_manager.models import Profile
+
+from siteconfig.models import SiteConfig
+from courses.models import CourseStudent, Course
+from model_bakery import baker
+
+
+from django.test.utils import override_settings
+
+User = get_user_model()
+
+
+class ProfleTasksTests(TenantTestCase):
+    """
+    Run tasks (from tenant module) asyncronously with apply()
+    """
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_recalculate_current_xp_profile_on_all_schemas(self):
+        self.course = baker.make(Course)
+        self.active_semester = SiteConfig().get().active_semester
+
+        names = [f"user-{index}" for index in range(8)][::-1]
+
+        active_semester_students = baker.make(User, username=names.pop, _quantity=2)
+
+        for user in active_semester_students:
+            baker.make(
+                CourseStudent,
+                user=user,
+                course=self.course,
+                semester=self.active_semester,
+            )
+
+            # Set the current xp to an arbitrary value just to make sure it gets reset
+            user.profile.xp_cached = 100
+            user.profile.mark_cached = 100
+            user.profile.save()
+
+            self.assertEqual(user.profile.xp_cached, 100)
+            self.assertEqual(user.profile.mark_cached, 100)
+
+        # Run the task for recalculating the current xp
+        invalidate_profile_cache_in_all_schemas.apply()
+
+        for profile in Profile.objects.all_for_active_semester():
+            self.assertEqual(profile.xp_cached, 0)
+            self.assertEqual(profile.mark_cached, 0)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

I've added a periodic task that runs daily that invalidates every profile cache for all schemas

Resolves #1500 

### Why?

If a student doesn't trigger a mark recalculation by earning XP, then their mark stays at whatever it was without going down.

### How?

There is a simple celery task created that gets run daily to all schemas and then loops through each profile and invalidates the cache causing it to recalculate

### Testing?

Added a test where I manually set the xp_cached and mark_cached to 100 and then if the task for invalidating the cache is called, it should revert it back to 0.

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
