### PR TITLE
Fix: Crash at 11 PM; Closes #1327

### DIFF
--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -170,12 +170,15 @@ class QuestTestModel(TenantTestCase):
         self.assertFalse(q.active)
 
         # create and test a quest that won't be available until one hour later in the same day
-        q = baker.make(
-            Quest,
-            date_available=timezone.localdate(),
-            time_available=(timezone.localtime() + timezone.timedelta(hours=1)).time()
-        )
-        self.assertFalse(q.active)
+        # using freeze_time to prevent time_available from looping from 23:00 to 0:00 when adding 1 hour
+        dt = datetime.datetime(2024, 1, 1, 6, tzinfo=timezone.get_current_timezone())
+        with freeze_time(dt):
+            q = baker.make(
+                Quest,
+                date_available=timezone.localdate(),
+                time_available=(timezone.localtime() + timezone.timedelta(hours=1)).time()
+            )
+            self.assertFalse(q.active)
 
         dt = timezone.get_current_timezone().localize(timezone.datetime(2023, 6, 13, 12, 0, 0))
         with freeze_time(dt):


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed a test that would crash at 11:00 PM.

### Why?
See #1327

### How?
Constrained the test that crashes with ```freeze_time```.

only occuring at 11:00 PM because...
(using 24 hour clock for now)

At 23:00 when creating a ```Quest``` object.
```
q = baker.make(
	Quest,
	date_available=timezone.localdate(),
	time_available=(timezone.localtime() + timezone.timedelta(hours=1)).time()
)
self.assertFalse(q.active)
```

```time_available=(timezone.localtime() + timezone.timedelta(hours=1)).time()``` is equivalent to ```23:00 + 1 hour``` or ```0:00```

Then causes this specific check in ```Quest.active``` to fail (if statement false)
```
# an XPItem object is inactive on the day it's made available if its availability time is in the future
	if self.date_available == date_now and self.time_available > time_now:
		return False
```

inciting variables
```
time_available = 0:00  # current time + 1 hour
time_now = 23:00  # current time

(time_available > time_now) is false 
(0:00 > 23:00) is false
```

So this is more of a test_case error than something with the models. Hence why I only used ```freeze_time``` 

### Testing?
Only manually tested this using ```freeze_time ``` and changing my system clock
![image](https://github.com/bytedeck/bytedeck/assets/39788517/799d5060-2255-45b5-8d35-4a0fdc0906a4)

Before fix at 11:00 PM (using develop branch):
![image](https://github.com/bytedeck/bytedeck/assets/39788517/aae4656e-f2cb-4b13-b143-6a2acdddcc2a)
After fix:
![image](https://github.com/bytedeck/bytedeck/assets/39788517/1393f4fc-af80-4c63-ba94-11f8e37a140f)


### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for quest availability by using `freeze_time` to handle time calculations accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->