### PR TITLE
added id to line 55

### DIFF
--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -77,7 +77,7 @@
 
 <script>
   $('body').on('click', '#end-semester', function(e) {
-      if(!confirm("Are you sure?")) {
+      if(!confirm("WARNING!  Once a semester is closed, it can't be re-opened. It will archive all announcements, and delete any in-progress submissions. Are you sure you want to do this?")) {
           e.preventDefault();
           return;
       }

--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -52,7 +52,7 @@
         </a>
         {% endif %}
         {% if not object.closed and object == config.active_semester%}
-        <a class="btn btn-danger" href="{% url 'courses:end_active_semester' %}" role="button"
+        <a class="btn btn-danger" href="{% url 'courses:end_active_semester' %}" role="button" id="end-semester"
           title="Close this semester. WARNING!  Once a semester is closed, it can't be re-opened. This will permanently record all student XP for the semester. Which means changing or deleting quests, submissions, or badges will no longer affect their marks.  It will also archive all announcements, and delete any in-progress submissions.">
           <i class="fa fa-calendar-times-o"></i>
         </a>

--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -53,7 +53,7 @@
         {% endif %}
         {% if not object.closed and object == config.active_semester%}
         <a class="btn btn-danger" href="{% url 'courses:end_active_semester' %}" role="button" id="end-semester"
-          title="Close this semester. WARNING!  Once a semester is closed, it can't be re-opened. This will permanently record all student XP for the semester. Which means changing or deleting quests, submissions, or badges will no longer affect their marks.  It will also archive all announcements, and delete any in-progress submissions.">
+          title="Close this semester. WARNING!  Once a semester is closed, it can't be re-opened. This will permanently record all student XP for the semester. Which means changing or deleting quests, submissions, or badges will no longer affect their marks.  It will also archive all announcements and delete any in-progress submissions.">
           <i class="fa fa-calendar-times-o"></i>
         </a>
         {% endif %}
@@ -77,7 +77,7 @@
 
 <script>
   $('body').on('click', '#end-semester', function(e) {
-      if(!confirm("WARNING!  Once a semester is closed, it can't be re-opened. It will archive all announcements, and delete any in-progress submissions. Are you sure you want to do this?")) {
+      if(!confirm("WARNING!  Once a semester is closed, it can't be re-opened. It will archive all announcements and delete any in-progress submissions. Are you sure you want to do this?")) {
           e.preventDefault();
           return;
       }


### PR DESCRIPTION
I was asked to add a confirmation step to prevent mistakenly ending a semester 

Upon looking into the file i noticed that there was already a js script tag at the very bottom with the onclick property on a tag 
id-ed "endsemester" however there was no tag that was id-ed that particular name. So I just id-ed the respective anchor tag mentioned as "endsemester".  

Another approach to this would be to use the "onclick()" function directly on the responsible anchor tag and use the "confirm" function within it. I am also ready to try out this approach. 

I apologize for any oversight that I may have made. I had no intention of wasting anybody's time. 