### PR TITLE
Add queue when running celery tasks

### DIFF
--- a/src/hackerspace_online/celery.py
+++ b/src/hackerspace_online/celery.py
@@ -32,10 +32,16 @@ app.conf.beat_schedule = {
     "Send daily email of notifications to all schemas": {
         "task": "notifications.tasks.email_notification_to_users_on_all_schemas",
         "schedule": crontab(minute=0, hour=5),
+        "options": {
+            "queue": "default",
+        }
     },
     "Invalidate Profile XP Cache for all schemas daily task": {
         "task": "profile_manager.tasks.invalidate_profile_xp_cache_in_all_schemas",
         "schedule": crontab(minute=0, hour=0),
+        "options": {
+            "queue": "default",
+        }
     },
 }
 

--- a/src/notifications/tasks.py
+++ b/src/notifications/tasks.py
@@ -20,7 +20,9 @@ def email_notification_to_users_on_all_schemas():
     for tenant in get_tenant_model().objects.exclude(schema_name='public'):
         with tenant_context(tenant):
             root_url = tenant.get_root_url()
-            email_notifications_to_users_on_schema.delay(root_url)
+            email_notifications_to_users_on_schema.apply_async(args=[root_url], queue='default')
+
+    return "Scheduled email_notifications_to_users_on_schema for all schemas"
 
 
 @app.task(name='notifications.tasks.email_notifications_to_users_on_schema')
@@ -30,6 +32,8 @@ def email_notifications_to_users_on_schema(root_url):
     connection = mail.get_connection()
     connection.send_messages(notification_emails)
     # send_email_notification_tenant.delay(root_url)
+
+    return f"Sent {len(notification_emails)} notification emails"
 
 
 def get_notification_emails(root_url):

--- a/src/profile_manager/tasks.py
+++ b/src/profile_manager/tasks.py
@@ -11,7 +11,9 @@ def invalidate_profile_xp_cache_in_all_schemas():
     """
     for tenant in get_tenant_model().objects.exclude(schema_name="public"):
         with tenant_context(tenant):
-            invalidate_profile_xp_cache_on_schema.delay()
+            invalidate_profile_xp_cache_on_schema.apply_async(queue='default')
+
+    return "Scheduled invalidate_profile_xp_cache_on_schema for all schemas"
 
 
 @app.task(name="profile_manager.tasks.invalidate_profile_xp_cache_on_schema")
@@ -21,5 +23,8 @@ def invalidate_profile_xp_cache_on_schema():
     """
 
     profiles_qs = Profile.objects.all_for_active_semester()
+
     for profile in profiles_qs:
         profile.xp_invalidate_cache()
+
+    return f"Successfully invalidated {profiles_qs.count()} profiles."


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fix for celery tasks not running

### Why?

Celery tasks ran with `.delay()` gets put in the `celery` queue. Since we are running celery with the `-Q default` args, it only runs tasks put in the `default` queue. 

### How?

By passing in the `options` and the queue

### Testing?

Manually tested

### Screenshots (if front end is affected)

<img width="1728" alt="image" src="https://github.com/bytedeck/bytedeck/assets/10972027/af253993-443d-4752-b6b9-ce9e37258890">


### Anything Else?
### Review request
@tylerecouture
