### PR TITLE
Fix automatic portfolio creation

### DIFF
--- a/src/portfolios/templates/portfolios/list.html
+++ b/src/portfolios/templates/portfolios/list.html
@@ -6,7 +6,7 @@
 {% block content %}
 
     <p><a class="btn btn-primary"
-          href="{% url 'portfolios:detail' request.user.id %}">View Your Portfolio</a></p>
+          href="{% url 'portfolios:current_user' %}">View Your Portfolio</a></p>
 
     <!-- <table class="table table-striped"> -->
     <table data-toggle='table'

--- a/src/portfolios/tests/test_views.py
+++ b/src/portfolios/tests/test_views.py
@@ -158,6 +158,8 @@ class PortfolioViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertFalse(Portfolio.objects.filter(user=user).exists())
 
         self.client.force_login(user)
+
+        self.assert200('portfolios:detail', args=[user.pk])
         self.assert200('portfolios:current_user')
 
         # accessing the detail page above should have created the portfolio

--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -24,9 +24,15 @@
           role="button"><i class="fa fa-line-chart"></i></a>
       {% endif %}
 
-      <a class= "btn btn-success" title="View your Portfolio"
-        href="{% url 'portfolios:detail' object.user.id %}"
-        role="button"><i class="fa fa-picture-o"></i></a>
+      {% if request.user == object.user %}
+        <a class= "btn btn-success" title="View your Portfolio"
+          href="{% url 'portfolios:current_user' %}"
+          role="button"><i class="fa fa-picture-o"></i></a>
+      {% else %}
+        <a class= "btn btn-success" title="View their Portfolio"
+          href="{% url 'portfolios:detail' object.user_id %}"
+          role="button"><i class="fa fa-picture-o"></i></a>
+      {% endif %}
     </div>
 {% endblock %}
 

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -101,7 +101,7 @@
         <i class="fa fa-user fa-fw"></i>&nbsp; Profile
       </a>
       <a id="portfolio-menu" class="list-group-item {% if '/portfolios/' in request.path_info %}active{% endif %}"
-         href="{% url 'portfolios:detail' request.user.id %}">
+         href="{% url 'portfolios:current_user' %}">
         <i class="fa fa-picture-o fa-fw"></i>&nbsp; Portfolio
       </a>
     </div>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

This fixes automatic portfolio creation when accessing their portfolio links

Fixes #1496 

### Why?

It creates a bad user experience

### How?

The `PortfolioDetail` is used for 2 urls. One for `portfolios:current_user` and the other for `portfolios:detail`.

The `if pk is None` check for the portfolio is used for the first url and if it doesn't contain the pk, it automatically creates the portfolio. Latter doesn't have this logic that automatically creates the portfolio causing the 404 portfolio does not exist error.

Also the reason why this wasn't captured in the tests is because we were only testing the `portfolios:current_user` url and not the other.

I fixed the logic by checking if a primary key is supplied or not. It will use the current user if the primary key. is not supplied, else it will try to query the id of the supplied `pk`.

Next is it will try to use the `user.portfolio` if it exists, else it will create one for the user.


### Testing?

Added the `portfolios:detail` in the test case

### Screenshots (if front end is affected)
### Anything Else?

Fixed some of the template links

### Review request
@tylerecouture
