### PR TITLE
Chore: updated bs4 to >=4.12.3,<4.13

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,6 +1,6 @@
 django-tenants>=3.4,<3.6
 backports.csv>=1.0.7,<1.1
-beautifulsoup4>=4.8,<4.12
+beautifulsoup4>=4.12.3,<4.13
 celery>=5.2.2,<5.4
 Django==3.2.25  # temp pinned at .19 while resolvoing issue #1353
 django-allauth>=0.54,<0.55

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 
 from django_tenants.test.cases import TenantTestCase
+from unittest import TestCase
 from model_bakery import baker
 from model_bakery.recipe import Recipe
 
@@ -65,7 +66,7 @@ class NotificationModelTest(TenantTestCase):
         self.assertEqual(notes_unread.count(), 1)
 
 
-class NotificationModel_html_strip_Test(TenantTestCase):
+class NotificationModel_html_strip_Test(TestCase):
     """
         This test class is specialized on testing the html_strip() method of Notification model
     """

--- a/src/quest_manager/tests/test_signals.py
+++ b/src/quest_manager/tests/test_signals.py
@@ -36,19 +36,19 @@ class TestTidyHtml(unittest.TestCase):
         result = tidy_html(markup)
 
         # Then
-        expected = "<div>\n  <p>\n    Hello, world!\n  </p>\n</div>"
+        expected = "<div>\n  <p>\n    Hello, world!\n  </p>\n</div>\n"
         self.assertEqual(result, expected)
 
     def test_tidy_html__with_inline_tags(self):
         """inline tags such as <b> and <span> should not be indented"""
         # Given
-        markup = "<div><p><b>Hello</b>, <span>world</span>!</p></div>"
+        markup = "<div><p><b>Hello</b>, <span>world</span>!</p></div>\n"
 
         # When
         result = tidy_html(markup)
 
         # Then
-        expected = "<div>\n  <p>\n    <b>Hello</b>, <span>world</span>!\n  </p>\n</div>"
+        expected = "<div>\n  <p>\n    <b>Hello</b>, <span>world</span>!\n  </p>\n</div>\n"
         self.assertEqual(result, expected)
 
     def test_tidy_html__formatting_math(self):
@@ -61,19 +61,19 @@ class TestTidyHtml(unittest.TestCase):
 
     def test_quest_html_formatting_tabs(self):
         markup_tests = [  # test, expected out come
-            ("<p>some text</p>", "<p>\n  some text\n</p>"),
-            ("<p>some text\n\n</p>", "<p>\n  some text\n</p>"),
-            ("<p>some \ntext</p>", "<p>\n  some \ntext\n</p>"),
-            ("<p>some \n text</p>", "<p>\n  some \n text\n</p>"),
-            ("<ol><li>test</li></ol>", "<ol>\n  <li>\n    test\n  </li>\n</ol>"),
-            (" <p>", "<p>\n</p>"),  # fix unclosed paragraphs
+            ("<p>some text</p>", "<p>\n  some text\n</p>\n"),
+            ("<p>some text\n\n</p>", "<p>\n  some text\n</p>\n"),
+            ("<p>some \ntext</p>", "<p>\n  some \ntext\n</p>\n"),
+            ("<p>some \n text</p>", "<p>\n  some \n text\n</p>\n"),
+            ("<ol><li>test</li></ol>", "<ol>\n  <li>\n    test\n  </li>\n</ol>\n"),
+            (" <p>", "<p>\n</p>\n"),  # fix unclosed paragraphs
             ('<img src="\n example.png">', '<img src="\n example.png"/>\n'),  # don't indent within properties
             ('<img src="example.png\n">', '<img src="example.png\n"/>\n'),  # don't indent within properties
-            ('<ol><li>text', "<ol>\n  <li>\n    text\n  </li>\n</ol>"),  # fix unclosed lists
-            ('<script>alert("Hello")</script>', '<script>\n  alert("Hello")\n</script>'),  # don't strip scripts here
+            ('<ol><li>text', "<ol>\n  <li>\n    text\n  </li>\n</ol>\n"),  # fix unclosed lists
+            ('<script>alert("Hello")</script>', '<script>\n  alert("Hello")\n</script>\n'),  # don't strip scripts here
             # standard Youtube embed
             ('<div class="embed-responsive embed-responsive-16by9" style="float: none;"><iframe src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0&amp;loop=0" allowfullscreen="true" class="embed-responsive note-video-clip" width="auto" height="auto" frameborder="0"></iframe></div>',  # noqa
-             '<div class="embed-responsive embed-responsive-16by9" style="float: none;">\n  <iframe allowfullscreen="true" class="embed-responsive note-video-clip" frameborder="0" height="auto" src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0&loop=0" width="auto">\n  </iframe>\n</div>'),  # noqa
+             '<div class="embed-responsive embed-responsive-16by9" style="float: none;">\n  <iframe allowfullscreen="true" class="embed-responsive note-video-clip" frameborder="0" height="auto" src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0&loop=0" width="auto">\n  </iframe>\n</div>\n'),  # noqa
             ('', '')
         ]
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
updated bs4 to `>=4.12.3,<4.13`

### Why?
requested review for https://github.com/bytedeck/bytedeck/pull/1644

### How?
Changed version in `requirements.txt`. Fixed breaking changes in tests.

Breaking changes
https://git.launchpad.net/beautifulsoup/tree/CHANGELOG
```
4.12.1
...
Tag.prettify() will now consistently end prettified markup with a newline.
```

Since ending prettified markup with a newline is expected behaviour, I updated tests to reflect this instead of changing `tidy_html` (which is the only part of our codebase that uses `prettify`)

### Testing
All instances of code using bs4 as a feature have their own tests, and I specifically ran them to make sure it all works.
- `comments.tests.test_models.CleanHTMLTests`
- `quest_manager.tests.test_signals.TestTidyHtml`
- `notifications.tests.test_models.NotificationModel_html_strip_Test`

### Screenshots (if front end is affected)
### Anything Else?
I changed `notifications.tests.test_models.NotificationModel_html_strip_Test` from using `TenantTestCase` to `unittest.TestCase` as `NotificationModel_html_strip_Test` uses `notifications.html_strip` directly instead of interacting with the db

### Review request
@tylerecouture 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `beautifulsoup4` package version range in `requirements-production.txt` for better compatibility.

- **Tests**
  - Refactored `NotificationModel_html_strip_Test` to inherit from `unittest.TestCase` for better test organization.
  - Added newline characters to HTML strings in `test_signals.py` test cases to ensure proper formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->