### PR TITLE
Refactor: simplify notification rendering by removing removable check

### DIFF
--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -2,7 +2,6 @@ import json
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import Http404, HttpResponseRedirect, redirect, render
@@ -97,15 +96,10 @@ def ajax(request):
         notifications = notifications[:limit]
         notes = []
         for note in notifications:
-            removable = note.target_content_type != ContentType.objects.get(
-                app_label="announcements",
-                model='announcement'
-            )
             notes.append(
                 {
                     'link': str(note.get_link()),
                     'id': str(note.id),
-                    'removable': removable,
                 }
             )
 

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -248,14 +248,11 @@
 
               // Add a menu item and remove button for each notification
               $(data.notifications).each(function(){
-                if (this.removable) {
-                  remove_link = "<a class='notification-mark-read' title='Remove' href='#' data-id='" +
-                                this.id +
-                                "'><i class='fa fa-times fa-fw text-muted'></i></a>";
-                  $menu_item = $("<li class='dropdown-horizontal-group'>"+ this.link + remove_link + "</li>");
-                }
-                else
-                  $menu_item = $("<li>"+ this.link +"</li>");
+                remove_link = "<a class='notification-mark-read' title='Remove' href='#' data-id='" +
+                              this.id +
+                              "'><i class='fa fa-times fa-fw text-muted'></i></a>";
+                $menu_item = $("<li class='dropdown-horizontal-group'>"+ this.link + remove_link + "</li>");
+
 
                 $menu.append($menu_item);
               });

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -248,14 +248,11 @@
 
               // Add a menu item and remove button for each notification
               $(data.notifications).each(function(){
-                if (this.removable) {
                   remove_link = "<a class='notification-mark-read' title='Remove' href='#' data-id='" +
                                 this.id +
                                 "'><i class='fa fa-times fa-fw text-muted'></i></a>";
                   $menu_item = $("<li class='dropdown-horizontal-group'>"+ this.link + remove_link + "</li>");
-                }
-                else
-                  $menu_item = $("<li>"+ this.link +"</li>");
+
 
                 $menu.append($menu_item);
               });

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -248,11 +248,14 @@
 
               // Add a menu item and remove button for each notification
               $(data.notifications).each(function(){
+                if (this.removable) {
                   remove_link = "<a class='notification-mark-read' title='Remove' href='#' data-id='" +
                                 this.id +
                                 "'><i class='fa fa-times fa-fw text-muted'></i></a>";
                   $menu_item = $("<li class='dropdown-horizontal-group'>"+ this.link + remove_link + "</li>");
-
+                }
+                else
+                  $menu_item = $("<li>"+ this.link +"</li>");
 
                 $menu.append($menu_item);
               });


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Made it so that the little 'x' appears next to announcements as well
### Why?
To resolve issue #1233 
### How?
I removed code checking if 'this.removable' so far no errors have occurred and it passes tests
### Testing?
Ran the testing and checked the website to see the changes, implemented no tests
### Screenshots (if front end is affected)
![image](https://github.com/user-attachments/assets/083cae12-e67e-4228-9de5-890c867b2cfd)

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - All notifications in the dropdown menu now display a remove button, ensuring a consistent appearance and interaction for every notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->