### PR TITLE
Chore: requirement simplification

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,7 +1,3 @@
-django-tenants>=3.5,<3.6  # latest version that supports python 3.8
-backports.csv>=1.0.7,<1.1
-beautifulsoup4>=4.12.3,<4.13
-celery>=5.2.2,<5.4
 Django==3.2.25
 django-allauth>=0.54,<0.55
 django-querysetsequence>=0.16
@@ -9,29 +5,33 @@ django-bootstrap-datepicker-plus>=5.0.5,<6.0
 django-celery-beat>=2.2,<2.7
 django-colorful>=1.3,<2.0
 django-crispy-forms>=1.8.1,<1.15
-django-datetime-widget>=0.9.3,<1.0
 django-decorator-include==3.0
 django-embed-video>=1.1.2,<1.5
+django-environ>=0.4.5,<0.12
 django-grappelli>=4.0.1,<5
 django-import-export==3.3.9  # latest version that supports django 3.2
-bleach[css]>=5,<6
-cssutils==2.11.1
-html2text==2020.1.16
-django-redis>=5.2.0,<5.3
-django-select2>=8.2.1,<8.3
-django-summernote>=0.8,<0.9
-django-url-or-relative-url-field>=0.2.0,<0.3.0
-django-resized>=0.3.11,<1.1
-django-utils-six==2.0
-numpy==1.22
-psycopg2-binary>=2.8.6,<2.10
-python-memcached>=1.58,<2.0
-tenant-schemas-celery>=2.2,<3.1
-django-environ>=0.4.5,<0.12
+django-querysetsequence>=0.16
 django-recaptcha>=2.0.6,<3.1
-tzdata
-django-storages>=1.12,<2
-boto3>=1.21,<1.35
+django-redis>=5.2.0,<5.3
+django-resized>=0.3.11,<1.1
+django-select2>=8.2.1,<8.3
+django-storages[boto3]>=1.12,<2
+django-summernote>=0.8,<0.9
 django-taggit>=2.1,<5.0
+django-tenants>=3.5,<3.6  # latest version that supports python 3.8
+django-url-or-relative-url-field>=0.2.0,<0.3.0
+django-utils-six==2.0  # only 2.0 exists. Previous version was removed back in Django 3.0
+tenant-schemas-celery>=2.2,<3.1
+
+# non django
+beautifulsoup4>=4.12.3,<4.13
+bleach[css]>=5,<6
+celery>=5.2.2,<5.4
+cssutils==2.11.1
 dnspython>=2.6.1,<3.0
-pillow>=10.3,<11.0
+html2text==2020.1.16
+numpy==1.22
+
+# subdependencies
+psycopg2-binary>=2.8.6,<2.10  # since our backend is PostgreSQL, Django and django-tenants use this to interact with the db
+pillow>=10.3,<11.0  # used implicitly by django_resized (does not exist as an extra package either)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,16 @@
 -r requirements-production.txt
 django-debug-toolbar>=2.1
 django-debug-toolbar-template-timings>=0.9
-ipdb>=0.12
-model_bakery>=1.1,<2.0
+
+# CLI
+coveralls  # includes coverage
+flake8>=3.7
 pipdeptree>=0.13.2
+pre-commit
+
+# code debugging/tests
 freezegun>=0.3.12
 mock>=2.0,<6.0
-flake8>=3.7
-coveralls  # includes coverage
-names
+model_bakery>=1.1,<2.0
 namegenerator
-tblib
-pre-commit
+names


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Simplified some requirements by removing dependencies.

### Why?
Part of #1691 

### How?

#### Removed dependencies 

`python-memcached`
https://pymemcache.readthedocs.io/en/latest/getting_started.html
Looks like we're using `django.core.cache.cache()` over this. As there are zero references to this lib in our repo.

`backports.csv`
https://pypi.org/project/backports.csv/
I think `import-export` superceded this because any csv reference is of `import-export`
Also zero references to this package in our repo.
	
`tzdata`
`django-celery` requires this and installs it automatically
`django-bootstrap-datepicker-plus` has it as a extra package but doesnt use it in its source code (its listed as any version in their [repo](https://github.com/monim67/django-bootstrap-datepicker-plus/blob/master/poetry.lock)).
![image](https://github.com/user-attachments/assets/b7bcb2a7-46b0-4dc9-848f-fb4f1b747632)

`django-datetime-widget`
zero references to it in our repo.
likely superceded by `django-bootstrap-datepicker-plus` as all datewidgets are from `django-bootstrap-datepicker-plus`
Also no reference to this in our repo.

`ipdb`
According to geekforgeeks its an code debugger. https://www.geeksforgeeks.org/using-ipdb-to-debug-python-code/
Requires importing it to use.
No reference to `import ipdb` in our repo 
	
`tblib`
https://python-tblib.readthedocs.io/en/latest/readme.html#documentation
"Pickle tracebacks and raise exceptions with pickled tracebacks in different processes."
No `from tblib import pickling_support` in our repo.
	
#### Modified dependencies 

`django-storages` / `boto3`
changed to 
`django-storages[boto3]>=1.12,<2`

According to `django-storages` [docs](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#installation) `boto3` is a required dependency. (Which i find weird since its listed as a optional package in their [repo](https://github.com/jschneier/django-storages/blob/master/pyproject.toml))

![image](https://github.com/user-attachments/assets/0fc570f7-383d-4b6c-aa11-bdde207473ce)
![image](https://github.com/user-attachments/assets/7688c59a-c8dd-44e7-a886-dcd0191116d9)

only time where we use `django-storages` backend
![image](https://github.com/user-attachments/assets/f4263e56-93d6-4e9a-99ff-51125be1395e)


#### Sub dependencies kept

`pillow`
This package is used by `django-resized`. But does not list it as a required or optional package in their [repo](https://github.com/un1t/django-resized/blob/master/setup.py)
only `required` key exists
![image](https://github.com/user-attachments/assets/ea4dd954-ac8e-46e5-8acf-2a6029ed7bf5)

Pillow in `django-resized` [repo](https://github.com/un1t/django-resized/blob/master/django_resized/forms.py)
![image](https://github.com/user-attachments/assets/f872f0b4-d0c1-48fc-8214-ff3bce1b1061)

`psycopg2-binary`

We're using `PostgreSQL` as our backend and `Django` and `django-tenants` uses `psycopg2` as the framework to interact with `PostgreSQL`.

![image](https://github.com/user-attachments/assets/0ef40055-12a8-44fa-bb56-fcd2464f7e84)

### Testing?
Automated tests and manual test through the frontend.

Also like what was said in #1653 I cant test boto3 and django-storages. Since you need access to the production server

### Screenshots (if front end is affected)
None.

### Anything Else?
Moved and grouped dependencies for readability

### Review request
@tylerecouture 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Improved organization of package dependencies for better clarity and maintainability.
	- Commented on the usage status of packages, enhancing understanding of which dependencies are actively utilized.
	- Removed or marked obsolete packages from the dependency lists to streamline management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->