### PR TITLE
Add "tenant" object into template context, fix #1489

### DIFF
--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -135,6 +135,7 @@ def email_confirmed_handler(email_address, **kwargs):
     # send an email with instructions for how to log in with the username and password.
     user = email_address.user
     config = SiteConfig.get()
+    tenant = Tenant.get()
 
     # just verified email for a first time and never been logged into app before
     if user.last_login is not None:
@@ -145,6 +146,7 @@ def email_confirmed_handler(email_address, **kwargs):
 
     subject = get_template("tenant/email/welcome_subject.txt").render(context={
         "config": config,
+        "tenant": tenant,
         "user": user,
     })
     # email subject *must not* contain newlines
@@ -153,6 +155,7 @@ def email_confirmed_handler(email_address, **kwargs):
     # generate "welcome" email for new user
     msg = get_template("tenant/email/welcome_message.txt").render(context={
         "config": config,
+        "tenant": tenant,
         "user": user,
     })
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Add ``tenant`` object into template context, as requested here: https://github.com/bytedeck/bytedeck/issues/1489#issuecomment-1970462165
### Why?
As requested here https://github.com/bytedeck/bytedeck/issues/1489#issuecomment-1970462165
### How?

Calling ``Tenant.get`` and including returned object into context as ``tenant`` object.

### Testing?

Nope.

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email confirmation process by including tenant-specific information in the email templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->