### PR TITLE
importing now searches all local quests including archived; Closes #1834

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -144,14 +144,34 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         # import_id already on the current deck
         # TODO: When we add an overwrite feature, this quest will need to be modified to test that feature
 
-        # Create a quest in the local test schema
+        # Create quests in the local test schema with varying states
         quest = baker.make(Quest)
+        quest_2 = baker.make(Quest, visible_to_students=False)
+        quest_3 = baker.make(Quest, archived=True)
 
-        # create a quest in the library schema with same import_id
+        # create quests in the library schema with same import_ids
         with library_schema_context():
             library_quest = baker.make(Quest, import_id=quest.import_id)
+            library_quest_2 = baker.make(Quest, import_id=quest_2.import_id)
+            library_quest_3 = baker.make(Quest, import_id=quest_3.import_id)
 
         url = reverse('library:import_quest', args=[library_quest.import_id])
+
+        # Check that it sends you to the confrimation page with
+        self.assertContains(
+            self.client.get(url),
+            'Your deck already contains a quest with a matching Import ID'
+        )
+
+        url = reverse('library:import_quest', args=[library_quest_2.import_id])
+
+        # Check that it sends you to the confrimation page with
+        self.assertContains(
+            self.client.get(url),
+            'Your deck already contains a quest with a matching Import ID'
+        )
+
+        url = reverse('library:import_quest', args=[library_quest_3.import_id])
 
         # Check that it sends you to the confrimation page with
         self.assertContains(

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -127,8 +127,19 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
 
     def test_import_quest_to_current_deck(self):
         """
-        Add tests that check if the import quest to current deck view works.
-        2 tests where the quest doesn't import and 1 test of a quest succeeding to import
+        Tests the quest import view for various scenarios:
+
+        - Case 1: Fails to import a non-existent quest (invalid import_id).
+        - Case 2: Fails to import a quest that already exists locally in one of three states:
+            a) Published and active
+            b) Unpublished
+            c) Archived
+        In all cases, the import is blocked and a confirmation message is shown.
+        - Case 3: Successfully imports a new library quest that does not yet exist on the local deck.
+        Verifies:
+            - The quest is added to the local schema.
+            - It is not immediately visible to students.
+            - A success message with a link to the imported quest is displayed.
         """
         self.client.force_login(self.test_teacher)
 
@@ -144,7 +155,10 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         # import_id already on the current deck
         # TODO: When we add an overwrite feature, this quest will need to be modified to test that feature
 
-        # Create quests in the local test schema with varying states
+        # Create quests in the local test schema
+        # First is a published quest that's not archived
+        # Second is a quest that's not published also not archived
+        # Third is a quest that's archived
         quest = baker.make(Quest)
         quest_2 = baker.make(Quest, visible_to_students=False)
         quest_3 = baker.make(Quest, archived=True)
@@ -155,6 +169,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
             library_quest_2 = baker.make(Quest, import_id=quest_2.import_id)
             library_quest_3 = baker.make(Quest, import_id=quest_3.import_id)
 
+        # Published quest
         url = reverse('library:import_quest', args=[library_quest.import_id])
 
         # Check that it sends you to the confrimation page with
@@ -163,6 +178,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
             'Your deck already contains a quest with a matching Import ID'
         )
 
+        # Unpublished quest
         url = reverse('library:import_quest', args=[library_quest_2.import_id])
 
         # Check that it sends you to the confrimation page with
@@ -171,6 +187,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
             'Your deck already contains a quest with a matching Import ID'
         )
 
+        # Archived quest
         url = reverse('library:import_quest', args=[library_quest_3.import_id])
 
         # Check that it sends you to the confrimation page with

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -133,7 +133,7 @@ class ImportQuestView(View):
                 - quest: The quest from the shared library.
                 - local_quest: The local quest with a matching import_id, if one exists.
         """
-        # Check for local existence to warn the user before importing
+        # Look for a matching local quest (even if archived) to show a warning if it already exists
         local_quest = Quest.objects.all_including_archived().filter(import_id=quest_import_id).first()
 
         # Fetch the quest from the shared library
@@ -142,6 +142,7 @@ class ImportQuestView(View):
 
         return render(request, self.template_name, {
             'quest': quest,
+            # A Quest from the local deck matching the import_id, or None if not found.
             'local_quest': local_quest,
         })
 

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -134,7 +134,7 @@ class ImportQuestView(View):
                 - local_quest: The local quest with a matching import_id, if one exists.
         """
         # Check for local existence to warn the user before importing
-        local_quest = Quest.objects.filter(import_id=quest_import_id).first()
+        local_quest = Quest.objects.all_including_archived().filter(import_id=quest_import_id).first()
 
         # Fetch the quest from the shared library
         with library_schema_context():
@@ -163,7 +163,7 @@ class ImportQuestView(View):
         dest_schema = connection.schema_name
 
         # Block import if the quest already exists locally (shouldn't happen because import button would be disabled)
-        if Quest.objects.filter(import_id=quest_import_id).exists():
+        if Quest.objects.all_including_archived().filter(import_id=quest_import_id).exists():
             raise PermissionDenied(f'Quest with import_id {quest_import_id} already exists in the current deck.')
 
         with library_schema_context():


### PR DESCRIPTION
added tests for finding a local quest in various states

Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

This PR fixes a bug where archived quests on the local deck were not being detected during library import, resulting in a confusing UX where clicking “Import” appeared to do nothing.  
The fix ensures archived quests are included in the lookup when checking if a quest has already been imported.

### Why?

Previously, when a user archived an imported quest and tried to re-import the same quest from the library, the system failed to detect the existing (archived) quest.  
This allowed the "Import" button to appear active but did nothing on click, leading to an error.  
We now include archived quests in this lookup so users aren't allowed to import duplicates — even if archived.

https://github.com/bytedeck/bytedeck/issues/1834

### How?

- Updated `Quest.objects.filter(...)` to `Quest.objects.all_including_archived().filter(...)` in the relevant library import views.
- Ensures the check for existing quests includes archived ones.

### Testing?

Added test cases that:
- Create local quests in all three states: visible, invisible (draft), and archived.
- Create corresponding library quests with matching `import_id`s.
- Confirm that attempting to import any of the matching library quests (even if the local one is archived) results in a message:  
  `'Your deck already contains a quest with a matching Import ID'`.

### Screenshots (if front end is affected)

N/A

### Anything Else?


### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import checks to prevent importing quests with matching IDs, including archived and unpublished quests.

* **Tests**
  * Expanded test coverage to verify import restrictions and user notifications for quests in various states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->