### PR TITLE
Refactor create_notification_tasks

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -31,7 +31,7 @@ numpy==1.22
 Pillow>=9.0.0,<9.1
 psycopg2-binary>=2.8.6,<2.10
 python-memcached>=1.58,<2.0
-tenant-schemas-celery>=2.0,<2.1
+tenant-schemas-celery>=2.2,<2.3
 future>=0.18.2,<0.19
 django-environ>=0.4.5,<0.5
 django-recaptcha>=2.0.6,<3.1

--- a/src/hackerspace_online/celery.py
+++ b/src/hackerspace_online/celery.py
@@ -29,10 +29,14 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 # always attempt to run a schedule that is listed in the database even if
 # it is not listed here or the name of the task is changed.
 app.conf.beat_schedule = {
+    "Send daily email of noticiations to all schemas": {
+        "task": "notifications.tasks.email_notification_to_users_on_all_schemas",
+        "schedule": crontab(minute=0, hour=5),
+    },
     "Invalidate Profile Cache for all schemas daily task": {
         "task": "profile_manager.tasks.invalidate_profile_cache_in_all_schemas",
         "schedule": crontab(minute=0, hour=0),
-    }
+    },
 }
 
 

--- a/src/hackerspace_online/celery.py
+++ b/src/hackerspace_online/celery.py
@@ -29,12 +29,12 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 # always attempt to run a schedule that is listed in the database even if
 # it is not listed here or the name of the task is changed.
 app.conf.beat_schedule = {
-    "Send daily email of noticiations to all schemas": {
+    "Send daily email of notifications to all schemas": {
         "task": "notifications.tasks.email_notification_to_users_on_all_schemas",
         "schedule": crontab(minute=0, hour=5),
     },
-    "Invalidate Profile Cache for all schemas daily task": {
-        "task": "profile_manager.tasks.invalidate_profile_cache_in_all_schemas",
+    "Invalidate Profile XP Cache for all schemas daily task": {
+        "task": "profile_manager.tasks.invalidate_profile_xp_cache_in_all_schemas",
         "schedule": crontab(minute=0, hour=0),
     },
 }

--- a/src/notifications/apps.py
+++ b/src/notifications/apps.py
@@ -1,16 +1,5 @@
-# import json
 from django.apps import AppConfig
-from django.db.utils import ProgrammingError
 
 
 class NotificationsConfig(AppConfig):
-    name = 'notifications'
-
-    def ready(self):
-        # if the project is already up and running, all the tables should exist and this should run
-        # otherwise, if this is being run for the first time (e.g. testing or new db), this with cause an exception
-        try:
-            from notifications.tasks import create_email_notification_tasks
-            create_email_notification_tasks()
-        except ProgrammingError:
-            pass
+    name = "notifications"

--- a/src/notifications/tasks.py
+++ b/src/notifications/tasks.py
@@ -1,16 +1,12 @@
-import json
-
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import get_template
-from django.utils import timezone
-from django_tenants.utils import get_tenant_model
+from django_tenants.utils import get_tenant_model, tenant_context
 
 from hackerspace_online.celery import app
 from quest_manager.models import QuestSubmission
-# from celery import shared_task
 
 from siteconfig.models import SiteConfig
 
@@ -19,8 +15,16 @@ from .models import Notification
 User = get_user_model()
 
 
-@app.task(name='notifications.tasks.email_notifications_to_users')
-def email_notifications_to_users(root_url):
+@app.task(name='notifications.tasks.email_notification_to_users_on_all_schemas')
+def email_notification_to_users_on_all_schemas():
+    for tenant in get_tenant_model().objects.exclude(schema_name='public'):
+        with tenant_context(tenant):
+            root_url = tenant.get_root_url()
+            email_notifications_to_users_on_schema.delay(root_url)
+
+
+@app.task(name='notifications.tasks.email_notifications_to_users_on_schema')
+def email_notifications_to_users_on_schema(root_url):
 
     notification_emails = get_notification_emails(root_url)
     connection = mail.get_connection()
@@ -72,64 +76,3 @@ def generate_notification_email(user, root_url):
         return email_msg
     else:
         return None
-
-
-def create_email_notification_tasks():
-    """Create a scheduled beat tasks for each tenant, so that emails are sent out.  The tasks themselves are
-    saved on the public schema
-
-    THIS METHOD MUST REMAIN IDEMPOTENT, so that it can be run multiple times without errors
-    """
-
-    # https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.ready
-    # Can't import models at the module level, so need to import in the method.
-    from django_celery_beat.models import CrontabSchedule, PeriodicTask
-
-    minute = 0
-
-    for tenant in get_tenant_model().objects.exclude(schema_name='public'):
-
-        # Bump each one by 1 minute, to spread out the tasks.
-        email_notifications_schedule, _ = CrontabSchedule.objects.get_or_create(
-            minute=minute,
-            hour='5',
-            day_of_week='*',
-            day_of_month='*',
-            month_of_year='*',
-            timezone=timezone.get_current_timezone()
-        )
-
-        minute += 1
-
-        task_name = f'Send daily email of notifications for schema {tenant.schema_name}',
-        # PeriodicTask doesn't have an update_or_create() method for some reason, so do it long way
-        # https://github.com/celery/django-celery-beat/issues/106
-
-        defaults = {
-            'crontab': email_notifications_schedule,
-            'task': 'notifications.tasks.email_notifications_to_users',
-            'queue': 'default',
-            'kwargs': json.dumps({  # beat needs json serializable args, so make sure they are
-                'root_url': tenant.get_root_url(),
-            }),
-            # Inject the schema name into the task's header, as that's where tenant-schema-celery
-            # will be looking for it to ensure it is tenant aware
-            'headers': json.dumps({
-                '_schema_name': tenant.schema_name,
-            }),
-            'one_off': False,
-            'enabled': True,
-        }
-
-        try:
-            task = PeriodicTask.objects.get(name=task_name)
-            for key, value in defaults.items():
-                setattr(task, key, value)
-            task.save()
-        except PeriodicTask.DoesNotExist:
-            new_values = {'name': task_name}
-            new_values.update(defaults)
-            task = PeriodicTask(**new_values)
-            task.save()
-
-        # End manual update_or_create() ############

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -1,8 +1,5 @@
-import json
-from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives
-from django_celery_beat.models import PeriodicTask
 from unittest.mock import patch
 
 from model_bakery import baker
@@ -10,7 +7,7 @@ from django_tenants.test.cases import TenantTestCase
 
 from notifications import tasks
 from notifications.models import Notification
-from notifications.tasks import create_email_notification_tasks, generate_notification_email, get_notification_emails
+from notifications.tasks import generate_notification_email, get_notification_emails
 from siteconfig.models import SiteConfig
 
 User = get_user_model()
@@ -75,7 +72,7 @@ class NotificationTasksTests(TenantTestCase):
         self.assertEqual(len(emails), 2)
 
     def test_email_notifications_to_users(self):
-        task_result = tasks.email_notifications_to_users.apply(
+        task_result = tasks.email_notifications_to_users_on_schema.apply(
             kwargs={
                 "root_url": "https://test.com",
             }
@@ -142,36 +139,3 @@ class NotificationTasksTests(TenantTestCase):
 
         emails = get_notification_emails(root_url)
         self.assertEqual(len(emails), 1)
-
-
-class CreateEmailNotificationTasksTest(TenantTestCase):
-    """ Tests of the create_email_notification_tasks() method"""
-
-    def setUp(self):
-        self.app = apps.get_app_config('notifications')
-
-    def test_task_is_created_with_new_tenant(self):
-        """ The email notifcation task should be created in ready() on when the app starts up
-        BUT DOES NOT HAPPEN ON TEST DB!
-        This is because the ready() method runs on the default db, before django knows it is testing.
-        https://code.djangoproject.com/ticket/22002
-        However, we also call the method when initializing a new tenant in
-        tenant.initialization.load_initial_tenant_data()
-        """
-        tasks = PeriodicTask.objects.filter(task='notifications.tasks.email_notifications_to_users')
-        self.assertEqual(tasks.count(), 1)
-
-        # ready is idempotent, doesn't cause problems running it again, doesn't create a new task:
-        self.app.ready()
-        tasks = PeriodicTask.objects.filter(task='notifications.tasks.email_notifications_to_users')
-        self.assertEqual(tasks.count(), 1)
-
-    def test_create_email_notification_tasks(self):
-        """ A task should have been created for the test tenant"""
-        create_email_notification_tasks()
-        tasks = PeriodicTask.objects.filter(task='notifications.tasks.email_notifications_to_users')
-        self.assertEqual(tasks.count(), 1)
-        task = tasks.first()
-        self.assertEqual(task.headers, json.dumps({"_schema_name": "test"}))
-        self.assertTrue(task.enabled)
-        self.assertFalse(task.one_off)

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -71,6 +71,10 @@ class NotificationTasksTests(TenantTestCase):
         emails = get_notification_emails(root_url)
         self.assertEqual(len(emails), 2)
 
+    def test_email_notifications_to_users_on_all_schemas(self):
+        task_result = tasks.email_notification_to_users_on_all_schemas.apply()
+        self.assertTrue(task_result.successful())
+
     def test_email_notifications_to_users(self):
         task_result = tasks.email_notifications_to_users_on_schema.apply(
             kwargs={

--- a/src/profile_manager/tasks.py
+++ b/src/profile_manager/tasks.py
@@ -4,20 +4,20 @@ from django_tenants.utils import tenant_context, get_tenant_model
 from .models import Profile
 
 
-@app.task(name="profile_manager.tasks.invalidate_profile_cache_in_all_schemas")
-def invalidate_profile_cache_in_all_schemas():
+@app.task(name="profile_manager.tasks.invalidate_profile_xp_cache_in_all_schemas")
+def invalidate_profile_xp_cache_in_all_schemas():
     """
-    Recalculate the xp of all profiles for all schemas
+    Dispatcher task that calls invalidate_xp_cache_on_schema for each schema
     """
     for tenant in get_tenant_model().objects.exclude(schema_name="public"):
         with tenant_context(tenant):
-            invalidate_profile_cache_on_schema.delay()
+            invalidate_profile_xp_cache_on_schema.delay()
 
 
-@app.task(name="profile_manager.tasks.invalidate_profile_cache_on_schema")
-def invalidate_profile_cache_on_schema():
+@app.task(name="profile_manager.tasks.invalidate_profile_xp_cache_on_schema")
+def invalidate_profile_xp_cache_on_schema():
     """
-    Recalculate the xp of all profiles for a schema
+    Invalidate xp cache of all profiles for a schema to recalculate xp
     """
 
     profiles_qs = Profile.objects.all_for_active_semester()

--- a/src/profile_manager/tests/test_tasks.py
+++ b/src/profile_manager/tests/test_tasks.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 
 from django_tenants.test.cases import TenantTestCase
 
-from profile_manager.tasks import invalidate_profile_cache_in_all_schemas
+from profile_manager.tasks import invalidate_profile_xp_cache_in_all_schemas
 from profile_manager.models import Profile
 
 from siteconfig.models import SiteConfig
@@ -46,7 +46,7 @@ class ProfleTasksTests(TenantTestCase):
             self.assertEqual(user.profile.mark_cached, 100)
 
         # Run the task for recalculating the current xp
-        invalidate_profile_cache_in_all_schemas.apply()
+        invalidate_profile_xp_cache_in_all_schemas.apply()
 
         for profile in Profile.objects.all_for_active_semester():
             self.assertEqual(profile.xp_cached, 0)

--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -43,9 +43,6 @@ def load_initial_tenant_data():
     create_initial_badges()
     create_orientation_campaign()
 
-    from notifications.tasks import create_email_notification_tasks
-    create_email_notification_tasks()
-
 
 def set_initial_icons(object_list):
     """


### PR DESCRIPTION
### What?

Refactor creating notification tasks

Resolves #1510 

### Why?

The current implementation has a problem since the `create_notification_tasks` gets run if the app is redeployed. Meaning, newly created tenants won't have that daily task in their periodic task queue.

### How?


A dispatcher task inside `src/notifications/tasks.py::email_notification_to_users_on_all_schemas` is added to celery's periodic task via `celery.py::app.conf.beat_schedule` which gets called at 5:00 daily. This task then calls `src/notifications/tasks.py::email_notification_to_users_on_schema` that contains the code that sends the email notifications to users. 


### Testing?
### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
