### PR TITLE
Feat: full_clean everything as a management command; Closes #1634

### DIFF
--- a/src/hackerspace_online/management/commands/full_clean.py
+++ b/src/hackerspace_online/management/commands/full_clean.py
@@ -1,0 +1,87 @@
+from django.apps import apps
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
+from django_tenants.utils import schema_context
+from tenant.models import Tenant
+
+
+class Command(BaseCommand):
+    """ Because model.save() does not call full_clean() there might be a couple of integrity issues because of that.
+    This command can loop through every single tenant (unless specified) and call full_clean() to check for any issues.
+    See "https://github.com/bytedeck/bytedeck/issues/1634" for more details.
+
+    format of full_clean validation error
+        # Exception found on cleaning "<Object Name>" (<Model Name>) of type <Error Name>: <Error Log>
+
+    examples of full_clean validation errors:
+        "Profile" object called "admin" with a "grad_year" validation error
+        - Exception found on cleaning "admin" (Profile) of type ValidationError: {'grad_year': ['This field cannot be blank.']}
+
+        "CytoElement" object called "5: Badge: ByteDeck Proficiency (2)" with "href" validation error
+        - Exception found on cleaning "5: Badge: ByteDeck Proficiency (2)" (CytoElement) of type ValidationError: {'href': ['Enter a valid URL.']}
+
+    """
+    # colors from https://stackoverflow.com/a/287944
+    EXCEPTION_C = '\033[91m'
+    MODEL_C = '\033[94m'
+    OBJECT_C = '\033[96m'
+    END_C = '\033[0m'
+
+    LOCAL_APPS = (
+        'quest_manager',
+        'profile_manager',
+        'announcements',
+        'comments',
+        'notifications',
+        'courses',
+        'prerequisites',
+        'badges',
+        'djcytoscape',
+        'portfolios',
+        'utilities',
+        'siteconfig',
+        'tags',
+        'library',
+    )
+
+    help = ("Loops through a list of tenants (all by default), and validates each object in the database using full_clean().",
+            "Any validation errors are printed to the console.")
+
+    def add_arguments(self, parser):
+
+        # optional arguments
+        parser.add_argument(
+            '--tenants', action='store', nargs='+',
+            help='A space separated list of tenant schemas. Specifies which tenant to loop through. Defaults to all tenants'
+        )
+
+    def handle(self, *args, **options):
+        tenant_names = options.get('tenants')
+
+        tenants = Tenant.objects.filter(schema_name__in=tenant_names) if tenant_names else Tenant.objects.all()
+
+        # querying models from these gives a relation error
+        tenants = tenants.exclude(schema_name__in=['public'])
+
+        # loop through all tenants
+        for tenant in tenants:
+            # loop through all models inside tenant
+            with schema_context(tenant.schema_name):
+
+                # loop through each model
+                for app_name in self.LOCAL_APPS:
+                    for model in apps.get_app_config(app_name).get_models():
+
+                        # full clean each object in model
+                        for object_ in model.objects.all().iterator(chunk_size=100):
+                            try:
+                                object_.full_clean()
+                                object_.save()
+                            except ValidationError as e:
+                                exception_string = self.EXCEPTION_C + "Exception" + self.END_C
+                                object_string = self.OBJECT_C + str(object_) + self.END_C
+                                model_string = self.MODEL_C + model.__name__ + self.END_C
+                                error_type = self.EXCEPTION_C + type(e).__name__ + self.END_C
+
+                                # Exception found on cleaning "<Object Name>" (<Model Name>) of type <Error Name>: <Error Log>
+                                print(f'{exception_string} found on cleaning "{object_string}" ({model_string}) of type {error_type}:', e)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added a management command that full_clean() all objects for all tenants

### Why?
See #1634 

### How?
used `BaseCommand` for management command.
used `schema_context` to "enter" each tenant to check for objects

### Testing?
Added a test with two tenants with separate expected validation issues. 

### Screenshots (if front end is affected)
![image](https://github.com/bytedeck/bytedeck/assets/39788517/16173a1b-2f5d-4627-8b57-75ac084fb915)

### Anything Else?
Maybe its a good idea to split some of the looping to celery? im not sure though.

Added color to the terminal. I found its way easier to read the logs when its split by color

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new management command to validate and clean tenant-specific objects, ensuring data integrity.

- **Refactor**
  - Reorganized `INSTALLED_APPS` into separate lists for core, third-party, and local apps to improve clarity and maintainability.

- **Tests**
  - Added new test cases to verify the functionality and error handling of the new management command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->