### PR TITLE
Fix: generate_quests also generates campaigns; Closes #1014

### DIFF
--- a/src/hackerspace_online/tests/test_shell_utils.py
+++ b/src/hackerspace_online/tests/test_shell_utils.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django_tenants.test.cases import TenantTestCase
 
 from hackerspace_online.shell_utils import generate_quests, generate_students
-from quest_manager.models import Quest
+from quest_manager.models import Quest, Category
 
 # from django_tenants.test.client import TenantClient
 
@@ -26,8 +26,22 @@ class ShellUtilsTest(TenantTestCase):
 
     def test_generate_quests(self):
         """ Generates the provided number of students (10) """
-        create_this_many = 10
+        num_quest = 5
+        num_campaigns = 2
+
         num_quest_before = Quest.objects.count()
-        generate_quests(num_quest_per_campaign=5, num_campaigns=2, quiet=True)
+        num_campaigns_before = Category.objects.count()
+
+        generate_quests(num_quest_per_campaign=num_quest, num_campaigns=num_campaigns, quiet=True)
+
         num_quests_after = Quest.objects.count()
-        self.assertEqual(num_quests_after, num_quest_before + create_this_many)
+        num_campaigns_after = Category.objects.count()
+
+        # check if number of quest and campaigns is correct after generation
+        self.assertEqual(num_campaigns_after, num_campaigns_before + num_campaigns)
+        self.assertEqual(num_quests_after, num_quest_before + (num_quest * num_campaigns))
+
+        # get the last (num_quest * num_campaigns) quests created and check if its related to only 2 campaigns
+        quest_qs = Quest.objects.order_by('-pk')[:num_quest * num_campaigns]
+        campaign_ids = set(quest_qs.values_list('campaign_id', flat=True))
+        self.assertEqual(len(campaign_ids), num_campaigns)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Modified the ```generate_quest``` command to use campaigns.
Its previous behaviour did not link quests to any campaigns.

using the ```tenant_shell```
```
(bytedeck) D:\#\BYTEDECK_FORK\bytedeck\src>python manage.py tenant_command shell
Enter Tenant Schema ('?' to list schemas): testtenant2
Python 3.10.6 (tags/v3.10.6:9c7b4bd, Aug  1 2022, 21:53:49) [MSC v.1932 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.24.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from hackerspace_online.shell_utils import generate_content

In [2]: generate_content()
Generating content...
Campaign-clammy-tan-discus
        stealthy-wheat-seal
        zippy-black-terrier
        jumpy-salmon-reindeer
        grumpy-jade-octopus
        skanky-turquoise-anteater
        beady-jade-uakari
        cheeky-teal-hamster
        ugly-periwinkle-orangutan
        snoopy-vermilion-setter
        craggy-plum-impala
Campaign-stuffy-alizarin-jackal
        grumpy-ochre-lobster
        gloppy-amethyst-bloodhound
        crappy-champagne-lizard
        blurry-brown-raccoon
        snippy-buff-affenpinscher
        pasty-purple-dragonfly
        thirsty-mauve-dragonfly
        hazy-aquamarine-stoat
        pokey-celadon-whale
        ready-tomato-penguin
Campaign-hilly-rose-eel
        shabby-cream-mastiff
        freaky-zucchini-spoonbill
        pokey-malachite-gecko
        clammy-rust-alligator
        slaphappy-yellow-drever
        crappy-sepia-kiwi
        pokey-pumpkin-urchin
        bumpy-ivory-zebra
        shaky-viridian-devil
        craggy-violet-chameleon
Campaign-geeky-cream-hippopotamus
        jumpy-yellow-spider
        randy-rose-cuscus
        cozy-emerald-fossa
        lanky-grey-mist
        slaphappy-maroon-eleuth
        stuffy-lemon-robin
        gimpy-jade-crocodile
        trippy-lavender-ibis
        lumpy-myrtle-spaniel
        smelly-scarlet-shark
Campaign-snappy-copper-bulldog
        gimpy-buff-flamingo
        muzzy-razzmatazz-spoonbill
        pretty-turquoise-eagle
        tacky-chartreuse-stoat
        clammy-flax-liger
        baggy-maroon-axolotl
        paltry-teal-mongoose
        nippy-amethyst-birman
        lousy-magnolia-chicken
        clammy-bronze-frigatebird
50 Quests generated in 5 campaigns.


Generating 100 students:
lisa.kessinger
anthony.jacobson
kristy.lowery
debbie.parshall
ronald.harmon
nikki.rippy
pamela.blanchard
alissa.cox
james.valdez
freddie.beyett
lana.andersen
chester.lunde
christine.rauch
evangeline.strawderman
alfred.broker
cecil.immediato
mariela.budge
ralph.tusing
robert.rodriguez
lorraine.cantrell
joshua.smith
dana.mahi
shirley.desantis
ida.harrison
james.moser
dennis.snellgrove
tara.dixon
nicholas.ramirez
roy.weston
leo.williams
camille.mullane
kathleen.jordan
pat.glahn
george.fraser
jennifer.hockenberry
andrew.durham
christopher.isbell
david.bonaccorsi
gary.hutchins
cassandra.aucoin
richard.roseberry
rebecca.herring
charles.rodriguez
william.blackwell
jana.lyster
michelle.price
jerry.poulin
barbara.william
kai.miller
john.bufkin
carmon.boyda
scott.spencer
russell.chavez
asa.holling
dawn.green
arthur.campbell
daniel.mallory
james.garcia
jerry.valentin
cole.simmons
carole.traylor
katherine.robinson
robert.oliveira
robert.thibodeau
patrick.ortiz
james.perkins
thomas.karst
clementina.thomas
mildred.abrams
dan.costello
joshua.lovelace
glenn.villegas
cedric.corbin
theresa.pineda
angel.carpenter
jose.lemmons
jeff.clapp
ellen.wiggins
david.whisenand
lori.cilley
mark.leiva
susan.spillman
david.fehlinger
kyle.boyce
rebecca.lybert
adolfo.rodriguez
tracy.venegas
david.harris
leda.ballard
wilson.coulter
adrienne.adams
michael.hunter
maurice.saunders
matthew.davis
karen.rivera
john.tucker
robert.caldwell
cliff.lebovic
brian.lee
valerie.davis

100 students generated.
```

### Why?
See #1014

### How?
Generated a campaign with a unique name using the same method for quests.
Updated docstring.
Updated tests to reflect this.

### Testing?
only modifed the ```test_generate_quests``` to test for campaigns

### Screenshots (if front end is affected)
after running the command
![image](https://github.com/bytedeck/bytedeck/assets/39788517/ab086d17-7764-490e-b916-6dbe599093a3)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/2ba7eb08-74a0-4111-902b-c7a8b2950c78)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/2a182731-498b-489b-bbc1-50ec009c27e8)

### Anything Else?
I noticed that nothing was printing the ```initial_quest``` so i added that.
Adding indents to the print output. so its easier to read when ```quiet=False```

### Review request
@tylerecouture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced campaign generation with additional quests, allowing for more detailed and varied gameplay experiences.

- **Tests**
  - Updated test cases to reflect changes in quest and campaign generation, ensuring robust validation of new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->