### PR TITLE
Fix: Default Submission replies should be in p tags; Closes #1235

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -604,7 +604,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
         # make sure the comment was created
         comments = self.sub.get_comments()
         self.assertEqual(comments.count(), 1)
-        self.assertEqual(comments[0].text, comment)
+        self.assertEqual(comments[0].text, f'<p>{comment}</p>')
 
     def test_no_comment_verification_not_required_quick_reply_form(self):
         """ When a quest is automatically approved, it does not require a comment
@@ -724,7 +724,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
         # make sure the comment was created
         comments = self.sub.get_comments()
         self.assertEqual(comments.count(), 1)
-        self.assertEqual(comments[0].text, comment)
+        self.assertEqual(comments[0].text, f'<p>{comment}</p>')
 
     def test_comment_button_no_comment_verification_not_required(self):
         """ When commenting on an already completed quest, needs to actually comment with something
@@ -2025,7 +2025,7 @@ class ApproveViewTest(ViewTestUtilsMixin, TenantTestCase):
         from comments.models import Comment
         comments = Comment.objects.all_with_target_object(self.sub)
         self.assertEqual(comments.count(), 1)
-        self.assertEqual(comments.first().text, f"<p>{comment_text}</p>")
+        self.assertEqual(comments.first().text, comment_text)
 
         # And the student should have a notification
         # get_user_target is a weird method, should probably be refactored or better documented...
@@ -2220,7 +2220,7 @@ class ApproveViewTest(ViewTestUtilsMixin, TenantTestCase):
         from comments.models import Comment
         comments = Comment.objects.all_with_target_object(self.sub)
         self.assertEqual(comments.count(), 1)
-        self.assertEqual(comments.first().text, f"<p>{comment_text}</p>")
+        self.assertEqual(comments.first().text, comment_text)
 
         # And the student should have a notification
         # get_user_target is a weird method, should probably be refactored or better documented...

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -696,7 +696,7 @@ def approve(request, submission_id):
                     + "<i class='fa fa-shield fa-stack-1x'></i>"
                     + "</span>"
                 )
-                blank_comment_text = SiteConfig.get().blank_approval_text
+                blank_comment_text = f"<p>{SiteConfig.get().blank_approval_text}</p>"
                 submission.mark_approved()
             elif "comment_button" in request.POST:
                 note_verb = "commented on"
@@ -706,7 +706,7 @@ def approve(request, submission_id):
                     + "<i class='fa fa-comment-o fa-stack-2x text-info'></i>"
                     + "</span>"
                 )
-                blank_comment_text = "(no comment added)"
+                blank_comment_text = "<p>(no comment added)</p>"
             elif "return_button" in request.POST:
                 note_verb = "returned"
                 icon = (
@@ -715,7 +715,7 @@ def approve(request, submission_id):
                     + "<i class='fa fa-ban fa-stack-2x text-danger'></i>"
                     + "</span>"
                 )
-                blank_comment_text = SiteConfig.get().blank_return_text
+                blank_comment_text = f"<p>{SiteConfig.get().blank_return_text}</p>"
                 submission.mark_returned()
             elif "skip_button" in request.POST:
                 note_verb = "skipped"
@@ -725,22 +725,21 @@ def approve(request, submission_id):
                     + "</span>"
                 )
                 blank_comment_text = (
-                    "(Skipped - You were not granted XP for this quest)"
+                    "<p>(Skipped - You were not granted XP for this quest)</p>"
                 )
                 submission.mark_approved(transfer=True)
             else:
                 raise Http404("unrecognized submit button")
 
             comment_text_form = form.cleaned_data.get("comment_text")
-            if not comment_text_form:
+            if not comment_text_form or comment_text_form == "<p><br></p>":
                 comment_text = blank_comment_text
             else:
                 comment_text = comment_text_form
             comment_new = Comment.objects.create_comment(
                 user=request.user,
                 path=origin_path,
-                # wrap comment text in <p> tag so default submission replies and quick replies are formatted correctly
-                text=f"<p>{comment_text}</p>{comment_text_addition}",
+                text=comment_text + comment_text_addition,
                 target=submission,
             )
 
@@ -993,7 +992,7 @@ def complete(request, submission_id):
 
         if form.is_valid():
             comment_text = form.cleaned_data.get("comment_text")
-            if not comment_text:
+            if not comment_text or comment_text == "<p><br></p>":
                 if submission.quest.verification_required and not request.FILES:
                     messages.error(
                         request,
@@ -1017,7 +1016,7 @@ def complete(request, submission_id):
             comment_new = Comment.objects.create_comment(
                 user=request.user,
                 path=origin_path,
-                text=comment_text,
+                text=f"<p>{comment_text}</p>",
                 target=submission,
             )
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Default submission replies ('Approved...', 'Returned...', etc) aren't encapsulated in \<p\> tags.
The current solution to #1235 had everything encapsulated in \<p\> tags, which caused doubled nested \<p\> tags with summernote submitted comments.

So I fixed that.

### Why?
This issue is a formatting error. As nested \<p\> tags is unexpected error.

### How?
surrounded "blank_comment_text" in \<p\> tags, and undid the comment_text \<p\> tag encapsulation as summernote does that by default.

ie.
```
# original
blank_comment_text = SiteConfig.get().blank_return_text

# fixed
blank_comment_text = f"<p>{SiteConfig.get().blank_return_text}</p>"
```

### Testing?
There already exist testing for quest submission comments. So i edited them. Furthermore, I manually tested the comments to see if any unexpected behavior occurred (see screenshots)

### Screenshots (if front end is affected)
quick reply
![image](https://github.com/bytedeck/bytedeck/assets/39788517/cf4e881c-bb76-4321-bd30-08e144cd4cec)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/e2bf250a-592e-40e1-a88e-cc2ce29366a3)

submitted summernote comment
![image](https://github.com/bytedeck/bytedeck/assets/39788517/4b7fbef5-7646-4aa1-9bea-f045719af0cc)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/63a27a35-33f4-495e-896f-5669b3f50f32)

default approve
![image](https://github.com/bytedeck/bytedeck/assets/39788517/91cd529c-00d4-481c-b9a1-0005e01353f7)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/64e99353-bf8e-48a3-a35c-862b4155e9c6)

default return
![image](https://github.com/bytedeck/bytedeck/assets/39788517/7e205131-c0e2-4606-8b2e-d22bf271b33e)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/3efa27ab-4fca-415b-a9ea-596faa48f40d)

default empty comment
![image](https://github.com/bytedeck/bytedeck/assets/39788517/86d8b208-e3d6-48fe-8bab-6f30c34a9196)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/bf3874f2-6d86-4a1c-a453-e8286b476921)


### Anything Else?
I noticed a comment about empty comments not working with the old fix so I fixed that too with teacher and student versions

### Review request
@tylerecouture
