### PR TITLE
Public tenant list expiry date highlights

### DIFF
--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -17,6 +17,8 @@ from django.contrib.admin.utils import unquote
 from django.contrib.admin.exceptions import DisallowedModelAdminToField
 from django.contrib.admin.options import TO_FIELD_VAR, IS_POPUP_VAR
 from django.utils.translation import gettext as _
+from django.utils.html import format_html
+from django.utils.formats import date_format
 from django.urls import reverse
 
 from allauth.socialaccount.models import SocialApp
@@ -126,7 +128,7 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         'schema_name', 'owner_full_name_text', 'owner_full_name_deprecated',
         'owner_email_text', 'owner_email_deprecated',
         'last_staff_login', 'google_signon_enabled',
-        'paid_until', 'trial_end_date',
+        'paid_until_text', 'trial_end_date_text',
         'max_active_users', 'active_user_count', 'total_user_count',
         'max_quests', 'quest_count',
     )
@@ -186,6 +188,28 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         """This field will be removed in a future update"""
         return obj.owner_email
     owner_email_deprecated.admin_order_field = "owner_email"
+
+    @admin.display(description="paid until", ordering="paid_until")
+    def paid_until_text(self, obj):
+        """Returns htmlized value of `paid_until` field"""
+        if not obj.paid_until:
+            return None
+        return format_html(
+            "<span data-date=\"{}\">{}</span>",
+            obj.paid_until,
+            date_format(obj.paid_until, use_l10n=True),
+        )
+
+    @admin.display(description="trial end date", ordering="trial_end_date")
+    def trial_end_date_text(self, obj):
+        """Returns htmlized value of `trial_end_date` field"""
+        if not obj.trial_end_date:
+            return None
+        return format_html(
+            "<span data-date=\"{}\">{}</span>",
+            obj.trial_end_date,
+            date_format(obj.trial_end_date, use_l10n=True),
+        )
 
     def get_search_results(self, request, queryset, search_term):
         """

--- a/src/tenant/templates/admin/tenant/tenant/change_list.html
+++ b/src/tenant/templates/admin/tenant/tenant/change_list.html
@@ -9,23 +9,54 @@
 
         // https://stackoverflow.com/a/4017627/2700631
         $('table#result_list tbody tr').each(function() {
-            $max_users_cell = $(this).children('td.field-max_active_users')
-            max_users = Number($max_users_cell.text());
+            $max_users_cell = $(this).children('td.field-max_active_users');
+            $active_users_cell = $(this).children('td.field-active_user_count');
 
-            $active_users_cell = $(this).children('td.field-active_user_count')
+            max_users = Number($max_users_cell.text());
             active_users = Number($active_users_cell.text());
             if (active_users > max_users && max_users > -1) {  // -1 indicates unlimited
                 $active_users_cell.css('background-color', 'gold');
                 $max_users_cell.css('background-color', 'gold');
             }
 
-            // paid_until = $(this).children('td.field-paid_until').text();
-            // trial_end = $(this).children('td.field-trial_end_date').text();
+            // get current date
+            var now = new Date("{% now "Y-m-d" %}");
 
-            // console.log(paid_until);
-            // console.log(trial_end);
-
-
+            // public tenant list expiry date highlights
+            $paid_until_cell = $(this).children('td.field-paid_until_text');
+            if ($paid_until_cell.children('span').attr("data-date")) {
+                var paid_until = new Date($paid_until_cell.children('span').attr("data-date"));
+                // highlight green if current date is < date
+                if (now < paid_until) {
+                    $paid_until_cell.css('background-color', 'lime');
+                }
+                if (now >= paid_until) {
+                    // now - paid_until returns difference in milliseconds, then convert it to days
+                    var days = Number(new Date(now - paid_until) / 1000 / 60 / 60 / 24);
+                    // highlighted red if current date > 30 days AFTER the date
+                    if (days > 30) {
+                        $paid_until_cell.css('background-color', 'tomato');
+                    }
+                    else {
+                        // highlighted yellow if current date is 0-30 days AFTER the date
+                        $paid_until_cell.css('background-color', 'gold');
+                    }
+                }
+            }
+            $trial_end_cell = $(this).children('td.field-trial_end_date_text');
+            if ($trial_end_cell.children('span').attr("data-date")) {
+                var trial_end = new Date($trial_end_cell.children('span').attr("data-date"));
+                // highlight green if current date < trial end date
+                if (now < trial_end) {
+                    $trial_end_cell.css('background-color', 'lime');
+                }
+                if (now > trial_end) {
+                    // highlight yellow if current date > trial end date AND paid until date is None
+                    if (!$paid_until_cell.children('span').attr("data-date")) {
+                        $trial_end_cell.css('background-color', 'gold');
+                    }
+                }
+            }
         });
     });
 })(django.jQuery);


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
This PR is for feature requested in https://github.com/bytedeck/bytedeck/issues/1494, request was to add expiry date highlights in admin change list.

### Why?

It was requested in #1494 

### How?

Two step solution:

1. htmlize content of `paid_until` and `trial_end_data` columns, by wrapping them into ``<span data-date="YYYY-MM-DD">...</span>`` tags 
2. parse htmlized columns and apply colors according to defined rules.

### Testing?

Yes, but only backend part
### Screenshots (if front end is affected)

![Screenshot 2023-11-04 at 11 14 25](https://github.com/bytedeck/bytedeck/assets/144783/c7eba7d5-7f57-445d-bad8-6481dcffff38)

### Anything Else?

Closes #1494 
### Review request
@tylerecouture
