### PR TITLE
Chore: Update django-url-or-relative-url-field to >=0.2.0,<0.3.0

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -20,7 +20,7 @@ html2text==2020.1.16
 django-redis>=5.2.0,<5.3
 django-select2>=8.2.1,<8.3
 django-summernote>=0.8,<0.9
-django-url-or-relative-url-field>=0.1.1,<0.2
+django-url-or-relative-url-field>=0.2.0,<0.3.0
 django-resized>=0.3.11,<1.1
 django-utils-six==2.0
 numpy==1.22


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Updated a dependency  

### Why?
Part of #1691

### How?
in `requirements-production.txt` i set `django-url-or-relative-url-field>=0.2.0,<0.3.0`

`django-url-or-relative-url-field < 0.2.0`  has an implicit incompatibility with Django 4.0.
`django.utils.translation.ugettext_lazy` which was deprecated in Django 3,0 has now been removed for 4.0

`django-url-or-relative-url-field==0.2.0` fixes this issue by changing it to `gettext_lazy`
The specific commit in their repo:
![image](https://github.com/user-attachments/assets/5d4692d2-3074-4e0c-9db9-7240b239a82e)
![image](https://github.com/user-attachments/assets/1ee2b353-0995-4d29-afdd-b55660f79206)


### Testing?
ran automated tests using `django-url-or-relative-url-field`

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `django-url-or-relative-url-field` package to include new features and improvements from version 0.2.0 while ensuring compatibility with future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->