### PR TITLE
Tweak: Added CRISPY_FAIL_SILENTLY to settings.py; Closes #629

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -454,6 +454,9 @@ STATICFILES_DIRS = env(
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
+# https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_forms.html#make-crispy-forms-fail-loud
+CRISPY_FAIL_SILENTLY = not DEBUG  # logs crispy-forms failures as exceptions when True
+
 SITE_ID = 1
 
 # https://github.com/charettes/django-colorful


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added an option to settings.py

### Why?
See #629

### How?
Added `CRISPY_FAIL_SILENTLY = not DEBUG` to `settings.py`

This means that when debug=True crispy form failures, which usually are silently logged, are displayed as exceptions 

### Testing?
Not sure if we should add tests to settings stuff.
We dont have an area to test that anyway

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture
