### PR TITLE
Stabilize notification test suite by fixing outdated test data

### DIFF
--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from djcytoscape.models import CytoScape
 
+from profile_manager.models import Profile
 from hackerspace_online.tests.utils import ViewTestUtilsMixin, generate_form_data
 
 User = get_user_model()
@@ -25,6 +26,10 @@ class ViewTests(ViewTestUtilsMixin, TenantTestCase):
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         self.test_teacher = User.objects.create_user('test_teacher', password=self.test_password, is_staff=True)
         self.test_student1 = User.objects.create_user('test_student', password=self.test_password)
+
+        # Ensure profiles exist without duplicating them (in case a signal already created them)
+        Profile.objects.get_or_create(user=self.test_teacher)
+        Profile.objects.get_or_create(user=self.test_student1)
 
         self.map = baker.make('djcytoscape.CytoScape')
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Fixes intermittent notification test failures caused by stale test data persisting across test runs.

### Why?

Although the renamed model fields were unrelated to notifications, leftover database state was causing notification tests to fail unpredictably in CI but not locally, leading to false negatives.

### How?

- Updated test setup to ensure notification-related data is cleanly created and isolated per test.
- Removed dependencies on stale or leftover data that could cause inconsistencies.
- Confirmed notification tests align with current database state.

### Testing?

- Verified notification creation and string representation tests behave as expected locally.

### Screenshots (if front end is affected)

### Anything Else?


### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated notification model tests to explicitly create notification instances within each test, improving clarity and test isolation.
  * Ensured user profiles exist for test users in view tests to prevent duplicate profile creation and improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->