### PR TITLE
Library accordion; Closes #1757

### DIFF
--- a/src/library/templates/library/library_bttns.html
+++ b/src/library/templates/library/library_bttns.html
@@ -1,9 +1,0 @@
-{% if request.user.is_staff %}
-  <div id="preview-btns-{{ q.id }}" class="pull-right" style="margin-bottom: 1em;">
-    <a href="{% url 'library:import_quest' q.import_id %}"
-       class="btn btn-primary"
-       title="Import this Quest into your Deck. The Quest will appear in your Drafts tab.">
-      <i class="fa fa-download"></i> Import Quest
-    </a>
-  </div>
-{% endif %}

--- a/src/library/urls.py
+++ b/src/library/urls.py
@@ -4,10 +4,6 @@ from library import views
 app_name = 'library'
 
 urlpatterns = [
-    # AJAX endpoints
-    path('quests/ajax_quest_info/<int:id>/', views.ajax_quest_info, name='ajax_library_info'),
-    path('quests/ajax_quest_info/', views.ajax_quest_info, name='ajax_library_root'),
-
     # Library pages
     path('quests/', views.quests_library_list, name='quest_list'),
     path('campaigns/', views.campaigns_library_list, name='category_list'),

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -4,9 +4,6 @@ from django.contrib.auth.decorators import login_required
 from hackerspace_online.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
-from django.template.loader import render_to_string
-from django.http import JsonResponse
-from django.views.decorators.http import require_POST
 from quest_manager.models import Quest
 from quest_manager.models import Category
 
@@ -29,7 +26,7 @@ def quests_library_list(request):
 
     with library_schema_context():
         # Get the active quests and force the query to run while still in the library schema
-        # by calling list() on the queryset
+        # by calling len() on the queryset
         library_quests = Quest.objects.get_active().select_related('campaign').prefetch_related('tags')
         num_library = len(library_quests)
 
@@ -41,20 +38,6 @@ def quests_library_list(request):
         }
 
     return render(request, 'library/library_quests.html', context)
-
-
-@require_POST
-@login_required
-def ajax_quest_info(request, id):
-    """
-    AJAX POST returning detailed HTML of a quest by id,
-    always checking library schema.
-    """
-    with library_schema_context():
-        quest = get_object_or_404(Quest, pk=id)
-        template = 'quest_manager/preview_content_quests_avail.html'
-        html = render_to_string(template, {'q': quest}, request)
-        return JsonResponse({'quest_info_html': html})
 
 
 @login_required

--- a/src/quest_manager/static/quest_manager/css/bootstrap-table-accordion.css
+++ b/src/quest_manager/static/quest_manager/css/bootstrap-table-accordion.css
@@ -150,27 +150,3 @@ tr.detail-view > td > div > ul > .list-group-item:last-child,
 tr.detail-view > td > div > .list-group-item:last-child  {
   border-bottom-color: var(--accordian-table-border-color);
 }
-
-/* Library-specific: Flex layout for quest header */
-.quest-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  flex-wrap: wrap;
-}
-
-/* Button container for preview/detail views */
-.library-preview-btns {
-  margin-left: 1em;
-  margin-bottom: 1em;
-}
-
-@media (max-width: 767px) {
-  .quest-header {
-    flex-direction: column;
-  }
-  .library-preview-btns {
-    margin: 1em 0 0 0;
-    text-align: right;
-  }
-}

--- a/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
+++ b/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
@@ -51,6 +51,7 @@ function loadQuestOrSubmissionContent(id) {
   // Determine the correct AJAX URL based on the current page
   var currentURL = window.location.href;
   var ajax_url;
+  var postData = { csrfmiddlewaretoken: window.contextData.csrfToken };
 
   if (currentURL.includes("/inprogress/")) {
       ajax_url = `${window.contextData.ajax_submission_root}${id}/`;
@@ -61,7 +62,8 @@ function loadQuestOrSubmissionContent(id) {
   } else if (currentURL.includes("/approvals/")) {
       ajax_url = `${window.contextData.ajax_approval_root}${id}/`;
   } else if (currentURL.includes("/library/")) {
-      ajax_url = `${window.contextData.ajax_library_root}${id}/`;
+      ajax_url = `${window.contextData.ajax_quest_root}${id}/`;
+      postData.use_schema = "library";
   } else {
       ajax_url = `${window.contextData.ajax_quest_root}${id}/`; // Default for available quests or drafts
   }
@@ -70,7 +72,7 @@ function loadQuestOrSubmissionContent(id) {
   $.ajax({
       type: "POST",
       url: ajax_url,
-      data: { csrfmiddlewaretoken: window.contextData.csrfToken },
+      data: postData,
       success: function (data) {
           $contentContainer.html(data.quest_info_html).addClass("ajax-content-loaded");
           $('div.pack').pack();

--- a/src/quest_manager/templates/quest_manager/base.html
+++ b/src/quest_manager/templates/quest_manager/base.html
@@ -24,7 +24,6 @@
         ajax_submission_root: "{% url 'quests:ajax_submission_root' %}",
         ajax_approval_root: "{% url 'quests:ajax_approval_root' %}",
         ajax_quest_root: "{% url 'quests:ajax_quest_root' %}",
-        ajax_library_root:"{% url 'library:ajax_library_root' %}"
       };
     </script>
     <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}?v=1.2"></script>

--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -2,33 +2,49 @@
 
 <div id='preview-btns-{{ q.id }}' class="pull-right">
     {% if not no_details %} <!-- no_details if you are already viewing the details =) -->
-      <a title="View Details: preview the content of this quest without starting it"
-         class="btn btn-info" href="{% url 'quests:quest_detail' q.id %}" role="button">
+      {% if is_library_view %}
+        {% comment %} TODO: add a detail view for library quests {% endcomment %}
+        {% comment %} <a title="View Details: preview the content of this quest without importing it"
+          class="btn btn-info" href="#" role="button">
           <i class="fa fa-fw fa-info-circle"></i><span class="visible-lg-inline-block icon-text">View Details</span>
-      </a>
+        </a> {% endcomment %}
+      {% else %}
+        <a title="View Details: preview the content of this quest without starting it"
+          class="btn btn-info" href="{% url 'quests:quest_detail' q.id %}" role="button">
+            <i class="fa fa-fw fa-info-circle"></i><span class="visible-lg-inline-block icon-text">View Details</span>
+        </a>
+      {% endif %}
     {% endif %}
 
     {% if  request.user.is_staff or request.user == q.editor %}
-        <a class="btn btn-warning" href="{% url 'quests:quest_update' q.id %}" role="button"
-          title = "Edit the quest" >
-          <i class="fa fa-edit"></i>
-        </a>
-        <a class="btn btn-primary" href="{% url 'quests:quest_copy' q.id %}" role="button"
-          title = "Create a copy of this quest" >
-          <i class="fa fa-copy"></i>
-        </a>
-        <a class="btn btn-default" href="{% url 'quests:approved_for_quest' q.id %}" role="button"
-          title = "View past submissions of this quest" >
-          <i class="fa fa-folder-open-o"></i>
-        </a>
-        <a class="btn btn-default" href="{% url 'quests:summary' q.id %}" role="button"
-          title="View summary data for this quest" >
-          <i class="fa fa-fw fa-bar-chart"></i>
-        </a>
-        <a class="btn btn-danger" href="{% url 'quests:quest_delete' q.id %}" role="button"
-          title = "Delete this quest" >
-          <i class="fa fa-trash-o"></i>
-        </a>
+        {% if is_library_view %}
+          <a href="{% url 'library:import_quest' q.import_id %}"
+              class="btn btn-primary"
+              title="Import this Quest into your Deck. The Quest will appear in your Drafts tab.">
+            <i class="fa fa-download"></i><span class="visible-lg-inline-block icon-text">Import Quest</span>
+          </a>
+        {% else %}
+          <a class="btn btn-warning" href="{% url 'quests:quest_update' q.id %}" role="button"
+            title = "Edit the quest" >
+            <i class="fa fa-edit"></i>
+          </a>
+          <a class="btn btn-primary" href="{% url 'quests:quest_copy' q.id %}" role="button"
+            title = "Create a copy of this quest" >
+            <i class="fa fa-copy"></i>
+          </a>
+          <a class="btn btn-default" href="{% url 'quests:approved_for_quest' q.id %}" role="button"
+            title = "View past submissions of this quest" >
+            <i class="fa fa-folder-open-o"></i>
+          </a>
+          <a class="btn btn-default" href="{% url 'quests:summary' q.id %}" role="button"
+            title="View summary data for this quest" >
+            <i class="fa fa-fw fa-bar-chart"></i>
+          </a>
+          <a class="btn btn-danger" href="{% url 'quests:quest_delete' q.id %}" role="button"
+            title = "Delete this quest" >
+            <i class="fa fa-trash-o"></i>
+          </a>
+          {% endif %}
 
     {% else %}
 

--- a/src/quest_manager/templates/quest_manager/preview_content_quests_avail.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_quests_avail.html
@@ -8,11 +8,7 @@
 
 </div>
 <hr class ="visible-xs-block" >
-{% if '/library/' in request.path %}
-  {% include "library/library_bttns.html" %}
-{% else %}
-  {% include "quest_manager/buttons.html" %}
-{% endif %}
+{% include "quest_manager/buttons.html" %}
   <p>{{q.short_description|safe}}</p>
 {% if request.user.is_staff or request.user == q.editor %}
 

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -537,11 +537,12 @@ def ajax_quest_info(request, quest_id=None):
         template = 'quest_manager/preview_content_quests_avail.html'
 
         with from_library_schema_first(request):
+            is_library_view = (request.POST.get('use_schema') == 'library')
             if quest_id:
                 quest = get_object_or_404(Quest, pk=quest_id)
 
                 template = 'quest_manager/preview_content_quests_avail.html'
-                quest_info_html = render_to_string(template, {'q': quest}, request=request)
+                quest_info_html = render_to_string(template, {'q': quest, 'is_library_view': is_library_view}, request=request)
 
                 data = {'quest_info_html': quest_info_html}
 
@@ -552,7 +553,7 @@ def ajax_quest_info(request, quest_id=None):
                 all_quest_info_html = {}
 
                 for q in quests:
-                    all_quest_info_html[q.id] = render_to_string(template, {'q': q}, request=request)
+                    all_quest_info_html[q.id] = render_to_string(template, {'q': q, 'is_library_view': is_library_view}, request=request)
 
                 data = json.dumps(all_quest_info_html)
                 return JsonResponse(data, safe=False)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

This PR adds the front-end and back-end support for the Library tab under Quests. It includes:

- A new `bootstrap-table-accordion.js` and corresponding CSS for the Library section
- AJAX views and URL routes for displaying quest information dynamically
- New HTML templates and tab structure updates (`tab_library_quests.html`)
- A comprehensive test suite covering the AJAX endpoints and rendering logic

### Why?

The existing accordion JS used in the `quest_manager` section was tightly coupled with deck-specific logic and assumptions. We needed a separate version for the Library to:
- Avoid clashing with identifiers or UI behaviors used in user decks
- Introduce library-specific formatting and dynamic info loading via AJAX
- Maintain visual consistency while preserving the separation of concerns between "My Decks" and the shared Library

Addresses issue [#1757](https://github.com/bytedeck/bytedeck/issues/1757) I started fixing this on another issue, and since I'd done the work I thought I'd make this PR.

### How?

- **Frontend**
  - Created a new JS module: `bootstrap-table-accordion.js` scoped for Library use
  - Added Library-specific CSS rules for styling accordion rows in a way that has similarities with local deck quest tabs
  - Updated `tab_library_quests.html` to use this new accordion behavior and hook into the AJAX quest info view

- **Backend**
  - Added `ajax_quest_library_list` view that returns metadata for quests in the Library schema
  - Added `ajax_quest_info_by_import_id` view to return rendered HTML for quest details via POST
  - Registered these views under `library/urls.py` with appropriate namespacing

- **Tests**
  - Added `test_ajax_quest_library_list` to verify JSON response and icon metadata
  - Added `test_ajax_quest_info_returns_html` to validate correct rendering and status
  - Added `test_ajax_quest_info_invalid_import_id_returns_404` to ensure robustness for invalid IDs

### Testing?

Tests added in `library.tests.test_views.QuestLibraryTestsCase`:

- ✅ `test_ajax_quest_library_list`
- ✅ `test_ajax_quest_info_returns_html`
- ✅ `test_ajax_quest_info_invalid_import_id_returns_404`

Manual verification was also performed to confirm:
- Accordion toggle and quest expansion work as expected
- Dynamic quest info loads via AJAX and displays correctly
- Error states are gracefully handled

### Screenshots (if front end is affected)


https://github.com/user-attachments/assets/baa53ae5-6239-460b-87f7-0f8e4289d65c


### Anything Else?

- The new JS/CSS will only be loaded on Library pages
- The accordion behavior intentionally avoids assuming local deck ownership
- Future work will include UI enhancements and more granular filtering on Library quests
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quest library now features an interactive, expandable quest list with status indicators for repeatable and blocking quests.
  * Collapsible detail views with loading spinners are available for each quest in the library.
  * The "Library" tab in the quest manager displays a badge showing the total number of library quests.

* **Improvements**
  * Quest list rendering is more dynamic and responsive, with enhanced accessibility and mobile-friendly display.
  * Optimized quest data loading for improved performance.
  * Button actions in the quest manager adapt based on whether you are viewing library quests or your own quests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->