### PR TITLE
Add defensive guard in prereq signal and fix test Quest creation with…

### DIFF
--- a/src/djcytoscape/signals.py
+++ b/src/djcytoscape/signals.py
@@ -39,6 +39,9 @@ def badge_regenerate_related_maps(sender, instance, **kwargs):
 @receiver([post_save, post_delete], sender=Prereq)
 def prereq_regenerate_related_maps(sender, instance, **kwargs):
     """ Regenerates any related map(s) when a prereq is saved or deleted. """
+    if not instance.parent_content_type or not instance.parent_object_id:
+        # Prereq is incomplete or missing required references
+        return
 
     # get parent object of prereq
     model_class = instance.parent_content_type.model_class()
@@ -48,6 +51,7 @@ def prereq_regenerate_related_maps(sender, instance, **kwargs):
 
     # means this signal was called when object_ was deleted
     except model_class.DoesNotExist:
+        # Parent object was deleted
         return
 
     regenerate_related_maps(object_)

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -107,9 +107,9 @@ class HasPrereqsMixinTest(TenantTestCase):
 
 class IsAPrereqMixinTest(TenantTestCase):
     def setUp(self):
-        self.quest_parent = baker.make('quest_manager.Quest', name="parent")
-        self.quest_prereq = baker.make('quest_manager.Quest', name="prereq")
-        self.quest_or_prereq = baker.make('quest_manager.Quest', name="or_prereq")
+        self.quest_parent = baker.make('quest_manager.Quest', name="parent", verification_required=True)
+        self.quest_prereq = baker.make('quest_manager.Quest', name="prereq", verification_required=True)
+        self.quest_or_prereq = baker.make('quest_manager.Quest', name="or_prereq", verification_required=True)
 
         self.prereq_with_or = Prereq.objects.create(
             parent_object=self.quest_parent,
@@ -117,7 +117,7 @@ class IsAPrereqMixinTest(TenantTestCase):
             or_prereq_object=self.quest_or_prereq
         )
 
-        self.quest_prereq2 = baker.make('quest_manager.Quest', name="prereq2")
+        self.quest_prereq2 = baker.make('quest_manager.Quest', name="prereq2", verification_required=True)
 
         self.prereq_without_or = Prereq.objects.create(
             parent_object=self.quest_parent,


### PR DESCRIPTION
… required field

Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added a defensive check in the `prereq_regenerate_related_maps` signal to avoid errors when `Prereq` instances are incomplete. Also ensured test `Quest` instances include the required `verification_required` field to stabilize test data creation.

### Why?
Intermittent test failures were caused by the signal trying to access attributes on incomplete `Prereq` instances. Tests also sometimes failed due to missing required fields in factory-generated `Quest` objects.

### How?
- Added a guard clause in the signal to return early if `parent_content_type` or `parent_object_id` is missing.
- Updated test setup to explicitly set `verification_required=True` when creating `Quest` instances.

### Testing?
Ran existing tests multiple times locally and in CI to confirm reduced flakiness and no regressions.

### Screenshots (if front end is affected)
N/A

### Anything Else?
No breaking changes; purely defensive and test setup improvements.

### Review request
@tylerecouture
