### PR TITLE
Fix: Importing a Badge with new BadgeType no longer fails; Closes #794

### DIFF
--- a/src/badges/admin.py
+++ b/src/badges/admin.py
@@ -30,6 +30,10 @@ class BadgeTypeAdmin(NonPublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
 class BadgeResource(NonPublicSchemaOnlyAdminAccessMixin, resources.ModelResource):
     prereq_import_ids = Field(column_name='prereq_import_ids')
 
+    badge_type_name = Field()
+    badge_type_sort = Field()
+    badge_type_icon = Field()
+
     class Meta:
         model = Badge
         import_id_fields = ('import_id',)
@@ -44,6 +48,43 @@ class BadgeResource(NonPublicSchemaOnlyAdminAccessMixin, resources.ModelResource
             elif p.prereq_content_type == ContentType.objects.get_for_model(Badge):
                 prereq_import_ids += "&" + str(p.get_prereq().import_id)
         return prereq_import_ids
+
+    def dehydrate_badge_type_name(self, badge):
+        """ For processing "badge_type_name" field on export
+
+        Using the name instead of id.
+        We cannot guarantee exportee's ids are the same as import's ids
+        Use badge_type.name instead as it is unique.
+        """
+        # dehydrate runs twice per row during import.
+        # (despite import_export docs saying nothing about it running in import)
+        # first run every variable is "None" and the only
+        # accessible thing that doesnt produce an error is "badge.id"
+        if not badge.id:
+            return None
+        return str(badge.badge_type)
+
+    def dehydrate_badge_type_sort(self, badge):
+        """ For processing "badge_type_sort" field on export
+        """
+        # dehydrate runs twice per row during import.
+        # (despite import_export docs saying nothing about it running in import)
+        # first run every variable is "None" and the only
+        # accessible thing that doesnt produce an error is "badge.id"
+        if not badge.id:
+            return None
+        return badge.badge_type.sort_order
+
+    def dehydrate_badge_type_icon(self, badge):
+        """ For processing "badge_type_icon" field on export
+        """
+        # dehydrate runs twice per row during import.
+        # (despite import_export docs saying nothing about it running in import)
+        # first run every variable is "None" and the only
+        # accessible thing that doesnt produce an error is "badge.id"
+        if not badge.id:
+            return None
+        return badge.badge_type.fa_icon
 
     def generate_simple_prereqs(self, parent_object, data_dict):
         # check that the prereq quest exists as an import-linked quest via import_id
@@ -75,7 +116,40 @@ class BadgeResource(NonPublicSchemaOnlyAdminAccessMixin, resources.ModelResource
                     # Create a new prereq to this quest
                     Prereq.add_simple_prereq(parent_object, prereq_object)
 
+    def generate_badge_type(self, row):
+        """ modifies the row "badge_type" to the correct BadgeType.id defined by
+         + badge_type_name
+         + badge_type_sort
+         + badge_type_icon
+        If badge type doesn't exist, it creates it.
+        If staff cancels import anything created here will be rolled back automatically.
+        """
+        bt_name = row['badge_type_name']
+        bt_sort = row['badge_type_sort']
+        bt_icon = row['badge_type_icon']
+
+        if bt_name:
+            defaults = {'fa_icon': bt_icon}
+
+            # if bt_sort is None badge creation will throw an error
+            if bt_sort:
+                defaults['sort_order'] = bt_sort
+
+            badge_type, _ = BadgeType.objects.get_or_create(
+                name=bt_name,
+                defaults=defaults,
+            )
+
+            row['badge_type'] = badge_type.id
+
+    def before_import_row(self, row, **kwargs):
+        """ https://django-import-export.readthedocs.io/en/2.0.2/api_resources.html#import_export.resources.Resource.before_import_row """
+        # can create badge type here as it seems like the new badgetype will be saved only be saved
+        # after admin has accepted the import changes
+        self.generate_badge_type(row)
+
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):
+        """ https://django-import-export.readthedocs.io/en/2.0.2/api_resources.html#import_export.resources.Resource.after_import """
         for data_dict in dataset.dict:
             import_id = data_dict["import_id"]
             parent_badge = Badge.objects.get(import_id=import_id)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where if you import a badge from an exportee with a BadgeType the importer doesn't have. It will fail.

### Why?
See #794 

### How?
1. Added new importing field and dehydrate method for that field
![image](https://github.com/bytedeck/bytedeck/assets/39788517/bc8ce74d-2d1c-4af3-8b7b-769e3c2ef5ac)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/ce8fceb1-0f9b-4fd2-84f2-fbaae2390eac)

2. added before import, which gets or creates the BadgeType referencing `badge_type_name` and using that to modify `badge_type`
![image](https://github.com/bytedeck/bytedeck/assets/39788517/5c39a8b3-bff2-4d1f-8130-ca2c7a491669)

Have to create a `BadgeType` before `save_instance` (and by extension `after_import`) because `BadgeType` is a required field. Therefore, im unable to copy the same method as how `campaigns` are imported with `quests`

### Testing?
Not sure about automated testing as our version of [`import_export`](https://django-import-export.readthedocs.io/en/2.0.2/search.html?q=test&check_keywords=yes&area=default) does not mention testing. And later versions use `tox.`

Only alternative was manual testing. What I did:
1. On one tenant, create 2 badges. `Badge (Success)` works on import in `develop` branch, while `Badge (Fail)` does not (as it references a new badge type)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/cc9cacc0-7ede-4877-889d-dce7fd3ae554)
2. export each Badge as a separate file
![image](https://github.com/bytedeck/bytedeck/assets/39788517/1de35ce4-3f7b-4991-9268-2195c859880d)
3. import each file on a new tenat.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/ca18400d-891b-472c-870b-10872dd03ee6)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/435ee62a-c07e-4227-bd21-ca365f31f7b1)
4. result
![image](https://github.com/bytedeck/bytedeck/assets/39788517/e88b13a4-850b-43e7-8447-2d6f467d9ea8)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/ee14aaa0-71a4-435d-b24d-abcb4debf555)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/d52d43dc-4e02-40b8-a1d4-1567a046b08e)

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved badge handling during import operations with new fields: `badge_type_name`, `badge_type_sort`, and `badge_type_icon`.
  - Enhanced import functionality by generating badge types based on provided information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->