### PR TITLE
Fix: Redirect when canceling the deleltion of comment; Closes #1497

### DIFF
--- a/src/comments/templates/comments/confirm_delete.html
+++ b/src/comments/templates/comments/confirm_delete.html
@@ -11,7 +11,7 @@
     <p>Date Posted: {{object.timestamp}}</p>
     <p>Comment: {{object.text|safe}}</p>
   </div>
-  <a href="{{comment.path}}" role="button" class="btn btn-info">Cancel</a>
+  <a href="{{object.path}}" role="button" class="btn btn-info">Cancel</a>
   <input type="submit" value="Delete" class="btn btn-danger" />
 </form>
 {% endblock %}

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -98,7 +98,7 @@ class CommentViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
 
     def test_delete_comment_path(self):
-        ''' test if comment.path is inside 'Cancel' button in src/comments/templates/comments/confirm_delete.html
+        ''' Test if the 'Cancel' button in src/comments/templates/comments/confirm_delete.html correctly contains the `comment.path` as its href attribute.
         '''
         self.client.force_login(self.teacher)
 

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -98,7 +98,8 @@ class CommentViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
 
     def test_delete_comment_path(self):
-        ''' Test if the 'Cancel' button in src/comments/templates/comments/confirm_delete.html correctly contains the `comment.path` as its href attribute.
+        ''' Test if the 'Cancel' button in src/comments/templates/comments/confirm_delete.html
+        correctly contains the `comment.path` as its href attribute.
         '''
         self.client.force_login(self.teacher)
 

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -6,6 +6,7 @@ from django_tenants.test.client import TenantClient
 from unittest.mock import patch
 from model_bakery import baker
 from comments.models import Comment
+from bs4 import BeautifulSoup
 
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
 
@@ -95,3 +96,18 @@ class CommentViewTests(ViewTestUtilsMixin, TenantTestCase):
         response = self.client.post(reverse('comments:delete', args=[self.comment.id]))
         self.assertRedirects(response, path)
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
+
+    def test_delete_comment_path(self):
+        ''' test if comment.path is inside 'Cancel' button in src/comments/templates/comments/confirm_delete.html
+        '''
+        self.client.force_login(self.teacher)
+
+        # get confirm delete content html
+        response = self.client.get(reverse('comments:delete', args=[self.comment.id]))
+        self.assertContains(response, 'Cancel')
+
+        soup = BeautifulSoup(response.content.decode('utf-8'), features='html.parser')
+
+        # find the Cancel Button
+        tag = soup.find('a', href=self.announcement.get_absolute_url(), role='button', text='Cancel')
+        self.assertIsNotNone(tag)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Stated in #1497, there is an issue with the cancel button when deleting a comment (via comment confirm delete.)
This PR fixes that by redirecting the comment to its comment.path URL, or the source link of where the user commented. 

### Why?
This issue is an unexpected behaviour as the cancel button implies that it cancels the deleltion of a comment. In reality, it does nothing.

### How?
By changing the "comment" variable to "object" in src/comments/templates/comments/confirm_delete.html. As "comment" is not referenced at all in the context but "object" is. 
From:
```
{{comment.path}}
```
To:
```
{{object.path}}
```

### Testing?
Manually clicking cancel with an admin account and visually confirming if it redirected to the announcement page.

Also created an automated test inside comments test apps, where (using bs4) checks if the comments path is inside the cancel button.
ie.
``` <a href="COMMENT PATH" role="button" class="btn btn-info">Cancel</a> ```


### Screenshots (if front end is affected)
Before pressing cancel:
![image](https://github.com/bytedeck/bytedeck/assets/39788517/e7c2b99a-95c6-4fc5-a1ef-3f496655a24e)
After pressing cancel:
![image](https://github.com/bytedeck/bytedeck/assets/39788517/f76b2466-dce7-4fd6-8e62-9b875593a65d)


### Anything Else?
I've also noticed this behavior also applies to comments for quests submissions. This pr should also fix it. Tested using the same method mentioned above

### Review request
@tylerecouture