### PR TITLE
Feat: generate_content as management command; Closes #1163

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,22 +113,28 @@ If everything has worked so far, you should now be able to create your own byted
 ### Installing more Sample Data
 New tenants will come with some basic initial data already installed, but if you want masses of data to simulate a more realistic site in production:
 
-1. Open a Python shell specific to your tenant (make sure your virtual environment is activated), enter your tenant's name (for example, `hackerspace`) and paste these commands:
-    ```
-    $ python src/manage.py tenant_command shell
-    Enter Tenant Schema ('?' to list schemas): hackerspace
++ Using venv: ```python src/manage.py generate_content hackerspace```
++ Using docker: ```docker compose exec web bash -c "python src/manage.py generate_content hackerspace"```
 
-    In [1]: from hackerspace_online.shell_utils import generate_content
+This will create 100 fake students, and 5 campaigns of 10 quests each, and maybe some other stuff we've added since writing this!  You should see the output of the objects being created.  Go to your map page and regenerate the map to see them.
 
-    In [2]: generate_content()
-    ```
+Some examples of the command in use:
+```
+$ python src/manage.py generate_content --help
+# lists positional arguments and optional flags
 
-    You can also do this from docker with:
-    `docker compose exec web bash -c "python src/manage.py tenant_command shell"`
+$ python src/manage.py generate_content --quiet
+# Generates fake students, campaigns, and quests without printing anything to the console
 
-2. This will create 100 fake students, and 5 campaigns of 10 quests each, and maybe some other stuff we've added since writing this!  You should see the output of the objects being created.  Go to your map page and regenerate the map to see them.
-3. use Ctrl + D or `exit()` to close the Python shell.
+$ python src/manage.py generate_content hackerspace --num_quests_per_campaign 7 --num_campaigns 3
+# Creates 3 campaigns of 7 quest each. Additionally creates 100 students because `--num_students` were unspecified
 
+$ python src/manage.py generate_content hackerspace --num_students 50
+# Creates 50 fake students. Additionally creates 5 campaigns of 10 quests each because both `--num_quests_per_campaign` and `--num_campaigns` were unspecified
+
+$ python src/manage.py generate_content hackerspace --num_quests_per_campaign 7 --num_campaigns 3 --num_students 50
+# create 50 fake students, and 3 campaigns of 7 quests each.
+```
 
 ### Enabling Google Sign In (Optional)
 

--- a/src/hackerspace_online/management/commands/generate_content.py
+++ b/src/hackerspace_online/management/commands/generate_content.py
@@ -1,0 +1,62 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django_tenants.utils import schema_context
+from tenant.models import Tenant
+
+from hackerspace_online.shell_utils import generate_content
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "This command procedurally generates quests, campaigns, and students"
+
+    def add_arguments(self, parser):
+        # argument(s)
+        parser.add_argument(
+            'schema_name', action='store', type=str,
+            help='The name of the tenant/schema you want to add content to.'
+        )
+
+        # optional arguments
+        parser.add_argument(
+            '--num_quests_per_campaign', action='store', type=int,
+            help='Number of new quests per campaign created.\nIf left empty defaults to 10'
+        )
+        parser.add_argument(
+            '--num_campaigns', action='store', type=int,
+            help='Number of new campaign created.\nIf left empty defaults to 5'
+        )
+        parser.add_argument(
+            '--num_students', action='store', type=int,
+            help='Number of new students created.\nIf left empty defaults to 100'
+        )
+        parser.add_argument(
+            '--quiet', action='store_true',
+            help='This determines if command prints what it generates in the console. Defaults to False'
+        )
+
+    def handle(self, *args, **options):
+
+        # grab variables
+        schema_name = options.get('schema_name')
+        num_quests_per_campaign = options.get('num_quests_per_campaign') or 10
+        num_campaigns = options.get('num_campaigns') or 5
+        num_students = options.get('num_students') or 100
+        quiet = options.get('quiet') or False
+
+        # error handling
+        try:
+            tenant = Tenant.objects.get(schema_name=schema_name)
+        except Tenant.DoesNotExist:
+            raise CommandError(f'Error: Schema name: "{schema_name}" does not exist!')
+
+        # tenant exist, proceed
+        with schema_context(tenant.schema_name):
+            # proceed with generation
+            generate_content(
+                num_quests_per_campaign,
+                num_campaigns,
+                num_students,
+                quiet,
+            )

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -6,15 +6,47 @@ from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.models import Site
 from django.core.management import call_command
 from django.test import TestCase
+from django_tenants.test.cases import TenantTestCase
 from django_tenants.utils import tenant_context
 
 # from hackerspace_online.management.commands import find_replace
+from quest_manager.models import Quest, Category
 from tenant.models import Tenant
 
 User = get_user_model()
 
 
-class FindReplaceTest(TestCase):
+class CommandMixin:
+    """
+    Mixin to simplify calling management commands in tests.
+    It captures the command output and handles errors if the command name is not set.
+
+    need to set name variable in the class that uses this mixin.
+    ie.
+    ```
+        def CustomCommandTest(CommandMixin):
+            name = "custom_command"
+    ```
+    """
+    name = None
+
+    def call_command(self, *args, **kwargs):
+        if not isinstance(self.name, str):
+            raise TypeError('Error: command name expects a string')
+
+        out = StringIO()
+        call_command(
+            self.name,
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+
+class FindReplaceTest(TestCase, CommandMixin):
+    name = "find_replace"
 
     # def setUp(self):
     #     self.tenant = Tenant(
@@ -23,17 +55,6 @@ class FindReplaceTest(TestCase):
     #         name='testdeck'
     #     )
     #     self.tenant.save()
-
-    def call_command(self, *args, **kwargs):
-        out = StringIO()
-        call_command(
-            "find_replace",
-            *args,
-            stdout=out,
-            stderr=StringIO(),
-            **kwargs,
-        )
-        return out.getvalue()
 
     def test_tenants_all(self):
         # Constant error, not sure why Category table is empty:
@@ -51,20 +72,10 @@ class FindReplaceTest(TestCase):
         # self.assertEqual(out, "In dry run mode (--write not passed)\n")
 
 
-class InitDbTest(TestCase):
+class InitDbTest(TestCase, CommandMixin):
     """ Note that this is NOT a TenantTestCase
     """
-
-    def call_command(self, *args, **kwargs):
-        out = StringIO()
-        call_command(
-            "initdb",
-            *args,
-            stdout=out,
-            stderr=StringIO(),
-            **kwargs,
-        )
-        return out.getvalue()
+    name = "initdb"
 
     def test_initdb(self):
         """ Test that initdb command sets up the public tenant, including:
@@ -85,3 +96,35 @@ class InitDbTest(TestCase):
             self.assertTrue(Site.objects.exists())
 
             Tenant.objects.get(schema_name=apps.get_app_config('library').TENANT_NAME)  # no assert, but will throw exception if doesn't exist
+
+
+class GenerateContentTest(TenantTestCase, CommandMixin):
+    """ generate_content adds items to an existing tenant.
+    Dont need extensive testing as tests exist in "test_shell_utils.py"
+    """
+    name = "generate_content"
+
+    def test_added_rows_to_db(self):
+        """ test checks if "generate_content" adds objects to the db """
+        new_campaigns = 2
+        new_quests = 5
+        new_students = 5
+
+        # expected
+        expected_quest_count = Quest.objects.count() + (new_campaigns * new_quests)
+        expected_campaign_count = Category.objects.count() + new_campaigns
+        expected_user_count = User.objects.count() + new_students
+
+        #
+        self.call_command(
+            self.tenant.schema_name,
+            '--num_quests_per_campaign', new_quests,
+            '--num_campaigns', new_campaigns,
+            '--num_students', new_students,
+            '--quiet'
+        )
+
+        # test if the command added new objects
+        self.assertEqual(Quest.objects.count(), expected_quest_count)
+        self.assertEqual(Category.objects.count(), expected_campaign_count)
+        self.assertEqual(User.objects.count(), expected_user_count)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Created ```generate_content``` as a django management command.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/af949143-f720-439b-8289-7a07d83cab1b)
Also updated the readme

### Why?
See https://github.com/bytedeck/bytedeck/issues/1163

### How?
Used djangos management command class to create ```generate_content```

### Testing?
Added a quick test to see if the command is called with ```--quiet```. All it does is check if the amount of quests, campaigns, and students have changed.
Im thinking detailed testing should be in ```test_shell_utils```
Using tenanttestcase adds like 20 seconds to the test

### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/e354d92b-f773-4b52-aa39-26e7f1aa524c)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/174b2fde-ac71-4441-a279-8bc858ccc40a)

### Anything Else?
I noticed the management tests were using boilerplate code. I put ```call_command``` in a mixin.

I thought this might be an option to include in the management command. But thought since its a management command and ran by an admin its uneccessary. It basically constrains the users and quests added to the ```tenant.max_users``` and ```tenant.max_quests```
![image](https://github.com/bytedeck/bytedeck/assets/39788517/65ac65a9-c72c-42ec-85b0-92ba833de249)


### Review request
~~Tests should fail since its depending on PR https://github.com/bytedeck/bytedeck/pull/1615~~
@tylerecouture 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Simplified data initialization for new tenants by allowing the `generate_content` command to accept tenant names directly as an argument.

- **Documentation**
  - Updated README to reflect new command usage for generating content in a Docker environment, making setup instructions clearer and more user-friendly.

- **Tests**
  - Added comprehensive tests for the new `generate_content` command to ensure reliability and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->