### PR TITLE
Disable campaign delete

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -12,10 +12,24 @@
                 title = "Edit this campaign" >
             <i class="fa fa-edit"></i>
             </a>
-            <a class="btn btn-danger" href="{% url 'quests:category_delete' object.id %}" role="button"
+            {% if object.quest_count != 0 %}
+            <span title="Unpublish or delete all quests before deleting campaign">
+                <a class="btn btn-danger disabled"
+                    href="#"
+                    tabindex="-1"
+                    aria-disabled="true"
+                    role="button"
+                    title = "Unpublish or delete all quests before deleting campaign" >
+                <i class="fa fa-trash-o"></i>
+                </a>
+            </span>
+            {% else %}
+            <a class="btn btn-danger"
+                href="{% url 'quests:category_delete' object.id %}" role="button"
                 title = "Delete this campaign" >
             <i class="fa fa-trash-o"></i>
             </a>
+            {% endif %}
         </div>
     {% endif %}
     {% if object.active or request.user.is_staff %}

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -37,12 +37,25 @@
                title="Edit this campaign">
               <i class="fa fa-edit"></i>
             </a>
-            <a class="btn btn-danger"
-               href="{% url 'quests:category_delete' object.id %}"
-               role="button"
-               title="Delete this campaign">
-              <i class="fa fa-trash-o"></i>
-            </a>
+            {% if object.quest_count != 0 %}
+            <span title="Unpublish or delete all quests before deleting campaign">
+              <a class="btn btn-danger disabled"
+                href="#"
+                tabindex="-1"
+                aria-disabled="true"
+                role="button"
+                title="Unpublish or delete all quests before deleting campaign">
+                <i class="fa fa-trash-o"></i>
+              </a>
+            </span>
+            {% else %}
+              <a class="btn btn-danger"
+                href="{% url 'quests:category_delete' object.id %}"
+                role="button"
+                title="Delete this campaign">
+                <i class="fa fa-trash-o"></i>
+              </a>
+            {% endif %}
           {% else %}
             <a href="{% url 'library:import_category' object.title %}"
                class="btn btn-sm btn-default"


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Introduced a disabled state for the "Delete Campaign" button when the campaign has associated quests (`quest_count != 0`), and ensured that a tooltip explains why the button is disabled.

### Why?
Previously, the "Delete Campaign" button was always enabled, even when the campaign contained quests. Per [issue #1773](https://github.com/bytedeck/bytedeck/issues/1773), we want to prevent deletion in such cases and clearly communicate the reason via a tooltip.

### How?
- Added a condition to apply the `.disabled` class to the button only when `object.quest_count != 0`.
- Wrapped the button in a `<span>` element, which holds the `title`.
- This allows the tooltip to appear on hover even when the button is disabled.
- Included Bootstrap suggested safety features `tab-index="-1"` and `aria-disabled="true"`

> Note: The `<span>` element is there because the `.disabled` class forces `pointer-events: none;`
> which would cause the title of the button to not display when hovered

### Testing?
- Manually verified that:
  - When `quest_count == 0`, the button is active and links to the delete URL.
  - When `quest_count > 0`, the button appears disabled and the tooltip is visible on hover.

### Screenshots (if front end is affected)

<details>
<summary>Campaign with Quests (Disabled Button with Tooltip)</summary>

![Screenshot 2025-05-22 095532](https://github.com/user-attachments/assets/4794aef2-f65b-4129-b64e-f433b59db7d8)
![Screenshot 2025-05-22 095803](https://github.com/user-attachments/assets/fe3d3777-4159-4171-a2da-207c4778b58b)


</details>

<details>
<summary>Campaign without Quests (Active Button)</summary>

![Screenshot 2025-05-22 101241](https://github.com/user-attachments/assets/acad980c-2452-4fba-adae-cfd6c288a22d)
![Screenshot 2025-05-22 101254](https://github.com/user-attachments/assets/85921e28-41cc-4f3f-8ef6-ece206e10e0d)

</details>


### Anything Else?


### Review request
@tylerecouture
