### PR TITLE
Library cbv update; Closes #1813

### DIFF
--- a/src/library/urls.py
+++ b/src/library/urls.py
@@ -4,8 +4,8 @@ from library import views
 app_name = 'library'
 
 urlpatterns = [
-    path('quests-list/', views.quests_library_list, name='quest_list'),
-    path('campaign-list/', views.campaigns_library_list, name='category_list'),
-    path('import-campaign/<uuid:campaign_import_id>/', views.import_campaign, name='import_category'),
-    path('import-quest/<uuid:quest_import_id>/', views.import_quest_to_current_deck, name='import_quest'),
+    path('quests-list/', views.LibraryQuestListView.as_view(), name='quest_list'),
+    path('campaign-list/', views.LibraryCampaignListView.as_view(), name='category_list'),
+    path('import-campaign/<uuid:campaign_import_id>/', views.ImportCampaignView.as_view(), name='import_category'),
+    path('import-quest/<uuid:quest_import_id>/', views.ImportQuestView.as_view(), name='import_quest'),
 ]


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Refactors library views to use class-based views (CBVs) instead of function-based views.

### Why?

https://github.com/bytedeck/bytedeck/issues/1813

### How?

- Replaced function-based views with the following CBVs:
  - `LibraryQuestListView` (replaces quest list view)
  - `LibraryCampaignListView` (replaces campaign list view)
  - `ImportQuestView` (handles single quest import via GET + POST)
  - `ImportCampaignView` (handles full campaign import via GET + POST)
- Applied `@method_decorator` for `login_required` and `staff_member_required` to enforce access control on all CBVs.
- Moved all rendering and context-building logic into the appropriate class methods (`get_context_data`, `get`, `post`).
- Kept template names and route behavior consistent to avoid regressions.

### Testing?

- Manually tested all affected views in the browser with various permission levels and schema contexts.
- Verified:
  - Quest and campaign listings load from the shared library.
  - Import confirmation screens display correctly.
  - Import actions function and redirect as expected.
- Existing tests for these views were already comprehensive and still pass.

### Screenshots (if front end is affected)

_No visual changes were made; behavior remains identical._

### Anything Else?

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated quest and campaign list and import pages to use a more robust and maintainable structure.
  * Improved separation of page display and import actions for quests and campaigns.
  * Enhanced error handling and consistency when importing quests or campaigns.
  * No changes to URLs or user-facing page layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->