### PR TITLE
Campaign information fix; Closes #1801

### DIFF
--- a/src/library/views.py
+++ b/src/library/views.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
 from django.db import connection
-from django.db.models import Count, Sum, Q
 from django.contrib.auth.decorators import login_required
 from hackerspace_online.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.db import connection
+from django.db.models import Count, Sum, Q
 from django.contrib.auth.decorators import login_required
 from hackerspace_online.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?  
Updated the existing `CategoryManager.all_active_with_importable_quests` method by:
- Adding a new annotation `xp_sum` to sum the XP of importable quests (quests visible to students and not archived).
- Renaming `current_quest_count` to `quest_count` to match usage in the template.

Also added tests to verify the correctness of these annotations and to ensure only active campaigns with importable quests are returned.

### Why?  
The `xp_sum` annotation enables the UI to show the total XP for a campaign’s importable quests without additional queries.

Renaming the quest count field helps standardize naming in both the code and the template.

https://github.com/bytedeck/bytedeck/issues/1801

### How?  
- Annotated the queryset in `all_active_with_importable_quests` with `quest_count` and `xp_sum`, both filtered to only include quests that are visible to students and not archived.  
- Added tests covering various quest states (archived, invisible, inactive campaigns).  
- Added cleanup steps in tests to prevent cross-test contamination in the shared library schema.

### Testing?  
- Confirmed all tests pass.  
- Validated behavior across a variety of quest visibility/archive/campaign activity combinations.

### Screenshots (if front end is affected)  
<img width="947" height="872" alt="image" src="https://github.com/user-attachments/assets/db26d70e-d6b8-40f2-9424-d37302844c7d" />

### Anything Else?  
None.



### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and clarity of campaign listings by ensuring only active campaigns with at least one visible, non-archived quest are shown, along with correct quest counts and XP totals.

* **Tests**
  * Added comprehensive tests to verify correct filtering and annotation of campaigns with importable quests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->