### PR TITLE
Feat: Quest sub-menu 'Quest Library' added to sidebar; Closes #1656

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -15,6 +15,7 @@ from siteconfig.models import SiteConfig
 from tenant.models import Tenant
 from tenant.models import TenantDomain
 
+
 User = get_user_model()
 
 
@@ -145,3 +146,22 @@ class QuestLibraryTestsCase(ViewTestUtilsMixin, TenantTestCase):
 
         # Ensure that the newly imported quest is not visible to students
         self.assertFalse(quest_qs.get().visible_to_students)
+
+    def test_side_bar_library_drop_down(self):
+        """ Checks if library drop down is available when siteconfig.enable_shared_library is true """
+        staff = baker.make(User, is_staff=True)
+        self.client.force_login(staff)
+
+        config = SiteConfig.get()
+
+        # if `enable_shared_library=False` then "Quest Library" should not exist
+        config.enable_shared_library = False
+        config.save()
+        response = self.assert200('library:library_quest_list')
+        self.assertNotContains(response, '</i>&nbsp; Quest Library</a>')
+
+        # if `enable_shared_library=True` then "Quest Library" should exist
+        config.enable_shared_library = True
+        config.save()
+        response = self.assert200('library:library_quest_list')
+        self.assertContains(response, '</i>&nbsp; Quest Library</a>')

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -30,6 +30,9 @@
         <ul class="dropdown-menu dropdown-menu-right">
           {% if request.user.is_staff %}
             <li><a href="{% url 'quests:drafts' %}"><i class="fa fa-shield fa-flip-horizontal fa-fw"></i>&nbsp; Draft Quests</a></li>
+            {% if config.enable_shared_library %}
+            <li><a href="{% url 'library:library_quest_list' %}"><i class="fa fa-book fa-fw"></i>&nbsp; Quest Library</a></li>
+            {% endif %}
             <li role="separator" class="divider"></li>
             <li class="dropdown-header">Quest Setup</li>
             <li><a href="{% url 'tags:list' %}"><i class="fa fa-fw fa-tags"></i>&nbsp;{{ config.custom_name_for_tag }}s</a></li>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added a new button to quest dropdown bar

### Why?
See #1656

### How?
Added a new button to `sidebar.html` that links to `library:library_quest_list`

### Testing?
Added a new test ca;;ed `test_side_bar_library_drop_down`. Which verifies that the dropdown has "Quest Library" when `SiteConfig.enable_shared_library` is True

### Screenshots (if front end is affected)
![image](https://github.com/user-attachments/assets/becdef38-de41-45a3-8877-40d3797486e3)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Added a "Quest Library" dropdown in the sidebar, visible only when the shared library feature is enabled.

- **Tests**
	- Introduced new tests to ensure proper visibility of the "Quest Library" dropdown based on configuration settings, enhancing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->