### PR TITLE
WIP Chore: full_clean announcements app

### DIFF
--- a/src/announcements/tasks.py
+++ b/src/announcements/tasks.py
@@ -72,6 +72,7 @@ def publish_announcement(user_id, announcement_id, root_url):
     announcement.datetime_released = timezone.now()
     announcement.draft = False
     announcement.auto_publish = False
+    announcement.full_clean()
     announcement.save()
 
     absolute_url = announcement.get_absolute_url()


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added full_clean() to each instance of model.save() in announcements app

### Why?
See #1630

### How?

Added full clean to tasks.
Added full clean to tests
   - since `announcement.author` is `null=True` but `blank=False` it fails validation. So i added the author manually in the tests

### Testing?
### Screenshots (if front end is affected)
### Anything Else?

>> If something fails, it could mean we have some bad code that is trying to save incomplete/unvalidated model instance. REPORT the failing part back here for discussion, and we can determine what to do on a case by case.

Not sure why its failing since im not familiar with celery tasks
![image](https://github.com/bytedeck/bytedeck/assets/39788517/eca38c9b-4ad7-4ac3-9bb7-135eba32a2b3)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/fa4deca5-64f8-4c80-acb0-d0d54d7017a4)

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for announcements by adding additional cleaning steps before saving.

- **Tests**
  - Updated tests for announcement creation and publishing to include author information and additional validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->