### PR TITLE
Chore: locking django-tenants version to 3.5.0; Closes #1663

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,4 +1,4 @@
-django-tenants>=3.4,<3.6
+django-tenants>=3.5,<3.6  # latest version that supports python 3.8
 backports.csv>=1.0.7,<1.1
 beautifulsoup4>=4.12.3,<4.13
 celery>=5.2.2,<5.4


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Locked django-tenants version and added a comment explaining why

### Why?
See #1663

### How?
Set `django-tenants==3.5.0` and added a comment explaining that our codebase uses python 3.8 and `3.5.0` is the last version that supports 3.8

In our README
![image](https://github.com/user-attachments/assets/81d3b5cc-06e5-4377-a3f8-af565ca7303a)

django-tenants changelog
![image](https://github.com/user-attachments/assets/a92cfba6-a46c-442b-8889-4e43bba6490a)

### Testing?
None. `django-tenants 3.5.0` is our current version rn. 

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the version specification of the `django-tenants` package to a newer range, maintaining compatibility while ensuring stability within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->