### PR TITLE
Fix: Tag detail view shows duplicate ordinal for repeatable quests; Closes #1210

### DIFF
--- a/src/tags/templates/tags/snippets/related-xp-item.html
+++ b/src/tags/templates/tags/snippets/related-xp-item.html
@@ -17,7 +17,6 @@
                         <li>
                             <a href="{{ submission.quest.get_absolute_url }}">
                                 {{ submission }}
-                                {% if submission.is_multiple %}({{submission.ordinal}}){% endif %}
                                 ({% firstof submission.xp_requested submission.quest.xp %} XP)
                             </a>
                         </li>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where ordinality appears twice in student TagDetailView but only for repeat quests.

### Why?
This issue is a formatting error. Ordinal values showing up twice is unexpected behaviour
See #1210

### How?
The issue was that ordinal value is added to the quest name if its a repeat quest. While the DetailView does the same thing in the html via template tags.

The solution is to use the ```QuestSubmission.__str__``` value by itself
```
Original code
+ Quest (1)
+ Quest (2) (2)  # Quest (2) is the __str__ value of the quest submission
Solution using __str__ by itself
+ Quest  # ordinality does not show up but is expected behaviour
+ Quest (2)
```

I fixed it by removing the html template tag that adds the extra ordinal values. Hence removing the extra "(2)", "(3)", etc.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/dda8cdd8-90bc-4aef-a9ac-2e5d6b331119)

### Testing?
Added test case for checking correct ordinality.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/e320720d-f26d-420d-9d42-2a6b8054f63b)

### Screenshots (if front end is affected)
screen shot of what the test case looks like
![image](https://github.com/bytedeck/bytedeck/assets/39788517/bede5891-47b7-4259-8b22-94d5845da7eb)

### Anything Else?
None

### Review request
@tylerecouture
