### PR TITLE
Feat: List of related maps in Quest and Badge view; Closes #273

### DIFF
--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -34,6 +34,7 @@
         </div>
         <div class="col-sm-6">
           <ul class="list-unstyled">
+            <li>Maps: {% include 'djcytoscape/snippets/map-list.html' %}</li>
             {% if not request.user.is_staff %}
             <li>{% tag_name %}s: {% include 'tags/snippets/tag-list.html' with object=badge user_obj=request.user %}<br></li>
             {% else %}

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -20,6 +20,7 @@ from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 
 from .forms import BadgeAssertionForm, BadgeForm, BulkBadgeAssertionForm
 from .models import Badge, BadgeAssertion, BadgeType
+from djcytoscape.models import CytoScape
 
 
 class AchievementRedirectView(NonPublicOnlyViewMixin, LoginRequiredMixin, RedirectView):
@@ -126,6 +127,7 @@ def detail(request, badge_id):
         "current": True,
         "assertions_of_this_badge": BadgeAssertion.objects.all_for_user_badge(request.user, badge, False),
         "user_assertion_count": BadgeAssertion.objects.user_badge_assertion_count(badge, True),
+        "maps": CytoScape.objects.get_related_maps(badge),
     }
     return render(request, 'badges/detail.html', context)
 
@@ -142,6 +144,7 @@ def detail_all(request, badge_id):
         "current": False,
         "assertions_of_this_badge": BadgeAssertion.objects.all_for_user_badge(request.user, badge, False),
         "user_assertion_count": BadgeAssertion.objects.user_badge_assertion_count(badge, False),
+        "maps": CytoScape.objects.get_related_maps(badge),
     }
     return render(request, 'badges/detail.html', context)
 

--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -444,6 +444,17 @@ class CytoScapeManager(models.Manager):
         except ObjectDoesNotExist:
             return None
 
+    def get_related_maps(self, object_):
+        """ returns all CytoScape maps associated with object as a queryset """
+        selector_id = CytoElement.generate_selector_id(object_)
+
+        related_ids = CytoElement.objects.filter(
+            group=CytoElement.NODES,
+            selector_id=selector_id,
+        ).values_list('scape__id', flat=True)
+
+        return self.get_queryset().filter(id__in=related_ids)
+
 
 class CytoScape(models.Model):
     ALLOWED_INITIAL_CONTENT_TYPES = models.Q(app_label='quest_manager', model='quest') | \

--- a/src/djcytoscape/templates/djcytoscape/snippets/map-list.html
+++ b/src/djcytoscape/templates/djcytoscape/snippets/map-list.html
@@ -1,0 +1,23 @@
+<div class='tags-list'>
+    <ul class='left-aligned'>
+    {% if maps.count > 4 %}
+        {% for map in maps %}
+
+        <a href={% if request.user.is_staff %} "{% url 'djcytoscape:quest_map' map.id %}" {% else %} "{% url 'djcytoscape:quest_map_personalized' scape_id=map.id user_id=request.user.id %}" {% endif %}>
+            {{ map.name }}{% if not forloop.last %}, {% endif %}
+        </a>
+
+        {% empty %} None
+        {% endfor %}
+    {% else %}
+        {% for map in maps %}
+
+        <li><a href={% if request.user.is_staff %} "{% url 'djcytoscape:quest_map' map.id %}" {% else %} "{% url 'djcytoscape:quest_map_personalized' scape_id=map.id user_id=request.user.id %}" {% endif %}>
+            {{ map.name }}
+        </a></li>
+
+        {% empty %} <li>None</li>
+        {% endfor %}
+    {% endif %}
+    </ul>
+</div>

--- a/src/quest_manager/templates/quest_manager/quest_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/quest_detail_content.html
@@ -18,9 +18,9 @@
     <div class="row">
       <div class="col-sm-6">
         <ul class="list-unstyled">
-          <li><h4>XP: {{quest.xp}}{% if quest.xp_can_be_entered_by_students %}+ <small>(student entered)</small>{% endif %}
-          </h4></li>
+          <li><h4>XP: {{quest.xp}}{% if quest.xp_can_be_entered_by_students %}+ <small>(student entered)</small>{% endif %}</h4></li>
           <li>Campaign: {% if quest.campaign %}{% if user.is_staff %}<a href="{% url 'quests:category_detail' quest.campaign.id %}">{{ quest.campaign }}</a>{% else %}{{ quest.campaign }}{% endif %}{% else %}-{% endif %}</li>
+          <li>Maps: {% include 'djcytoscape/snippets/map-list.html' %}</li>
           {% if request.user.is_staff %}
           <li>{% tag_name %}s: {% with quest as object %}{% include 'tags/snippets/tag-list.html' %}{% endwith %}</li>
           {% else %}

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -41,6 +41,7 @@ from .forms import (
     CommonDataForm,
 )
 from .models import Quest, QuestSubmission, Category, CommonData
+from djcytoscape.models import CytoScape
 
 User = get_user_model()
 
@@ -622,6 +623,7 @@ def detail(request, quest_id):
         "heading": q.name,
         "q": q,
         "available": available,
+        "maps": CytoScape.objects.get_related_maps(q),
     }
 
     return render(request, "quest_manager/detail.html", context)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added a list of related maps in Quest and Badge views

### Why?
See #273

### How?

Added a new method in `CytoScapeManager`, called `get_related_map`. Gets all related maps to "ContentType"/selector id.
Added the query to the context of Quest and Badge detail views.
Formatted the html similar to tags list

### Testing?
added testing for `get_related_maps` which tests for correct query when quest is:
+ part of no maps
+ part of exactly one map
+ part of three maps

### Screenshots (if front end is affected)

Quest
![image](https://github.com/bytedeck/bytedeck/assets/39788517/fae448f4-4b85-4744-9331-93d057c49224)
Badge
![image](https://github.com/bytedeck/bytedeck/assets/39788517/82a83760-8f1e-43e5-a55f-10dfb6009282)

### Anything Else?
Noticed the  `help_text` for `CytoElement.selector_id` was slighly incorrect. Saying Selector id is `model-#` instead of `model: #`

I'll probably make an extra pr to fix that. But it might be too inconsequential to make a migration for


### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Maps" section in badge and quest detail views to display related maps.
  - Added conditional rendering of maps based on their count.

- **Tests**
  - Added tests to ensure maps are correctly associated with quests.

- **Bug Fixes**
  - None

- **Documentation**
  - None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->