### PR TITLE
Fix: Failing build because of tenant test case

### DIFF
--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -145,7 +145,7 @@ class TenantInitializationTest(TenantTestCase):
         """ test if intro tag is properly assigned to
         "Welcome to ByteDeck!" + all quests in the orientation campaign.
         """
-        q_intro = Quest.objects.filter(tags__name="Intro")
+        q_intro = Quest.objects.filter(tags__name="intro")
         self.assertEqual(q_intro.count(), 6)
         self.assertTrue(q_intro.filter(name="Welcome to ByteDeck!").exists())
         self.assertTrue(q_intro.filter(name="ByteDeck Class Contract").exists())
@@ -158,7 +158,7 @@ class TenantInitializationTest(TenantTestCase):
         """ test if intro tag is properly assigned to
         "Bytedeck Proficiency"
         """
-        b_intro = Badge.objects.filter(tags__name="Intro")
+        b_intro = Badge.objects.filter(tags__name="intro")
         self.assertEqual(b_intro.count(), 1)
         self.assertTrue(b_intro.filter(name="ByteDeck Proficiency").exists())
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
What?
Small issue with the test case causing builds to fail

Why?
Causing builds to fail because of https://github.com/bytedeck/bytedeck/pull/1595

How?
was filtering for "Intro" instead of "intro"
![image](https://github.com/bytedeck/bytedeck/assets/39788517/dd39bf85-0510-4318-8d92-04088342d94a)


Testing?
Screenshots (if front end is affected)
Anything Else?
Review request
@tylerecouture