### PR TITLE
Removed "active" column from tab_campaigns_list.html file; Closes #1749

### DIFF
--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -10,7 +10,6 @@
       <th>Icon</th>
       <th data-sortable='true' data-field='count'># of Quests</th>
       <th data-sortable='true' data-field='xp'>XP Available</th>
-      <th data-sortable='true' data-field='active'>Active</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -24,7 +23,6 @@
         </td>
         <td>{{ object.quest_count }}</td>
         <td>{{ object.xp_sum }}</td>
-        <td>{{ object.active }}</td>
         <td>
           {% if not library_tab_active %}
             <a class="btn btn-info"


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/

### What?
Removed the "Active" column from the /quests/campaigns/ Available tab.
### Why?
To resolve issue #1749

### How?
In the HTML file tab_campaigns_list.html I removed:
1. line 13 "<th data-sortable='true' data-field='active'>Active</th>"
2. line 27 "<td>{{ object.active }}</td>"

### Testing?
Since I only removed two lines from a template, I kept checking the website to see what my changes affected in real time. Otherwise no other tests were done.

### Screenshots (if front end is affected)
![Screenshot 2025-05-13 120512](https://github.com/user-attachments/assets/d8061b07-ec71-4e4e-98fc-88651f7d5a5b)

### Anything Else?
I'm fairly certain this is the only change required to remove the column, my real time view of the changes seen in the screenshot seem to confirm this.

### Review request
@tylerecouture



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "Active" column from the campaigns list table, so campaign active status is no longer displayed. Other table details remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->