### PR TITLE
Added fallback value for number of quests and total xp and specified …

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -15,8 +15,8 @@
     <div class="row">
       <div class="col-sm-6">
         <ul class="list-unstyled">
-          <li>Quests in this campaign: {% firstof category_quest_count category.quest_count %}</li>
-          <li>Total XP available: {% firstof category_total_xp_available category.xp_sum %}</li>
+          <li>Published quests in this campaign: {% firstof category_quest_count category.quest_count "0" %}</li>
+          <li>Total XP available: {% firstof category_total_xp_available category.xp_sum "0" %}</li>
           <li>Active: {% firstof category_active category.active %}</li>
         </ul>
       </div>


### PR DESCRIPTION
…what quests are shown

default for number of quests 0
default for amount of xp 0

Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
### Why?
closes issue #1748
### How?
### Testing?
As done in the last pull request, I'm sorry that I made an oopsie and in the last one more files were edited/committed than I thought, won't happen again. 
### Screenshots (if front end is affected)

![Screenshot 2025-05-16 114757](https://github.com/user-attachments/assets/216db059-722f-480b-9f19-21e176403306)

### Anything Else?
I'm so sorry, I started messing around with the git graph trying to discover things and merged the old campaign-detail-view with some other changes so when I updated it I had more commits than I wanted/needed. Won't happen again, and I'll make sure my issue solving is for sure separated from now on. Thank you for under standing.

Everything should be resolved now and I made the change from your comment:

"""
While you are in this code, can you verify whether this shows ALL quests in a campaign, or if it only shows published quests? I think it only shows published quests.

If you confirm it is only published quests, can you change the text to "Published quests in this campaign"?

If it includes all of them, leave it as is.
"""
### Review request
@tylerecouture
