### PR TITLE
Fix: full_clean clearer error printout; Closes #1669

### DIFF
--- a/src/hackerspace_online/management/commands/full_clean.py
+++ b/src/hackerspace_online/management/commands/full_clean.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
     EXCEPTION_C = '\033[91m'
     MODEL_C = '\033[94m'
     OBJECT_C = '\033[96m'
+    TENANT_C = '\033[92m'
     END_C = '\033[0m'
 
     LOCAL_APPS = (
@@ -44,7 +45,7 @@ class Command(BaseCommand):
         'library',
     )
 
-    help = ("Loops through a list of tenants (all by default), and validates each object in the database using full_clean().",
+    help = ("Loops through a list of tenants (all by default), and validates each object in the database using full_clean()."
             "Any validation errors are printed to the console.")
 
     def add_arguments(self, parser):
@@ -79,9 +80,13 @@ class Command(BaseCommand):
                                 object_.save()
                             except ValidationError as e:
                                 exception_string = self.EXCEPTION_C + "Exception" + self.END_C
+                                tenant_string = self.TENANT_C + str(tenant.schema_name) + self.END_C
                                 object_string = self.OBJECT_C + str(object_) + self.END_C
                                 model_string = self.MODEL_C + model.__name__ + self.END_C
                                 error_type = self.EXCEPTION_C + type(e).__name__ + self.END_C
 
                                 # Exception found on cleaning "<Object Name>" (<Model Name>) of type <Error Name>: <Error Log>
-                                print(f'{exception_string} found on cleaning "{object_string}" ({model_string}) of type {error_type}:', e)
+                                print(
+                                    f'{exception_string} found on {tenant_string} cleaning "{object_string}" ({model_string}) of type {error_type}:',
+                                    e
+                                )

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -173,6 +173,9 @@ class FullCleanTest(TestCase, CommandMixin):
             # "Exception found on cleaning "<Object Name>" (<Model Name>) of type <Error Name>: <Error Log>"
             log = buf.getvalue()
 
+            # capture schema name
+            self.assertTrue('test_schema1' in log)
+
             # profile is here because of grad_year being `None` for admin and owner
             # grad_year is `null=True` and `blank=False`. Which means that objects with None will fail full clean.
             # ie. `{'grad_year': ['this field cannot be blank.']}`
@@ -192,6 +195,9 @@ class FullCleanTest(TestCase, CommandMixin):
             # should capture any print statements by self.call_command
             # "Exception found on cleaning "<Object Name>" (<Model Name>) of type <Error Name>: <Error Log>"
             log = buf.getvalue()
+
+            # capture schema name
+            self.assertTrue('test_schema2' in log)
 
             # check explanation comment above for why profile is here
             self.assertTrue('Profile' in log)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Expanded the print to include the tenant schema name, and fixed the issue where `full_clean` command couldnt be called outside of `src` folder

### Why?
See #1669

### How?

+ added tenant name with `\033[92m` to f-string to the print of `full_clean`
+ `full_clean` command's help had a comma seperating the two strings making it a tuple instead of one string.

### Testing?
+ expanded the existing full clean test to look for tenant name

### Screenshots (if front end is affected)
![image](https://github.com/user-attachments/assets/cf8099ce-a91b-4e59-85f4-2d56e1c70270)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new color constant for console output to enhance readability.
	- Updated error messages to include tenant schema names for clearer reporting.

- **Bug Fixes**
	- Improved error reporting in validation processes, providing better context for debugging.

- **Tests**
	- Enhanced test coverage by adding assertions to verify tenant schema names in log outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->