### PR TITLE
Chore: Update django-bootstrap-datepicker-plus to >=5.0.5,<6.0; Closes #1678

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -5,7 +5,7 @@ celery>=5.2.2,<5.4
 Django==3.2.25
 django-allauth>=0.54,<0.55
 django-querysetsequence>=0.16
-django-bootstrap-datepicker-plus>=4.0,<5.0
+django-bootstrap-datepicker-plus>=5.0.5,<6.0
 django-celery-beat>=2.2,<2.7
 django-colorful>=1.3,<2.0
 django-crispy-forms>=1.8.1,<1.15

--- a/src/announcements/forms.py
+++ b/src/announcements/forms.py
@@ -28,9 +28,9 @@ class AnnouncementForm(forms.ModelForm):
         # > Or if you're using django-crispy-forms, please use this.
         widgets = {
             'content': ByteDeckSummernoteSafeInplaceWidget(),
-            'sticky_until': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
-            'datetime_released': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
-            'datetime_expires': DateTimePickerInput(format='%Y-%m-%d %H:%M'),
+            'sticky_until': DateTimePickerInput(options={"format": "YYYY-MM-DD HH:mm"}),
+            'datetime_released': DateTimePickerInput(options={"format": "YYYY-MM-DD HH:mm"}),
+            'datetime_expires': DateTimePickerInput(options={"format": "YYYY-MM-DD HH:mm"}),
         }
 
     def clean(self):

--- a/src/courses/forms.py
+++ b/src/courses/forms.py
@@ -3,10 +3,23 @@ from django import forms
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Layout
 from crispy_forms.bootstrap import Accordion, AccordionGroup
-from bootstrap_datepicker_plus.widgets import DateTimePickerInput, TimePickerInput
+from bootstrap_datepicker_plus.widgets import DatePickerInput, TimePickerInput
 
 from .models import Block, Course, CourseStudent, MarkRange, Semester, ExcludedDate
 from siteconfig.models import SiteConfig
+
+
+class NoScriptTagDatePickerInput(DatePickerInput):
+    """ Widget to override build_attrs.
+    As of bootstrap_datepicker_plus 5.0.0 the widget when rendered comes with script tags if debug=True.
+    This script tag breaks the javascript in `semester_form.html`.
+    Furthermore, the widget.attrs responsible is 'data-dbdp-debug' which has to be removed. Not set False/True
+    to stop the script tag from showing up.
+    """
+    def build_attrs(self, *args, **kwargs):
+        attrs = super().build_attrs(*args, **kwargs)
+        attrs.pop('data-dbdp-debug', None)
+        return attrs
 
 
 class MarkRangeForm(forms.ModelForm):
@@ -110,8 +123,8 @@ class SemesterForm(forms.ModelForm):
         model = Semester
         fields = ('name', 'first_day', 'last_day')
         widgets = {
-            'first_day': DateTimePickerInput(format='%Y-%m-%d'),
-            'last_day': DateTimePickerInput(format='%Y-%m-%d'),
+            'first_day': DatePickerInput(),
+            'last_day': DatePickerInput(),
         }
 
     def __init__(self, *args, **kwargs):
@@ -135,7 +148,7 @@ class ExcludedDateForm(forms.ModelForm):
         model = ExcludedDate
         fields = ['date', 'label']
         widgets = {
-            'date': DateTimePickerInput(format='%Y-%m-%d'),
+            'date': NoScriptTagDatePickerInput(),
         }
         help_texts = {
             'label': None

--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -65,9 +65,6 @@
     const formInitialForms = document.getElementById("id_form-INITIAL_FORMS");
     const initialForms = parseInt(formInitialForms.getAttribute("value"))-1;
 
-    var cached_datepicker_data = null;
-
-
     function AddForm() {
         // management form change data
         var totalForms = parseInt(formTotalForms.getAttribute("value"));
@@ -80,31 +77,28 @@
         // create input field + add button to last el
         var newIndex = totalForms
 
-        // container for field + buttons
+        // container for field + buttons [+, -]
         var formRowElement = document.createElement('div');
         formRowElement.setAttribute("class", "row");
         formRowElement.setAttribute("id", `form-${newIndex}-container`);
         container.insertAdjacentElement("beforeend", formRowElement);
 
-        // field
-        formRowElement.innerHTML = `{% crispy formset.empty_form helper  %}`.replaceAll("__prefix__", newIndex);
+        // ExcludeDate form field
+        formRowElement.innerHTML = `{% crispy formset.empty_form helper %}`.replaceAll("__prefix__", newIndex);
 
-        // container for buttons
+        // container for buttons [+, -]
         var buttonElement = document.createElement('div');
         buttonElement.setAttribute("class", "button-container col-xs-1");
         formRowElement.insertAdjacentElement("beforeend", buttonElement);
 
         buttonElement.insertAdjacentHTML("beforeend", addButtonCopy);
 
-        if (!cached_datepicker_data) {
-            var datepicker = document.getElementById(`id_form-${newIndex}-date`);
-            cached_datepicker_data = JSON.parse(datepicker.getAttribute("data-dp-config")).options;
-        }
+        // get the datepicker options from newly added form field
+        // initialize the datepicker widget using the options from its class
+        var $datepicker = $(`#id_form-${newIndex}-date`)
+        var options = JSON.parse($datepicker.attr("data-dbdp-config")).options;
+        $datepicker.datetimepicker(options);
     }
-
-    $('body').on('focus',".datetimepickerinput", function(e) {
-        $("[data-dp-config]:not([disabled])").djangoDatetimePicker();
-    })
 
     function RemoveForm(index) {
         var fieldContainer = document.getElementById(`form-${index}-container`);

--- a/src/portfolios/forms.py
+++ b/src/portfolios/forms.py
@@ -21,7 +21,7 @@ class ArtworkForm(forms.ModelForm):
         model = Artwork
         fields = ['title', 'description', 'date', 'image_file', 'video_file', 'video_url', ]
         widgets = {
-            'date': DatePickerInput(format='%Y-%m-%d'),
+            'date': DatePickerInput(),
         }
 
     def clean(self):

--- a/src/portfolios/templates/portfolios/art_form.html
+++ b/src/portfolios/templates/portfolios/art_form.html
@@ -1,12 +1,13 @@
 {% extends "portfolios/base.html" %}
 {% load static %}
 {% load crispy_forms_tags %}
-{{ form.media }}
 
 {% block head %}
-  <!-- need these loaded first for date-time picker widgets to work I think -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script src="{% static 'js/bootstrap-datetimepicker.js' %}"></script>
+<!-- need these loaded first for date-time picker widgets to work I think -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script src="{% static 'js/bootstrap-datetimepicker.js' %}"></script>
+
+{{ form.media }}
 {% endblock %}
 
 {% block heading_inner %}{{ heading }}{% endblock %}

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -97,10 +97,10 @@ class QuestForm(forms.ModelForm):
             'submission_details': ByteDeckSummernoteAdvancedInplaceWidget(),
             'instructor_notes': ByteDeckSummernoteAdvancedInplaceWidget(),
 
-            'date_available': DatePickerInput(format='%Y-%m-%d'),
+            'date_available': DatePickerInput(),
 
             'time_available': TimePickerInput(),
-            'date_expired': DatePickerInput(format='%Y-%m-%d'),
+            'date_expired': DatePickerInput(),
             'time_expired': TimePickerInput(),
 
             # TODO: Campaign Autocomplete


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Update django-bootstrap-datepicker-plus to >=5.0.5,<6.0
fixed some issues that came along with updating.

### Why?
See #1678

### How?
`django-bootstrap-datepicker-plus 5.0.0` broke alot of our stuff. Unfortunately, none of their changes was documented in the form of changelogs.
![image](https://github.com/user-attachments/assets/a2ff9f85-84c5-44bc-8b3d-327e2322da97)

These are all the issues i've found:

---

Datepicker's format attribute is deprecated and ignored.
`bootstrap_datepicker_plus._base.BasePickerInput.__init__`
![image](https://github.com/user-attachments/assets/6421a854-e14e-400c-af42-871b97fca1a3)

fixed this by removing `format` and replacing with `options={'format':'date'}` for all `bootstrap_datepicker_plus` widgets

---

All of the forms using `DatePickerInput` were using `format='%Y-%m-%d` are now redundant.
As that format is now the default format
![image](https://github.com/user-attachments/assets/8ad08cbf-656c-4aaf-9ff7-97779d4f1f6a)

removing the `format` arg was enough

---

Adding `script` tags to the datepicker widget's broke `semester_form.html`'s javascript.

`bootstrap_datepicker_plus.templates.bootstrap_datepicker_plus.input.html`
![image](https://github.com/user-attachments/assets/7da7fd71-1b3c-4e89-8354-b35bd5bc0453)

Since its checking if "data-dbdp-debug" exists within `widget.attrs`. I had to create a new widget inheriting `DatePickerInput` that deletes it.

I only added it to ExcludeDatesForm nowhere else, in case that script tag might be relevant later in the future (unlikely)

---

`djangoDatetimePicker` global function was removed from
`bootstrap_datepicker_plus.static.bootstrap_datepicker_plus.datepicker-widget.js`

This also broke `semester_form.html`'s javascript.
Refactored some javascript to fix this.
Instead of a event listener, that initializes the datepickerwidget. I put initializing the datepickerwidget inside `AddForm`.

However, one problem that i came across is that the textfield is now the button to activate the widget and not the calendar icon. I did try to fix this but i cant recreate its exact functionality.

---

artwork portfolio form had an error where `form.media` wasnt loaded.
![image](https://github.com/user-attachments/assets/435b56f7-dacc-43ad-a195-8eef3bbb6cb8)

All i did was move form.media to `<head>` tag instead of the beginning of the file

---

### Testing?
None. We dont test js, and everything else is covered already.

### Screenshots (if front end is affected)
Semester Form
![image](https://github.com/user-attachments/assets/1bb034b8-9ba5-4cb5-b171-3ecef6f6cc22)
![image](https://github.com/user-attachments/assets/0ea6d103-23f9-4c67-932e-ccb388a14f0f)

Quests Form
![image](https://github.com/user-attachments/assets/c9c18894-f4ce-49a5-bc13-6571c1ca1de7)

Portfolio Form
![image](https://github.com/user-attachments/assets/3a4b6bd4-d76e-4073-93bd-9e50879f2e72)

### Anything Else?

this package is using `DOMNodeInserted` events in `bootstrap_datepicker_plus.static.bootstrap_datepicker_plus.datepicker-widget.js`

about a month ago [google](https://chromestatus.com/feature/5083947249172480) removed support for those types of events in favor for mutation observers

I dont think anything broke from this. Since all widgets still work.

![image](https://github.com/user-attachments/assets/dc2712c0-1ac6-439b-b69f-8ef1a614efe8)
![image](https://github.com/user-attachments/assets/e04f6118-1aa1-42c6-9c45-a4513b7a23a3)

### Review request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new date picker widget that simplifies user input by removing unnecessary script tags.
	- Updated forms to utilize enhanced date picker functionalities, allowing for date-only inputs.

- **Bug Fixes**
	- Improved JavaScript functionality by removing cached variables, ensuring optimal datepicker initialization.
	- Enhanced flexibility in date input handling by removing strict format enforcement in various forms.

- **Documentation**
	- Clarified comments in the JavaScript code for better readability and understanding of form initialization.

- **Chores**
	- Updated library dependency to a newer version, enhancing functionality and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->