### PR TITLE
Prevent calculating avaiable quest twice

### DIFF
--- a/src/prerequisites/signals.py
+++ b/src/prerequisites/signals.py
@@ -33,8 +33,17 @@ def update_cache_triggered_by_task_completion(sender, instance, *args, **kwargs)
         return
 
     list_of_models = ('BadgeAssertion', 'QuestSubmission', 'CourseStudent')
+
     if sender.__name__ in list_of_models:
         # TODO Since the cache is only for quests (as prereq parent object), only need to send for affected quests, not ALL quests?
+
+        # To prevent triggering update_quest_conditions_for_user more than once,
+        # we check if the QuestSubmission is complete and approved.
+        # When both conditions are met, that would be the only time we want to update available quests
+        # for the user.
+        if isinstance(instance, QuestSubmission) and (instance.is_completed is False or instance.is_approved is False):
+            return
+
         update_quest_conditions_for_user.apply_async(args=[instance.user_id], queue='default')
 
 

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -65,6 +65,7 @@ class PrerequisitesSignalsTest(TenantTestCase):
         """
         Updating a quest_submission (when completing a quest) should trigger a signal
         """
+        self.quest_submission.is_approved = True
         self.quest_submission.is_completed = True
         self.quest_submission.save()
         self.assertEqual(task.call_count, 1)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fixes a performance issue with a celery task that gets triggered twice whenever a quest is submitted

Fixes #1405 
Fixes #893 

### Why?

This can consume more resources in the server

### How?

Within `src/quest_manager/views.py::complete` it calls `submission.mark_completed` and `submission.mark_approved()`.

This triggers the `post_save` twice, thus running the celery task twice.

This is fixed by only running the celery task if the quest submission is both completed and approved.

 
### Testing?

Manually tested and verified that the task is only called once when a submission is completed and approved.

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
