### PR TITLE
Chore: updated django-storages to >=1.12,<2

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -32,7 +32,7 @@ future>=0.18.2,<0.19
 django-environ>=0.4.5,<0.5
 django-recaptcha>=2.0.6,<3.1
 tzdata
-django-storages>=1.12,<1.13
+django-storages>=1.12,<2
 boto3>=1.21,<1.29
 django-taggit>=2.1,<5.0
 dnspython>=2.6.1,<3.0


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Updated django storages to `>=1.12,<2`

### Why?
Part of https://github.com/bytedeck/bytedeck/issues/1640 and precedes https://github.com/bytedeck/bytedeck/pull/1505

### How? 
Updated `requirements.txt` ran all automated tests. Made sure there are no breaking changes in django-storages [docs](https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst) from 1.12.3 (develop) to 1.14.4 (branch)

### Testing?

as discussed below, I do not have access to the production server and im unable to test directly.
> I can test this in our AWS staging environment when I'm ready too. Please just note any breaking changes, or anything in the change log that stands out to you.

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture 

Using this as a way to test everything. As with the other pr, nothing failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `django-storages` version constraint to allow for a wider range of compatible versions (>=1.12,<2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->