### PR TITLE
Removed the call to notify the specific teacher; Closes #699

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1239,15 +1239,6 @@ def complete(request, submission_id):
 
         icon = "<i class='fa fa-shield fa-lg'></i>"
 
-        # Notify teacher if they are specific to quest but are not the student's current teacher
-        # current teacher doesn't need the notification because they'll see it in their approvals tabs already
-        if (
-            submission.quest.specific_teacher_to_notify
-            and submission.quest.specific_teacher_to_notify
-            not in request.user.profile.current_teachers()
-        ):
-            affected_users.append(submission.quest.specific_teacher_to_notify)
-
         # Send notification to current teachers when a comment is left on an auto-approved quest
         # since these quests don't appear in the approvals tab, teacher would never know about the comment.
         if (


### PR DESCRIPTION
Updated the test for that call

Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

This PR updates the behavior around quest submission notifications for quests with a `specific_teacher_to_notify`.

- Removes redundant notifications to the `specific_teacher_to_notify` (since the submissions appear in the "Approval" tab anyways)
- Updates and expands test coverage in the `QuestSubmission` test suite to reflect this behavior:
  - `test_specific_teacher_to_notify_own_teacher`: verifies that a teacher who is both the student's current teacher and the quest's specific notifier does **not** receive a notification. (Updated docstring)
  - `test_specific_teacher_to_notify_other_teacher`: verifies that a teacher set as `specific_teacher_to_notify` (but not the student’s current teacher) sees the submission in their "Approvals" tab without being notified. (Updated test)

### Why?

Previously, a `specific_teacher_to_notify` could receive a notification even if the quest submission already appeared in their "Approvals" tab. This was redundant and potentially noisy, especially for teachers already managing their review queue. The logic has now been tightened so that:

- Teachers who will see a submission in "Approvals" won’t be notified separately.

Resolves [issue #699](https://github.com/bytedeck/bytedeck/issues/699)

### How?

- Removed the code path that sends a notification to `specific_teacher_to_notify` if they are not the student's teacher.
- Updated the related test to explicitly assert both notification absence **and** presence in the appropriate approval list (`QuestSubmission.objects.all_awaiting_approval(teacher=...)`).
- Improved docstrings in test methods for clarity and maintainability.

### Testing?

- Updated test suite passes.
- Tests cover:
  - Submission visibility in the approvals tab.
  - Absence of unnecessary notifications.

### Screenshots (if front end is affected)

<details>
<summary>Has Before and After screenshots</summary>

I was testing to see if the code I was looking at was actually the code that sent the notification so I wanted both a before and after. I got lucky it was documented so well.

### Before:
![Image](https://github.com/user-attachments/assets/0de6e40d-ce87-4fc1-8783-895a0bd29d1b)

### After:
![Image](https://github.com/user-attachments/assets/8a87ce68-cc38-4ef5-ad71-36b4343302d9)

</details>

### Anything Else?

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted notification behavior so that specific teachers set to be notified for a quest will no longer receive duplicate notifications if the submission already appears in their "Approvals" tab.
  * Ensured that only relevant teachers see submissions in their "Approvals" tab without receiving unnecessary notifications.

* **Tests**
  * Improved test coverage and clarity for notification scenarios involving specific teachers and approval visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->