### PR TITLE
Fix: Site Owner only options can only be modifed by site owner; Closes #1651

### DIFF
--- a/src/siteconfig/forms.py
+++ b/src/siteconfig/forms.py
@@ -23,15 +23,21 @@ class SiteConfigForm(forms.ModelForm):
         # active_semester setting moved to Semester views.
         exclude = ["active_semester"]
 
+    advanced_fields = [
+        "custom_stylesheet",
+        "custom_javascript",
+        "deck_owner",
+        "enable_shared_library",
+    ]
+
     def __init__(self, *args, **kwargs):
         is_deck_owner = kwargs.pop('is_deck_owner', False)
 
         super().__init__(*args, **kwargs)
 
         if not is_deck_owner:
-            self.fields['custom_stylesheet'].disabled = True
-            self.fields['custom_javascript'].disabled = True
-            self.fields['deck_owner'].disabled = True
+            for field in self.advanced_fields:
+                self.fields[field].disabled = True
 
         self.fields['enable_google_signin'].disabled = True
         self.fields['enable_shared_library'].label = self.fields['enable_shared_library'].label + " - EXPERIMENTAL WIP"
@@ -76,10 +82,7 @@ class SiteConfigForm(forms.ModelForm):
                             "<b>Warning: </b> These features are only editable by the deck owner."
                             "</p></div>"
                         ),
-                        "custom_stylesheet",
-                        "custom_javascript",
-                        "deck_owner",
-                        "enable_shared_library",
+                        *self.advanced_fields,
                         active=False,
                         template="crispy_forms/bootstrap3/accordion-group.html",
                     ),
@@ -96,6 +99,11 @@ class SiteConfigForm(forms.ModelForm):
         This method overrides default `clean_<fieldname>` method and parse <fieldname> upload
         using `cssutils` library to determine whether it is "valid" stylesheet or not.
         """
+        # if field is disabled, clean should return None
+        # ie. custom_javascript returns None when it is disabled
+        if self.fields['custom_stylesheet'].disabled:
+            return None
+
         # get data from form upload or do nothing if there is no uploads
         value = self.cleaned_data.get("custom_stylesheet", False)
         if value or self.files.get("custom_stylesheet"):

--- a/src/siteconfig/tests/test_forms.py
+++ b/src/siteconfig/tests/test_forms.py
@@ -39,7 +39,7 @@ class SiteConfigFormTest(TenantTestCase):
             size=len(wrong_content),
             charset="utf-8",
         )
-        form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config)
+        form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config, is_deck_owner=True)
         self.assertFalse(form.is_valid())
         self.assertIn(
             "CSSStyleRule: No start { of style declaration found: 'Lorem ipsum dolor sit amet...' [1:30: ]",
@@ -57,7 +57,7 @@ class SiteConfigFormTest(TenantTestCase):
             size=len(invalid_css),
             charset="utf-8",
         )
-        form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config)
+        form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config, is_deck_owner=True)
         self.assertFalse(form.is_valid())
         self.assertIn("This stylesheet is not valid CSS.", form.errors["custom_stylesheet"])
 
@@ -71,7 +71,7 @@ class SiteConfigFormTest(TenantTestCase):
             size=len(valid_css),
             charset="utf-8",
         )
-        form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config)
+        form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config, is_deck_owner=True)
         # print(form.errors)
         self.assertTrue(form.is_valid())
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Made enable_shared_library be only modifiable by deck owner

### Why?
See #1651

### How?
Added `self.fields['enable_shared_library'].disabled = True` when current user is deck_owner to `SiteConfigForms`

### Testing?
Added a test case called `test_owner_only_fields_can_only_be_changed_by_owner` that checks if staff user can modify deck owner only options and verifies if deck_owner can modify them as well.

### Screenshots (if front end is affected)
I cant screenshot my cursor, but this sign appears when hovering over `enable_shared_library`
![image](https://github.com/user-attachments/assets/740de981-9aea-4570-b3dc-0dde25f9db43)
![image](https://github.com/user-attachments/assets/d33fdd08-3d81-43fd-a42a-e1dcb3d4e116)

### Anything Else?
I noticed `custom_stylesheet` was able to be modifed despite being disabled. I fixed it by adding a conditional in `clean_custom_stylesheet`

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved form handling by centralizing disabled fields for better maintainability.
  - Introduced a parameter to manage form behavior based on user roles, specifically for deck owners.

- **Tests**
  - Added a new test to ensure only the owner can modify specific advanced fields.
  - Enhanced form data handling and validation within the tests to reflect user role restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->