### PR TITLE
remove initial value for date_available field

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -114,8 +112,6 @@ class QuestForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.fields['date_available'].initial = date.today().strftime('%Y-%m-%d'),
 
         self.fields['common_data'].label = 'Common Quest Info'
         self.fields['common_data'].queryset = CommonData.objects.filter(active=True)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Bug fix for #1741 

### Why?

Could not create quest

### How?

Seems that the `initial_value` bug has been fixed with the recent update for django bootstrap datepicker and the hack I made for setting the initial value for the `date_available` field caused this

### Testing?

Manually tested

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the quest submission form by removing the automatic population of the available date field. Users will now need to manually enter the date when filling out the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->