### PR TITLE
Feat: Earned badge and ranked popup; Closes #551

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -16,6 +16,7 @@ from notifications.signals import notify
 
 from prerequisites.models import Prereq, IsAPrereqMixin, HasPrereqsMixin
 from tags.models import TagsModelMixin
+from notifications.models import notify_rank_up
 
 
 # Create your models here.
@@ -425,3 +426,13 @@ def post_save_receiver(sender, **kwargs):
             affected_users=[assertion.user, ],
             icon=icon,
             verb="granted you a")
+
+        # if user ranked up notify them
+        if not assertion.do_not_grant_xp:
+            notify_rank_up(
+                assertion.user,
+                assertion.user.profile.xp_cached,
+
+                # since post-save signal. this is before user.profile.xp_invalidate_cache()
+                assertion.user.profile.xp_cached + assertion.badge.xp,
+            )

--- a/src/badges/templates/badges/snippets/badge_notification_popup.html
+++ b/src/badges/templates/badges/snippets/badge_notification_popup.html
@@ -1,0 +1,58 @@
+
+<div class="modal fade" id="newBadgeModal" tabindex="-1" role="dialog" aria-labelledby="newBadgeLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" id="newBadgeLabel">
+            {% if badge_total == 1 %}
+            Congratulations! You've gained a badge!
+            {% else %}
+            Congratulations! You have earned {{ badge_total }} new {{ badge_name }}s!
+            {% endif %}
+          </h4>
+        </div>
+        <div class="modal-body row">
+          {% for type, badges in new_badges_by_type.items %}
+            <div class="list-group-item list-group-item-info">
+                <i class="pull-right fa fa-fw {{type.fa_icon}}"></i>
+                {{type.name}}s
+            </div>
+
+            <div class="list-group-item">
+            {% for badge in badges %}
+
+              {# only use popover on wider screens #}
+              <span class="hidden-xs">
+                <a {% include 'badges/snippets/badge_popover.html' with object=badge user_obj=request.user %} >
+                  <div class="icon-badge-container">
+                    <img class="icon-xl img-rounded" src="{{badge.get_icon_url}}">
+                    {% if badge.duplicates > 1 %}
+                      <span class="badge badge-icon-lg progress-bar-info">{{badge.duplicates}}</span>
+                    {% endif %}
+                  </div>
+                </a>
+              </span>
+
+              {# direct link on mobile #}
+              <span class="visible-xs-inline-block">
+                <a href="{{badge.get_absolute_url}}">
+                  <div inert class="icon-badge-container">
+                    <img class="icon-xl img-rounded" src="{{badge.get_icon_url}}">
+                    {% if badge.duplicates > 1 %}
+                      <span class="badge badge-icon-lg progress-bar-info">{{badge.duplicates}}</span>
+                    {% endif %}
+                  </div>
+                </a>
+              </span>
+
+            {% endfor %}
+            </div>
+
+          {% endfor %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal" id="newBadgeDissmissButton">Dismiss</button>
+        </div>
+      </div>
+    </div>
+</div>

--- a/src/badges/urls.py
+++ b/src/badges/urls.py
@@ -29,4 +29,8 @@ urlpatterns = [
     path('types/create/', views.BadgeTypeCreate.as_view(), name='badge_type_create'),
     path('types/<int:pk>/edit', views.BadgeTypeUpdate.as_view(), name='badge_type_update'),
     path('types/<int:pk>/delete', views.BadgeTypeDelete.as_view(), name='badge_type_delete'),
+
+    # Ajax
+    path('ajax/on_show_badge_popup/', views.Ajax_OnShowBadgePopup.as_view(), name='ajax_on_show_badge_popup'),
+    path('ajax/on_close_badge_popup/', views.Ajax_OnCloseBadgePopup.as_view(), name='ajax_on_close_badge_popup'),
 ]

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -4,14 +4,19 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, redirect, render
+from django.http import JsonResponse
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
+from django.views import View
 from django.views.generic import RedirectView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
+from django.template.loader import render_to_string
+from django.db.models import Count
 
-from hackerspace_online.decorators import staff_member_required
+from hackerspace_online.decorators import staff_member_required, xml_http_request_required
 
 from notifications.signals import notify
 from prerequisites.views import ObjectPrereqsFormView
@@ -21,6 +26,7 @@ from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 from .forms import BadgeAssertionForm, BadgeForm, BulkBadgeAssertionForm
 from .models import Badge, BadgeAssertion, BadgeType
 from djcytoscape.models import CytoScape
+from notifications.models import Notification
 
 
 class AchievementRedirectView(NonPublicOnlyViewMixin, LoginRequiredMixin, RedirectView):
@@ -295,3 +301,97 @@ def assertion_delete(request, assertion_id):
 
     template_name = 'badges/assertion_confirm_delete.html'
     return render(request, template_name, {'object': assertion})
+
+
+# ########## Badge Ajax Views #########################
+
+@method_decorator(xml_http_request_required, name='dispatch')
+class Ajax_BadgePopup(NonPublicOnlyViewMixin, LoginRequiredMixin, View):
+
+    def get_unread_badge_notifications(self):
+        """ returns a qs of unread notifications for user with badge as target """
+        notifications = Notification.objects.all_for_user(self.user).get_unread().filter(
+            target_content_type=ContentType.objects.get_for_model(Badge),
+
+            # this might have to change if the way badges are granted changes
+            verb__contains="granted",
+        )
+        return notifications
+
+
+class Ajax_OnShowBadgePopup(Ajax_BadgePopup):
+    """ This is responsible for giving the html for 'ajaxNewBadgePopup' in 'javascript.js' """
+
+    def get(self, *args, **kwargs):
+        self.user = self.request.user
+        json_data = self.get_json_data()
+        return JsonResponse(data=json_data)
+
+    def get_json_data(self):
+        """ returns json data for ajax request """
+        badges_by_type = self.get_new_badges()
+        show = self._get_badges_sum(badges_by_type) != 0
+        html_text = self.get_html_text(badges_by_type) if show else None
+
+        return {
+            'show': show,
+            'html': html_text,
+        }
+
+    def get_html_text(self, badges_by_type):
+        """ returns context filled template """
+        template_name = 'badges/snippets/badge_notification_popup.html'
+        context = {
+            'badge_name': SiteConfig.get().custom_name_for_badge,
+            'badge_total': self._get_badges_sum(badges_by_type),
+            'new_badges_by_type': badges_by_type,
+        }
+        return render_to_string(template_name, context)
+
+    def _get_badges_sum(self, badges_by_type):
+        """ helper func to return the total amount of badges of badges_by_type """
+        return sum(
+            sum(badge.duplicates for badge in badges)
+            for badges in badges_by_type.values()
+        )
+
+    def get_new_badges(self):
+        """ returns qs of badges related to the notifications of self.get_unread_badge_notifications """
+        notifications = self.get_unread_badge_notifications()
+
+        # end queries early if no unread notifications
+        if notifications.count() == 0:
+            return {}
+
+        # get the ids of each badge and count duplicates
+        # follows this format { id : # of duplicates }
+        badges_info = notifications.values('target_object_id').annotate(count=Count('target_object_id')).order_by()
+        badges_info = {item['target_object_id']: item['count'] for item in badges_info}
+
+        # get the the Badges using unread notifications
+        badges = Badge.objects.filter(id__in=badges_info.keys())
+
+        # group badges by their type
+        badge_type_ids = badges.values_list('badge_type__id', flat=True)
+        badge_types = BadgeType.objects.filter(id__in=badge_type_ids)
+        badge_by_type = [badges.filter(badge_type=ba_type) for ba_type in badge_types]
+        badges_by_type = dict(zip(badge_types, badge_by_type))
+
+        # inject "duplicates" variable for each badge
+        # has to be last because filter resets variable injections
+        for badges in badges_by_type.values():
+            for badge in badges:
+                badge.duplicates = badges_info[badge.id]
+
+        return badges_by_type
+
+
+class Ajax_OnCloseBadgePopup(Ajax_BadgePopup):
+    """ When user dismisses badge popup.
+    Mark all badge notifications related to the popup as read """
+
+    def get(self, *args, **kwargs):
+        self.user = self.request.user
+        # mark notifications as read
+        self.get_unread_badge_notifications().mark_all_read(self.user)
+        return JsonResponse(data={})

--- a/src/courses/templates/courses/snippets/rank_notification_popup.html
+++ b/src/courses/templates/courses/snippets/rank_notification_popup.html
@@ -1,0 +1,45 @@
+
+<div class="modal fade" id="newRankModal" tabindex="-1" role="dialog" aria-labelledby="newRankLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="newRankLabel">New Rank!</h4>
+      </div>
+      <div class="modal-body text-center">
+
+
+        <div class="row align-items-center">
+          <div>
+            <p>Congratulations! Your <strong>{{ earned_xp }} XP</strong> has earned you the rank of <strong>{{ earned_rank }}</strong>.</p>
+            <i class="text-warning {{ earned_rank.fa_icon }} fa-3x"></i>
+          </div>
+        </div>
+
+        {% if related_map %}
+
+          <p>You have gained access to a new Quest Map by earning this rank:</p>
+
+          <a href={% if request.user.is_staff %} "{% url 'djcytoscape:quest_map' related_map.id %}" {% else %} "{% url 'djcytoscape:quest_map_personalized' scape_id=related_map.id user_id=request.user.id %}" {% endif %}>
+            {{ related_map.name }}{% if not forloop.last %}, {% endif %}
+          </a>
+
+        {% endif %}
+
+        <div class="row align-items-center">
+        {% if next_rank %}
+          <div>
+            <p>To hit the next rank, <strong>{{ next_rank }}</strong>, you need <strong>{{ next_rank.xp }} XP</strong>.</p>
+            <i class="text-warning {{ next_rank.fa_icon }} fa-3x"></i>
+          </div>
+        {% else %}
+          <p>You've achieved the highest rank</p>
+        {% endif %}
+        </div>
+
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" id="newRankDismissButton">Dismiss</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/courses/urls.py
+++ b/src/courses/urls.py
@@ -31,6 +31,8 @@ urlpatterns = [
     path('ranks/create/', views.RankCreate.as_view(), name='rank_create'),
     path('ranks/<pk>/edit/', views.RankUpdate.as_view(), name='rank_update'),
     path('ranks/<pk>/delete/', views.RankDelete.as_view(), name='rank_delete'),
+    path('ajax/on_show_ranked_popup/', views.Ajax_OnShowRankPopup.as_view(), name='ajax_on_show_ranked_popup'),
+    path('ajax/on_close_ranked_popup/', views.Ajax_OnCloseRankPopup.as_view(), name='ajax_on_close_ranked_popup'),
 
     # Marks
     path('marks/', views.mark_calculations, name='my_marks'),

--- a/src/hackerspace_online/decorators.py
+++ b/src/hackerspace_online/decorators.py
@@ -1,6 +1,7 @@
 from django.utils.decorators import method_decorator
 from django.contrib.auth import settings
 from django.shortcuts import render, redirect, reverse
+from django.http import JsonResponse
 
 
 def staff_member_required(f):
@@ -16,6 +17,24 @@ def staff_member_required(f):
             return f(request, *args, **kwargs)
 
         return render(request, '403.html', status=403)
+
+    return wrapper
+
+
+def xml_http_request_required(f):
+    """
+    Ensures that the request accessing the view is an ajax request.
+
+    According to django docs:
+        The HttpRequest.is_ajax() method is deprecated as it relied on a jQuery-specific way of signifying AJAX calls
+        ...
+        If you are writing your own AJAX detection method, request.is_ajax() can be reproduced exactly
+        as request.headers.get('x-requested-with') == 'XMLHttpRequest'.
+    """
+    def wrapper(request, *args, **kwargs):
+        if request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
+            return f(request, *args, **kwargs)
+        return JsonResponse({'error': 'This endpoint only accepts AJAX requests.'}, status=400)
 
     return wrapper
 

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -19,9 +19,9 @@ from django.http import JsonResponse
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 from unittest.mock import patch
-from model_bakery import baker
+from model_bakery import baker, recipe
 
-from courses.models import Block
+from courses.models import Block, Rank
 from hackerspace_online.tests.utils import ViewTestUtilsMixin, generate_form_data
 from notifications.models import Notification
 from quest_manager.models import Category, CommonData, Quest, QuestSubmission, XPItem
@@ -631,6 +631,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
         # log in the student for all tests here
         self.client.force_login(self.test_student)
 
+        self.semester = SiteConfig.get().active_semester
         self.quest = baker.make(Quest, xp=5)
         self.draft_comment = baker.make(Comment, text="test draft comment")
         self.sub = baker.make(QuestSubmission, user=self.test_student, quest=self.quest,
@@ -667,6 +668,62 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
         comments = self.sub.get_comments()
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments[0].text, f'<p>{comment}</p>')
+
+    def test_complete__no_verification(self):
+        """ Checks if a student completing a submission that causes their XP to go over
+        the threshold for 'Digital Novice' rank (60 XP) generates a notification
+        """
+        # digital novice is 60 xp
+        # create quest that can hit that rank with 2 submissions
+        self.assertTrue(Rank.objects.filter(name='Digital Novice').exists())
+        quest = baker.make(Quest, xp=40, max_repeats=-1, verification_required=False)
+        sub_recipe = recipe.Recipe(QuestSubmission, quest=quest, user=self.test_student, is_completed=True, semester=self.semester)
+
+        # confirm theres no false positive with the notification
+        # as 40 xp (submission) < 60 xp (rank)
+        submission1 = sub_recipe.make()
+        response = self.client.post(reverse('quests:complete', args=[submission1.id]), data={'complete': True})
+        self.assertEqual(response.status_code, 302)
+
+        # Should be no notifications since no approval and no rank up
+        self.assertEqual(Notification.objects.all_for_user(self.test_student).count(), 0)
+
+        # another completed submission should rank self.test_student up
+        # as 80 xp (40 + 40 xp) > 60 xp (rank)
+        submission2 = sub_recipe.make()
+        response = self.client.post(reverse('quests:complete', args=[submission2.id]), data={'complete': True})
+        self.assertEqual(response.status_code, 302)
+
+        # notifications: 1 promoted
+        self.assertEqual(Notification.objects.all_for_user(self.test_student).count(), 1)
+
+        # assert that xp matches rank
+        self.test_student.refresh_from_db()
+        self.assertEqual(self.test_student.profile.xp_cached, 80)
+
+    def test_complete__no_verification_and_custom_xp(self):
+        """ Checks if a student completing a submission with custom xp that causes their XP to go over
+        the threshold for 'Digital Novice' rank (60 XP) generates a notification
+        """
+        self.assertTrue(Rank.objects.filter(name='Digital Novice').exists())
+
+        # Ensure rank popup will only show if xp_requested is taken into account.
+        # if not it wont since standard xp is 40 (40 xp < 60 xp (rank))
+        # request xp is 80 (80 xp > 60 xp (rank))
+        quest = baker.make(Quest, xp=40, xp_can_be_entered_by_students=True, verification_required=False)
+        # complete view doesn't take in xp_request attribute, only as form data
+        submission_custom_xp = baker.make(QuestSubmission, quest=quest, user=self.test_student, is_completed=True, semester=self.semester)
+
+        #
+        response = self.client.post(reverse('quests:complete', args=[submission_custom_xp.id]), data={'complete': True, 'xp_requested': 80})
+        self.assertEqual(response.status_code, 302)
+
+        # notifications: 1 promoted
+        self.assertEqual(Notification.objects.all_for_user(self.test_student).count(), 1)
+
+        # assert that xp matches rank
+        self.test_student.refresh_from_db()
+        self.assertEqual(self.test_student.profile.xp_cached, 80)
 
     def test_no_comment_verification_not_required_quick_reply_form(self):
         """ When a quest is automatically approved, it does not require a comment
@@ -2414,6 +2471,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, TenantTestCase):
         # other_teacher_block = baker.make('courses.Block', current_teacher=self.other_teacher)
         # baker.make('courses.CourseStudent', block=other_teacher_block, user=self.test_student, semester=SiteConfig.get().active_semester)
 
+        self.semester = SiteConfig.get().active_semester
         self.quest = baker.make(Quest, name="Test Quest")
         self.sub = baker.make(QuestSubmission, quest=self.quest)
 
@@ -2470,6 +2528,62 @@ class ApprovalsViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertTrue(response.context['current_teacher_only'])
         self.assertIsNone(response.context['quest'])
         self.assertURLEqual(response.context['tab_list'][2]['url'], reverse('quests:approved'))
+
+    def test_approve__normal_quest(self):
+        """ Checks if approving a quest submission that causes a user's XP to go over
+        the threshold for 'Digital Novice' rank (60 XP) generates a notification
+        """
+        # digital novice is 60 xp
+        # create quest that can hit that rank with 2 submissions
+        self.assertTrue(Rank.objects.filter(name='Digital Novice').exists())
+        quest = baker.make(Quest, xp=40, max_repeats=-1)
+
+        # confirm theres no false positive with the notification
+        # as 40 xp (submission) < 60 xp (rank)
+        submission1 = baker.make(QuestSubmission, quest=quest, user=self.test_student, is_completed=True, semester=self.semester)
+        response = self.client.post(reverse('quests:approve', args=[submission1.id]), data={'comment_text': "", 'approve_button': True})
+        self.assertEqual(response.status_code, 302)
+
+        # notifications: approved
+        self.assertEqual(Notification.objects.all_for_user(self.test_student).count(), 1)
+
+        # another approved submission should rank self.test_student up
+        # as 80 xp (40 + 40 xp) > 60 xp (rank)
+        submission2 = baker.make(QuestSubmission, quest=quest, user=self.test_student, is_completed=True, semester=self.semester)
+        response = self.client.post(reverse('quests:approve', args=[submission2.id]), data={'comment_text': "", 'approve_button': True})
+        self.assertEqual(response.status_code, 302)
+
+        # notifications: 2 approved, 1 promoted
+        self.assertEqual(Notification.objects.all_for_user(self.test_student).count(), 3)
+
+        # assert that xp matches rank
+        self.test_student.refresh_from_db()
+        self.assertEqual(self.test_student.profile.xp_cached, 80)
+
+    def test_approve__custom_xp(self):
+        """ Checks if approving a quest submission with custom xp that causes user's XP to go over
+        the threshold for 'Digital Novice' rank (60 XP) generates a notification
+        """
+        self.assertTrue(Rank.objects.filter(name='Digital Novice').exists())
+
+        # Ensure rank popup will only show if xp_requested is taken into account.
+        # if not it wont since standard xp is 40 (40 xp < 60 xp (rank))
+        # request xp is 80 (80 xp > 60 xp (rank))
+        quest = baker.make(Quest, xp=40, xp_can_be_entered_by_students=True)
+        submission_custom_xp = baker.make(
+            QuestSubmission, quest=quest, user=self.test_student, is_completed=True, semester=self.semester, xp_requested=80
+        )
+
+        #
+        response = self.client.post(reverse('quests:approve', args=[submission_custom_xp.id]), data={'comment_text': "", 'approve_button': True})
+        self.assertEqual(response.status_code, 302)
+
+        # notifications: 1 approved, 1 promoted
+        self.assertEqual(Notification.objects.all_for_user(self.test_student).count(), 2)
+
+        # assert that xp matches rank
+        self.test_student.refresh_from_db()
+        self.assertEqual(self.test_student.profile.xp_cached, 80)
 
     def test_flagged(self):
         with patch('quest_manager.views.QuestSubmission.objects.flagged', return_value=[self.sub]):

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -70,8 +70,84 @@
               $("#announcements-badge").html(announcements_count);
             }
           }
+
+          // if webpage is already loaded and ajaxNotificationsBadge() again with 0 notifications
+          // does not clear .notification-badge
+          if (document.readyState == "complete" && count == 0) {
+            $(".notification-badge").html('');
+          }
+
         }
       });
+    }
+
+    // For badge popup
+    function ajaxOnShowBadgePopup() {
+      $.ajax({
+        type: "GET",
+        url: "{% url 'badges:ajax_on_show_badge_popup' %}",
+
+        success: function(data) {
+          if (data.show) {
+            // insert and show modal popup
+            document.body.insertAdjacentHTML('beforeend', data.html);
+            $('#newBadgeModal').modal('show');
+
+            // active popover else hover popup wont activate
+            $('#newBadgeModal [data-toggle="popover"]').popover();
+
+            // link close button to ajaxOnCloseNewBadgePopup
+            $('#newBadgeDissmissButton').click(function () {
+              OnCloseBadgePopup();
+            });
+          }
+        }
+      })
+    }
+    // since djangos are stored server side we have to use ajax
+    // instead of modifying cookies here (only cookie available would be session id)
+    function OnCloseBadgePopup() {
+      $.ajax({
+        type: "GET",
+        url: "{% url 'badges:ajax_on_close_badge_popup' %}",
+        success: function(data) {
+          // update notification number as this request marks some read
+          ajaxNotificationsBadge();
+        }
+      })
+    }
+
+    // For rank popup
+    function ajaxOnShowRankPopup() {
+      $.ajax({
+        type: "GET",
+        url: "{% url 'courses:ajax_on_show_ranked_popup' %}",
+
+        success: function(data) {
+          if (data.show) {
+            // insert and show modal popup
+            document.body.insertAdjacentHTML('beforeend', data.html);
+            $('#newRankModal').modal('show');
+
+            // link close button to ajaxOnCloseNewBadgePopup
+            $('#newRankDismissButton').click(function () {
+              ajaxOnCloseRankPopup();
+            });
+          }
+        }
+      })
+    }
+
+    //
+    function ajaxOnCloseRankPopup() {
+      $.ajax({
+        type: "GET",
+        url: "{% url 'courses:ajax_on_close_ranked_popup' %}",
+        success: function(data) {
+          // update notification number as this request marks some read
+          ajaxNotificationsBadge();
+        }
+      })
     }
 
     function ajaxMarkNotificationRead(notification_id, $item) {
@@ -123,7 +199,14 @@
       {% if request.user.is_authenticated %}
         ajaxNotificationsBadge()
         setInterval(ajaxNotificationsBadge, timeout);
+
+        {% if not request.user.is_staff %}
+        ajaxOnShowBadgePopup();
+        ajaxOnShowRankPopup();
+        {% endif %}
+
       {% endif %}
+
 
       {% if request.user.is_staff %}
         ajaxApprovalsBadge()


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Created a popup everytime a badge or rank is earned. User's can dismiss the popup by clicking on "dismiss". Refreshing or clearing the popup by clicking on the greyed out background will trigger the popup again when page is reset.

### Why?
See #551

### How?

#### Badge
Created an ajax request in ```javascript.js``` linked to ```base.html.```
On webpage startup calls `courses:ajax_on_show_badge_popup` 

The ajax request calls a view that returns a `JsonResponse` with html the javascript can load into the page.
The html snippet has all the recent badges the user has gotten, using unmarked badge notifications.

#### Rank
When user has their quest approved a new notification is sent out if their new xp reaches a new rank.

When webpage is loaded an ajax request in ```javascript.js```( linked to ```base.html.```) is called to `courses:ajax_on_show_ranked_popup`.

The ajax request then returns a `JsonResponse` with html, then with client side code can load into the page.
The html snippet has `earned_rank`, the new rank the user has achieved, and `next_rank`, the next rank the user can achieve.
The request gets `earned_rank` by filtering the users unread notifications for the new "promoted" notification (see screenshots).
 
### Testing?
Created ajax tests
`BadgeAjaxTests` tests for `Ajax_OnShowBadgePopup` and `Ajax_OnCloseBadgePopup`
`AjaxRankPopupTests` tests for `Ajax_OnShowRankPopup` and `Ajax_OnCloseRankPopup`
Created notification testing for `complete` and `approved` views for the new notification type
Created notification testing for `post_save_reciever` for badge assertions

Did not add testing for `QuestSubmission.does_not_grant_xp` as `complete` and `approved` views use `submission.mark_approved()`. Which automatically sets `does_not_grant_xp` to `False`

### Screenshots (if front end is affected)

Video of both popups showing up and being dismissed

https://github.com/user-attachments/assets/83bcb51f-8061-427b-bee1-26e8ada35255

#### Badges
Badge popup
![image](https://github.com/user-attachments/assets/21c3d7d8-09c8-434e-a383-c22320c54a75)
![image](https://github.com/user-attachments/assets/bdb21644-9bdb-4e43-9bb9-2d7e33dc7030)


#### Ranks
new notification for rank up

Ranked popup
![image](https://github.com/user-attachments/assets/e9011f3f-07fd-4661-8355-724cb84ca107)

ranked popup with a related map
![image](https://github.com/user-attachments/assets/0ab1ed01-e833-4f5c-83d6-7af8d6e7c7d1)

New notification to indicate rank. Recieved when user's xp goes over the threshold when getting a new badge or when quest is approved
![image](https://github.com/bytedeck/bytedeck/assets/39788517/ec0894e6-fa8e-4ea8-b316-34f612fd88a3)

### Anything Else?
+ Added a new decorator. `xml_http_request_required` which checks if request is an ajax request
+ Fixed a bug where calling `ajaxNotificationsBadge()` with notifications then calling it again does not clear `.notification-badge`

cant seem to add a ranked object to a map if its already related to another map. Is that a bug?

### Review request
@tylerecouture 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a notification feature for rank upgrades.
  - Introduced badge and rank popups that display congratulatory messages dynamically.
  - Added AJAX functionality for showing and closing badge and rank popups.
  - New decorators to enhance AJAX request handling.

- **Bug Fixes**
  - Ensured correct creation and display of notifications for badge assertions and rank changes.

- **Tests**
  - Added comprehensive tests for badge and rank popup notifications.
  - Enhanced tests for quest submissions and XP granting logic.

- **Chores**
  - Updated templates to include AJAX functions for badge and rank notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->