### PR TITLE
Feat: Updated Tablib to 3.5 and Import_Export to 3.3.9

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -13,13 +13,11 @@ django-datetime-widget>=0.9.3,<1.0
 django-decorator-include==3.0
 django-embed-video>=1.1.2,<1.5
 django-grappelli>=2.13.3,<2.14
-django-import-export>=2.0,<2.1
-#freeze tablib to 0.14.0 until django-import-export fixes its own dependencies
-# https://github.com/django-import-export/django-import-export/issues/1064
+django-import-export==3.3.9
 bleach[css]>=5,<6
 cssutils==2.6.0
 html2text==2020.1.16
-tablib==0.14.0
+tablib==3.5.0
 django-redis>=5.2.0,<5.3
 django-select2>=6.3.1,<6.4
 django-summernote>=0.8,<0.9

--- a/src/badges/admin.py
+++ b/src/badges/admin.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from import_export import resources
 from import_export.admin import ImportExportActionModelAdmin
 from import_export.fields import Field
+from import_export.formats.base_formats import CSV
 
 from prerequisites.models import Prereq
 from prerequisites.admin import PrereqInline
@@ -143,13 +144,13 @@ class BadgeResource(NonPublicSchemaOnlyAdminAccessMixin, resources.ModelResource
             row['badge_type'] = badge_type.id
 
     def before_import_row(self, row, **kwargs):
-        """ https://django-import-export.readthedocs.io/en/2.0.2/api_resources.html#import_export.resources.Resource.before_import_row """
+        """ https://django-import-export.readthedocs.io/en/3.3.9/api_resources.html#import_export.resources.Resource.before_import_row """
         # can create badge type here as it seems like the new badgetype will be saved only be saved
         # after admin has accepted the import changes
         self.generate_badge_type(row)
 
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):
-        """ https://django-import-export.readthedocs.io/en/2.0.2/api_resources.html#import_export.resources.Resource.after_import """
+        """ https://django-import-export.readthedocs.io/en/3.3.9/api_resources.html#import_export.resources.Resource.after_import """
         for data_dict in dataset.dict:
             import_id = data_dict["import_id"]
             parent_badge = Badge.objects.get(import_id=import_id)
@@ -162,6 +163,14 @@ class BadgeAdmin(NonPublicSchemaOnlyAdminAccessMixin, ImportExportActionModelAdm
     inlines = [
         PrereqInline,
     ]
+
+    def get_import_formats(self):
+        """ file formats for importing """
+        return [CSV]
+
+    def get_export_formats(self):
+        """ file formats for exporting """
+        return [CSV]
 
 
 class BadgeSeriesAdmin(NonPublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):

--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -6,7 +6,8 @@ from django.contrib.contenttypes.models import ContentType
 
 from import_export import resources
 from import_export.fields import Field
-from import_export.admin import ImportExportActionModelAdmin, ExportActionMixin
+from import_export.formats.base_formats import CSV
+from import_export.admin import ImportExportActionModelAdmin
 
 from prerequisites.models import Prereq
 from prerequisites.admin import PrereqInline
@@ -178,8 +179,7 @@ class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteAdvanced
         PrereqInline,
     ]
 
-    actions = ExportActionMixin.actions + [publish_selected_quests, archive_selected_quests,
-                                           prettify_code_selected_quests, fix_whitespace_bug]  # noqa
+    actions = [publish_selected_quests, archive_selected_quests, prettify_code_selected_quests, fix_whitespace_bug]
 
     change_list_filter_template = "admin/filter_listing.html"
 
@@ -191,6 +191,14 @@ class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteAdvanced
     # fieldsets = [
     #     ('Available', {'fields': ['date_available', 'time_available']}),
     # ]
+
+    def get_import_formats(self):
+        """ file formats for importing """
+        return [CSV]
+
+    def get_export_formats(self):
+        """ file formats for exporting """
+        return [CSV]
 
 
 class CategoryAdmin(NonPublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Updated `Tablib` to 3.5 and `Import_Export` to 3.3.9

### Why?
Part of https://github.com/bytedeck/bytedeck/issues/1640 and supersedes https://github.com/bytedeck/bytedeck/pull/1611 

### How?
The original goal was to update `tablib` to 3.6.1. However `Import_Export` 3.3.9 which is the latest version that supports our current version of `django` (3.2) only supports `tablib` 3.5.0.

Couldnt find it on the changelog but `ExportActionMixin.actions` in `admin.QuestAdmin` was crashing on startup. Removing it fixed the issue and kept the extra actions.
Note: `ExportActionMixin.actions` only adds import and export functions in `import_export` 2.0.2 which is now redundant in this current version.
![image](https://github.com/bytedeck/bytedeck/assets/39788517/6cfec1d9-e90e-4e06-b431-f3c802173975)

> While you working in here, can you see if you can somehow limit the available formats in the Import form? Currently it lists many, but we only use CSV, and only need csv.

limited the file type of import/export to csv only
quest
![image](https://github.com/bytedeck/bytedeck/assets/39788517/cb2edc0c-5d2e-4b43-9373-21a45d4c34ae)
badges
![image](https://github.com/bytedeck/bytedeck/assets/39788517/a8a7b885-ed05-4b4f-a612-01a64ef4520c)


### Testing?
Since we never used tablib explicity and only through import_export. I manually tested the import export functionality of badges and quests.

badge importing success
![image](https://github.com/bytedeck/bytedeck/assets/39788517/61fc732d-1b69-4fab-91d0-042e57a3739a)
quest importing success
![image](https://github.com/bytedeck/bytedeck/assets/39788517/01ed3bcc-4b26-452f-acb6-6c194615e61a)

#### Possible Tablib breaking changes:
None we dont use tablib outside import_export

##### Possible Import_export breaking changes: 
```
3.0.0
    This release makes some minor changes to the public API. If you have overridden any methods from the resources or widgets modules, you may need to update your implementation to accommodate these changes.
```

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
  - Updated `django-import-export` to version 3.3.9.
  - Updated `tablib` to version 3.5.0.

- **Documentation**
  - Updated docstring URLs in badge administration to reflect new `django-import-export` documentation.

- **Refactor**
  - Simplified actions list in Quest administration by removing unnecessary import mixin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->