### PR TITLE
Fix badge sort order

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -270,8 +270,9 @@ class BadgeAssertionManager(models.Manager):
         This only works in a postgresql database, but the app is designed around postgres
         https://docs.djangoproject.com/en/1.10/ref/models/querysets/#distinct
         """
-        qs = self.get_queryset(False).get_user(user).order_by('badge_id').distinct('badge_id')
-        sorted_qs = sorted(qs, key=lambda x: x.badge.sort_order or 0)  # sort_order defaults to 0 if not set
+        qs = self.get_queryset(False).select_related('badge', 'badge__badge_type').get_user(user).order_by('badge_id').distinct('badge_id')
+        sorted_qs = sorted(qs, key=lambda x: [(x.badge.badge_type.sort_order or 0), (x.badge.sort_order or 0)])  # sort_order defaults to 0 if not set
+
         return sorted_qs
 
     def badge_assertions_dict_items(self, user):

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -270,7 +270,8 @@ class BadgeAssertionManager(models.Manager):
         This only works in a postgresql database, but the app is designed around postgres
         https://docs.djangoproject.com/en/1.10/ref/models/querysets/#distinct
         """
-        qs = self.get_queryset(False).select_related('badge', 'badge__badge_type').get_user(user).order_by('badge_id').distinct('badge_id')
+        qs = self.get_queryset(False).prefetch_related('badge', 'badge__badge_type').get_user(user).order_by('badge_id').distinct('badge_id')
+
         sorted_qs = sorted(qs, key=lambda x: [(x.badge.badge_type.sort_order or 0), (x.badge.sort_order or 0)])  # sort_order defaults to 0 if not set
 
         return sorted_qs

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -157,9 +157,9 @@ class BadgeAssertionManagerTest(TenantTestCase):
         """
 
         # create badges to assign to user
-        badge1 = baker.make(Badge)  # sort order should default to 0 when not set
-        badge2 = baker.make(Badge, sort_order=1)
-        badge3 = baker.make(Badge, sort_order=2)
+        badge1 = baker.make(Badge, name='Badge 0')  # sort order should default to 0 when not set
+        badge2 = baker.make(Badge, name='Badge 1', sort_order=1)
+        badge3 = baker.make(Badge, name='Badge 2', sort_order=2)
 
         # give the student two of badge1
         badge_assertion = baker.make(BadgeAssertion, user=self.student, badge=badge1)

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -151,7 +151,7 @@ class BadgeAssertionManagerTest(TenantTestCase):
     def test_all_for_user_distinct(self):
         """
         BadgeAssertion.objects.all_for_user_distinct() returns a queryset of BadgeAssertions assigned to a user
-        that are distinct by badge, and sorted by badge.sort_order
+        that are distinct by badge, and sorted by badge.badge_type.sort_order, badge.sort_order
 
         Badge objects without a defined sort_order value should default to sort_order = 0
         """
@@ -175,6 +175,30 @@ class BadgeAssertionManagerTest(TenantTestCase):
         # and they should be sorted by badge.sort_order
         qs = BadgeAssertion.objects.all_for_user_distinct(user=self.student)
         self.assertQuerysetEqual(qs, [badge_assertion, badge_assertion2, badge_assertion3])
+
+    def test_all_for_user_distinct__badge_type_order_correct(self):
+        """
+        This test is the same with test_all_for_user_distinct, except that this test checks
+        that the badges are sorted by badge_type.sort_order, badge.sort_order.
+        """
+
+        # create badges to assign to user but with badge_type in reverse order
+        badge1 = baker.make(Badge, name='Badge 0', badge_type__sort_order=2)
+        badge2 = baker.make(Badge, name='Badge 1', badge_type__sort_order=1, sort_order=1)
+        badge3 = baker.make(Badge, name='Badge 2', badge_type__sort_order=0, sort_order=2)
+
+        # give the student two of badge1
+        badge_assertion = baker.make(BadgeAssertion, user=self.student, badge=badge1)
+        baker.make(BadgeAssertion, user=self.student, badge=badge1)  # should not be returned by all_for_user_distinct so not stored in a variable
+
+        # one of badge2
+        badge_assertion2 = baker.make(BadgeAssertion, user=self.student, badge=badge2)
+
+        # and one of badge3
+        badge_assertion3 = baker.make(BadgeAssertion, user=self.student, badge=badge3)
+
+        qs = BadgeAssertion.objects.all_for_user_distinct(user=self.student)
+        self.assertQuerysetEqual(qs, [badge_assertion3, badge_assertion2, badge_assertion])
 
 
 class BadgeAssertionTestModel(TenantTestCase):


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fix incorrect badge type sort order

Fixes #1484 

### Why?

To be consistent with the sort order of the badge type displayed

### How?


Inside `src/badges/models.py::BadgeAssertionManager::all_for_user_distinct`, we call the `sorted` function. But the parameters for sorting only considers the `badge.sort_order` which leaves out the badge type order.

To fix this, we simply need to pass a list or tuple that contains the badge type's sort order and the badge's sort order 

### Testing?

Added a test that includes modifying the sort_order of the badge_type so we know that it would consider sorting the queryset by badge_type.sort_order and then badge.sort_order

### Screenshots (if front end is affected)
### Anything Else?

Reduced the number of queries when performing the sort by using `prefetch_related` when listing a student's badge

### Review request
@tylerecouture
