### PR TITLE
Fix: Adding an ExcludeDates does not activate datepicker; Closes #1682

### DIFF
--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -102,22 +102,12 @@
         }
     }
 
-    // https://stackoverflow.com/a/42453540
-    $("body").on("DOMNodeInserted", function (e) {
+    $('body').on('focus',".datetimepickerinput", function(e) {
         $("[data-dp-config]:not([disabled])").djangoDatetimePicker();
     })
 
     function RemoveForm(index) {
         var fieldContainer = document.getElementById(`form-${index}-container`);
-
-        // // remove if its not initialized else
-        // if (index > initialForms) {
-        //     var totalForms = parseInt(formTotalForms.getAttribute("value"));
-        //     formTotalForms.setAttribute("value", totalForms-1);
-
-        //     fieldContainer.remove();
-        //     return;
-        // }
 
         // make invisible
         fieldContainer.style.display = "none";


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed an issue where adding an extra ExcludeDate in `courses/semesters/1/edit/` didn't activate the picker ui

### Why?
See #1682

### How?
According to [google](https://chromestatus.com/feature/5083947249172480). They removed support for mutation events, in favor for mutation observers, at the end of july (2024). This broke the UI for exclude dates.

So instead of the js listening for the `DOMNodeInserted` mutation events. I reverted back to listening for when user clicked on the date picker.

I could use mutation events but from tutorials on youtube and some answers on stackoverflow, it looked too clunky to use for this case.

### Testing?
No automated testing since its js.
But ive tested the functionality on chrome and microsoft edge

### Screenshots (if front end is affected)
![image](https://github.com/user-attachments/assets/a163e4b4-f2cd-4d6a-9f8b-7422e8c7a7da)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced datetime picker functionality to initialize only when the user interacts with the input field, improving performance and reliability.

- **Bug Fixes**
  - Removed outdated logic from the form management system, which may affect how forms are counted when removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->