### PR TITLE
Chore: Added Acceptable Use Policy to the pages footer

### DIFF
--- a/src/templates/public/snippets/footer.html
+++ b/src/templates/public/snippets/footer.html
@@ -22,6 +22,7 @@
              <li><a href="/pages/about-us/">About us</a></li>
              <li><a href="/pages/privacy/">Privacy</a></li>
              <li><a href="/pages/accessibility/">Accessibility</a></li>
+             <li><a href="/pages/use-policy/">Acceptable Use Policy</a></li>
            </ul>
 
          </div>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Added the `Acceptable Use Policy` item to the appropriate list in the footer of the pages/ tab.

### Why?

To resolve [issue #1796](https://github.com/bytedeck/bytedeck/issues/1796)

### How?

By adding this line of code into src/templates/public/snippets/footer.html

`<li><a href="/pages/use-policy/">Acceptable Use Policy</a></li>`

Here's a bit more context for the line

```
         <div class="col-xs-6 col-md-4">

           <h1-BD>More Info</h1-BD>
           <hr style="width:100px">
           <ul class="BD-footer-links">
             <li><a href="/pages/about-us/">About us</a></li>
             <li><a href="/pages/privacy/">Privacy</a></li>
             <li><a href="/pages/accessibility/">Accessibility</a></li>
 +           <li><a href="/pages/use-policy/">Acceptable Use Policy</a></li>
           </ul>

         </div>
```

### Testing?

Since it's just an html block I visually tested to see if it showed up on my localhost.

### Screenshots (if front end is affected)

![image](https://github.com/user-attachments/assets/2178f3c2-331f-4bb7-979d-9e822e30bce5)


### Anything Else?

Because it's on my localhost it doesn't load the page, but based off of all the other links it should work for the bytedeck website.

Let me know if you want it to be the full link or it's fine to keep it as a root-relative url.
Happy to update to the full link if that's what you want. 😄

### Review request
@tylerecouture
