### PR TITLE
Feat: updated django-grappelli to 4.0.1

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -12,7 +12,7 @@ django-crispy-forms>=1.8.1,<1.15
 django-datetime-widget>=0.9.3,<1.0
 django-decorator-include==3.0
 django-embed-video>=1.1.2,<1.5
-django-grappelli>=2.13.3,<2.14
+django-grappelli>=4.0.1,<5
 django-import-export==3.3.9
 bleach[css]>=5,<6
 cssutils==2.6.0


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
updated django-grappelli to 4.0.1 (the latest version)

### Why?
Part of #1640 and supersedes https://github.com/bytedeck/bytedeck/pull/1203

### How?
In `requirements-production.txt` changed `django-grappelli` from `>=2.13.3,<2.14` to `==4.0.1`

decided to use the latest version instead of `<3.1` as according to dependabot
> A newer version of django-grappelli exists, but since this PR has been edited by someone other than Dependabot I haven't updated it. You'll get a PR for the updated version as normal once this PR is merged.

### Testing?
since according to django-grappelli [docs](https://django-grappelli.readthedocs.io/en/latest/), its an alternative to django admin interface. I've mostly tested the admin interface.

> (Make sure to check the prerequisite formset at the bottom of a quest form, also the import/export)

Quest Form. Tested all interactable elements
Basic
![image](https://github.com/bytedeck/bytedeck/assets/39788517/a9bf111c-1f9b-45d7-84a1-305953cf2c43)
Advanced
![image](https://github.com/bytedeck/bytedeck/assets/39788517/d2894d55-3ee9-419b-88b9-bb628a6613c5)


manually tested the functionality of the admin interface. Such as create, update, and delete.

tested import export functionality
![image](https://github.com/bytedeck/bytedeck/assets/39788517/a8436d3f-190d-4b0b-8a6a-092c0cf7700e)
tested quest prerequisites (it seems to have restored the magnifying glass in the prereq search bar)
current
![image](https://github.com/bytedeck/bytedeck/assets/39788517/5cfd75f3-8415-4958-99c0-6ee829f64594)
develop branch
![image](https://github.com/bytedeck/bytedeck/assets/39788517/a7aec98e-681f-4756-a328-ffa08eb7a0f6)

### Screenshots (if front end is affected)
### Anything Else?
No breaking changes to the [changelog](https://github.com/sehmaschine/django-grappelli/blob/master/docs/changelog.rst)
However, the oldest version in the changelog is `3.1`.  anything older I couldnt find.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `django-grappelli` dependency to ensure compatibility with future releases up to version 5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->