### PR TITLE
Fix: importing a single quest with campaign deactivates campaign; Closes #1810

### DIFF
--- a/src/library/importer.py
+++ b/src/library/importer.py
@@ -1,19 +1,31 @@
 from django_tenants.utils import schema_context
 from quest_manager.admin import QuestResource
-from quest_manager.models import Quest
+from quest_manager.models import Quest, Category
 
 from .utils import library_schema_context
 
 
 def import_quests_to(*, destination_schema, quest_import_ids):
     """
-    :param destination_schema: schema to import the quest to
-    :param quest_import_ids: list of quest import ids
+    Imports one or more quests from the library schema into the given destination schema.
+
+    Automatically sets imported quests to not be visible to students, and deactivates
+    the associated campaign if one is present.
+
+    Args:
+        destination_schema (str): The schema to import the quests into.
+        quest_import_ids (list): A list of quest import UUIDs to import.
     """
 
     with library_schema_context():
         quests = Quest.objects.select_related('campaign').filter(visible_to_students=True, import_id__in=quest_import_ids)
         export_data = QuestResource().export(quests)
+
+        # Grab the campaign's import_id from the first quest (if present)
+        campaign_import_id = None
+        first_quest = quests.first()
+        if first_quest and first_quest.campaign:
+            campaign_import_id = first_quest.campaign.import_id
 
     dry_run = False
     with schema_context(destination_schema):
@@ -26,5 +38,9 @@ def import_quests_to(*, destination_schema, quest_import_ids):
         # Set visible_to_students to False for imported quests
         # since the imported quests will be orphans
         Quest.objects.filter(pk__in=object_ids).update(visible_to_students=False)
+
+        # Deactivate related campaign if one exists
+        if campaign_import_id:
+            Category.objects.filter(import_id=campaign_import_id).update(active=False)
 
     return res

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -191,6 +191,12 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         # Ensure that the newly imported quest is not visible to students
         self.assertFalse(quest_qs.get().visible_to_students)
 
+        # Check that the campaign is imported
+        imported_campaign = Category.objects.filter(import_id=campaign.import_id).first()
+        self.assertIsNotNone(imported_campaign)
+        # Check that the campaign is deactivated
+        self.assertFalse(imported_campaign.active)
+
     def test_side_bar_library_drop_down(self):
         """Checks if library drop down is available when siteconfig.enable_shared_library is true"""
         staff = baker.make(User, is_staff=True)

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -178,6 +178,4 @@ def import_campaign(request, campaign_import_id):
             import_quests_to(destination_schema=dest_schema, quest_import_ids=quest_ids)
             messages.success(request, f"Successfully imported '{category.name}' to your deck.")
 
-        # Set the campaign to inactive after importing
-        local_category_qs.update(active=False)
     return redirect('quest_manager:categories_inactive')


### PR DESCRIPTION
removed reduntant deactivate call from view

added test functionality for importing a single quest with campaign

Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fix quest import logic to ensure that any associated campaign is also deactivated when importing a single quest from the library. Also adds test coverage to validate this behavior.

### Why?

Previously, importing a quest did not consistently deactivate the associated campaign if it was brought over during the import process. This could lead to imported quests being associated with active campaigns that should be made inactive by default. Campaigns are supposed to be inactive until explicitly enabled after being imported.

[Issue #1810](https://github.com/bytedeck/bytedeck/issues/1810)

### How?

- Updated `import_quests_to()` to ensure the related campaign (if present) is properly looked up and deactivated.
- Ensured only one campaign is checked, since only one campaign should exist per quest.
- Extended the `test_import_quest_to_current_deck()` test to assert that the related campaign is inactive after importing a quest with one.

### Testing?

- Added an assertion to check that the imported campaign's `active` field is `False`.
- Verified the existing import scenarios still pass (nonexistent import ID, duplicate import, and successful import).

### Screenshots (if front end is affected)

#### Importing a single quest that has a campaign
https://github.com/user-attachments/assets/f5c6de3a-b336-42b2-8110-afa8dda8dc7b

#### Importing a campaign with multiple quests (making sure functionality stays the same)
https://github.com/user-attachments/assets/dd780d9a-ddfe-45a2-a208-94d4d8f4f61f


### Anything Else?

### Review request
@tylerecouture
