### PR TITLE
Changelog now references the right issue for Add rate limit 429 error page; Closes #1825

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This file chronologically records all notable changes to this website, including
  - Avatar styling on profile page [#822](https://github.com/bytedeck/bytedeck/issues/822)
 * Refactor/Optimizations:
 * Bugfixes:
- - Add rate limit 429 error page [#1776](https://github.com/bytedeck/bytedeck/issues/1776)
+ - Add rate limit 429 error page [#1766](https://github.com/bytedeck/bytedeck/issues/1766)
  - Handle empty 'XP Requested' field [#1561](https://github.com/bytedeck/bytedeck/issues/1561)
  - Add blank values for Quests in Campaign and Total XP available on Campaign detail view [#1748](https://github.com/bytedeck/bytedeck/issues/1748)
  - Fix user access to the Library tab.  Only authenticated staff can access [#1789](https://github.com/bytedeck/bytedeck/issues/1789)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Changed
```
 - Add rate limit 429 error page [#1776](https://github.com/bytedeck/bytedeck/issues/1776)
```
To
```
 - Add rate limit 429 error page [#1766](https://github.com/bytedeck/bytedeck/issues/1766)
```
### Why?
So that it references the right issue
### How?
### Testing?
Clicked the link to make sure it  was the right one
### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the issue number for the rate limit 429 error page bugfix in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->