### PR TITLE
Library import message update; Closes #1817

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1,5 +1,6 @@
 import uuid
 from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
 from django.db import connection
 from django.urls import reverse
 from django_tenants.test.cases import TenantTestCase
@@ -191,6 +192,16 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         # Ensure that the newly imported quest is not visible to students
         self.assertFalse(quest_qs.get().visible_to_students)
 
+        # Ensure the success message includes a link to the imported quest
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        message = messages[0].message
+
+        imported_quest = quest_qs.get()
+        expected_link = f'<a href="{imported_quest.get_absolute_url()}">{imported_quest.name}</a>'
+
+        self.assertIn(expected_link, message)
+
     def test_quest_library_list__shows_correct_badge_count(self):
         """
         Ensure the quests tab displays the correct badge count for active quests.
@@ -317,6 +328,15 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
 
         # all imported quests should be inactive for this campaign
         self.assertEqual(imported_library_campaign.quest_set.filter(visible_to_students=False).count(), 3)
+
+        # Assert that the success message includes a link to the imported campaign
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        message = messages[0].message
+
+        expected_link = f'<a href="{imported_library_campaign.get_absolute_url()}">{imported_library_campaign.name}</a>'
+
+        self.assertIn(expected_link, message)
 
     def test_campaigns_tab__shows_correct_badge_count(self):
         """

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -252,11 +252,10 @@ class ImportCampaignView(View):
             # Collect import IDs for all quests in the campaign
             # Inactive quests are filtered out by the importer
             quest_ids = list(category.quest_set.values_list('import_id', flat=True))
-            link = f'<a href="{category.get_absolute_url()}">{category.name}</a>'
             # Use dest_schema because current schema is library
             import_quests_to(destination_schema=dest_schema, quest_import_ids=quest_ids)
 
-        # Show a message with a link to the imported campiagn
+        # Show a message with a link to the imported campaign
         category = get_object_or_404(Category, import_id=campaign_import_id)
         link = f'<a href="{category.get_absolute_url()}">{category.name}</a>'
         messages.success(request, f"Successfully imported '{link}' to your deck.")

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -170,7 +170,11 @@ class ImportQuestView(View):
             quest = get_object_or_404(Quest, import_id=quest_import_id)
             # Use dest_schema because current schema is library
             import_quests_to(destination_schema=dest_schema, quest_import_ids=[quest.import_id])
-            messages.success(request, f"Successfully imported '{quest.name}' to your deck.")
+
+        # Show a message with a link to the imported quest
+        quest = get_object_or_404(Quest, import_id=quest_import_id)
+        link = f'<a href="{quest.get_absolute_url()}">{quest.name}</a>'
+        messages.success(request, f"Successfully imported '{link}' to your deck.")
 
         return redirect('quests:drafts')
 
@@ -248,9 +252,14 @@ class ImportCampaignView(View):
             # Collect import IDs for all quests in the campaign
             # Inactive quests are filtered out by the importer
             quest_ids = list(category.quest_set.values_list('import_id', flat=True))
+            link = f'<a href="{category.get_absolute_url()}">{category.name}</a>'
             # Use dest_schema because current schema is library
             import_quests_to(destination_schema=dest_schema, quest_import_ids=quest_ids)
-            messages.success(request, f"Successfully imported '{category.name}' to your deck.")
+
+        # Show a message with a link to the imported campiagn
+        category = get_object_or_404(Category, import_id=campaign_import_id)
+        link = f'<a href="{category.get_absolute_url()}">{category.name}</a>'
+        messages.success(request, f"Successfully imported '{link}' to your deck.")
 
         # Make the campaign inactive post-import
         # The quests are made inactive by the importer


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Adds clickable links to the success messages shown after importing a quest or campaign from the shared library. Updates the associated test cases to verify that these links are present in the messages.

### Why?

Previously, the success messages confirmed the import but didn’t give users a direct way to access the imported quest or campaign. Adding links improves usability and clarity.

The message logic already existed — this change enhances it by embedding links, and adds corresponding tests to verify the link rendering.

https://github.com/bytedeck/bytedeck/issues/1817

### How?

- Updated `ImportQuestView` and `ImportCampaignView` to wrap the quest/campaign name in an `<a>` tag using `.get_absolute_url()`.
- Updated tests for successful quest and campaign import:
  - Retrieved Django messages from the response.
  - Used `assertIn()` to check that the expected `<a>` tag is included in the message.

### Testing?

- `test_import_quest_to_current_deck` now checks that the message contains a link to the newly imported quest.
- `test_import_campaign__success` now checks that the message contains a link to the imported campaign.

All tests pass locally.

### Screenshots (if front end is affected)

<img width="479" height="76" alt="image" src="https://github.com/user-attachments/assets/b2b167c5-c527-4261-9844-d466375d5316" />

<img width="441" height="68" alt="image" src="https://github.com/user-attachments/assets/ffc9d35c-d899-472f-8bc9-8788f70ada36" />


### Anything Else?

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Success messages after importing quests or campaigns now include clickable links to the detail pages of the imported items.

* **Tests**
  * Enhanced tests to verify that success messages after imports contain direct links to the newly imported quests or campaigns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->