### PR TITLE
Fix comment absolute url

### DIFF
--- a/src/comments/models.py
+++ b/src/comments/models.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.urls import reverse
 from django.utils.html import urlize, escape
 
 from notifications.models import deleted_object_receiver
@@ -158,9 +157,7 @@ class Comment(models.Model):
 
     def get_absolute_url(self):
         """ Find the aboslute url of the target object, then add the comment"""
-        # find absolute url of the target
-        self.target_object.get_absolute_url()
-        return reverse('comments:threads', kwargs={'id': self.id})
+        return self.path
 
     def get_origin(self):
         return self.path

--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -101,6 +101,12 @@ class CommentModelTest(TenantTestCase):
         self.assertIsInstance(comment, Comment)
         self.assertEqual(str(comment), comment.text)
 
+    def test_get_absolute_url(self):
+        comment = baker.make(Comment)
+        self.assertIsInstance(comment, Comment)
+        self.assertEqual(str(comment), comment.text)
+        self.assertIsNotNone(comment.get_absolute_url())
+
     def test_orphaned_li_tags(self):
         bad_comment_texts = [
             "<li>1</li><li>2</li>",


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fix for #1515 

### Why?

Creates a bad user experience for users accessing the notifications page

### How?

Comment.path is being set whenever a comment is created and it already contains the absolute url that targets the comment.

It was just a matter of adding `comment.path` to the `get_absolute_url` function so it works properly.

### Testing?

Manually tested in the screen recording below and an additional test case that checks for the `get_absolute_url`

### Screenshots (if front end is affected)

https://github.com/bytedeck/bytedeck/assets/10972027/d4a089fc-85ba-4b09-a6bd-3ec3a4c8f043



### Anything Else?

I think we can remove the `comments:thread` since it's not being used anywhere else

### Review request
@tylerecouture
