### PR TITLE
Add auto-incrementing next weekday to excluded dates formset on add; Closes #1419

### DIFF
--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -65,17 +65,64 @@
     const formInitialForms = document.getElementById("id_form-INITIAL_FORMS");
     const initialForms = parseInt(formInitialForms.getAttribute("value"))-1;
 
+    // Parse date string as local date to avoid timezone issues
+    function parseLocalDate(dateStr) {
+        const [year, month, day] = dateStr.split('-').map(Number);
+        return new Date(year, month - 1, day);  // months are zero-based
+    }
+
+    function getNextWeekday(date) {
+        const d = new Date(date);
+        do {
+            d.setDate(d.getDate() + 1);
+        } while (d.getDay() === 0 || d.getDay() === 6); // skip Sunday(0) and Saturday(6)
+        return d;
+    }
+
     function AddForm() {
         // management form change data
         var totalForms = parseInt(formTotalForms.getAttribute("value"));
-        formTotalForms.setAttribute("value", totalForms+1);
 
-        // replace add button of second last el with remove button
+        // find last visible form's date and label
+        let lastDateInput = null;
+        let lastLabelInput = null;
+        for (let i = totalForms - 1; i >= 0; i--) {
+            const dateInput = document.querySelector(`#id_form-${i}-date`);
+            const labelInput = document.querySelector(`#id_form-${i}-label`);
+            if (dateInput && dateInput.closest(`#form-${i}-container`).style.display !== 'none') {
+                lastDateInput = dateInput;
+                lastLabelInput = labelInput;
+                break;
+            }
+        }
+
+        // determine next date
+        let nextDateStr = '';
+        if (lastDateInput && lastDateInput.value) {
+            const lastDate = parseLocalDate(lastDateInput.value);
+            if (lastDate) {
+                const nextDate = getNextWeekday(lastDate);
+                const yyyy = nextDate.getFullYear();
+                const mm = String(nextDate.getMonth() + 1).padStart(2, '0');
+                const dd = String(nextDate.getDate()).padStart(2, '0');
+                nextDateStr = `${yyyy}-${mm}-${dd}`;
+            }
+        }
+
+        // copy label value
+        let copiedLabel = '';
+        if (lastLabelInput && lastLabelInput.value) {
+            copiedLabel = lastLabelInput.value;
+        }
+
+        // increment form count
+        formTotalForms.setAttribute("value", totalForms + 1);
+
         var buttonContainer = container.lastElementChild.querySelector(".button-container");
         buttonContainer.innerHTML = removeButtonCopy.replaceAll("__prefix__", totalForms-1);
 
         // create input field + add button to last el
-        var newIndex = totalForms
+        var newIndex = totalForms;
 
         // container for field + buttons [+, -]
         var formRowElement = document.createElement('div');
@@ -85,6 +132,16 @@
 
         // ExcludeDate form field
         formRowElement.innerHTML = `{% crispy formset.empty_form helper %}`.replaceAll("__prefix__", newIndex);
+
+        // set copied values
+        const newDateInput = document.querySelector(`#id_form-${newIndex}-date`);
+        if (newDateInput && nextDateStr) {
+            newDateInput.value = nextDateStr;
+        }
+        const newLabelInput = document.querySelector(`#id_form-${newIndex}-label`);
+        if (newLabelInput && copiedLabel) {
+            newLabelInput.value = copiedLabel;
+        }
 
         // container for buttons [+, -]
         var buttonElement = document.createElement('div');


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added JavaScript logic to the excluded dates formset so that when a new date is added using the "+" button, it automatically sets the date input to the next weekday after the last visible excluded date, skipping weekends.

### Why?
To improve usability by pre-filling the next excluded date sequentially, reducing manual input and avoiding weekends which are already excluded by default.

https://github.com/bytedeck/bytedeck/issues/1419

### How?
- Modified the `AddForm` JavaScript function to find the last visible date input.
- Calculated the next weekday date, skipping Saturdays and Sundays.
- Set the new date input’s value to this calculated next weekday.
- Kept changes minimal and localized to the JS adding new form logic.

### Testing?
Manually tested adding multiple excluded dates, verifying that each new date increments by one weekday and skips weekends as expected.

### Screenshots (if front end is affected)

https://github.com/user-attachments/assets/b1c757a9-1c14-4917-899c-08b625919f3b


### Anything Else?

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New form rows now default their date to the next weekday after the last visible row and copy that row's label; defaults are derived before the new row is added.
  * Datepicker for the new row is initialized with the existing configuration so UI behavior remains consistent.

* **Bug Fixes**
  * Date handling improved to parse and set dates in local time to avoid timezone-related shifts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->