### PR TITLE
fix: changed the form submitted too many times alert message; Closes #1778

### DIFF
--- a/src/static/js/jquery-double-submission.js
+++ b/src/static/js/jquery-double-submission.js
@@ -7,7 +7,7 @@ jQuery.fn.preventDoubleSubmission = function () {
 
         if ($form.data('submitted') === true) {
             // Previously submitted - don't submit again
-            alert('I\'m working on it! Extra clicks not required. Thanks!');
+            alert("This form has already been submitted, please be patient while your request is being processed. You can also refresh the page if you want to try to resubmit the form.");
             e.preventDefault();
         } else {
             // Mark it so that the next submit can be ignored


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Updated the alert message in the `preventDoubleSubmission` jQuery plugin to provide clearer and more helpful guidance when a form has already been submitted.

### Why?
The previous alert text was informal and could confuse users, especially in cases where the form submission is delayed or the UI doesn’t immediately update. The new message improves clarity and user experience.

To resolve **issue #1778**

### How?
Replaced the old alert message with:
> "This form has already been submitted, please be patient while your request is being processed. You can also refresh the page if you want to try to resubmit the form."

### Testing?
- Verified the new alert message shows up on double form submissions.
- Confirmed that the plugin still prevents multiple submissions effectively.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Style**
  - Updated the alert message shown when attempting to submit a form multiple times for improved clarity and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->