### PR TITLE
Feat: Intro tag to starter quests and badges; Closes #1207

### DIFF
--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -25,6 +25,10 @@ from utilities.models import MenuItem
 
 User = get_user_model()
 
+# tag for all initial quests (welcome + orientation campaign)
+# including bytedeck proficiency badge
+intro_tag = "intro"
+
 
 def load_initial_tenant_data():
 
@@ -238,7 +242,7 @@ def create_initial_badge_rarities():
 def create_initial_badges():
     # Talents
     badge_type = BadgeType.objects.get(name="Talent")  # created in previous data migration
-    Badge.objects.create(
+    bytedeck_proficiency = Badge.objects.create(
         name="ByteDeck Proficiency",
         xp=2,
         short_description="<p>You have demonstrated your proficiency with this online platform. I hope you enjoy using it for this course!</p>",
@@ -247,6 +251,7 @@ def create_initial_badges():
         active=True,
         import_id='fa3b0518-cf9c-443c-8fe4-f4a887b495a7'
     )
+    bytedeck_proficiency.tags.add(intro_tag)
 
     # Awards
     badge_type = BadgeType.objects.get(name="Award")  # created in previous data migration
@@ -344,6 +349,7 @@ def create_orientation_campaign():
         verification_required=False,
 
     )
+    welcome_quest.tags.add(intro_tag)
 
     orientation_campaign = Category.objects.create(
         title="Orientation",
@@ -407,6 +413,13 @@ def create_orientation_campaign():
         available_outside_course=1,
         hideable=False,
     )
+
+    # intro tag for all orientation campaign
+    contract_quest.tags.add(intro_tag)
+    avatar_quest.tags.add(intro_tag)
+    screenshots_quest.tags.add(intro_tag)
+    cc_quest.tags.add(intro_tag)
+    message_quest.tags.add(intro_tag)
 
     # quests with icons need to have them uploaded programmatically from static files to be displayed properly in development, same as badges.
     if not settings.TESTING:

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -141,6 +141,27 @@ class TenantInitializationTest(TenantTestCase):
         owner = User.objects.filter(username="owner", is_staff=True).first()
         self.assertEqual(message_quest.specific_teacher_to_notify, owner)
 
+    def test_create_orientation_campaign__default_tags_created(self):
+        """ test if intro tag is properly assigned to
+        "Welcome to ByteDeck!" + all quests in the orientation campaign.
+        """
+        q_intro = Quest.objects.filter(tags__name="Intro")
+        self.assertEqual(q_intro.count(), 6)
+        self.assertTrue(q_intro.filter(name="Welcome to ByteDeck!").exists())
+        self.assertTrue(q_intro.filter(name="ByteDeck Class Contract").exists())
+        self.assertTrue(q_intro.filter(name="Create an Avatar").exists())
+        self.assertTrue(q_intro.filter(name="Screenshots").exists())
+        self.assertTrue(q_intro.filter(name="Who owns your creations?").exists())
+        self.assertTrue(q_intro.filter(name="Send your teacher a Message").exists())
+
+    def test_create_initial_badges__default_tags_created(self):
+        """ test if intro tag is properly assigned to
+        "Bytedeck Proficiency"
+        """
+        b_intro = Badge.objects.filter(tags__name="Intro")
+        self.assertEqual(b_intro.count(), 1)
+        self.assertTrue(b_intro.filter(name="ByteDeck Proficiency").exists())
+
     def test_site_config_created(self):
         """ Test that the SiteConfig object exists and the Deck name has expected defaults.
         """


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added new tag "Intro" to"Welcome to ByteDeck!" quest + all quests in the orientation campaign, and "Bytedeck Proficiency" badge

### Why?
see #1207

### How?
Manually added the tag to the quests and badges.

![image](https://github.com/bytedeck/bytedeck/assets/39788517/2c2b43a5-c675-492b-9a6b-7b30ca24294d)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/26fa13b1-88b5-4332-a1e1-db848afb7e8b)

### Testing?
Added 2 new test cases where it tests to see if intro tag is created on initialization of a new tenant.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/7848dd73-608a-45cc-b1cf-4cdcd2b62e96)

### Screenshots (if front end is affected)
None
### Anything Else?
None
### Review request
@tylerecouture
