### PR TITLE
Feat: mark ranges without graph; Closes #1508

### DIFF
--- a/src/courses/templates/courses/mark_calculations.html
+++ b/src/courses/templates/courses/mark_calculations.html
@@ -179,6 +179,15 @@ for {{user}}
         </div> <!-- tab-content -->
       </div>  <!-- tab container -->
 
+      <h3>Current Mark Ranges by XP</h3>
+      <ul>
+          {% for markrange in markranges %}
+          <li>
+              {{ markrange.name }} ({{ markrange.minimum_mark }}%): {{ markrange.xp_needed }} XP
+          </li>
+          {% endfor %}
+      </ul>
+
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added a new section to ``` /courses/marks ``` called "Current Mark Ranges by XP"

### Why?
See #1508

### How?

inside view added xp_needed variable to the markranges. Used the xp formula inside ```xp_chart_progress.html``` as reference
![image](https://github.com/bytedeck/bytedeck/assets/39788517/f8663ce0-da5f-46fa-9289-2770350ad02a)
xp formula 
![image](https://github.com/bytedeck/bytedeck/assets/39788517/4db26647-e022-4513-bca5-a80bb2c83d1b)

inside html I used the xp_needed to display the format specified in #1508.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/3b0727a9-137d-4e6a-9d9c-9d94446623e6)

### Testing?
Added a new test class for mark ranges.
I did originally add this to the courseview test cases. But had a lot of issues with mock patch not working inside that test case
![image](https://github.com/bytedeck/bytedeck/assets/39788517/c8e6e108-3c9d-427f-8bef-b1a0fa13f009)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/6af1edac-f63b-4dca-96e3-12b4e4f585ab)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/fcd5568b-3d88-4574-9a4b-acb3adfaafbd)

### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/12d203bb-7159-484d-9bb6-ba5ccdd5f49f)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a section to display current mark ranges by XP in the mark calculations view.
  - Introduced new tests to ensure correct display of mark ranges by XP for different completion levels of the semester.

- **Bug Fixes**
  - Fixed the calculation and display of XP needed for passing mark ranges based on minimum marks and completion percentage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->