### PR TITLE
Refactor docker-compose files to fix #940.

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: "2.2"
 
 ###############################################################################
 #
@@ -25,7 +25,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-    - 5432:5432  # Expose port so app can connect to db when developing locally with `python src/manage.py [runserver|test src]
+      - 5432:5432 # Expose port so app can connect to db when developing locally with `python src/manage.py [runserver|test src]
 
   redis:
     image: "redis:5.0-alpine"
@@ -41,18 +41,18 @@ services:
       timeout: 3s
       retries: 30
     ports:
-    - 6379:6379  # Expose port so app can connect to redis when developing locally with `python src/manage.py [runserver|test src]
+      - 6379:6379 # Expose port so app can connect to redis when developing locally with `python src/manage.py [runserver|test src]
 
   web:
+    build:
+      context: .
+      dockerfile: ./local/Dockerfile
     stdin_open: true
-    tty: true   # Enabled together with stdin_open so it won't raise an error when we are in pdb mode. Attach using `docker attach $(docker compose ps -q web)`
+    tty: true # Enabled together with stdin_open so it won't raise an error when we are in pdb mode. Attach using `docker attach $(docker compose ps -q web)`
     environment:
-      POSTGRES_HOST: db  # takes precendent over .env file
-      REDIS_HOST: redis  # takes precendent over .env file
-    command: bash -c "cd /app/src/ &&
-                      python manage.py migrate_schemas --shared &&
-                      python manage.py migrate_schemas --executor=multiprocessing &&
-                      python manage.py runserver 0.0.0.0:8000"   # no need for uwsgi in development, this is easier
+      POSTGRES_HOST: db # takes precendent over .env file
+      REDIS_HOST: redis # takes precendent over .env file
+    command: /start-django
     depends_on:
       db:
         condition: service_healthy
@@ -60,24 +60,36 @@ services:
         condition: service_healthy
 
   celery:
+    build:
+      context: .
+      dockerfile: ./local/Dockerfile
     environment:
-      POSTGRES_HOST: db  # takes precendent over .env file
-      REDIS_HOST: redis  # takes precendent over .env file
+      POSTGRES_HOST: db # takes precendent over .env file
+      REDIS_HOST: redis # takes precendent over .env file
+    entrypoint: /celery-entrypoint
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+      web:
+        condition: service_started
 
   celery-beat:
+    build:
+      context: .
+      dockerfile: ./local/Dockerfile
     environment:
-      POSTGRES_HOST: db  # takes precendent over .env file
-      REDIS_HOST: redis  # takes precendent over .env file
+      POSTGRES_HOST: db # takes precendent over .env file
+      REDIS_HOST: redis # takes precendent over .env file
+    entrypoint: /celery-entrypoint
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+      web:
+        condition: service_started
 
   pg-admin:
     image: dpage/pgadmin4

--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: "2.2"
 
 ###############################################################################
 #
@@ -12,20 +12,30 @@ version: '2.2'
 
 services:
   web:
-    command: bash -c "cd /app/src/ &&
-                      python manage.py migrate_schemas --shared &&
-                      python manage.py migrate_schemas --executor=multiprocessing &&
-                      python manage.py collectstatic --noinput &&
-                      uwsgi --ini uwsgi.aws.ini"
+    build:
+      context: .
+      dockerfile: ./production/Dockerfile
+    command: /start-django
     volumes:
       - .:/app
       # - static_data:/app/src/static  # use static dir as a fallback for hardcoded urls hitting app directly
       # - media_data:/app/media
       # - socket_data:/bytedeck-volume
     user: $WUID:$WGID
+    entrypoint: /entrypoint
 
   celery:
+    build:
+      context: .
+      dockerfile: ./production/Dockerfile
     user: $WUID:$WGID
+    entrypoint: /celery-entrypoint
+
+  celery-beat:
+    build:
+      context: .
+      dockerfile: ./production/Dockerfile
+    entrypoint: /celery-entrypoint
 
   nginx:
     build:
@@ -34,7 +44,7 @@ services:
         WUID: $WUID
         WGID: $WGID
     volumes:
-        - /etc/letsencrypt:/etc/letsencrypt
+      - /etc/letsencrypt:/etc/letsencrypt
     #   - static_data:/var/www/bytedeck/static
     #   - socket_data:/bytedeck-volume
     #   - media_data:/var/www/bytedeck/media/
@@ -46,10 +56,8 @@ services:
     user: $WUID:$WGID
     networks:
       - backend-network
-
 # volumes:
 #  static_data:       # commenting static_data volume as collectstatic cmd picking this up instead of S3 for STATIC_ROOT.
 #  socket_data:
 #  media_data:
-
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: "2.2"
 
 ###############################################################################
 #
@@ -10,7 +10,6 @@ version: '2.2'
 ################################################################################
 
 services:
-
   web:
     build:
       context: .
@@ -34,8 +33,7 @@ services:
       context: .
       dockerfile: Dockerfile
     env_file: .env
-    command: bash -c "cd src &&
-                      celery -A hackerspace_online worker -l info -c 3 -Q default"
+    command: /start-celeryworker
     volumes:
       - .:/app
     networks:
@@ -46,8 +44,7 @@ services:
       context: .
       dockerfile: Dockerfile
     env_file: .env
-    command: bash -c "cd src &&
-                      celery -A hackerspace_online beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler"
+    command: /start-celerybeat
     volumes:
       - .:/app
     networks:

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
 
 RUN pip install pylint
 
+RUN apt-get install -y wait-for-it
+
 # Install git, process tools, lsb-release (common in install instructions for CLIs)
 RUN apt-get install -y git procps lsb-release
 
@@ -70,8 +72,30 @@ RUN python3 -m pip install -r requirements.txt
 
 # Set working directory for subsequent RUN ADD COPY CMD instructions
 COPY . /app/
-WORKDIR /app/
 
+COPY ./local/docker-entrypoint /entrypoint
+RUN sed -i 's/\r$//g' /entrypoint
+RUN chmod +x /entrypoint
+
+COPY ./local/celery-entrypoint /celery-entrypoint
+RUN sed -i 's/\r$//g' /celery-entrypoint
+RUN chmod +x /celery-entrypoint
+
+COPY ./local/start-django /start-django
+RUN sed -i 's/\r$//g' /start-django
+RUN chmod +x /start-django
+
+COPY ./local/start-celery-worker /start-celeryworker
+RUN sed -i 's/\r$//g' /start-celeryworker
+RUN chmod +x /start-celeryworker
+
+COPY ./local/start-celery-beat /start-celerybeat
+RUN sed -i 's/\r$//g' /start-celerybeat
+RUN chmod +x /start-celerybeat
+
+WORKDIR /app
+
+ENTRYPOINT ["/entrypoint"]
 
 #### More from https://github.com/Microsoft/vscode-remote-try-python ##
 

--- a/local/celery-entrypoint
+++ b/local/celery-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# if any of the commands in your code fails for any reason, the entire script fails
+set -o errexit
+# exits if any of your variables is not set
+set -o nounset
+
+wait-for-it -t 120 web:8000
+
+# Run the main container command.
+exec "$@"

--- a/local/docker-entrypoint
+++ b/local/docker-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# if any of the commands in your code fails for any reason, the entire script fails
+set -o errexit
+# fail exit if one of your pipe command fails
+set -o pipefail
+# exits if any of your variables is not set
+set -o nounset
+
+# Run the main container command.
+exec "$@"

--- a/local/start-celery-beat
+++ b/local/start-celery-beat
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+cd src
+celery -A hackerspace_online beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/local/start-celery-worker
+++ b/local/start-celery-worker
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+cd src
+celery -A hackerspace_online worker -l info -c 1 -Q default

--- a/local/start-django
+++ b/local/start-django
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# if any of the commands in your code fails for any reason, the entire script fails
+set -o errexit
+# fail exit if one of your pipe command fails
+set -o pipefail
+# exits if any of your variables is not set
+set -o nounset
+
+cd /app/src/
+python manage.py migrate_schemas --shared
+python manage.py migrate_schemas --executor=multiprocessing
+python manage.py runserver 0.0.0.0:8000

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,0 +1,105 @@
+FROM python:3.8-slim
+
+#### For development within the container in VS Code ##
+# https://code.visualstudio.com/docs/remote/containers
+# https://github.com/Microsoft/vscode-remote-try-python
+
+# Allow for an orderly, graceful shutdown of services
+# Specifically in our case:
+# 1. give coverage a chance to send its report to coveralls.io
+# 2. allow celerybeat to delete its pid file (does this actually happen?)
+STOPSIGNAL SIGINT
+
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+RUN pip install pylint
+
+RUN apt-get install -y wait-for-it
+
+# Install git, process tools, lsb-release (common in install instructions for CLIs)
+RUN apt-get install -y git procps lsb-release
+
+# Required for psycopg2: https://github.com/psycopg/psycopg2/issues/699
+RUN apt-get install -y --no-install-recommends libpq-dev
+
+# Install any missing dependencies for enhanced language service
+RUN apt-get install -y libicu[0-9][0-9]
+
+# Install uwsgi
+RUN apt-get install -y build-essential
+
+#https://stackoverflow.com/questions/21669354/rebuild-uwsgi-with-pcre-support
+RUN apt-get install -y libpcre3 libpcre3-dev
+
+RUN python3 -m pip install --upgrade pip
+
+# Why isn't this in requirements?!  Move it there?
+RUN python3 -m pip install uwsgi
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog
+
+# Set the default shell to bash rather than sh
+ENV SHELL /bin/bash
+
+# Set environment variables
+
+# Don't create .pyc files (why don't we want these?)
+ENV PYTHONDONTWRITEBYTECODE 1
+# Prevent docker from buffering console output
+ENV PYTHONUNBUFFERED 1
+
+
+# Install python requirements
+# Docker only rebuilds when there are changes to these files
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+COPY ./requirements-production.txt requirements-production.txt
+COPY ./requirements.txt requirements.txt
+RUN python3 -m pip install -r requirements.txt
+######################################################
+
+# Enable below when uwsgi-nginx uses unix sock
+# RUN mkdir /bytedeck-volume
+# ARG WUID
+# ARG WGID
+# RUN chown -R ${WUID}:${WGID} /bytedeck-volume
+
+# Set working directory for subsequent RUN ADD COPY CMD instructions
+COPY . /app/
+
+COPY ./production/docker-entrypoint /entrypoint
+RUN sed -i 's/\r$//g' /entrypoint
+RUN chmod +x /entrypoint
+
+COPY ./production/celery-entrypoint /celery-entrypoint
+RUN sed -i 's/\r$//g' /celery-entrypoint
+RUN chmod +x /celery-entrypoint
+
+COPY ./production/start-django /start-django
+RUN sed -i 's/\r$//g' /start-django
+RUN chmod +x /start-django
+
+COPY ./production/start-celery-worker /start-celeryworker
+RUN sed -i 's/\r$//g' /start-celeryworker
+RUN chmod +x /start-celeryworker
+
+COPY ./production/start-celery-beat /start-celerybeat
+RUN sed -i 's/\r$//g' /start-celerybeat
+RUN chmod +x /start-celerybeat
+
+WORKDIR /app
+
+ENTRYPOINT ["/entrypoint"]
+
+#### More from https://github.com/Microsoft/vscode-remote-try-python ##
+
+#######################################################################
+
+# RUN adduser --disabled-password appuser
+# USER appuser

--- a/production/celery-entrypoint
+++ b/production/celery-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# if any of the commands in your code fails for any reason, the entire script fails
+set -o errexit
+# exits if any of your variables is not set
+set -o nounset
+
+wait-for-it -t 120 web:8000
+
+# Run the main container command.
+exec "$@"

--- a/production/docker-entrypoint
+++ b/production/docker-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# if any of the commands in your code fails for any reason, the entire script fails
+set -o errexit
+# fail exit if one of your pipe command fails
+set -o pipefail
+# exits if any of your variables is not set
+set -o nounset
+
+# Run the main container command.
+exec "$@"

--- a/production/start-celery-beat
+++ b/production/start-celery-beat
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+cd src
+celery -A hackerspace_online beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/production/start-celery-worker
+++ b/production/start-celery-worker
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+cd src
+celery -A hackerspace_online worker -l info -c 1 -Q default

--- a/production/start-django
+++ b/production/start-django
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# if any of the commands in your code fails for any reason, the entire script fails
+set -o errexit
+# fail exit if one of your pipe command fails
+set -o pipefail
+# exits if any of your variables is not set
+set -o nounset
+
+cd /app/src/
+python manage.py migrate_schemas --shared
+python manage.py migrate_schemas --executor=multiprocessing
+python manage.py collectstatic --noinput
+uwsgi --ini uwsgi.aws.ini"


### PR DESCRIPTION

### What?
Refactor docker-compose files to start celery and celery-beat after django migrations 
### Why?
When running `docker-compose up` the celery container will be ready before the web container.
However, migrations are run by the web container:
which means celery might be trying to access columns or tables that don't exist yet. 

### How?
* Introduce separate Dockerfiles for development and production builds.
* Update service configurations to use custom pass through entrypoints.
* Entry points for celery and celery-beat wait for django app to be reachable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Docker setup to include specific entrypoints and commands for services like web, celery, and celery-beat.
  - Added installations and scripts for improved service management in Docker environments.
  
- **Bug Fixes**
  - Corrected Docker compose configurations and indentation issues for better reliability and clarity.

- **Documentation**
  - Updated comments and documentation within Docker configuration files for clearer understanding and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->