### PR TITLE
Feat: Tests added for PR; Closes #1204

### DIFF
--- a/src/tags/tests/test_models.py
+++ b/src/tags/tests/test_models.py
@@ -104,6 +104,61 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, TenantTes
         badge_assertion_qs = get_badge_assertion_by_tags(self.user, ['tag0', 'tag1', 'tag2'])
         self.assertEqual(badge_assertion_qs.count(), 6)
 
+    def test_correct_quest_submission_tagged(self):
+        """ check if 'correct tag' is retrieved and no other submission from a different tag or no tag """
+        # with correct tag
+        co_1, cs_1 = self.create_quest_and_submissions(1)
+        co_2, cs_2 = self.create_quest_and_submissions(1)
+        co_1.tags.add('correct tag')
+        co_2.tags.add('correct tag')
+
+        cs_1 = cs_1[0]
+        cs_2 = cs_2[0]
+
+        # with incorrect tag
+        for _i in range(3):
+            quest, _ = self.create_quest_and_submissions(1)
+            quest.tags.add('incorrect tag')
+
+        # no tag
+        no_tag, _ = self.create_quest_and_submissions(1)
+
+        # check the amount of submissions are correct
+        quest_submission_qs = get_quest_submission_by_tag(self.user, ['correct tag'])
+        self.assertEqual(quest_submission_qs.count(), 2)
+
+        # check if the submissions are the correct ones
+        self.assertTrue(cs_1 in quest_submission_qs)
+        self.assertTrue(cs_2 in quest_submission_qs)
+
+    def test_correct_badge_assertion_tagged(self):
+        """ check if 'correct tag' is retrieved and no other assertion from a different tag or no tag """
+
+        # with correct tag
+        co_1, ca_1 = self.create_badge_and_assertions(1)
+        co_2, ca_2 = self.create_badge_and_assertions(1)
+        co_1.tags.add('correct tag')
+        co_2.tags.add('correct tag')
+
+        ca_1 = ca_1[0]
+        ca_2 = ca_2[0]
+
+        # with incorrect tag
+        for _i in range(3):
+            badge, _ = self.create_badge_and_assertions(1)
+            badge.tags.add('incorrect tag')
+
+        # no tag
+        no_tag, _ = self.create_badge_and_assertions(1)
+
+        # check the amount of submissions are correct
+        badge_assertion_qs = get_badge_assertion_by_tags(self.user, ['correct tag'])
+        self.assertEqual(badge_assertion_qs.count(), 2)
+
+        # check if the submissions are the correct ones
+        self.assertTrue(ca_1 in badge_assertion_qs)
+        self.assertTrue(ca_2 in badge_assertion_qs)
+
 
 class Tag_get_user_tags_and_xp_Tests(TagHelper, TenantTestCase):
     """

--- a/src/tags/tests/test_models.py
+++ b/src/tags/tests/test_models.py
@@ -104,16 +104,17 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, TenantTes
         badge_assertion_qs = get_badge_assertion_by_tags(self.user, ['tag0', 'tag1', 'tag2'])
         self.assertEqual(badge_assertion_qs.count(), 6)
 
-    def test_correct_quest_submission_tagged(self):
+    def test_get_quest_submission_by_tags__correct_quest_submission_tagged(self):
         """ check if 'correct tag' is retrieved and no other submission from a different tag or no tag """
         # with correct tag
-        co_1, cs_1 = self.create_quest_and_submissions(1)
-        co_2, cs_2 = self.create_quest_and_submissions(1)
-        co_1.tags.add('correct tag')
-        co_2.tags.add('correct tag')
+        correct_quest_1, submission_1 = self.create_quest_and_submissions(1)
+        correct_quest_2, submission_2 = self.create_quest_and_submissions(1)
+        correct_quest_1.tags.add('correct tag')
+        correct_quest_2.tags.add('correct tag')
 
-        cs_1 = cs_1[0]
-        cs_2 = cs_2[0]
+        # since create_quest_and_submissions returns a list, get the first element
+        submission_1 = submission_1[0]
+        submission_2 = submission_2[0]
 
         # with incorrect tag
         for _i in range(3):
@@ -128,20 +129,21 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, TenantTes
         self.assertEqual(quest_submission_qs.count(), 2)
 
         # check if the submissions are the correct ones
-        self.assertTrue(cs_1 in quest_submission_qs)
-        self.assertTrue(cs_2 in quest_submission_qs)
+        self.assertTrue(submission_1 in quest_submission_qs)
+        self.assertTrue(submission_2 in quest_submission_qs)
 
-    def test_correct_badge_assertion_tagged(self):
+    def test_get_badge_assertion_by_tags__correct_badge_assertion_tagged(self):
         """ check if 'correct tag' is retrieved and no other assertion from a different tag or no tag """
 
         # with correct tag
-        co_1, ca_1 = self.create_badge_and_assertions(1)
-        co_2, ca_2 = self.create_badge_and_assertions(1)
-        co_1.tags.add('correct tag')
-        co_2.tags.add('correct tag')
+        correct_badge_1, assertion_1 = self.create_badge_and_assertions(1)
+        correct_badge_2, assertion_2 = self.create_badge_and_assertions(1)
+        correct_badge_1.tags.add('correct tag')
+        correct_badge_2.tags.add('correct tag')
 
-        ca_1 = ca_1[0]
-        ca_2 = ca_2[0]
+        # since create_badge_and_assertions returns a list, get the first element
+        assertion_1 = assertion_1[0]
+        assertion_2 = assertion_2[0]
 
         # with incorrect tag
         for _i in range(3):
@@ -156,8 +158,8 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, TenantTes
         self.assertEqual(badge_assertion_qs.count(), 2)
 
         # check if the submissions are the correct ones
-        self.assertTrue(ca_1 in badge_assertion_qs)
-        self.assertTrue(ca_2 in badge_assertion_qs)
+        self.assertTrue(assertion_1 in badge_assertion_qs)
+        self.assertTrue(assertion_2 in badge_assertion_qs)
 
 
 class Tag_get_user_tags_and_xp_Tests(TagHelper, TenantTestCase):

--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -25,6 +25,10 @@ from utilities.models import MenuItem
 
 User = get_user_model()
 
+# tag for all initial quests (welcome + orientation campaign)
+# including bytedeck proficiency badge
+intro_tag = "intro"
+
 
 def load_initial_tenant_data():
 
@@ -238,7 +242,7 @@ def create_initial_badge_rarities():
 def create_initial_badges():
     # Talents
     badge_type = BadgeType.objects.get(name="Talent")  # created in previous data migration
-    Badge.objects.create(
+    bytedeck_proficiency = Badge.objects.create(
         name="ByteDeck Proficiency",
         xp=2,
         short_description="<p>You have demonstrated your proficiency with this online platform. I hope you enjoy using it for this course!</p>",
@@ -247,6 +251,7 @@ def create_initial_badges():
         active=True,
         import_id='fa3b0518-cf9c-443c-8fe4-f4a887b495a7'
     )
+    bytedeck_proficiency.tags.add(intro_tag)
 
     # Awards
     badge_type = BadgeType.objects.get(name="Award")  # created in previous data migration
@@ -344,6 +349,7 @@ def create_orientation_campaign():
         verification_required=False,
 
     )
+    welcome_quest.tags.add(intro_tag)
 
     orientation_campaign = Category.objects.create(
         title="Orientation",
@@ -407,6 +413,13 @@ def create_orientation_campaign():
         available_outside_course=1,
         hideable=False,
     )
+
+    # intro tag for all orientation campaign
+    contract_quest.tags.add(intro_tag)
+    avatar_quest.tags.add(intro_tag)
+    screenshots_quest.tags.add(intro_tag)
+    cc_quest.tags.add(intro_tag)
+    message_quest.tags.add(intro_tag)
 
     # quests with icons need to have them uploaded programmatically from static files to be displayed properly in development, same as badges.
     if not settings.TESTING:

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -141,6 +141,27 @@ class TenantInitializationTest(TenantTestCase):
         owner = User.objects.filter(username="owner", is_staff=True).first()
         self.assertEqual(message_quest.specific_teacher_to_notify, owner)
 
+    def test_create_orientation_campaign__default_tags_created(self):
+        """ test if intro tag is properly assigned to
+        "Welcome to ByteDeck!" + all quests in the orientation campaign.
+        """
+        q_intro = Quest.objects.filter(tags__name="Intro")
+        self.assertEqual(q_intro.count(), 6)
+        self.assertTrue(q_intro.filter(name="Welcome to ByteDeck!").exists())
+        self.assertTrue(q_intro.filter(name="ByteDeck Class Contract").exists())
+        self.assertTrue(q_intro.filter(name="Create an Avatar").exists())
+        self.assertTrue(q_intro.filter(name="Screenshots").exists())
+        self.assertTrue(q_intro.filter(name="Who owns your creations?").exists())
+        self.assertTrue(q_intro.filter(name="Send your teacher a Message").exists())
+
+    def test_create_initial_badges__default_tags_created(self):
+        """ test if intro tag is properly assigned to
+        "Bytedeck Proficiency"
+        """
+        b_intro = Badge.objects.filter(tags__name="Intro")
+        self.assertEqual(b_intro.count(), 1)
+        self.assertTrue(b_intro.filter(name="ByteDeck Proficiency").exists())
+
     def test_site_config_created(self):
         """ Test that the SiteConfig object exists and the Deck name has expected defaults.
         """


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added two new test cases for ```Tag_get_quest_submission_badge_assertion_by_tag_Tests```
I decided to add these test cases for models because ```DetailView``` explicitly uses ```get_quest_submission_by_tag``` and ```get_badge_assertion_by_tags```

### Why?
See Issue #1204. 

### How?
Added a test to see if only the correct submissions/assertions will show
![image](https://github.com/bytedeck/bytedeck/assets/39788517/af19968e-f431-4cc1-abc6-291e3dbf0990)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/f4f0525b-b34e-43f9-9813-e179ad7be788)

### Testing?
See "What"

### Screenshots (if front end is affected)
None

### Anything Else?
None

### Review request
@tylerecouture
