### PR TITLE
Library quest tab badge number fix; Closes #1829

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -197,12 +197,16 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         """
         self.client.force_login(self.test_teacher)
         with library_schema_context():
-            # Get the correct quest count
+            # Get the correct quest and campaign count
             quest_count = Quest.objects.get_active().count()
+            campaign_count = Category.objects.all_active_with_importable_quests().count()
+
         url = reverse('library:quest_list')
         response = self.client.get(url)
-        # The badge should show the correct quest count
+
+        # The badges should show the correct quest count
         self.assertContains(response, f'<span class="badge">{quest_count}</span>', html=True)
+        self.assertContains(response, f'<span class="badge">{campaign_count}</span>', html=True)
 
     def test_library_sidebar__shown_if_shared_library_enabled(self):
         """
@@ -324,11 +328,15 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         """
         self.client.force_login(self.test_teacher)
         with library_schema_context():
-            # get the correct campiagn count
+            # get the correct quest and campiagn count
+            quest_count = Quest.objects.get_active().count()
             campaign_count = Category.objects.all_active_with_importable_quests().count()
+
         url = reverse('library:category_list')
         response = self.client.get(url)
-        # The badge should show the correct campaign count
+
+        # The badges should show the correct campaign count
+        self.assertContains(response, f'<span class="badge">{quest_count}</span>', html=True)
         self.assertContains(response, f'<span class="badge">{campaign_count}</span>', html=True)
 
     def test_campaigns_tab__only_shows_library_campaigns(self):

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -47,7 +47,7 @@ class LibraryQuestListView(TemplateView):
             # this forces all quests to load.
             quests = Quest.objects.get_active().select_related('campaign').prefetch_related('tags')
             num_quests = len(quests)
-            num_campaigns = Category.objects.filter(active=True).count()
+            num_campaigns = Category.objects.all_active_with_importable_quests().count()
 
         context.update({
             'heading': 'Library',


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Updated the badge count logic and associated tests in both the quest and campaign library views.

### Why?

The badge numbers displayed in the UI tabs for "Quests" and "Campaigns" should reflect only currently importable content. Previously:
- The quest view used `Category.objects.filter(active=True).count()` for the campaign count, which could include campaigns with no importable quests.
- Tests only checked the relevant badge for their tab, potentially missing mismatches in the other.

### How?

- In `LibraryQuestListView`, updated the context to use `Category.objects.all_active_with_importable_quests().count()` instead of counting all active categories.
- Modified `test_quest_library_list__shows_correct_badge_count` to also assert the campaign badge number.
- Modified `test_campaigns_list__shows_correct_badge_count` to also assert the quest badge number.

### Testing?

- Ran the updated test suite to confirm both views display the correct badge counts.
- Verified the counts match what’s expected from the library schema using forced evaluation via `len()` inside `library_schema_context`.

### Screenshots (if front end is affected)

<img width="1070" height="274" alt="image" src="https://github.com/user-attachments/assets/9a07f466-a58a-419d-947a-7d503c94682d" />
<img width="1088" height="260" alt="image" src="https://github.com/user-attachments/assets/fec58e14-a997-4c70-8e41-344153b1025a" />


### Anything Else?


### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the badge counts on the quests and campaigns tabs to accurately display both the number of active quests and the number of active campaigns with importable quests.

* **Tests**
  * Updated tests to verify that both quest and campaign badge counts are shown correctly in the library views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->