### PR TITLE
Trigger map regeneration on update; Closes #1739

### DIFF
--- a/src/djcytoscape/views.py
+++ b/src/djcytoscape/views.py
@@ -53,6 +53,11 @@ class ScapeUpdate(NonPublicOnlyViewMixin, UpdateView):
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        self.object.regenerate()
+        return response
+
 
 @method_decorator(staff_member_required, name='dispatch')
 class ScapeDelete(NonPublicOnlyViewMixin, DeleteView):


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Triggers automatic regeneration of a CytoScape map whenever it is updated through the `ScapeUpdate` view.  
Adds a test to ensure `regenerate()` is called on successful update.

### Why?

Previously, updates to a map did not guarantee that the visual representation was refreshed.  
This ensures that any change immediately reflects in the rendered output.

https://github.com/bytedeck/bytedeck/issues/1739

### How?

- Called `self.object.regenerate()` in `form_valid` of `ScapeUpdate` view.
- Updated `test_ScapeUpdateView__POST` to mock and assert `regenerate()` is called.

### Testing?

Covered by `test_ScapeUpdateView__POST`, which now verifies the `regenerate()` call after a successful form submission.

### Screenshots (if front end is affected)

**BEFORE**

https://github.com/user-attachments/assets/40172424-fae3-42ab-b9e0-94cffb4c6ca7


**AFTER**

https://github.com/user-attachments/assets/f27b6f3b-8f30-48b2-a605-f0d659e37094



### Anything Else?


### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * After updating a map, the system now automatically regenerates the map to reflect changes immediately.

* **Tests**
  * Improved tests to verify that map regeneration is triggered after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->