### PR TITLE
Feat: Preq with rank creates assosiated map; Closes #88

### DIFF
--- a/src/prerequisites/models.py
+++ b/src/prerequisites/models.py
@@ -86,6 +86,19 @@ class HasPrereqsMixin:
         content_type = ContentType.objects.get_for_model(self).name
         return f"({content_type}) {str(self)}"
 
+    @staticmethod
+    def content_type_is_registered(content_type):
+        """Check if model represented by this content_type implements HasPrereqsMixin"""
+        return HasPrereqsMixin.model_is_registered(content_type.model_class())
+
+    @staticmethod
+    def model_is_registered(model_class):
+        """Check if class implements HasPrereqsMixin"""
+        if model_class and issubclass(model_class, HasPrereqsMixin):
+            return True
+        else:
+            return False
+
 
 class IsAPrereqMixin:
     """


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Every time a quest or badge is created/updated with a rank prerequisite, if no related map exist then a new map is created with the rank as its initial object.

### Why?
See #88

### How?
Created a ```post_save``` signal that checks if a ```Prerequisite``` created has the parent ```Quest``` or ```Badge```.
Then creates a new cytoscape map is it passes these conditions:
+ ```invert``` is False
+ ```content_type``` is 'rank'
+ A map with the rank as its initial object does not exist

### Testing?
Created a test in ```prerequisites.tests.test_signals``` to check if maps are being created.
With ```prereq``` and ```or_prereq```

### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/0453d817-75cd-4e9e-90e5-dab39d81bd70)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/b670678b-5c0a-4e87-a07c-0f09c68d5336)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/a0856a70-f853-4e10-ae7c-84ec555f1343)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/a2b30e0c-3c30-44d7-875a-61d0da452925)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced checks for model registration in system prerequisites.
  - Added functionality to create a new map under specific conditions when saving quest badges with rank requirements.
  
- **Tests**
  - Added tests for validating the creation of prerequisites with rank requirements that generate a new map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->