### PR TITLE
Chore: Removed duplicate `django-querysetsequence` from requirements

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,6 +1,5 @@
 Django==3.2.25
 django-allauth>=0.54,<0.55
-django-querysetsequence>=0.16
 django-bootstrap-datepicker-plus>=5.0.5,<6.0
 django-celery-beat>=2.2,<2.7
 django-colorful>=1.3,<2.0


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Removed a duplicate dependency

### Why?
Duplicate dependency. Only one is needed

### How?
Removed the first instance of `django-querysetsequence` from `requirements.-production.txt`

### Testing?
None

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
