### PR TITLE
Fix: XP earned by Tag no longer shows unapproved quests; Closes #1208

### DIFF
--- a/src/tags/models.py
+++ b/src/tags/models.py
@@ -24,7 +24,7 @@ def get_tags_from_user(user):
     BadgeAssertion = apps.get_model("badges", "BadgeAssertion")
 
     # tags related to user's quests
-    quest_ids = QuestSubmission.objects.filter(user=user).distinct().values_list('quest', flat=True)
+    quest_ids = QuestSubmission.objects.all_approved(user=user).distinct().values_list('quest', flat=True)
     quest_tags = Tag.objects.filter(quest__id__in=quest_ids)
 
     # tags related to user's badges

--- a/src/tags/tests/test_models.py
+++ b/src/tags/tests/test_models.py
@@ -179,6 +179,30 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, TenantTestCase):
 
         self.assertEqual(expected_order, calculated_order)
 
+    def test_query_tag_from_approved_quest(self):
+        """
+            When getting all quests related to tag and user, check if only submitted and approved tags show
+        """
+        # create quests with submissions
+        q_unrelated = baker.make(Quest)
+        q_approved, s_approved = self.create_quest_and_submissions(5)
+        q_submitted, s_submitted = self.create_quest_and_submissions(10)
+        s_submitted[0].is_approved = False
+        s_submitted[0].is_completed = False
+        s_submitted[0].save()
+
+        # tags
+        q_unrelated.tags.add('unrelated')
+        q_approved.tags.add('approved')
+        q_submitted.tags.add('submitted')
+
+        # check if only q_approved is in the query
+        tags = [tag_tuple[0].name for tag_tuple in get_user_tags_and_xp(self.user)]
+
+        self.assertFalse('unrelated' in tags)
+        self.assertTrue('approved' in tags)
+        self.assertFalse('submitted' in tags)
+
 
 class Tag_get_tags_from_user_Tests(TagHelper, TenantTestCase):
     """


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where submitted but not approved quest show in "XP Earned by Tag" column in profile detail page
This is an issue because "XP Earned by Tag" indicates anthing in that table is xp that was earned. Submitted but not approved quests do not give xp. Therefore this is an error.

### Why?
See #1208

### How?
Tweaking one the query filters in get_tags_from_user fixed this. Specifically adding an is_approved=True.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/abb7d0d0-1020-411e-9950-1514b108de52)

### Testing?
Created a test case where 3 unique quests linked to a tag, with 2 unique submissions were created.
Only 1 of the 3 quests was approved.

The test will only pass if that one quest is in get_tags_from_user

### Screenshots (if front end is affected)
unapproved quest with screenshot tag
![image](https://github.com/bytedeck/bytedeck/assets/39788517/54f33d23-b9b9-42c0-bf68-acee6043edc0)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/139e4b44-9e9a-4d05-af2c-601202219e1c)

### Anything Else?
None

### Review request
@tylerecouture
