### PR TITLE
Tweak: added spacing for maps-list in badges

### DIFF
--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -34,7 +34,7 @@
         </div>
         <div class="col-sm-6">
           <ul class="list-unstyled">
-            <li>Maps: {% include 'djcytoscape/snippets/map-list.html' %}</li>
+            <li>Maps: {% include 'djcytoscape/snippets/map-list.html' %}<br></li>
             {% if not request.user.is_staff %}
             <li>{% tag_name %}s: {% include 'tags/snippets/tag-list.html' with object=badge user_obj=request.user %}<br></li>
             {% else %}


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added spacing between maps-list and tags-list in badge view.

### Why?
See #1668

### How?
badges had a ending `<br>` tag when displaying tags-list. Made sure maps-list had the same

Im not sure if quest views needs this spacing?
![image](https://github.com/user-attachments/assets/86ca0590-49a7-46a4-8cb1-7f2fb1aa2138)
![image](https://github.com/user-attachments/assets/dab7506d-16d9-423c-bac4-f3314fa623ee)

### Testing?
None since all i added was a `<br>` tag

### Screenshots (if front end is affected)
Before
![image](https://github.com/user-attachments/assets/df459b44-eecb-449a-b1eb-abe726ac99cd)

After
![image](https://github.com/user-attachments/assets/9a6b7216-c1c0-40a3-971c-bd49902cc316)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved visual separation in the badges detail view by adding a line break after the "Maps" section, enhancing layout clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->