### PR TITLE
Chore: full clean badges app

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -312,6 +312,7 @@ class BadgeAssertionManager(models.Manager):
             do_not_grant_xp=transfer,
             semester_id=active_semester
         )
+        new_assertion.full_clean()
         new_assertion.save()
         user.profile.xp_invalidate_cache()  # recalculate user's XP
         return new_assertion

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -87,6 +87,7 @@ class BadgeTestModel(TenantTestCase):
 
         # give it an icon
         self.badge.icon = "test_icon.png"
+        self.badge.full_clean()
         self.badge.save()
         self.assertEqual(self.badge.get_icon_url(), self.badge.icon.url)
 

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -255,6 +255,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         # Change custom_name_for_badge to a non-default option
         config = SiteConfig.get()
         config.custom_name_for_badge = "CustomBadge"
+        config.full_clean()
         config.save()
 
         # Get Create view and assert header is correct
@@ -289,6 +290,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         # Change custom_name_for_badge to a non-default option
         config = SiteConfig.get()
         config.custom_name_for_badge = "CustomBadge"
+        config.full_clean()
         config.save()
 
         # Get Create view and assert every instance of custom label is present
@@ -407,6 +409,7 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, TenantTestCase):
         # Change custom_name_for_badge to a non-default option
         config = SiteConfig.get()
         config.custom_name_for_badge = "CustomBadge"
+        config.full_clean()
         config.save()
 
         # Get Create view and assert header is correct


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added full_clean() before any save in badges app

### Why?
See #1630

### How?
Added full_clean() before any model save()

### Testing?
Ran the automated testing for badges app.

### Screenshots (if front end is affected)
Ran full tests on badges app.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/5e354046-7eb1-44c3-baf4-fae71b23b8de)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Enhanced validation when creating badge assertions to prevent invalid data from being saved.

- **Tests**
  - Improved tests for badge models and views by adding additional validation steps to ensure data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->