### PR TITLE
Chore: Update django-select2 to <8.3; Closes #1664

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -19,7 +19,7 @@ cssutils==2.11.1
 html2text==2020.1.16
 tablib==3.5.0
 django-redis>=5.2.0,<5.3
-django-select2>=6.3.1,<6.4
+django-select2>=8.2.1,<8.3
 django-summernote>=0.8,<0.9
 django-url-or-relative-url-field>=0.1.1,<0.2
 django-resized>=0.3.11,<1.1

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -23,7 +23,17 @@ class BadgeLabel:
 
 
 class BadgeSelect2MultipleWidget(BadgeLabel, ModelSelect2MultipleWidget):
-    pass
+
+    def __init__(self, *args, **kwargs):
+        """ Despite what Select2 and django-select2 docs tell you. You cant actually change the default setting in javascript.
+        For now modify the `attrs` variable to set default attributes
+        """
+        attrs = kwargs.get('attrs', {})
+        # As of `django-select2 7.1.2`, Select2 by default now has a minimum input length of 2.
+        attrs.setdefault('data-minimum-input-length', '0')
+        kwargs['attrs'] = attrs
+
+        super().__init__(*args, **kwargs)
 
 
 class QuestForm(forms.ModelForm):
@@ -35,6 +45,7 @@ class QuestForm(forms.ModelForm):
         widget=ModelSelect2Widget(
             model=Quest,
             search_fields=['name__icontains'],
+            attrs={'data-minimum-input-length': 0},
         ),
     )
 
@@ -45,6 +56,7 @@ class QuestForm(forms.ModelForm):
         widget=ModelSelect2Widget(
             model=Badge,
             search_fields=['name__icontains'],
+            attrs={'data-minimum-input-length': 0},
         ),
     )
 

--- a/src/tags/forms.py
+++ b/src/tags/forms.py
@@ -17,6 +17,17 @@ class BootstrapTaggitSelect2Widget(TaggitSelect2Widget):
             'all': ('https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css',)
         }
 
+    def __init__(self, *args, **kwargs):
+        """ Despite what Select2 and django-select2 docs tell you. You cant actually change the default setting in javascript.
+        For now modify the `attrs` variable to set default attributes
+        """
+        attrs = kwargs.get('attrs', {})
+        # As of `django-select2 7.1.2`, Select2 by default now has a minimum input length of 2.
+        attrs.setdefault('data-minimum-input-length', '0')
+        kwargs['attrs'] = attrs
+
+        super().__init__(*args, **kwargs)
+
 
 def validate_unique_slug(value):
     """

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -40,7 +40,7 @@ class AutoResponseViewTests(ViewTestUtilsMixin, TenantTestCase):
         url = reverse('tags:auto-json')
         form = TaggitSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['tag'].widget))
+        field_id = signing.dumps(form.fields['tag'].widget.uuid)
         response = self.client.get(url, {'field_id': field_id, 'term': 'test-tag'})
         self.assertEqual(response.status_code, 200)
 
@@ -51,7 +51,7 @@ class AutoResponseViewTests(ViewTestUtilsMixin, TenantTestCase):
         url = reverse('tags:auto-json')
         form = TaggitSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['tag'].widget))
+        field_id = signing.dumps(form.fields['tag'].widget.uuid)
         response = self.client.get(url, {'field_id': field_id, 'term': 'test-tag'})
         self.assertEqual(response.json()['results'], [])
 
@@ -62,7 +62,7 @@ class AutoResponseViewTests(ViewTestUtilsMixin, TenantTestCase):
         url = reverse('tags:auto-json')
         form = TaggitSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['tag'].widget))
+        field_id = signing.dumps(form.fields['tag'].widget.uuid)
         response = self.client.get(url, {'field_id': field_id, 'term': 'test-tag'})
         data = json.loads(response.content.decode('utf-8'))
         assert data['results']

--- a/src/tags/widgets.py
+++ b/src/tags/widgets.py
@@ -11,6 +11,19 @@ class TaggitSelect2Widget(ModelSelect2TagWidget):
     model = Tag
     search_fields = ["name__icontains"]
 
+    def __init__(self, *args, **kwargs):
+        """ Despite what Select2 and django-select2 docs tell you. You cant actually change the default setting in javascript.
+        For now modify the `attrs` variable to set default attributes.
+
+        cant set defaults in `def build_attrs` since it populates the attrs with the select2 defaults beforehand.
+        """
+        attrs = kwargs.get('attrs', {})
+        # As of `django-select2 7.1.2`, Select2 by default now has a minimum input length of 2.
+        attrs.setdefault('data-minimum-input-length', '1')
+        kwargs['attrs'] = attrs
+
+        super().__init__(*args, **kwargs)
+
     def get_url(self):
         return reverse('tags:auto-json')
 

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -68,7 +68,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, TenantTestCase):
         group = self.groups[0]
         form = GFKSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['f'].widget))
+        field_id = signing.dumps(form.fields['f'].widget.uuid)
         url = reverse('utilities:querysetsequence_auto-json')
         response = self.client.get(url, {'field_id': field_id, 'term': group.name})
         assert response.status_code == 200
@@ -105,7 +105,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, TenantTestCase):
             }
         )
         widget.render('name', None)
-        field_id = signing.dumps(id(widget))
+        field_id = signing.dumps(widget.uuid)
 
         response = self.client.get(url, {'field_id': field_id, 'term': ''})
         assert response.status_code == 200
@@ -126,7 +126,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, TenantTestCase):
         form = GFKSelect2WidgetForm()
         form.fields['f'].widget = CustomGFKSelect2Widget()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['f'].widget))
+        field_id = signing.dumps(form.fields['f'].widget.uuid)
 
         # artist = artists[0]
         group = self.groups[0]
@@ -143,7 +143,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, TenantTestCase):
         group = self.groups[0]
         form = GFKSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['f'].widget))
+        field_id = signing.dumps(form.fields['f'].widget.uuid)
         cache_key = form.fields['f'].widget._get_cache_key()
         widget_dict = cache.get(cache_key)
         widget_dict['url'] = 'yet/another/url'


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Updated django-select2 to the latest version and fixed some issues

### Why?
Supersedes #1664

### How?
django-select2 has 2 changelogs. 
new owner (8.2.1 to 7.4.1)
https://github.com/codingjoe/django-select2/releases
previous owner (release to 7.3.1)
https://github.com/applegrew/django-select2/releases

```
django-select2 7.0.0
- Add request argument to ModelSelect2Mixin.filter_queryset
```
Fixed by adding request argument to `filter_queryset` in `GFKSelect2Mixin`

```
django-select2 7.1.2
- Update Select2 to version 4.0.12
```
Select2 by default now has a minimum input length of 2.
Despite what `Select2` and `django-select2` docs tell you. You cant actually change the default setting in javascript. 
Had to add a default attr dict for the __init__s in `GFKSelect2Mixin`, `BootstrapTaggitSelect2Widget`, `BadgeSelect2MultipleWidget`, and `TaggitSelect2Widget`

```
django-select2 7.3.1
- not mentioned in the changelog but
- the cache key is calculated in a different way. now uses uuid instead of the id(object)
```
This wasn't MENTIONED in the changelog at all. But the key used to store stuff in the cache was changed. made sure everything was using `uuid` instead of `id` when referencing the keys

### Testing?
Manually tested eveything with a select2 widget.
Manually ran tests.

### Screenshots (if front end is affected)
Staff Quest Submission form
![image](https://github.com/user-attachments/assets/f52a4e8b-26a1-4f8c-8a50-306cf5323665)

Generate map form
![image](https://github.com/user-attachments/assets/e3dc41c4-2561-48ba-bb89-6898e8c491a1)

Advanced prereq
![image](https://github.com/user-attachments/assets/899f6831-ee9c-4445-aae4-e957734b3923)

Basic prereq
![image](https://github.com/user-attachments/assets/fe8314a2-8d6d-4b3b-8d9b-b266f5b3eaf9)
![image](https://github.com/user-attachments/assets/cb0fd807-6707-4e00-9f4a-efb2354bf142)

Tags
![image](https://github.com/user-attachments/assets/04b064c1-6c39-4dcd-867c-9ce3090f8064)

### Anything Else?
There were pagination warnings during tests. IIRC when i updated to latest `django-select2` version they started showing everytime i interacted with a select dropdown. Ordering by id in `GFKSelect2Mixin` fixed that issue.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the input experience with a minimum input length requirement across various widgets.
	- Improved initialization process for the `Media` class, ensuring default attributes are set.

- **Bug Fixes**
	- Updated identifier generation in tests to use UUIDs for better uniqueness and traceability.

- **Improvements**
	- Expanded version compatibility for the `django-select2` package to allow for newer features and fixes.
	- Refined filtering logic in widget functionalities to better handle requests and maintain order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->