### PR TITLE
Fix: flake8 zombie issue; Closes #1622

### DIFF
--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -278,9 +278,9 @@ def assertion_delete(request, assertion_id):
             target=assertion.badge,
             recipient=user,
             affected_users=[user, ],
-            icon="<span class='fa-stack'>" + \
-                 "<i class='fa fa-certificate fa-stack-1x text-warning'></i>" + \
-                 "<i class='fa fa-ban fa-stack-2x text-danger'></i>" + \
+            icon="<span class='fa-stack'>" +
+                 "<i class='fa fa-certificate fa-stack-1x text-warning'></i>" +
+                 "<i class='fa fa-ban fa-stack-2x text-danger'></i>" +
                  "</span>",
             verb='revoked')
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where flake8 in git actions would show an issue at that was from a pr 8 years ago

### Why?
See #1622

### How?
`flake8` recently updated from `7.0.0` to `7.1.0` causing all prs using `7.1.0` to fail.
Fixed it by changing the cause of the error to adhere to `E502` extra backslashes

### Testing?
manually tested on github.

Manually tested if removing the brackets works using idle
![image](https://github.com/bytedeck/bytedeck/assets/39788517/8cf32f9f-c233-418f-89fe-b4e4edaed55a)


### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the linting workflow to use Flake8 version 7.0.0 for improved code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->