### PR TITLE
Add Video Start End Attributes (#1556)

### DIFF
--- a/src/badges/forms.py
+++ b/src/badges/forms.py
@@ -44,8 +44,8 @@ class BadgeAssertionForm(forms.ModelForm):
 class ProfileMultiSelectWidget(ModelSelect2MultipleWidget):
     model = Profile
     search_fields = [
-        'first_name__istartswith',
-        'last_name__istartswith',
+        'user__first_name__istartswith',
+        'user__last_name__istartswith',
         'preferred_name__istartswith',
         'user__username__istartswith',
     ]
@@ -67,7 +67,7 @@ class BulkBadgeAssertionForm(forms.Form):
     students = forms.ModelMultipleChoiceField(
         # TODO just use the user objects here instead of profile
         # Goign back to the user just to sort by profile string is...a hack.  How to do that properly?!
-        queryset=Profile.objects.all().order_by('user__profile'),
+        queryset=Profile.objects.all().order_by('user__first_name', 'user__last_name'),
         required=True,
         widget=ProfileMultiSelectWidget(),
     )

--- a/src/static/js/summernote-video-attributes.js
+++ b/src/static/js/summernote-video-attributes.js
@@ -6,7 +6,8 @@
   }else{
     factory(window.jQuery);
   }
-}(function($){
+}
+(function($){
   $.extend(true,$.summernote.lang,{
     'en-US':{ /* English */
       videoAttributes:{
@@ -26,6 +27,14 @@
         alignmentOption2:'Right',
         alignmentOption3:'Initial',
         alignmentOption4:'Inherit',
+        start: 'Start Time (Optional)',
+        startHrs: 'Hours',
+        startMin: 'Minutes',
+        startSec: 'Seconds',
+        end: 'End Time (Optional)',
+        endHrs: 'Hours',
+        endMin: 'Minutes',
+        endSec: 'Seconds',
         suggested:'Show Suggested videos when the video finishes',
         controls:'Show player controls',
         autoplay:'Autoplay',
@@ -50,6 +59,8 @@
       var $editable=context.layoutInfo.editable;
       var options=context.options;
       var lang=options.langInfo;
+      var startSeconds = 0;
+      var endSeconds = 0;
 
       context.memo('button.videoAttributes',function(){
         var button=ui.button({
@@ -72,7 +83,7 @@
           '<div class="form-group">'+
             '<label for="note-video-attributes-href" class="control-label col-xs-3">'+lang.videoAttributes.href+'</label>'+
             '<div class="input-group col-xs-9">'+
-              '<input type="text" id="note-video-attributes-href" class="note-video-attributes-href form-control">'+
+              '<input type="text" id="note-video-attributes-href" class="note-video-attributes-href form-control" required>'+
             '</div>'+
           '</div>'+
           '<div class="form-group">'+
@@ -99,7 +110,23 @@
               '</select>'+
             '</div>'+
           '</div>'+
-
+          //Start and end time inputs
+          '<div class="form-group row">' +
+            '<label for="note-video-attributes-start" class="control-label col-xs-3">' + lang.videoAttributes.start + '</label>' +
+            '<div class="input-group col-xs-9">' +
+              '<input type="number" min="0" max="999" id="note-video-attributes-start-hrs" class="note-video-attributes-start-hrs form-control" style="width:15%" placeholder="hrs">' +
+              '<input type="number" min="0" max="59" id="note-video-attributes-start-min" class="note-video-attributes-start-min form-control" style="width:15%" placeholder="min">' +
+              '<input type="number" min="0" max="59" id="note-video-attributes-start-sec" class="note-video-attributes-start-sec form-control" style="width:15%" placeholder="sec">' +            
+            '</div>' +
+          '</div>' +
+          '<div class="form-group row">' +
+            '<label for="note-video-attributes-end" class="control-label col-xs-3">'+ lang.videoAttributes.end + '</label>' +
+            '<div class="input-group col-xs-9">' +
+              '<input type="number" min="0" max="999" id="note-video-attributes-end-hrs" class="note-video-attributes-end-hrs form-control" style="width:15%" placeholder="hrs">' +
+              '<input type="number" min="0" max="999" id="note-video-attributes-end-min" class="note-video-attributes-end-min form-control" style="width:15%" placeholder="min">' +
+              '<input type="number" min="0" max="59" id="note-video-attributes-end-sec" class="note-video-attributes-end-sec form-control" style="width:15%" placeholder="sec">' +
+            '</div>' +
+          '</div>' +
             '<div class="control-label col-xs-3"></div>'+
             '<div class="input-group col-xs-9">'+
               '<div class="checkbox checkbox-success">'+
@@ -142,8 +169,65 @@
         this.$dialog=ui.dialog({
           title:lang.videoAttributes.dialogTitle,
           body:body,
-          footer:'<button href="#" class="btn btn-primary note-video-attributes-btn">'+lang.videoAttributes.ok+'</button>'
+          footer:'<button href="#" class="btn btn-primary note-video-attributes-btn" disabled=true title="URL required">'+lang.videoAttributes.ok+'</button>'
         }).render().appendTo($container);
+
+        //Listens to when start and end time inputs are changed
+        ['href', 'start-hrs', 'start-min', 'start-sec', 'end-hrs', 'end-min', 'end-sec'].forEach(function(field) {
+          self.$dialog.find('.note-video-attributes-' + field).on('input', function() {
+            self.validateInput();
+          });
+        });
+      };
+     
+      //Function that takes the start and end time inputs and validates that the start time is less than the end time
+      //If the start time is greater than the end time, the OK button is disabled and a tooltip is shown
+      this.validateInput = function() {
+        var $videoHref = self.$dialog.find('.note-video-attributes-href'),
+            $videoStartHrs = self.$dialog.find('.note-video-attributes-start-hrs'),
+            $videoStartMin = self.$dialog.find('.note-video-attributes-start-min'),
+            $videoStartSec = self.$dialog.find('.note-video-attributes-start-sec'),
+            $videoEndHrs = self.$dialog.find('.note-video-attributes-end-hrs'),
+            $videoEndMin = self.$dialog.find('.note-video-attributes-end-min'),
+            $videoEndSec = self.$dialog.find('.note-video-attributes-end-sec'),
+            $okBtn = self.$dialog.find('.note-video-attributes-btn');
+
+        var startHrs = parseInt($videoStartHrs.val()) || 0;
+        var startMin = parseInt($videoStartMin.val()) || 0;
+        var startSec = parseInt($videoStartSec.val()) || 0;
+        if (startMin > 59) {
+          startMin = 0;
+          $videoStartMin.val(0);
+        }
+        if (startSec > 59) {
+          startSec = 0;
+          $videoStartSec.val(0);
+        }
+
+        startSeconds = (startHrs * 3600) + (startMin * 60) + startSec;
+        
+        var endHrs = parseInt($videoEndHrs.val()) || 0;
+        var endMin = parseInt($videoEndMin.val()) || 0;
+        var endSec = parseInt($videoEndSec.val()) || 0;
+        if (endMin > 59) {
+          endMin = 0;
+          $videoEndMin.val(0);
+        }
+        if (endSec > 59) {
+          endSec = 0;
+          $videoEndSec.val(0);
+        }
+        endSeconds = (endHrs * 3600) + (endMin * 60) + endSec;
+        if (!self.$dialog.find('input')[0].checkValidity()) {
+          $okBtn.prop('disabled', true);
+          $okBtn.attr('title', 'URL is required');
+        } else if (endSeconds > 0 && startSeconds >= endSeconds) {
+          $okBtn.prop('disabled', true);
+          $okBtn.attr('title', 'Start time must be less than end time');
+        } else {
+          $okBtn.prop('disabled', false);
+          $okBtn.attr('title', '');
+        }
       };
       this.destroy=function(){
         ui.hideDialog(this.$dialog);
@@ -206,6 +290,12 @@
               if(!$videoControls.is(':checked'))urlVars+='&controls=0';
               if($videoAutoplay.is(':checked'))urlVars+='&autoplay=1';
               if(!$videoLoop.is(':checked'))urlVars+='&loop=0';
+              //adds start and end time to the video
+              if (startSeconds) urlVars += '&start=' + startSeconds;
+              if (endSeconds) urlVars += '&end=' + endSeconds;
+              //Enable JS API Control for YouTube watch tracking
+              urlVars+='&enablejsapi=1';
+
               var youtubeId=ytMatch[1];
               $video=$('<iframe>')
                 .attr('frameborder',0)
@@ -213,7 +303,8 @@
                 .attr('width',videoWidth)
                 .attr('allowfullscreen', allowfullscreen)
                 .attr('height',videoHeight);
-            }else if(igMatch&&igMatch[0].length){
+            }
+            else if(igMatch&&igMatch[0].length){
               $video=$('<iframe>')
                 .attr('frameborder',0)
                 .attr('src','https://instagram.com/p/'+igMatch[1]+'/embed/')
@@ -221,14 +312,16 @@
                 .attr('height',videoHeight)
                 .attr('scrolling','no')
                 .attr('allowtransparency','true');
-            }else if(vMatch&&vMatch[0].length){
+            }
+            else if(vMatch&&vMatch[0].length){
               $video=$('<iframe>')
                 .attr('frameborder',0)
                 .attr('src',vMatch[0]+'/embed/simple')
                 .attr('width',videoWidth)
                 .attr('height',videoHeight)
                 .attr('class','vine-embed');
-            }else if(vimMatch&&vimMatch[3].length){
+            }
+            else if(vimMatch&&vimMatch[3].length){
               if($videoAutoplay.is(':checked'))urlVars+='&autoplay=1';
               if($videoLoop.is(':checked'))urlVars+='&loop=1';
               $video=$('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
@@ -236,7 +329,8 @@
                 .attr('src','//player.vimeo.com/video/'+vimMatch[3]+'?'+urlVars)
                 .attr('width',videoWidth)
                 .attr('height',videoHeight);
-            }else if(dmMatch&&dmMatch[2].length){
+            }
+            else if(dmMatch&&dmMatch[2].length){
               if(!$videoSuggested.is(':checked'))urlVars+='related=1';
               if(!$videoAutoplay.is(':checked')){urlVars+='autoplay=1'}else{urlVars+='autoplay=0'};
               $video=$('<iframe>')
@@ -244,13 +338,15 @@
                 .attr('src','//www.dailymotion.com/embed/video/'+dmMatch[2])
                 .attr('width',videoWidth)
                 .attr('height',videoHeight);
-            }else if(youkuMatch&&youkuMatch[1].length){
+            }
+            else if(youkuMatch&&youkuMatch[1].length){
               $video=$('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
                 .attr('frameborder',0)
                 .attr('width',videoWidth)
                 .attr('height',videoHeight)
                 .attr('src','//player.youku.com/embed/'+youkuMatch[1]);
-            }else if(mp4Match||oggMatch||webmMatch){
+            }
+            else if(mp4Match||oggMatch||webmMatch){
               $video=$('<video controls>')
                 .attr('src',url)
                 .attr('width',videoWidth)
@@ -276,10 +372,10 @@
               e.preventDefault();
               deferred.resolve({
                 vidDom:vidInfo.vidDom,
-                href:$videoHref.val()
+                href:$videoHref.val(),
               });
             });
-            $videoHref.val(vidInfo.href).focus;
+            $videoHref.val(vidInfo.href).focus();
             self.bindEnterKey($editBtn);
             self.bindLabels();
           });


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What? Start and end attributes are added to summernote plugin. Also added check to ensure that there is something in the URL field
### Why? Allows admin to start/end videos without going into code view. Also stops trying to add a video without putting in url
### How? Start and end hours, minutes and seconds are converted into seconds and then added to YouTube iframe
### Testing? Frontend testing
### Screenshots (if front end is affected) 

Frontend look with check for URL
![image](https://github.com/user-attachments/assets/a1e69538-6219-4b16-b5bb-7278d9cf8385)

Check to see that start time is not after end time
![image](https://github.com/user-attachments/assets/58fc6126-9408-4f5d-8006-936d46258a7d)

What is added to code
![image](https://github.com/user-attachments/assets/8b3e2c1a-5ed7-4f0d-b64a-d14feaf95fe5)


### Anything Else?
### Review request
@tylerecouture
