### PR TITLE
Fix: navbar notification comment links to comment; Closes #1541

### DIFF
--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -241,6 +241,9 @@ class Notification(models.Model):
         # print("***** NOTIFICATION.get_url **********")
         try:
             target_url = self.target_object.get_absolute_url()
+
+            if 'commented on' in self.verb:
+                target_url += f'#comment-{self.action_object_id}'
         except:  # noqa
             # TODO make this except explicit, don't remember what it's doing
             target_url = reverse('notifications:list')
@@ -297,7 +300,7 @@ def new_notification(sender, **kwargs):
     :param sender: the object (any Model) initiating/causing the notification
     :param kwargs:
         target (any Model): The object being notified about (Submission, Comment, BadgeAssertion, etc.)
-        action (any Model): Not sure... not used I assume.
+        action (any Model): Used alongside "verb" to create syntax of notification ie. "<user> <verb> with <action>"
         recipient (User): The receiving User, required (but not used if affected_users are provided ...?)
         affected_users (list of Users): everyone who should receive the notification
         verb (string): sender 'verb' [target] [action]. E.g MrC 'commented on' SomeAnnouncement
@@ -335,7 +338,7 @@ def new_notification(sender, **kwargs):
                 sender_object_id=sender.id,
                 font_icon=icon,
             )
-            # Set the target if provided.  Action not currently used...
+            # Set the target if provided.
             for option in ("target", "action"):
                 # obj = kwargs.pop(option, None) #don't want to remove option with pop
                 try:


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where navbar notifications do not have a proper hash to comment, if action=comment

### Why?
See #1541

### How?
I noticed that `notifications:list` had correct functionality with `action=comment`. `notifications:list` uses `__str__` which manually checks for "on_comment" verb and appends the hash to the list.

I did the same thing for `get_url()`

### Testing?
Apart from manual tests, where I checked if the correct url appeared...
nav bar notification
![image](https://github.com/user-attachments/assets/330933d3-07aa-42db-a148-1fc31799b93a)
![image](https://github.com/user-attachments/assets/06602696-a9e4-43e3-b40c-e2a3f92caaf3)

I added a test `test_models.NotificationModelTests.test_url_correct_comment_hash` which tests if the comment hash correctly appears for both `__str__` and `get_url()`

### Screenshots (if front end is affected)
### Anything Else?
Made the doc string on `action` clearer for `new_notification`. The comments said it didnt do anything but its actually related to `__str__` and `get_url()`

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced notification URLs to include specific comment fragments when the verb includes 'commented on'.
  
- **Documentation**
  - Updated `new_notification` function documentation to clarify the usage of the `action` parameter.

- **Tests**
  - Added a test to ensure URLs with comment fragments are handled correctly in notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->