### PR TITLE
Fix: StudentList from Portolio gives correct link; Closes #1539

### DIFF
--- a/src/portfolios/templates/portfolios/detail.html
+++ b/src/portfolios/templates/portfolios/detail.html
@@ -20,7 +20,14 @@
             </div>
             <div class="panel-body">
                 Sharing your portfolio locally means a link to the portfolio will appear in the
-                <a href="{% url 'profiles:profile_list' %}">students list</a> accessed
+                <a href=
+                {% if request.user.is_staff %}
+                    "{% url 'profiles:profile_list' %}"
+                {% else %}
+                    "{% url 'profiles:profile_list_current' %}"
+                {% endif %}
+
+                >students list</a> accessed
                 from the Students button at the left.
                 <a href="{% url 'portfolios:edit' p.pk %}">Edit</a> your portfolio to change this setting.
             </div>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where if a student were to click on ``` student list ``` in ``` /portfolios/detail/ ```. they would get a 403 error.

### Why?
See issue #https://github.com/bytedeck/bytedeck/issues/1539

### How?
the link for student list for both admin and students is ```student/list/all```. which only allowed staff to view. This caused the 403 status code.
Solution is to add a simple if statement. all students if admin. current students if student.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/f38d595d-b447-4615-a822-90e65a08363d)

### Testing?
im not exactly sure if this needs a test. If it does lmk and ill add a beautiful soup test for it.

### Screenshots (if front end is affected)
click on student list
![image](https://github.com/bytedeck/bytedeck/assets/39788517/b3677fa5-61b5-493b-bed7-de79b50b7797)
get redirected to ```student/list/current``` instead of ```student/list/all```
![image](https://github.com/bytedeck/bytedeck/assets/39788517/1eda54db-b657-47cd-87cc-91c97f8f09d6)

### Anything Else?
### Review request
@tylerecouture
