### PR TITLE
Chore: remove explicit tablib, and comments for requirements.txt; Closes #1684

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -2,7 +2,7 @@ django-tenants>=3.4,<3.6
 backports.csv>=1.0.7,<1.1
 beautifulsoup4>=4.12.3,<4.13
 celery>=5.2.2,<5.4
-Django==3.2.25  # temp pinned at .19 while resolvoing issue #1353
+Django==3.2.25
 django-allauth>=0.54,<0.55
 django-querysetsequence>=0.16
 django-bootstrap-datepicker-plus>=4.0,<5.0
@@ -13,11 +13,10 @@ django-datetime-widget>=0.9.3,<1.0
 django-decorator-include==3.0
 django-embed-video>=1.1.2,<1.5
 django-grappelli>=4.0.1,<5
-django-import-export==3.3.9
+django-import-export==3.3.9  # latest version that supports django 3.2
 bleach[css]>=5,<6
 cssutils==2.11.1
 html2text==2020.1.16
-tablib==3.5.0
 django-redis>=5.2.0,<5.3
 django-select2>=6.3.1,<6.4
 django-summernote>=0.8,<0.9


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added/removed comments.
Removed a dependency

### Why?
See #1684

### How?
Added comments for `tablib` and `django-import-export`.
Removed comment for django-verision

Removed explicit installation of tablib

### Testing?

force reinstalled dependencies. Checked the tablib version
```
>pip install --force-reinstall -r ..\requirements-production.txt
...
>pip freeze | FINDSTR tablib
tablib==3.5.0
```

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity in the dependency requirements by adding comments to explain the rationale behind package versions. 
	- Removed outdated comments related to temporary pinning for Django package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->