### PR TITLE
Feat: update Django to 4.2 LTS; Closes #1691

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,4 +1,4 @@
-Django==3.2.25
+Django==4.2
 django-allauth>=0.54,<0.55
 django-bootstrap-datepicker-plus>=5.0.5,<6.0
 django-celery-beat>=2.2,<2.7

--- a/src/announcements/urls.py
+++ b/src/announcements/urls.py
@@ -1,20 +1,20 @@
 from announcements import views
 
-from django.conf.urls import url
+from django.urls import re_path
 
 app_name = 'announcements'
 
 urlpatterns = [
-    url(r'^$', views.list, name='list'),  # function based view
-    url(r'^archived/$', views.list, name='archived'),
+    re_path(r'^$', views.list, name='list'),  # function based view
+    re_path(r'^archived/$', views.list, name='archived'),
     # url(r'^$', views.List.as_view(), name='list'),  # CBV
     # url(r'^create/$', views.create, name='create'),
-    url(r'^create/$', views.Create.as_view(), name='create'),  # CBV
-    url(r'^(?P<pk>\d+)/delete/$', views.Delete.as_view(), name='delete'),
-    url(r'^(?P<pk>\d+)/edit/$', views.Update.as_view(), name='update'),
-    url(r'^(?P<ann_id>\d+)/copy/$', views.copy, name='copy'),
-    url(r'^(?P<ann_id>\d+)/publish/$', views.publish, name='publish'),
-    url(r'^(?P<ann_id>\d+)/comment/$', views.comment, name='comment'),
-    url(r'^(?P<ann_id>\d+)/$', views.list, name='list'),
+    re_path(r'^create/$', views.Create.as_view(), name='create'),  # CBV
+    re_path(r'^(?P<pk>\d+)/delete/$', views.Delete.as_view(), name='delete'),
+    re_path(r'^(?P<pk>\d+)/edit/$', views.Update.as_view(), name='update'),
+    re_path(r'^(?P<ann_id>\d+)/copy/$', views.copy, name='copy'),
+    re_path(r'^(?P<ann_id>\d+)/publish/$', views.publish, name='publish'),
+    re_path(r'^(?P<ann_id>\d+)/comment/$', views.comment, name='comment'),
+    re_path(r'^(?P<ann_id>\d+)/$', views.list, name='list'),
 
 ]

--- a/src/badges/forms.py
+++ b/src/badges/forms.py
@@ -64,7 +64,6 @@ class BulkBadgeAssertionForm(forms.Form):
             search_fields=['name__icontains'],
         )
     )
-    # students = forms.ModelMultipleChoiceField(queryset=None)
     students = forms.ModelMultipleChoiceField(
         # TODO just use the user objects here instead of profile
         # Goign back to the user just to sort by profile string is...a hack.  How to do that properly?!

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -260,7 +260,7 @@ class BadgeAssertionTestModel(TenantTestCase):
         values = []
         for _ in range(num):
             badge_assertion = self.badge_assertion_recipe.make()
-            values.append(repr(badge_assertion))
+            values.append(badge_assertion)
 
         qs = badge_assertion.get_duplicate_assertions()
         self.assertQuerysetEqual(list(qs), values, )

--- a/src/badges/urls.py
+++ b/src/badges/urls.py
@@ -1,8 +1,6 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from badges import views
-
-from django.conf.urls import url
 
 app_name = 'badges'
 
@@ -12,16 +10,16 @@ urlpatterns = [
     path('create/', views.badge_create, name='badge_create'),
     path('<int:badge_id>/', views.detail, name='badge_detail'),  # shows assertions of current students only
     path('<int:badge_id>/all/', views.detail_all, name='badge_detail_all'),  # show assertions of all students
-    url(r'^(?P<pk>[0-9]+)/edit/$', views.BadgeUpdate.as_view(), name='badge_update'),
-    url(r'^(?P<pk>[0-9]+)/prereqs/edit/$', views.BadgePrereqsUpdate.as_view(), name='badge_prereqs_update'),
-    url(r'^(?P<badge_id>[0-9]+)/copy/$', views.badge_copy, name='badge_copy'),
-    url(r'^(?P<pk>[0-9]+)/delete/$', views.BadgeDelete.as_view(), name='badge_delete'),
+    re_path(r'^(?P<pk>[0-9]+)/edit/$', views.BadgeUpdate.as_view(), name='badge_update'),
+    re_path(r'^(?P<pk>[0-9]+)/prereqs/edit/$', views.BadgePrereqsUpdate.as_view(), name='badge_prereqs_update'),
+    re_path(r'^(?P<badge_id>[0-9]+)/copy/$', views.badge_copy, name='badge_copy'),
+    re_path(r'^(?P<pk>[0-9]+)/delete/$', views.BadgeDelete.as_view(), name='badge_delete'),
 
     # Badge Assertions
-    url(r'^(?P<badge_id>[0-9]+)/grant/(?P<user_id>[0-9]+)/$', views.assertion_create, name='grant'),
-    url(r'^(?P<badge_id>[0-9]+)/grant/bulk/$', views.bulk_assertion_create, name='bulk_grant_badge'),
+    re_path(r'^(?P<badge_id>[0-9]+)/grant/(?P<user_id>[0-9]+)/$', views.assertion_create, name='grant'),
+    re_path(r'^(?P<badge_id>[0-9]+)/grant/bulk/$', views.bulk_assertion_create, name='bulk_grant_badge'),
     path('grant/bulk/', views.bulk_assertion_create, name='bulk_grant'),
-    url(r'^assertion/(?P<assertion_id>[0-9]+)/revoke/$', views.assertion_delete, name='revoke'),
+    re_path(r'^assertion/(?P<assertion_id>[0-9]+)/revoke/$', views.assertion_delete, name='revoke'),
 
 
     # Badge Types

--- a/src/comments/urls.py
+++ b/src/comments/urls.py
@@ -1,14 +1,11 @@
 from comments import views
 
-from django.conf.urls import url
+from django.urls import re_path
 
 app_name = 'comments'
 
 urlpatterns = [
-    # url(r'^(?P<id>\d+)/thread/$', views.comment_thread, name='threads'),
-    url(r'^(?P<id>\d+)/flag/$', views.flag, name='flag'),
-    url(r'^(?P<id>\d+)/unflag/$', views.unflag, name='unflag'),
-    url(r'^(?P<id>\d+)/delete/$', views.delete, name='delete'),
-    # url(r'^create/$', views.comment_create, name='create'),
-
+    re_path(r'^(?P<id>\d+)/flag/$', views.flag, name='flag'),
+    re_path(r'^(?P<id>\d+)/unflag/$', views.unflag, name='unflag'),
+    re_path(r'^(?P<id>\d+)/delete/$', views.delete, name='delete'),
 ]

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -138,7 +138,7 @@ class SemesterModelManagerTest(TenantTestCase):
 
     def test_get_current_as_queryset(self):
         """ Get's the current semester object in a quesryset  """
-        self.assertQuerysetEqual(Semester.objects.get_current(as_queryset=True), [repr(SiteConfig.get().active_semester)])
+        self.assertQuerysetEqual(Semester.objects.get_current(as_queryset=True), [SiteConfig.get().active_semester])
 
     def test_complete_active_semester(self):
         """ set current semester to closed and do lots of stuff..  """

--- a/src/djcytoscape/urls.py
+++ b/src/djcytoscape/urls.py
@@ -1,23 +1,22 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'djcytoscape'
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    re_path(r'^$', views.index, name='index'),
 
-    url(r'^generate/(?P<quest_id>[0-9]+)/(?P<scape_id>[0-9]+)$', views.ScapeGenerateMap.as_view(), name='generate_map'),
-    url(r'^generate/$', views.ScapeGenerateMap.as_view(), name='generate_unseeded'),
-    url(r'^primary/$', views.primary, name='primary'),
+    re_path(r'^generate/(?P<quest_id>[0-9]+)/(?P<scape_id>[0-9]+)$', views.ScapeGenerateMap.as_view(), name='generate_map'),
+    re_path(r'^generate/$', views.ScapeGenerateMap.as_view(), name='generate_unseeded'),
+    re_path(r'^primary/$', views.primary, name='primary'),
 
-    url(r'^(?P<scape_id>[0-9]+)/$', views.quest_map, name='quest_map'),
-    url(r'^(?P<scape_id>[0-9]+)/(?P<user_id>[0-9]+)/$', views.quest_map_personalized, name='quest_map_personalized'),
-    url(r'^(?P<ct_id>[0-9]+)/(?P<obj_id>[0-9]+)/(?P<originating_scape_id>[0-9]+)/$',
-        views.quest_map_interlink, name='quest_map_interlink'),
-    url(r'^(?P<pk>[0-9]+)/edit/$', views.ScapeUpdate.as_view(), name='update'),
-    url(r'^(?P<pk>[0-9]+)/delete/$', views.ScapeDelete.as_view(), name='delete'),
-    url(r'^list/$', views.ScapeList.as_view(), name='list'),
+    re_path(r'^(?P<scape_id>[0-9]+)/$', views.quest_map, name='quest_map'),
+    re_path(r'^(?P<scape_id>[0-9]+)/(?P<user_id>[0-9]+)/$', views.quest_map_personalized, name='quest_map_personalized'),
+    re_path(r'^(?P<ct_id>[0-9]+)/(?P<obj_id>[0-9]+)/(?P<originating_scape_id>[0-9]+)/$', views.quest_map_interlink, name='quest_map_interlink'),
+    re_path(r'^(?P<pk>[0-9]+)/edit/$', views.ScapeUpdate.as_view(), name='update'),
+    re_path(r'^(?P<pk>[0-9]+)/delete/$', views.ScapeDelete.as_view(), name='delete'),
+    re_path(r'^list/$', views.ScapeList.as_view(), name='list'),
 
-    url(r'^(?P<scape_id>[0-9]+)/regenerate/$', views.regenerate, name='regenerate'),
-    url(r'^all/regenerate/$', views.regenerate_all, name='regenerate_all'),
+    re_path(r'^(?P<scape_id>[0-9]+)/regenerate/$', views.regenerate, name='regenerate'),
+    re_path(r'^all/regenerate/$', views.regenerate_all, name='regenerate_all'),
 ]

--- a/src/hackerspace_online/decorators.py
+++ b/src/hackerspace_online/decorators.py
@@ -1,7 +1,6 @@
 from django.utils.decorators import method_decorator
 from django.contrib.auth import settings
 from django.shortcuts import render, redirect, reverse
-from django.http import JsonResponse
 
 
 def staff_member_required(f):
@@ -34,7 +33,7 @@ def xml_http_request_required(f):
     def wrapper(request, *args, **kwargs):
         if request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
             return f(request, *args, **kwargs)
-        return JsonResponse({'error': 'This endpoint only accepts AJAX requests.'}, status=400)
+        return render(request, '403.html', status=403)
 
     return wrapper
 

--- a/src/hackerspace_online/urls.py
+++ b/src/hackerspace_online/urls.py
@@ -1,20 +1,20 @@
 """hackerspace_online URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
+    https://docs.djangoproject.com/en/4.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include
@@ -32,48 +32,46 @@ admin.site.site_title = lambda: SiteConfig.get().site_name_short
 app_name = 'hackerspace_online'
 
 urlpatterns = [
-    url(r'^grappelli/', include('grappelli.urls')),
-    url(r'^admin/', admin.site.urls)
+    re_path(r'^grappelli/', include('grappelli.urls')),
+    re_path(r'^admin/', admin.site.urls)
 ]
 
 urlpatterns += [
-    url(r'^$', views.home, name='home'),
-    url(r'^a/simple/life/is/its/own/reward/', views.simple, name='simple'),
+    re_path(r'^$', views.home, name='home'),
+    re_path(r'^a/simple/life/is/its/own/reward/', views.simple, name='simple'),
     # quest_manager
-    url(r'^library/', include('library.urls', namespace='library')),
-    url(r'^quests/', include('quest_manager.urls', namespace='quests')),
+    re_path(r'^library/', include('library.urls', namespace='library')),
+    re_path(r'^quests/', include('quest_manager.urls', namespace='quests')),
     # profile_manager
-    url(r'^profiles/', include('profile_manager.urls', namespace='profiles')),
-    url(r'^announcements/', include('announcements.urls', namespace='announcements')),
-    url(r'^comments/', include('comments.urls', namespace='comments')),
-    url(r'^notifications/', include('notifications.urls', namespace='notifications')),
-    url(r'^courses/', include('courses.urls', namespace='courses')),
-    url(r'^achievements/', AchievementRedirectView.as_view()),
-    url(r'^badges/', include('badges.urls', namespace='badges')),
-    url(r'^maps/', include('djcytoscape.urls', namespace='maps')),
-    url(r'^portfolios/', include('portfolios.urls', namespace='portfolios')),
-    url(r'^utilities/', include('utilities.urls', namespace='utilities')),
-    url(r'^config/', include('siteconfig.urls', namespace='config')),
-    url(r'^decks/', include('tenant.urls', namespace='decks')),
+    re_path(r'^profiles/', include('profile_manager.urls', namespace='profiles')),
+    re_path(r'^announcements/', include('announcements.urls', namespace='announcements')),
+    re_path(r'^comments/', include('comments.urls', namespace='comments')),
+    re_path(r'^notifications/', include('notifications.urls', namespace='notifications')),
+    re_path(r'^courses/', include('courses.urls', namespace='courses')),
+    re_path(r'^achievements/', AchievementRedirectView.as_view()),
+    re_path(r'^badges/', include('badges.urls', namespace='badges')),
+    re_path(r'^maps/', include('djcytoscape.urls', namespace='maps')),
+    re_path(r'^portfolios/', include('portfolios.urls', namespace='portfolios')),
+    re_path(r'^utilities/', include('utilities.urls', namespace='utilities')),
+    re_path(r'^config/', include('siteconfig.urls', namespace='config')),
+    re_path(r'^decks/', include('tenant.urls', namespace='decks')),
     # bytedeck summernote
-    url(r'^summernote/', include('bytedeck_summernote.urls')),
+    re_path(r'^summernote/', include('bytedeck_summernote.urls')),
 
-    url(r'^tags/', include('tags.urls', namespace='tags')),
+    re_path(r'^tags/', include('tags.urls', namespace='tags')),
 
     # allauth
-    url(r'^accounts/password/reset/$',
-        views.CustomPasswordResetView.as_view(),
-        name='account_reset_password'),
-    url(r'^accounts/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$',
-        views.CustomPasswordResetFromKeyView.as_view(),
-        name='account_reset_password_from_key'),
+    re_path(r'^accounts/password/reset/$', views.CustomPasswordResetView.as_view(), name='account_reset_password'),
+    re_path(r'^accounts/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$',
+            views.CustomPasswordResetFromKeyView.as_view(), name='account_reset_password_from_key'),
     # apply `non_public_only_view` decorator on all `allauth` views, fix #1214
-    url(r'^accounts/', decorator_include(non_public_only_view, "allauth.urls")),
-    url(r'^pages/', include('django.contrib.flatpages.urls')),
+    re_path(r'^accounts/', decorator_include(non_public_only_view, "allauth.urls")),
+    re_path(r'^pages/', include('django.contrib.flatpages.urls')),
+
     # select2
-    url(r'^select2/', include('django_select2.urls')),
+    re_path(r'^select2/', include('django_select2.urls')),
     # Browsers looks for favicon.ico at root, redirect them to proper favicon to prevent constant 404s
-    url(r'^favicon\.ico$', views.FaviconRedirectView.as_view()),
+    re_path(r'^favicon\.ico$', views.FaviconRedirectView.as_view()),
 ]
 
 
@@ -85,5 +83,5 @@ if settings.DEBUG:
     import debug_toolbar
 
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ]

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -104,10 +104,6 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         with library_schema_context():
             library_quest = baker.make(Quest, import_id=quest.import_id)
 
-        q = Quest.objects.get(import_id=quest.import_id)
-        print(q.import_id)
-        print(library_quest.import_id)
-
         url = reverse('library:import_quest', args=[library_quest.import_id])
 
         # Test the confirmation page

--- a/src/notifications/signals.py
+++ b/src/notifications/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
-notify = Signal(providing_args=['recipient', 'verb', 'action', 'target', 'affected_users', 'icon'])
+# providing_args=['recipient', 'verb', 'action', 'target', 'affected_users', 'icon']
+notify = Signal()

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -34,8 +34,10 @@ class NotificationViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertRedirectsLogin('notifications:read', kwargs={'id': 1})
         self.assertRedirectsLogin('notifications:read_all')
 
-        self.assertRedirectsLogin('notifications:ajax')  # this doesn't make sense.  Should 404
-        self.assertRedirectsLogin('notifications:ajax_mark_read')  # this doesn't make sense.  Should 404
+        self.assert403('notifications:ajax')
+        self.assert403('notifications:ajax_mark_read')
+        self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 302)
+        self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 302)
 
     def test_all_notification_page_status_codes_for_students(self):
         # log in student1
@@ -52,8 +54,11 @@ class NotificationViewTests(ViewTestUtilsMixin, TenantTestCase):
         )
 
         # Inaccessible views:
-        self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read')).status_code, 404)  # requires AJAX
-        self.assertEqual(self.client.get(reverse('notifications:ajax')).status_code, 404)  # requires POST
+        # These views require an post request via ajax
+        self.assert403('notifications:ajax_mark_read')
+        self.assert403('notifications:ajax')
+        self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
+        self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
 
     def test_all_notification_page_status_codes_for_teachers(self):
         # log in student1
@@ -76,8 +81,11 @@ class NotificationViewTests(ViewTestUtilsMixin, TenantTestCase):
         )
 
         # Inaccessible views:
-        self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read')).status_code, 404)  # requires POST
-        self.assertEqual(self.client.get(reverse('notifications:ajax')).status_code, 404)  # requires POST
+        # These views require an post request via ajax
+        self.assert403('notifications:ajax_mark_read')
+        self.assert403('notifications:ajax')
+        self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
+        self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
 
     def test_ajax_mark_read(self):
         """ Marks a Notification as read via Ajax (by setting unread = FALSE)

--- a/src/notifications/urls.py
+++ b/src/notifications/urls.py
@@ -1,15 +1,14 @@
 from notifications import views
 
-from django.conf.urls import url
+from django.urls import re_path
 
 app_name = 'notifications'
 
 urlpatterns = [
-    url(r'^$', views.list, name='list'),  # function based view
-    url(r'^unread/$', views.list_unread, name='list_unread'),  # function based view
-    url(r'^ajax/$', views.ajax, name='ajax'),  # function based view
-    url(r'^read/(?P<id>\d+)/$', views.read, name='read'),  # function based view
-    url(r'^read/all/$', views.read_all, name='read_all'),  # function based view
-    url(r'^ajax/mark/read/$', views.ajax_mark_read, name='ajax_mark_read'),
-    # url(r'^options/$', views.options, name='options'), # function based view
+    re_path(r'^$', views.list, name='list'),  # function based view
+    re_path(r'^unread/$', views.list_unread, name='list_unread'),  # function based view
+    re_path(r'^read/(?P<id>\d+)/$', views.read, name='read'),  # function based view
+    re_path(r'^read/all/$', views.read_all, name='read_all'),  # function based view
+    re_path(r'^ajax/$', views.ajax, name='ajax'),  # function based view
+    re_path(r'^ajax/mark/read/$', views.ajax_mark_read, name='ajax_mark_read'),  # function based view
 ]

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -10,6 +10,8 @@ from django.urls import reverse
 from django.utils import timezone
 from tenant.views import non_public_only_view
 
+from hackerspace_online.decorators import xml_http_request_required
+
 from .models import Notification
 
 
@@ -81,10 +83,11 @@ def read(request, id):
         return HttpResponseRedirect(reverse('notifications:list'))
 
 
+@xml_http_request_required
 @non_public_only_view
 @login_required
 def ajax(request):
-    if request.is_ajax() and request.method == "POST":
+    if request.method == "POST":
 
         limit = 15
         notifications = Notification.objects.all_unread(request.user)
@@ -118,10 +121,11 @@ def ajax(request):
         raise Http404
 
 
+@xml_http_request_required
 @non_public_only_view
 @login_required
 def ajax_mark_read(request):
-    if request.is_ajax() and request.method == "POST":
+    if request.method == "POST":
 
         id = request.POST.get('id', None)
         n = Notification.objects.get(id=id)
@@ -129,30 +133,3 @@ def ajax_mark_read(request):
         return JsonResponse(data={})
     else:
         raise Http404
-
-# class NotifcationOptionsForm(ModelForm):
-#     class Meta:
-#         model = UserNotificationOptionSet
-#         fields = '__all__'
-#
-# def server_create(request, template_name='servers/server_form.html'):
-#     form = ServerForm(request.POST or None)
-#     if form.is_valid():
-#         form.save()
-#         return redirect('server_list')
-#     return render(request, template_name, {'form':form})
-#
-# def server_update(request, pk, template_name='servers/server_form.html'):
-#     server = get_object_or_404(Server, pk=pk)
-#     form = ServerForm(request.POST or None, instance=server)
-#     if form.is_valid():
-#         form.save()
-#         return redirect('server_list')
-#     return render(request, template_name, {'form':form})
-#
-# def server_delete(request, pk, template_name='servers/server_confirm_delete.html'):
-#     server = get_object_or_404(Server, pk=pk)
-#     if request.method=='POST':
-#         server.delete()
-#         return redirect('server_list')
-#     return render(request, template_name, {'object':server})

--- a/src/portfolios/urls.py
+++ b/src/portfolios/urls.py
@@ -1,23 +1,21 @@
-from django.conf.urls import url
+from django.urls import re_path
 from portfolios import views
 
 app_name = 'portfolios'
 
 urlpatterns = [
-    url(r'^$', views.PortfolioList.as_view(), name='list'),
-    url(r'^public/$', views.public_list, name='public_list'),
-    url(r'^(?P<pk>[0-9]+)/$', views.PortfolioDetail.as_view(), name='detail'),
-    url(r'^detail/$', views.PortfolioDetail.as_view(), name='current_user'),
-    url(r'^(?P<uuid>[0-9a-z-]+)/$', views.public, name='public'),
-    url(r'^(?P<pk>[0-9]+)/edit/$', views.PortfolioUpdate.as_view(), name='edit'),
+    re_path(r'^$', views.PortfolioList.as_view(), name='list'),
+    re_path(r'^public/$', views.public_list, name='public_list'),
+    re_path(r'^(?P<pk>[0-9]+)/$', views.PortfolioDetail.as_view(), name='detail'),
+    re_path(r'^detail/$', views.PortfolioDetail.as_view(), name='current_user'),
+    re_path(r'^(?P<uuid>[0-9a-z-]+)/$', views.public, name='public'),
+    re_path(r'^(?P<pk>[0-9]+)/edit/$', views.PortfolioUpdate.as_view(), name='edit'),
 
     # adding art via portfolio form
-    url(r'^art/(?P<pk>[0-9]+)/create/$', views.ArtworkCreate.as_view(), name='art_create'),
+    re_path(r'^art/(?P<pk>[0-9]+)/create/$', views.ArtworkCreate.as_view(), name='art_create'),
 
     # adding art from a file in a quest comment
-    url(r'^art/create/(?P<doc_id>[0-9]+)$', views.art_add, name='art_add'),
-    url(r'^art/(?P<pk>[0-9]+)/delete/$', views.ArtworkDelete.as_view(), name='art_delete'),
-    url(r'^art/(?P<pk>[0-9]+)/edit/$', views.ArtworkUpdate.as_view(), name='art_update'),
-
-    # url(r'^art/(?P<pk>[0-9]+)/$', views.art_detail, name='art_detail'),
+    re_path(r'^art/create/(?P<doc_id>[0-9]+)$', views.art_add, name='art_add'),
+    re_path(r'^art/(?P<pk>[0-9]+)/delete/$', views.ArtworkDelete.as_view(), name='art_delete'),
+    re_path(r'^art/(?P<pk>[0-9]+)/edit/$', views.ArtworkUpdate.as_view(), name='art_update'),
 ]

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -98,12 +98,12 @@ class ProfileTestModel(TenantTestCase):
         self.assertFalse(self.profile.current_courses().exists())
         # add one and test
         course_registration = self.create_active_course_registration()
-        self.assertQuerysetEqual(self.profile.current_courses(), [repr(course_registration)])
+        self.assertQuerysetEqual(self.profile.current_courses(), [course_registration])
         # add a second
         course_registration2 = self.create_active_course_registration()
         self.assertQuerysetEqual(
             self.profile.current_courses(),
-            [repr(course_registration), repr(course_registration2)]
+            [course_registration, course_registration2]
         )
 
     def test_profile_has_current_course(self):

--- a/src/profile_manager/urls.py
+++ b/src/profile_manager/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import url
-from django.urls import path
+from django.urls import re_path, path
 
 from profile_manager import views
 
@@ -11,19 +10,19 @@ from profile_manager import views
 app_name = 'profile_manager'
 
 urlpatterns = [
-    url(r'^list/all/$', views.ProfileList.as_view(), name='profile_list'),
-    url(r'^list/current/$', views.ProfileListCurrent.as_view(), name='profile_list_current'),
-    url(r'^list/block/(?P<pk>[0-9]+)/$', views.ProfileListBlock.as_view(), name='profile_list_block'),
-    url(r'^list/staff/$', views.ProfileListStaff.as_view(), name='profile_list_staff'),
-    url(r'^list/inactive/$', views.ProfileListInactive.as_view(), name='profile_list_inactive'),
-    url(r'^tour/$', views.tour_complete, name='tour_complete'),
-    url(r'^recalculate/current/$', views.recalculate_current_xp, name='recalculate_xp_current'),
-    url(r'^(?P<pk>[0-9]+)/$', views.ProfileDetail.as_view(), name='profile_detail'),
-    url(r'^(?P<profile_id>[0-9]+)/xp_toggle/$', views.xp_toggle, name='xp_toggle'),
-    url(r'^(?P<profile_id>[0-9]+)/comment_ban_toggle/$', views.comment_ban_toggle, name='comment_ban_toggle'),
-    url(r'^(?P<profile_id>[0-9]+)/comment_ban/$', views.comment_ban, name='comment_ban'),
-    url(r'^(?P<pk>[0-9]+)/edit/$', views.ProfileUpdate.as_view(), name='profile_update'),
-    url(r'^edit/own/$', views.ProfileUpdateOwn.as_view(), name='profile_edit_own'),
+    re_path(r'^list/all/$', views.ProfileList.as_view(), name='profile_list'),
+    re_path(r'^list/current/$', views.ProfileListCurrent.as_view(), name='profile_list_current'),
+    re_path(r'^list/block/(?P<pk>[0-9]+)/$', views.ProfileListBlock.as_view(), name='profile_list_block'),
+    re_path(r'^list/staff/$', views.ProfileListStaff.as_view(), name='profile_list_staff'),
+    re_path(r'^list/inactive/$', views.ProfileListInactive.as_view(), name='profile_list_inactive'),
+    re_path(r'^tour/$', views.tour_complete, name='tour_complete'),
+    re_path(r'^recalculate/current/$', views.recalculate_current_xp, name='recalculate_xp_current'),
+    re_path(r'^(?P<pk>[0-9]+)/$', views.ProfileDetail.as_view(), name='profile_detail'),
+    re_path(r'^(?P<profile_id>[0-9]+)/xp_toggle/$', views.xp_toggle, name='xp_toggle'),
+    re_path(r'^(?P<profile_id>[0-9]+)/comment_ban_toggle/$', views.comment_ban_toggle, name='comment_ban_toggle'),
+    re_path(r'^(?P<profile_id>[0-9]+)/comment_ban/$', views.comment_ban, name='comment_ban'),
+    re_path(r'^(?P<pk>[0-9]+)/edit/$', views.ProfileUpdate.as_view(), name='profile_update'),
+    re_path(r'^edit/own/$', views.ProfileUpdateOwn.as_view(), name='profile_edit_own'),
     path('chart/<pk>/', views.TagChart.as_view(), name='tag_chart'),
 
     path('oauth-merge-account/', views.oauth_merge_account, name='oauth_merge_account'),
@@ -32,9 +31,9 @@ urlpatterns = [
 
     # Examples
     # Template View Example
-    # url(r'^example/$', TemplateView.as_view(template_name='example.html'), name='example'),
+    # re_path(r'^example/$', TemplateView.as_view(template_name='example.html'), name='example'),
     # Function based view example, same as above
-    # url(r'^example/$', 'views.example', name='example'),
+    # re_path(r'^example/$', 'views.example', name='example'),
     # ex: /profile/25/
-    # url(r'^(?P<profile_id>[0-9]+)/$', views.profile, name='profile'),
+    # re_path(r'^(?P<profile_id>[0-9]+)/$', views.profile, name='profile'),
 ]

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -1,5 +1,6 @@
 import uuid
 import json
+import datetime
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -8,7 +9,7 @@ from django.db import models
 from django.db.models import Count, DateTimeField, ExpressionWrapper, F, Max, Q, Sum
 from django.db.models.functions import Greatest
 from django.urls import reverse
-from django.utils import timezone, datetime_safe
+from django.utils import timezone
 
 from siteconfig.models import SiteConfig
 
@@ -135,7 +136,7 @@ class XPItem(models.Model):
     )
     hours_between_repeats = models.PositiveIntegerField(default=0)
     date_available = models.DateField(default=timezone.localdate)  # timezone aware!
-    time_available = models.TimeField(default=datetime_safe.time.min)  # midnight local time
+    time_available = models.TimeField(default=datetime.time.min)  # midnight local time
     date_expired = models.DateField(blank=True, null=True,
                                     help_text='If both Date and Time expired are blank, then the quest never expires')
     time_expired = models.TimeField(blank=True, null=True,  # local time

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -619,19 +619,19 @@ class QuestSubmissionQuerysetTest(TenantTestCase):
         qs = QuestSubmission.objects.all()
 
         # Currently contains the submission from setup.
-        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [repr(self.sub)])
+        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [self.sub])
 
         # Add another submission from a different block, with a different teacher
         baker.make(QuestSubmission, quest=self.quest, semester=self.active_semester)
         # Should still only have the originally submission
         qs = QuestSubmission.objects.all()
-        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [repr(self.sub)])
+        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [self.sub])
 
         # Add another submission from a different block, but this time the quest should notify the teacher
         sub2 = baker.make(QuestSubmission, semester=self.active_semester, quest__specific_teacher_to_notify=self.teacher)
         # print(qs.for_teacher_only(self.teacher))
         qs = QuestSubmission.objects.all()
-        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [repr(self.sub), repr(sub2)], ordered=False)
+        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [self.sub, sub2], ordered=False)
 
     def test_for_teachers_only__with_deleted_quest(self):
         """for_teachers_only QuestSubmissions should be deleted for that quest if it is deleted"""
@@ -665,11 +665,11 @@ class QuestSubmissionManagerTest(TenantTestCase):
     def test_get_queryset_default(self):
         """QuestSubmissionManager.get_queryset by default should return all visible, not archived quest submissions"""
         qs = QuestSubmission.objects.get_queryset()
-        self.assertQuerysetEqual(qs, [repr(self.sub1), repr(self.sub2)], ordered=False)
+        self.assertQuerysetEqual(qs, [self.sub1, self.sub2], ordered=False)
 
     def test_get_queryset_for_active_semester(self):
         qs = QuestSubmission.objects.get_queryset(active_semester_only=True)
-        self.assertQuerysetEqual(qs, [repr(self.sub1)])
+        self.assertQuerysetEqual(qs, [self.sub1])
 
     def test_get_queryset_for_all_quests(self):
         qs = QuestSubmission.objects.get_queryset(
@@ -684,7 +684,7 @@ class QuestSubmissionManagerTest(TenantTestCase):
         quest = self.sub1.quest
         first = baker.make(QuestSubmission, user=self.student, quest=quest, semester=self.active_semester)
         qs = QuestSubmission.objects.all_for_user_quest(self.student, quest, True)
-        self.assertQuerysetEqual(qs, [repr(first)])
+        self.assertQuerysetEqual(qs, [first])
 
     def make_test_submissions_stack(self):
         """Generate 7 submissions, 3 from one semester and 4 from a different semester, each with different settings

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -181,7 +181,7 @@ class QuestTestModel(TenantTestCase):
             )
             self.assertFalse(q.active)
 
-        dt = timezone.get_current_timezone().localize(timezone.datetime(2023, 6, 13, 12, 0, 0))
+        dt = timezone.datetime(2023, 6, 13, 12, 0, 0).replace(tzinfo=timezone.get_current_timezone())
         with freeze_time(dt):
             # Quest that expires an hour ago
             dt_expired = timezone.localtime() - timezone.timedelta(hours=1)
@@ -216,7 +216,7 @@ class QuestTestModel(TenantTestCase):
         # Get the current local time zone
         local_tz = timezone.get_current_timezone()
         # Create a datetime object for noon on June 13th (arbitrary date)
-        dt = local_tz.localize(timezone.datetime(2023, 6, 13, 12, 0, 0))
+        dt = timezone.datetime(2023, 6, 13, 12, 0, 0).replace(tzinfo=local_tz)
 
         # Quest that expires at noon, date_expired=None by default
         quest = baker.make(Quest, time_expired=dt.time())
@@ -236,7 +236,7 @@ class QuestTestModel(TenantTestCase):
         # Get the current local time zone
         local_tz = timezone.get_current_timezone()
         # Create a datetime object for noon on June 13th (arbitrary date)
-        dt = local_tz.localize(timezone.datetime(2023, 6, 13, 12, 0, 0))
+        dt = timezone.datetime(2023, 6, 13, 12, 0, 0).replace(tzinfo=local_tz)
 
         # Quest that expires on June 13th, time_expired=None by default
         quest = baker.make(Quest, date_expired=dt.date())

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -145,7 +145,7 @@ class QuestViewQuickTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(self.client.get(reverse('quests:quest_prereqs_update', args=[q_pk])).status_code, 200)
 
         self.assertEqual(self.client.get(reverse('quests:summary', args=[q_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:ajax_summary_histogram', args=[q_pk])).status_code, 404)  # Ajax only
+        self.assertEqual(self.client.get(reverse('quests:ajax_summary_histogram', args=[q_pk])).status_code, 403)  # Ajax only
         response = self.client.get(
             reverse('quests:ajax_summary_histogram', args=[q_pk]),
             data={
@@ -1202,6 +1202,9 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(len(messages), 1)
         self.assertTrue(scape.name in str(messages[0]))
 
+        # to clear any messages before next test
+        self.assert200('quests:')
+
         # test messages for quest_delete
         response = self.client.post(reverse('quests:quest_delete', args=[quest.id]))
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
@@ -1881,18 +1884,18 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, TenantTestCase):
         baker.make('courses.CourseStudent', block=teacher_block,
                    user=self.test_student, semester=SiteConfig.get().active_semester)
 
-    def test_get_returns_404(self):
+    def test_get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.client.force_login(self.test_teacher)
-        self.assert404('quests:ajax_submission_count')
+        self.assert403('quests:ajax_submission_count')
 
-    def test_non_ajax_post_returns_404(self):
+    def test_non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.client.force_login(self.test_teacher)
         response = self.client.post(
             reverse('quests:ajax_submission_count')
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     def test_student_access_granted(self):
         """ The current behavior is that students can access the view.
@@ -1963,14 +1966,23 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, TenantTestCase):
         self.quest = baker.make(Quest)
         # self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
 
-    def test_get_returns_404(self):
+    def test_get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
-        self.assert404('quests:ajax_quest_info', args=[self.quest.id])
+        self.assert403('quests:ajax_quest_info', args=[self.quest.id])
 
-    def test_non_ajax_post_returns_404(self):
+    def test_non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.post(
             reverse('quests:ajax_quest_info', args=[self.quest.id])
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_ajax_get_returns_404(self):
+        """ This view is only accessible by an ajax POST request """
+        response = self.client.get(
+            reverse('quests:ajax_quest_info', args=[self.quest.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
         self.assertEqual(response.status_code, 404)
 
@@ -2013,14 +2025,23 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, TenantTestCase):
         self.submission = baker.make(QuestSubmission)
         # self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
 
-    def test_get_returns_404(self):
+    def test_get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
-        self.assert404('quests:ajax_approval_info', args=[self.submission.id])
+        self.assert403('quests:ajax_approval_info', args=[self.submission.id])
 
-    def test_non_ajax_post_returns_404(self):
+    def test_non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.post(
             reverse('quests:ajax_approval_info', args=[self.submission.id])
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_ajax_get_returns_404(self):
+        """ This view is only accessible by an ajax POST request """
+        response = self.client.get(
+            reverse('quests:ajax_quest_info', args=[self.quest.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
         self.assertEqual(response.status_code, 404)
 
@@ -2067,16 +2088,16 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, TenantTestCase):
         self.submission = baker.make(QuestSubmission, user=self.test_student)
         # self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
 
-    def test_get_returns_404(self):
+    def test_get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
-        self.assert404('quests:ajax_info_in_progress', args=[self.submission.id])
+        self.assert403('quests:ajax_info_in_progress', args=[self.submission.id])
 
-    def test_non_ajax_post_returns_404(self):
+    def test_non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.post(
             reverse('quests:ajax_info_in_progress', args=[self.submission.id])
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     def test_ajax_info_in_progress(self):
         response = self.client.post(

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -1,95 +1,90 @@
 """quest_manager URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
+    https://docs.djangoproject.com/en/4.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
 
 from quest_manager import views
 
-from django.conf.urls import url
-from django.urls import path
+from django.urls import re_path, path
 
 app_name = 'quest_manager'
 
 urlpatterns = [
-    url(r'^$', views.quest_list, name=''),
-    # url(r'^create/$', views.quest_create, name='quest_create'),
+    re_path(r'^$', views.quest_list, name=''),
 
     # Ajax
-    url(r'^ajax/$', views.ajax_submission_count, name='ajax_submission_count'),
-    url(r'^ajax_flag/$', views.ajax_flag, name='ajax_flag'),
-    url(r'^ajax_quest_info/(?P<quest_id>[0-9]+)/$', views.ajax_quest_info, name='ajax_quest_info'),
-    url(r'^ajax_quest_info/$', views.ajax_quest_info, name='ajax_quest_root'),
-    url(r'^ajax_quest_info/$', views.ajax_quest_info, name='ajax_quest_all'),
-    url(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/$', views.ajax_submission_info, name='ajax_info_in_progress'),
-    url(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/past/$', views.ajax_submission_info, name='ajax_info_past'),
-    url(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/completed/$', views.ajax_submission_info, name='ajax_info_completed'),
-    url(r'^ajax_submission_info/$', views.ajax_submission_info, name='ajax_submission_root'),
-    url(r'^ajax_submission_approve/(?P<submission_id>[0-9]+)/approve/$', views.ApproveView.as_view(), name='ajax_approve'),
-    url(r'^ajax_approval_info/$', views.ajax_approval_info, name='ajax_approval_root'),
-    url(r'^ajax_approval_info/(?P<submission_id>[0-9]+)/$', views.ajax_approval_info, name='ajax_approval_info'),
+    re_path(r'^ajax/$', views.ajax_submission_count, name='ajax_submission_count'),
+    re_path(r'^ajax_flag/$', views.ajax_flag, name='ajax_flag'),
+    re_path(r'^ajax_quest_info/(?P<quest_id>[0-9]+)/$', views.ajax_quest_info, name='ajax_quest_info'),
+    re_path(r'^ajax_quest_info/$', views.ajax_quest_info, name='ajax_quest_root'),
+    re_path(r'^ajax_quest_info/$', views.ajax_quest_info, name='ajax_quest_all'),
+    re_path(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/$', views.ajax_submission_info, name='ajax_info_in_progress'),
+    re_path(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/past/$', views.ajax_submission_info, name='ajax_info_past'),
+    re_path(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/completed/$', views.ajax_submission_info, name='ajax_info_completed'),
+    re_path(r'^ajax_submission_info/$', views.ajax_submission_info, name='ajax_submission_root'),
+    re_path(r'^ajax_submission_approve/(?P<submission_id>[0-9]+)/approve/$', views.ApproveView.as_view(), name='ajax_approve'),
+    re_path(r'^ajax_approval_info/$', views.ajax_approval_info, name='ajax_approval_root'),
+    re_path(r'^ajax_approval_info/(?P<submission_id>[0-9]+)/$', views.ajax_approval_info, name='ajax_approval_info'),
+
     # Lists
-    url(r'^list/(?P<quest_id>[0-9]+)/$', views.quest_list, name='quest_active'),
-    url(r'^available/$', views.quest_list, name='quests'),
-    url(r'^available/$', views.quest_list, name='available'),
-    url(r'^available/all/$', views.quest_list, name='available_all'),
-    url(r'^inprogress/$', views.quest_list, name='inprogress'),
-    url(r'^completed/$', views.quest_list, name='completed'),
-    url(r'^past/$', views.quest_list, name='past'),
-    url(r'^drafts/$', views.quest_list, name='drafts'),
+    re_path(r'^list/(?P<quest_id>[0-9]+)/$', views.quest_list, name='quest_active'),
+    re_path(r'^available/$', views.quest_list, name='quests'),
+    re_path(r'^available/$', views.quest_list, name='available'),
+    re_path(r'^available/all/$', views.quest_list, name='available_all'),
+    re_path(r'^inprogress/$', views.quest_list, name='inprogress'),
+    re_path(r'^completed/$', views.quest_list, name='completed'),
+    re_path(r'^past/$', views.quest_list, name='past'),
+    re_path(r'^drafts/$', views.quest_list, name='drafts'),
 
     # Approvals
-    url(r'^approvals/$', views.approvals, name='approvals'),
-    url(r'^approvals/submitted/$', views.approvals, name='submitted'),
-    url(r'^approvals/submitted/all/$', views.approvals, name='submitted_all'),
-    url(r'^approvals/returned/$', views.approvals, name='returned'),
-    url(r'^approvals/approved/$', views.approvals, name='approved'),
-    url(r'^approvals/flagged/$', views.approvals, name='flagged'),
-    # url(r'^approvals/skipped/$', views.approvals, name='skipped'),
-    # url(r'^approvals/submitted/(?P<quest_id>[0-9]+)/$', views.approvals, name='submitted_for_quest'),  # Not used
-    # url(r'^approvals/returned/(?P<quest_id>[0-9]+)/$', views.approvals, name='returned_for_quest'),  # Not used
-    url(r'^approvals/approved/(?P<quest_id>[0-9]+)/$', views.approvals, name='approved_for_quest'),
-    url(r'^approvals/approved/(?P<quest_id>[0-9]+)/all/$', views.approvals, name='approved_for_quest_all'),
-    # url(r'^approvals/skipped/(?P<quest_id>[0-9]+)/$', views.approvals, name='skipped_for_quest'),  # Not used
+    re_path(r'^approvals/$', views.approvals, name='approvals'),
+    re_path(r'^approvals/submitted/$', views.approvals, name='submitted'),
+    re_path(r'^approvals/submitted/all/$', views.approvals, name='submitted_all'),
+    re_path(r'^approvals/returned/$', views.approvals, name='returned'),
+    re_path(r'^approvals/approved/$', views.approvals, name='approved'),
+    re_path(r'^approvals/flagged/$', views.approvals, name='flagged'),
+    re_path(r'^approvals/approved/(?P<quest_id>[0-9]+)/$', views.approvals, name='approved_for_quest'),
+    re_path(r'^approvals/approved/(?P<quest_id>[0-9]+)/all/$', views.approvals, name='approved_for_quest_all'),
 
     # Quests
-    url(r'^(?P<quest_id>[0-9]+)/$', views.detail, name='quest_detail'),
-    url(r'^create/$', views.QuestCreate.as_view(), name='quest_create'),
-    url(r'^(?P<pk>[0-9]+)/edit/$', views.QuestUpdate.as_view(), name='quest_update'),
-    url(r'^(?P<pk>[0-9]+)/prereqs/edit/$', views.QuestPrereqsUpdate.as_view(), name='quest_prereqs_update'),
-    url(r'^(?P<quest_id>[0-9]+)/copy/$', views.QuestCopy.as_view(), name='quest_copy'),
-    url(r'^(?P<pk>[0-9]+)/delete/$', views.QuestDelete.as_view(), name='quest_delete'),
-    url(r'^(?P<quest_id>[0-9]+)/start/$', views.start, name='start'),
-    url(r'^(?P<quest_id>[0-9]+)/hide/$', views.hide, name='hide'),
-    url(r'^(?P<quest_id>[0-9]+)/unhide/$', views.unhide, name='unhide'),
-    url(r'^(?P<quest_id>[0-9]+)/skip/$', views.skipped, name='skip_for_quest'),
+    re_path(r'^(?P<quest_id>[0-9]+)/$', views.detail, name='quest_detail'),
+    re_path(r'^create/$', views.QuestCreate.as_view(), name='quest_create'),
+    re_path(r'^(?P<pk>[0-9]+)/edit/$', views.QuestUpdate.as_view(), name='quest_update'),
+    re_path(r'^(?P<pk>[0-9]+)/prereqs/edit/$', views.QuestPrereqsUpdate.as_view(), name='quest_prereqs_update'),
+    re_path(r'^(?P<quest_id>[0-9]+)/copy/$', views.QuestCopy.as_view(), name='quest_copy'),
+    re_path(r'^(?P<pk>[0-9]+)/delete/$', views.QuestDelete.as_view(), name='quest_delete'),
+    re_path(r'^(?P<quest_id>[0-9]+)/start/$', views.start, name='start'),
+    re_path(r'^(?P<quest_id>[0-9]+)/hide/$', views.hide, name='hide'),
+    re_path(r'^(?P<quest_id>[0-9]+)/unhide/$', views.unhide, name='unhide'),
+    re_path(r'^(?P<quest_id>[0-9]+)/skip/$', views.skipped, name='skip_for_quest'),
 
     # Quest/Submission Summary Metrics
     path('<int:pk>/summary/', views.QuestSubmissionSummary.as_view(), name='summary'),
     path('<int:pk>/summary/ajax', views.ajax_summary_histogram, name='ajax_summary_histogram'),
 
     # Submissions
-    url(r'^submission/(?P<submission_id>[0-9]+)/skip/$', views.skip, name='skip'),
-    url(r'^submission/(?P<submission_id>[0-9]+)/$', views.submission, name='submission'),
-    url(r'^submission/(?P<submission_id>[0-9]+)/drop/$', views.drop, name='drop'),
-    url(r'^submission/(?P<submission_id>[0-9]+)/complete/$', views.complete, name='complete'),
-    url(r'^submission/save/$', views.ajax_save_draft, name='ajax_save_draft'),
-    url(r'^submission/(?P<submission_id>[0-9]+)/approve/$', views.ApproveView.as_view(), name='approve'),
-    url(r'^submission/past/(?P<submission_id>[0-9]+)/$', views.submission, name='submission_past'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/skip/$', views.skip, name='skip'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/$', views.submission, name='submission'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/drop/$', views.drop, name='drop'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/complete/$', views.complete, name='complete'),
+    re_path(r'^submission/save/$', views.ajax_save_draft, name='ajax_save_draft'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/approve/$', views.ApproveView.as_view(), name='approve'),
+    re_path(r'^submission/past/(?P<submission_id>[0-9]+)/$', views.submission, name='submission_past'),
 
     # Flagged submissions
-    url(r'^submission/(?P<submission_id>[0-9]+)/flag/$', views.flag, name='flag'),
-    url(r'^submission/(?P<submission_id>[0-9]+)/unflag/$', views.unflag, name='unflag'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/flag/$', views.flag, name='flag'),
+    re_path(r'^submission/(?P<submission_id>[0-9]+)/unflag/$', views.unflag, name='unflag'),
 
     # Campaigns / Categories
     path('campaigns/', views.CategoryList.as_view(), name='categories'),

--- a/src/siteconfig/forms.py
+++ b/src/siteconfig/forms.py
@@ -5,7 +5,7 @@ from cssutils import CSSParser
 
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import Accordion, AccordionGroup
 from crispy_forms.helper import FormHelper

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -254,7 +254,7 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
         """
         Invalid slug names provided to Tag CreateView should be rejected
         validators that must be passed:
-        validate_slug https://docs.djangoproject.com/en/3.2/ref/validators/#validate-slug
+        validate_slug https://docs.djangoproject.com/en/4.2/ref/validators/#validate-slug
         validate_unique_slug (custom validator, located at tags.forms.validate_unique_slug)
         """
 

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -6,7 +6,7 @@ from django import forms
 from django.core import signing
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -74,7 +74,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, TenantTestCase):
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
         assert data['results']
-        assert {'id': self._ct_pk(group), 'text': smart_text(group)} in data['results'][0]['children']
+        assert {'id': self._ct_pk(group), 'text': smart_str(group)} in data['results'][0]['children']
 
     def test_no_field_id(self):
         group = self.groups[0]
@@ -135,7 +135,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, TenantTestCase):
 
         data = json.loads(response.content.decode('utf-8'))
         assert data['results']
-        assert {'id': self._ct_pk(group), 'text': smart_text(group.name.upper())} in data['results'][0]['children']
+        assert {'id': self._ct_pk(group), 'text': smart_str(group.name.upper())} in data['results'][0]['children']
 
     def test_url_check(self):
         from django_select2.cache import cache

--- a/src/utilities/urls.py
+++ b/src/utilities/urls.py
@@ -1,13 +1,11 @@
-from django.conf.urls import url
-from django.urls import path
+from django.urls import re_path, path
 
 from utilities import views
 
 app_name = 'utilities'
 
 urlpatterns = [
-    # url(r'^$', views.suggestion_list, name='list'),
-    url(r'^videos/$', views.videos, name='videos'),
+    re_path(r'^videos/$', views.videos, name='videos'),
 
     # flatpages
     path('custom-pages/', views.FlatPageListView.as_view(), name='flatpage_list'),


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Upgraded Django to 4.2 and fixed all the issues that came with it.

### Why?
See #1691 

### How?
Django lists all removed deprecations in their site. The ones listed below are the only ones I found relevant.
https://docs.djangoproject.com/en/dev/internals/deprecation/
```
4.1
	- TransactionTestCase.assertQuerysetEqual() will no longer automatically call repr() on a queryset when compared to string values.
4.0
	- django.utils.encoding.force_text() and smart_text() will be removed.
	- django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy() will be removed.
	- The HttpRequest.is_ajax() method will be removed.	
	- Support for the pre-Django 3.1 django.core.signing.Signer signatures (encoded with the SHA-1 algorithm) will be removed.
	- Support for the pre-Django 3.1 django.core.signing.dumps() signatures (encoded with the SHA-1 algorithm) in django.core.signing.loads() will be removed.		
	- The providing_args argument for django.dispatch.Signal will be removed.
	- django.conf.urls.url() will be removed.
```

How i fixed each issue

> TransactionTestCase.assertQuerysetEqual() will no longer automatically call repr() on a queryset when compared to string 

fixed this by removing instances of using `repr` in tests

> django.utils.encoding.force_text() and smart_text() will be removed.

using `smart_str` as it is the 4.2 equivalent

>  django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy() will be removed.

The only one out of the list above we use is `ugettext_lazy` which I replaced with `gettext_lazy`

> The HttpRequest.is_ajax() method will be removed.	

Replaced any `is_ajax` calls with `xml_http_request_required` method decorator (implemented in #1617)
This method decorator uses the intended way to check for ajax `request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'`

> Support for the pre-Django 3.1 django.core.signing.Signer signatures (encoded with the SHA-1 algorithm) will be removed.
> Support for the pre-Django 3.1 django.core.signing.dumps() signatures (encoded with the SHA-1 algorithm) in django.core.signing.loads() will be removed.	

I'm not entirely sure if this was the reason why `tenant.tests.test_views.TenantCreateViewTest.test_default`'s email confirmation link test was failing, but the issue seemed related. The `allauth` dependancy uses signer.dumps() + loads() which generate different keys when the timestamps change. (ie. different on monday vs tuesday)

I fixed this by using `freeze_time` to lock the timestamps to make the keys the same when comparing

Looking in Django's source code, it uses HMAC (HMAC uses timestamps according to Google). Additionally, the Django 3.2 release notes mention that "signing.dumps() and loads() have become shortcuts for TimestampSigner.sign_object() and unsign_object()."

![image](https://github.com/user-attachments/assets/b0c49ad6-982d-4b46-abf6-74d5d26ca2fb)

But this doesn't explain how `tags.tests.test_views.AutoResponseViewTests` doesn't fail even though it uses `signing.dumps`


> The providing_args argument for django.dispatch.Signal will be removed.

Fixed by removing `providing_args` for `notifications.singnals.notify`. I left the providing args as a comment for future reference.

> django.conf.urls.url() will be removed.

`django.conf.urls.url` was replaced with `django.urls.re_path`. Therefore, replaced everything with `url` with `re_path`

---
#### Stuff that has changed but i cant find a source:

you cannot use reverse foreign key relations on none saved objects

This caused `SemesterCreateUpdateFormsetMixin.get_formset_queryset` to crash on `SemesterCreate` because it uses an unsaved instance of `ExcludeDates`

Fixed by checking if `self.object.pk` exist 

`pytz` has been removed in favor for `zoneinfo`. This screwed with some datetime stuff in tests but i fixed it.

`response.wsgi_request._messages` carries over messages after each consecutive post request. I couldn't find an elegant way to clear the messages before each test. So i added a get request which does clear the messages.

### Testing?
Ran all automated tests individually.
Manually tested the site, making sure nothing on the js side caused any issues.

No tests but some tests were modified because of the changed above.

### Screenshots (if front end is affected)
### Anything Else?
I changed the return value of `xml_http_request_required` from a `JsonRepsonse 400` to a `HTTPResponse 403`
Reason was because of https://stackoverflow.com/a/5298527 saying how 403 is preferred over 400

- changed some tests regarding status_codes to accommodate for this change
- also had to add some tests because of `codecov` test
- added some status_code tests for Badge and Rank popups.
- noticed `Ajax_TagChart` doesn't have any tests associated with it
- I noticed i accentally put `django-querysetsequence>=0.16` twice. I removed one of them

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Updated to Django 4.2, potentially enhancing performance and adding new functionalities.
  - Enhanced AJAX views to ensure they are only accessible through AJAX requests.

- **Bug Fixes**
  - Adjusted expected HTTP status codes in multiple tests to reflect correct access control responses.

- **Documentation**
  - Updated comments and documentation to align with Django 4.2 changes.

- **Refactor**
  - Replaced `url()` with `re_path()` for improved URL routing flexibility across several modules.

- **Tests**
  - Added new tests to verify status codes for AJAX endpoints.
  - Improved assertions in tests by comparing object instances directly rather than their string representations. 

- **Chores**
  - Cleaned up unnecessary code and comments within various files for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->