### PR TITLE
Fix account inactive template

### DIFF
--- a/src/templates/account/account_inactive.html
+++ b/src/templates/account/account_inactive.html
@@ -1,0 +1,11 @@
+{% extends "base_no_sidebar.html" %}
+{% load crispy_forms_tags %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Account Inactive" %} | {% endblock %}
+{% block heading %}{% trans "Account Inactive" %}<i class="pull-right fa fa-key"></i>{% endblock %}
+{% block content %}
+  <p>{% trans "This account is inactive." %}</p>
+{% endblock %}
+


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/

### What?

Resolves #1553 

### Why?

The behavior is correct but it uses the default template which is not what we want.

### How?

By overriding the default template and adding our own account_inactive.html

### Testing?

Manually tested

### Screenshots (if front end is affected)

<img width="1728" alt="image" src="https://github.com/bytedeck/bytedeck/assets/10972027/58b1929b-7b22-40f2-958b-2e080fd5fcd8">


### Anything Else?
### Review request
@tylerecouture
