### PR TITLE
Add export quest button; Closes #1848

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -372,8 +372,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         url = reverse('library:export_quest', args=[self.local_quest.import_id])
         response = self.client.post(url)
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('quests:drafts'))
+        self.assertRedirects(response, reverse('quests:quests'))
 
         with library_schema_context():
             exported_quest = Quest.objects.get(import_id=self.local_quest.import_id)

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -352,7 +352,7 @@ class ExportQuestView(View):
             quest_import_id (UUID): The import ID of the quest to export.
 
         Returns:
-            HttpResponseRedirect: Redirect to the drafts list after successful export.
+            HttpResponseRedirect: Redirect to the main quests list after successful export.
 
         Raises:
             PermissionDenied: If a quest with the same import ID already exists in the library.
@@ -392,7 +392,7 @@ class ExportQuestView(View):
         # Success message displayed on local deck
         link = f'<a href="{quest.get_absolute_url()}">{quest.name}</a>'
         messages.success(request, f"Successfully exported '{link}' to the shared library.")
-        return redirect('quests:drafts')
+        return redirect('quests:quests')
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')

--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -52,6 +52,12 @@
             title="Archive this quest" >
             <i class="fa fa-fw fa-archive"></i>
           </a>
+          {% if can_export %}
+            <a class="btn btn-default" href="{% url 'library:export_quest' q.import_id %}" role="button"
+              title="Export this quest to the Library">
+              <i class="fa fa-fw fa-upload"></i>
+            </a>
+          {% endif %}
           <a class="btn btn-danger" href="{% url 'quests:quest_delete' q.id %}" role="button"
             title = "Delete this quest" >
             <i class="fa fa-trash-o"></i>

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -31,6 +31,7 @@ from siteconfig.models import SiteConfig
 from comments.models import Comment
 from profile_manager.models import Profile
 from djcytoscape.models import CytoScape
+from library.utils import library_schema_context
 
 from datetime import datetime
 
@@ -2120,7 +2121,7 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, TenantTestCase):
         self.test_student = User.objects.create_user('test_student', password="password")
         self.client.force_login(self.test_student)
         self.quest = baker.make(Quest)
-        # self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
+        self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
 
     def test_get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
@@ -2161,6 +2162,59 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(type(response), JsonResponse)
+
+    def test_can_export_student_false(self):
+        """
+        Students should never see can_export=True in the rendered preview.
+        """
+        response = self.client.post(
+            reverse('quests:ajax_quest_info', args=[self.quest.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        html = data['quest_info_html']
+        # The export button is rendered only if can_export=True
+        self.assertNotIn('id="export-quest"', html)
+
+    def test_can_export_staff_true(self):
+        """
+        Staff should see can_export=True if allowed by site config and schema is not library.
+        """
+        site_config = SiteConfig.get()
+        site_config.allow_staff_export = True
+        site_config.full_clean()
+        site_config.save()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('quests:ajax_quest_info', args=[self.quest.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        data = response.json()
+        html = data['quest_info_html']
+        # There should be something in the HTML rendered only if can_export=True
+        self.assertIn('title="Export this quest to the Library"', html)
+
+    def test_can_export_false_on_library_schema(self):
+        """
+        When on the Library, should not be able to export to the Library
+        """
+        self.client.force_login(self.test_teacher)
+
+        with library_schema_context():
+            response = self.client.post(
+                reverse('quests:ajax_quest_info', args=[self.quest.id]),
+                content_type='application/json',
+                HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+            )
+            data = response.json()
+            html = data['quest_info_html']
+            self.assertNotIn('id="export-quest"', html)
 
 
 class AjaxApprovalInfoTest(ViewTestUtilsMixin, TenantTestCase):
@@ -2341,6 +2395,7 @@ class DetailViewTest(ViewTestUtilsMixin, TenantTestCase):
 
     def setUp(self):
         self.client = TenantClient(self.tenant)
+        self.test_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
         self.test_student = User.objects.create_user('test_student', password="password")
         self.client.force_login(self.test_student)
 
@@ -2399,6 +2454,35 @@ class DetailViewTest(ViewTestUtilsMixin, TenantTestCase):
 
         # Should redirect them to the submission's page
         self.assertRedirects(response, reverse('quests:submission', args=[sub.id]))
+
+    def test_can_export_in_detail_view(self):
+        """
+        Verify 'can_export' context variable is correctly set in quest detail view
+        for staff and students, and that it is disabled in the library schema.
+        """
+        # Make a staff user
+        self.client.force_login(self.test_teacher)
+
+        site_config = SiteConfig.get()
+        site_config.allow_staff_export = True
+        site_config.full_clean()
+        site_config.save()
+
+        # Staff user in a normal tenant schema
+        response = self.client.get(reverse('quests:quest_detail', args=[self.quest.id]))
+        self.assertEqual(response.status_code, 200)
+
+        # Should be in the context
+        self.assertIn('can_export', response.context)
+
+        # Since staff and export allowed, should be True
+        self.assertTrue(response.context['can_export'])
+
+        # Now test as normal student
+        self.client.force_login(self.test_student)
+        response = self.client.get(reverse('quests:quest_detail', args=[self.quest.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['can_export'])
 
 
 class ApproveViewTest(ViewTestUtilsMixin, TenantTestCase):


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added an export quest button that is only visible to authorized users outside the library schema. This button allows exporting quests to the shared library.

### Why?
To ensure only users with proper permissions—either the deck owner or staff when allowed—can export quests. Also, to prevent showing the export button when browsing quests already in the library schema.

https://github.com/bytedeck/bytedeck/issues/1848

### How?
- Created a `can_export` template tag that checks if the current user can export based on site config and deck ownership.
- Updated quest templates to conditionally render the export button using the `can_export` tag.
- Added logic to hide the button when the current schema is the library schema.

### Testing?
- Verified the export button appears for the deck owner and staff (if allowed) on non-library schemas.
- Verified the export button is hidden when viewing quests in the library schema.
- Manual tests clicking the export button confirm correct routing and permissions.

### Screenshots (if front end is affected)
<img width="1466" height="680" alt="image" src="https://github.com/user-attachments/assets/9161d612-159a-4a02-8fca-d93f9a0430c6" />
<img width="1472" height="674" alt="image" src="https://github.com/user-attachments/assets/1beb18a6-c185-4d96-9d34-a3d58bc2c55c" />
<img width="1118" height="624" alt="image" src="https://github.com/user-attachments/assets/cae9e473-e882-4b19-a511-d59f27076b6b" />
<img width="1342" height="698" alt="image" src="https://github.com/user-attachments/assets/ff6230f8-fd9b-4f0e-957d-f60e8d4ee996" />
<img width="1487" height="542" alt="image" src="https://github.com/user-attachments/assets/770aaaa4-c4d2-4029-a2dd-d5750a24af12" />


### Anything Else?
Draft quests can still be exported at this time, I was unsure if we wanted to allow that or not. Do we want the templatetag check if the quest already exists on the library as well? They won't be able to export either way.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an “Export this quest to the Library” button for eligible users, visible outside the Library view and placed alongside existing actions.

- Bug Fixes
  - After exporting, users are redirected to the main Quests list (instead of drafts).

- Tests
  - Expanded tests to verify export button visibility, can_export behavior across roles and schema contexts, and the updated redirect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->