### PR TITLE
feat: add ability to publish a campaign and all its quests; Closes #1843

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -19,6 +19,15 @@
                 <i class="fa fa-edit"></i>
             </a>
 
+            {% if not object.published %}
+                <form method="post" action="{% url 'quests:category_publish' object.id %}" class="preview-action-form">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-success" title="Publish Campaign and all its Quests">
+                        <i class="fa fa-upload"></i>
+                    </button>
+                </form>
+            {% endif %}
+
             <a class="btn btn-danger"
                 {% if object.quest_count != 0 %}
                     disabled

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -97,6 +97,7 @@ urlpatterns = [
     path('campaigns/inactive/', views.CategoryList.as_view(), name='categories_inactive'),
     path('campaigns/add/', views.CategoryCreate.as_view(), name='category_create'),
     path('campaigns/<pk>/', views.CategoryDetail.as_view(), name='category_detail'),
+    path('campaigns/<int:pk>/publish/', views.CategoryPublish.as_view(), name='category_publish'),
     path('campaigns/<pk>/edit/', views.CategoryUpdate.as_view(), name='category_update'),
     path('campaigns/<pk>/delete/', views.CategoryDelete.as_view(), name='category_delete'),
 

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -192,6 +192,35 @@ class CategoryDelete(NonPublicOnlyViewMixin, DeleteView):
         return super().delete(request, *args, **kwargs)
 
 
+@method_decorator(staff_member_required, name='dispatch')
+class CategoryPublish(View):
+    http_method_names = ['post']
+
+    def post(self, request, pk):
+        """
+        Handle POST request to publish a campaign and all its associated quests.
+
+        Retrieves the Category by primary key (pk). Attempts to publish the campaign along
+        with all related quests using the model method `publish_with_quests()`. On success,
+        adds a success message linking to the campaign detail. On failure, adds an error message.
+
+        Finally, redirects the user to the campaigns list view.
+
+        Args:
+            request: The HTTP request object.
+            pk: Primary key of the campaign to publish.
+
+        Returns:
+            HttpResponseRedirect to the campaigns list page.
+        """
+        category = get_object_or_404(Category, pk=pk)
+        category.publish_with_quests()
+        link = f'<a href="{category.get_absolute_url()}">{category.title}</a>'
+        messages.success(request, f'Campaign "{link}" and all quests published.')
+
+        return redirect("quests:categories")
+
+
 class QuestDelete(NonPublicOnlyViewMixin, UserPassesTestMixin, UpdateMapMessageMixin, DeleteView):
     def test_func(self):
         return self.get_object().is_editable(self.request.user)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?  
Adds the ability for staff to publish a campaign and all quests within it in one action. Includes backend view, URL routing, template integration, styling, and test coverage.  

### Why?  
Previously, campaigns and quests had to be published individually. This was inefficient for staff. The new feature allows a single publish action at the campaign level, ensuring all related quests are published consistently.

https://github.com/bytedeck/bytedeck/issues/1843

### How?  
- Implemented `CategoryPublish` with staff-only permissions to set `published=True` on the campaign and all associated quests.  
- Added URL pattern for the new view.
- Updated campaign preview template to include a "Publish" button, styled inline with other preview actions.
- Created unpublished test data for accurate publish testing.

### Testing?  
- Unit tests added/updated in `test_views.py` to cover:  
  - Staff publishing a campaign and all associated quests.  
  - Button visibility for staff vs non-staff.  
  - Permission enforcement (403 for students).  
  - Preventing false positives by ensuring publish actually changes object states.  

### Screenshots (if front end is affected)  


### Anything Else?  
- No migrations
- Future improvement: support unpublishing at the campaign level in the same way.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff can publish a campaign and all its non-archived quests from the campaign detail page; a publish action and route are available.

* **Behavior**
  * Publishing runs atomically, shows a success message, and the publish button is hidden after use; archived quests remain unpublished.

* **Bug Fixes**
  * Publish action restricted to staff users (others receive forbidden).

* **Tests**
  * End-to-end tests for visibility, publish flow, archived-quest behavior, redirects, and access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->