### PR TITLE
Tweak: Semester form's javascript has incorrect date format

### DIFF
--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -96,8 +96,14 @@
         // get the datepicker options from newly added form field
         // initialize the datepicker widget using the options from its class
         var $datepicker = $(`#id_form-${newIndex}-date`)
-        var options = JSON.parse($datepicker.attr("data-dbdp-config")).options;
-        $datepicker.datetimepicker(options);
+        var config = JSON.parse($datepicker.attr("data-dbdp-config"));
+
+        // have to sub in `backend_date_format` if options.format does not exist
+        // Null-coalescing operator
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
+        config.options.format ??= config.backend_date_format;
+
+        $datepicker.datetimepicker(config.options);
     }
 
     function RemoveForm(index) {


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Fixed semester form's js

### Why?
ExcludeDates formset has incorrect time format. Will give a warning and reject the form data if submitted with the incorrect format.
Likely related to #1690

### How?

Im not exactly sure when this happened. I vividly remember the ExcludeDates formset having propper format.
Even #1690 has a screenshot.

Manually injected `backend_date_format` to `options` dictionary, when creating forms.

### Testing?
Manually tested since theres no testing stuff for js.

Manually tested if  form's `options` wont override existing widgets `options` with `backend_date_format`

ie `NoScriptTagDatePickerInput({'options={"format": "YYYY-MM-DD HH:mm"}'})`
will yield that format. instead of the backend_default "YYYY-MM-DD"

### Screenshots (if front end is affected)
Before change
![image](https://github.com/user-attachments/assets/5089c435-868c-48c4-8eb5-86d7f66a3259)

After change
![image](https://github.com/user-attachments/assets/4912356a-a7e1-4169-95e1-5486467e4fc2)

### Anything Else?
### Review request
@tylerecouture
