### PR TITLE
Chore: Updated django-celery to >=2.2,<2.7

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -6,7 +6,7 @@ Django==3.2.25  # temp pinned at .19 while resolvoing issue #1353
 django-allauth>=0.54,<0.55
 django-querysetsequence>=0.16
 django-bootstrap-datepicker-plus>=4.0,<5.0
-django-celery-beat>=2.2,<2.6
+django-celery-beat>=2.2,<2.7
 django-colorful>=1.3,<2.0
 django-crispy-forms>=1.8.1,<1.15
 django-datetime-widget>=0.9.3,<1.0


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Updated django-celery to `>=2.2,<2.7`

### Why?
Part of #1640, and supersedes #1612

### How?
In `requirements.txt`
Updated django-celery to `>=2.2,<2.7`

no breaking changes from 2.5 to 2.6 in django-celery [changelog](https://github.com/celery/django-celery-beat/blob/main/Changelog)

### Testing?
Ran automated tests no fails

### Screenshots (if front end is affected)
### Anything Else?
### Review request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated version constraint for `django-celery-beat` to `>=2.2,<2.7` to ensure compatibility with the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->