### PR TITLE
Disable category delete; Closes #1824

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_confirm_delete.html
+++ b/src/quest_manager/templates/quest_manager/category_confirm_delete.html
@@ -4,13 +4,22 @@
 {% block heading %}<i class="fa fa-compass pull-right"></i>{% block heading_inner %}Delete Campaign {% endblock %}{% endblock %}
 
 {% block content %}
-<form action="" method="post">{% csrf_token %}
-  <p>Are you sure you want to delete this campaign?<p>
+<form action="{% url 'quests:category_delete' object.id %}" method="post">{% csrf_token %}
+  <p>Are you sure you want to delete this campaign?</p>
   <div class="well">
     <p>Campaign Name: {{object.title}}</p>
     <p>Campaign ID: {{object.id}}</p>
   </div>
   <a href="{% url 'quests:categories'%}" role="button" class="btn btn-info">Cancel</a>
-  <input type="submit" value="Delete" class="btn btn-danger" />
+  <input
+    type="submit"
+    value="Delete"
+    class="btn btn-danger"
+    {% if object.quest_count != 0 %}
+      disabled
+      aria-disabled="true"
+      title="Can't delete a campaign that has published quests; you must unpublish or delete all quests in the campaign first"
+    {% endif %}
+  />
 </form>
 {% endblock %}


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

This PR enhances the existing `CategoryDelete` class-based view by adding safeguards to prevent deletion of campaigns (categories) that contain published quests.  
It also updates the delete confirmation template to disable the delete button with a tooltip when published quests exist.  
Tests were modified to verify that these deletion restrictions are properly enforced.

### Why?

Previously, the `CategoryDelete` view allowed deletion of campaigns even if they contained published quests, which could cause data integrity issues.  
Disabling the delete button on the `category_confirm_delete.html` and adding a tooltip informs users upfront why deletion is restricted.

https://github.com/bytedeck/bytedeck/issues/1824

### How?

- Added `post()` and overridden `delete()` methods in the existing `CategoryDelete` view to check for published quests before allowing deletion.  
- If published quests exist, the delete is blocked, an error message is shown, and the user is redirected.  
- The delete confirmation template disables the delete button and adds a tooltip if the campaign has published quests.  
- Updated tests to confirm that campaigns with published quests cannot be deleted while empty campaigns can be.

### Testing?

- Automated tests verify deletion is blocked for campaigns with published quests.  
- Confirmed deletion succeeds for empty campaigns.  
- Manual testing validated the disabled button and tooltip display in the UI.

### Screenshots (if front end is affected)

<img width="1124" height="495" alt="image" src="https://github.com/user-attachments/assets/6b2d0dd8-cea0-42dd-b290-7688822d694a" />

### Anything Else?

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deletion of campaigns is now prevented if the campaign contains any published quests. Users will see a disabled delete button with an explanatory tooltip in such cases.

* **Bug Fixes**
  * Improved user feedback and accessibility when attempting to delete campaigns with published quests.
  * Added server-side validation to block deletion if published quests exist, handling race conditions gracefully.

* **Tests**
  * Expanded test coverage to verify that campaigns with published quests cannot be deleted, while empty campaigns can be deleted successfully.
  * Added tests for race condition scenarios to ensure deletion is correctly blocked when quests become published during the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->