### PR TITLE
BugFix: changed width and height for profile avatar css classes: Closes #822

### DIFF
--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -45,7 +45,7 @@
 <div class="row">
   <div class="col-xs-12">
     <div class="bd-profile-row">
-      <img class="icon-avatar img-rounded bd-profile-avatar-col" src="{{object.get_avatar_url}}" alt="avatar"/>
+      <img class="img-rounded bd-profile-avatar-col" src="{{object.get_avatar_url}}" alt="avatar"/>
 
       <div class="bd-profile-xp-col">
         <div class="panel panel-primary">

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -499,10 +499,6 @@ form > div.alert.alert-block.alert-danger {
     width: 128px
 }
 
-.icon-avatar {
-    width: 140px;
-}
-
 .quest-icon {
     margin-right: 10px;
 }


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Changed the formatting of css classes for the avatar in the profile page to fit the webpage better.

### Why?

The positioning of the avatar in the profile page was making it almost collide with the row below and be out of sync with everything else in its row.

[issue #822](https://github.com/bytedeck/bytedeck/issues/822)

### How?
#### Previously in `custom_common.css`:
```
width: 170px;
height: 170px;
```

#### Now in `custom_common.css`:
```
width: 140px;
height: 140px;
```


### Testing?

Since its frontend only I verified by looking at the webpage and making sure the changes took the appropriate effect.
Made sure the changes in the css for this profile img didn't affect any of the other profile imgs on the page

### Screenshots (if front end is affected)
<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/51647a78-9224-41a0-8494-ba6083a37cea)

</details>

<details>
<summary>After</summary>

![Image](https://github.com/user-attachments/assets/5297640a-d931-4304-81f1-26d46d4d697e)

</details>

### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Reduced the size of profile avatar containers for a more compact appearance.
  - Removed the avatar icon styling for a cleaner profile display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->