### PR TITLE
Tweak: refactored approvals and quest_list to use enums for tabs; Closes #1150

### DIFF
--- a/src/library/templates/library/library_quests.html
+++ b/src/library/templates/library/library_quests.html
@@ -1,1 +1,1 @@
-{% extends "quest_manager/quests.html" %}
+{% include "quest_manager/quests.html" with view_type=-1%}

--- a/src/library/templates/library/tab_library_quests.html
+++ b/src/library/templates/library/tab_library_quests.html
@@ -22,7 +22,7 @@
     </thead>
     <tbody class="panel-group panel-group-packed" role="tablist" aria-multiselectable="true">
       {% for q in library_quests %}
-        <tr class="accordian-trigger panel-title
+        <tr class="panel-title
           {% if request.user.is_staff %}
             {% if not q.visible_to_students %}danger
             {% elif q.is_expired %}warning

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -34,8 +34,10 @@ from allauth.socialaccount.helpers import _complete_social_login
 User = get_user_model()
 
 
-class ViewTypes:
-    """ enum for ProfileList and its descendants """
+class ProfileViewTypes:
+    """ enum for ProfileList and its descendants.
+    Note: using enum.auto() will not work as django template tags cant properly define its value.
+    """
     LIST = 0
     CURRENT = 1
     STAFF = 2
@@ -48,8 +50,8 @@ class ProfileList(NonPublicOnlyViewMixin, UserPassesTestMixin, ListView):
     template_name = 'profile_manager/profile_list.html'
 
     # this will determine which button will be active in self.template_name
-    # also if view_type=ViewTypes.STAFF will render a different partial template
-    view_type = ViewTypes.LIST
+    # also if view_type=ProfileViewTypes.STAFF will render a different partial template
+    view_type = ProfileViewTypes.LIST
 
     def test_func(self):
         return self.request.user.is_staff
@@ -77,7 +79,7 @@ class ProfileList(NonPublicOnlyViewMixin, UserPassesTestMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['VIEW_TYPES'] = ViewTypes
+        context['VIEW_TYPES'] = ProfileViewTypes
         context['view_type'] = self.view_type
         return context
 
@@ -94,7 +96,7 @@ class ProfileListCurrent(ProfileList):
     Arguments:
         ProfileList -- Base class
     """
-    view_type = ViewTypes.CURRENT
+    view_type = ProfileViewTypes.CURRENT
 
     # override the staff requirement for ProfileList
     def test_func(self):
@@ -108,7 +110,7 @@ class ProfileListCurrent(ProfileList):
 @method_decorator(staff_member_required, name='dispatch')
 class ProfileListBlock(ProfileList):
     """lists all students in a given block, is accessed through the block list view and acts as a hybrid profile list and block detail view"""
-    view_type = ViewTypes.BLOCK
+    view_type = ProfileViewTypes.BLOCK
     block_object = None
 
     def get_queryset(self):
@@ -130,7 +132,7 @@ class ProfileListBlock(ProfileList):
 
 @method_decorator(staff_member_required, name='dispatch')
 class ProfileListStaff(ProfileList):
-    view_type = ViewTypes.STAFF
+    view_type = ProfileViewTypes.STAFF
 
     def get_queryset(self):
         return Profile.objects.filter(user__is_staff=True)
@@ -138,7 +140,7 @@ class ProfileListStaff(ProfileList):
 
 @method_decorator(staff_member_required, name='dispatch')
 class ProfileListInactive(ProfileList):
-    view_type = ViewTypes.INACTIVE
+    view_type = ProfileViewTypes.INACTIVE
 
     def get_queryset(self):
         return Profile.objects.all_inactive()

--- a/src/quest_manager/templates/quest_manager/quest_approval.html
+++ b/src/quest_manager/templates/quest_manager/quest_approval.html
@@ -11,7 +11,7 @@
 {% load static %}
 
 {% block heading_inner %}{{ heading }}
-    {% if submitted_tab_active %}
+    {% if view_type == VIEW_TYPES.SUBMITTED %}
       {% if show_all_blocks_button %}
         <div class="btn-group">
             <a href="{% url 'quests:submitted' %}"

--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -29,7 +29,7 @@ back to its original look.
   {% if request.user.is_staff or request.user.profile.is_TA %}
     <a class="btn btn-primary" href="{% url 'quests:quest_create' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
   {% endif %}
-  {% if available_tab_active and remove_hidden and request.user.profile.num_hidden_quests and request.user.profile.has_current_course %}
+  {% if view_type == VIEW_TYPES.AVAILABLE and remove_hidden and request.user.profile.num_hidden_quests and request.user.profile.has_current_course %}
     <a class="btn btn-default" href="{% url 'quests:available_all' %}" role="button">
       Show Hidden Quests <span class="badge badge-muted">{{ request.user.profile.num_hidden_quests }}</span>
     </a>
@@ -37,9 +37,8 @@ back to its original look.
 {% endblock %}
 
 {% block content %}
-
   <ul id='quest-tabs' class="nav nav-tabs nav-justified" role="tablist">
-    <li role="presentation" {% if available_tab_active %}class="active"{% endif %}>
+    <li role="presentation" {% if view_type == VIEW_TYPES.AVAILABLE %}class="active"{% endif %}>
       <a href="{% url 'quests:available' %}">
         Available
         <span class="badge">{{ num_available | default:"" }}</span>
@@ -47,20 +46,20 @@ back to its original look.
 
     </li>
     {% if not request.user.is_staff %}
-      <li role="presentation" {% if inprogress_tab_active %}class="active"{% endif %}>
+      <li role="presentation" {% if view_type == VIEW_TYPES.IN_PROGRESS %}class="active"{% endif %}>
         <a href="{% url 'quests:inprogress' %}">
           In Progress
           <span class="badge">{{ num_inprogress | default:"" }}</span>
         </a>
       </li>
-      <li role="presentation" {% if completed_tab_active %}class="active"{% endif %}>
+      <li role="presentation" {% if view_type == VIEW_TYPES.COMPLETED %}class="active"{% endif %}>
         <a href="{% url 'quests:completed' %}">
           Completed
           <span class="badge">{{ num_completed | default:"" }}</span>
         </a>
       </li>
       {% if request.user.profile.has_past_courses %}
-        <li role="presentation" {% if past_tab_active %}class="active"{% endif %}>
+        <li role="presentation" {% if view_type == VIEW_TYPES.PAST %}class="active"{% endif %}>
           <a href="{% url 'quests:past' %}">
             Past Courses
             <span class="badge">{{ num_past | default:"" }}</span>
@@ -68,9 +67,8 @@ back to its original look.
         </li>
       {% endif %}
     {% endif %}
-
     {% if request.user.profile.is_TA or request.user.is_staff %}
-      <li role="presentation" {% if drafts_tab_active %}class="active"{% endif %}>
+      <li role="presentation" {% if view_type == VIEW_TYPES.DRAFT %}class="active"{% endif %}>
         <a href="{% url 'quests:drafts' %}">
           Drafts
           <span class="badge">{{ num_drafts | default:"" }}</span>
@@ -91,7 +89,7 @@ back to its original look.
   <!-- Tab panes -->
   <div class="tab-content">
     <div role="tabpanel"
-         class="tab-pane fade {% if available_tab_active %}in active{% endif %}" id="available">
+         class="tab-pane fade {% if view_type == VIEW_TYPES.AVAILABLE %}in active{% endif %}" id="available">
       {% if not request.user.profile.has_current_course and not request.user.is_staff %}
         <p>You have not joined a course yet for this semester.</p>
         <p><a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a></p>
@@ -109,20 +107,20 @@ back to its original look.
       {% include 'quest_manager/tab_quests_available.html' %}
     </div>
     <div role="tabpanel"
-         class="tab-pane fade {% if inprogress_tab_active %}in active{% endif %}" id="inprogress">
+         class="tab-pane fade {% if view_type == VIEW_TYPES.IN_PROGRESS %}in active{% endif %}" id="inprogress">
       {% with submissions=in_progress_submissions %}
         {% include 'quest_manager/tab_quests_submission.html' %}
       {% endwith %}
     </div>
     <div role="tabpanel"
-         class="tab-pane fade {% if completed_tab_active %}in active{% endif %}" id="completed">
+         class="tab-pane fade {% if view_type == VIEW_TYPES.COMPLETED %}in active{% endif %}" id="completed">
       {% with submissions=completed_submissions completed=True %}
         {% include 'quest_manager/tab_quests_submission.html' %}
       {% endwith %}
     </div>
     {% if request.user.profile.has_past_courses %}
       <div role="tabpanel"
-           class="tab-pane fade {% if past_tab_active %}in active{% endif %}" id="past_submissions">
+           class="tab-pane fade {% if view_type == VIEW_TYPES.PAST %}in active{% endif %}" id="past_submissions">
         {% with submissions=past_submissions past=True %}
           {% include 'quest_manager/tab_quests_submission.html' %}
         {% endwith %}
@@ -130,7 +128,7 @@ back to its original look.
     {% endif %}
     {% if request.user.profile.is_TA or request.user.is_staff %}
       <div role="tabpanel"
-         class="tab-pane fade {% if drafts_tab_active %}in active{% endif %}" id="drafts">
+         class="tab-pane fade {% if view_type == VIEW_TYPES.DRAFT %}in active{% endif %}" id="drafts">
       {% with available_quests=draft_quests %}
         {% include 'quest_manager/tab_quests_available.html' %}
       {% endwith %}


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Ive made some views use enums for its tabs, instead of defining a separate boolean variable for each tab in context. 

### Why?
See #1150

### How?
Found only two views that use multiple variables instead of an enum: `approvals` and `quest_list`.
Changed the view to use enums instead.

### Testing?
added two tests that check if the expected enum is used when a tab is active.

### Screenshots (if front end is affected)
### Anything Else?
Unsure if  `approvals` needs the enums as it uses a list of dicts that store tab information 

Fixed an bug with library tab where it had accordion class attached to it. triggering `ajax_accordion` which caused this error.
![image](https://github.com/user-attachments/assets/0beecc9d-11de-4cc5-8094-a7b59a291cdd)
An alternative solution if we want to preserve accordion functionality for library quests is to make an ajax view to call for library quests, like this
![image](https://github.com/user-attachments/assets/9219d54b-3f4d-44dc-85f0-f04db2664880)

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced quest display logic by transitioning to a dynamic `view_type` system in templates, improving user interaction.
  - Introduced a structured enumeration for quest list view tabs, streamlining navigation.

- **Refactor**
  - Renamed `ViewTypes` to `ProfileViewTypes` for clearer documentation and usage in profile management views.
  - Simplified tab display logic in quest templates by using `view_type` constants.

- **Tests**
  - Updated test cases to use the new `view_type` logic for more accurate context validation.
  - Added new test methods to ensure each tab type can be activated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->