### PR TITLE
Do not allow auto publish if archive is True

### DIFF
--- a/src/announcements/forms.py
+++ b/src/announcements/forms.py
@@ -38,9 +38,12 @@ class AnnouncementForm(forms.ModelForm):
 
         auto_publish = data.get('auto_publish')
         datetime_released = data.get('datetime_released')
+        archived = data.get('archived')
 
         if auto_publish and datetime_released < timezone.now():
-            raise forms.ValidationError(
-                'An Announcement that is auto published cannot have a past release date.'
-            )
+            self.add_error("datetime_released", forms.ValidationError('An Announcement that is auto published cannot have a past release date.'))
+
+        if auto_publish and archived:
+            self.add_error("archived", forms.ValidationError('Cannot auto publish and archive an Announcement at the same time.'))
+
         return data

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -170,6 +170,21 @@ class AnnouncementViewTests(ViewTestUtilsMixin, TenantTestCase):
         )
         form = AnnouncementForm(data=model_to_dict(draft_announcement))
         self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['datetime_released'], ['An Announcement that is auto published cannot have a past release date.'])
+
+    def test_create_announcement_auto_publish_and_archive(self):
+        draft_announcement = baker.make(
+            Announcement,
+            datetime_released=timezone.now() - timedelta(days=3),
+            auto_publish=True,
+        )
+
+        form_data = model_to_dict(draft_announcement)
+        form_data['archived'] = True
+
+        form = AnnouncementForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['archived'], ['Cannot auto publish and archive an Announcement at the same time.'])
 
     def test_comment_on_announcement_by_student(self):
         # log in a student


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fix #1216 

### Why?

It does not make sense to auto publish an archived announcement

### How?

By adding a validation check if both auto_publish and archived is set in the form.

### Testing?

Added test in form validation

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
