### PR TITLE
Create quest_user_status view showing students’ submission statuses; Closes #918

### DIFF
--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -44,6 +44,12 @@
             title = "View past submissions of this quest" >
             <i class="fa fa-folder-open-o"></i>
           </a>
+          {% if request.resolver_match.url_name != 'quest_user_status' %}
+          <a class="btn btn-default" href="{% url 'quests:quest_user_status' q.id %}" role="button"
+            title="View status of all students for this quest">
+            <i class="fa fa-users"></i>
+          </a>
+          {% endif %}
           <a class="btn btn-default" href="{% url 'quests:summary' q.id %}" role="button"
             title="View summary data for this quest" >
             <i class="fa fa-fw fa-bar-chart"></i>

--- a/src/quest_manager/templates/quest_manager/quest_user_status.html
+++ b/src/quest_manager/templates/quest_manager/quest_user_status.html
@@ -1,0 +1,110 @@
+{% extends "quest_manager/base.html" %}
+{% load utility_tags %}
+
+{% block heading_inner %}Completion Statuses{% endblock %}
+
+{% block content %}
+  <h3>Quest: {{ q.name }}</h3>
+
+  {% include "quest_manager/buttons.html" %}
+
+  <div class="media quest-icon-description">
+    <div class="media-left">
+      <img class="media-object icon-lg img-rounded" src="{{ q.get_icon_url }}" alt="icon" />
+    </div>
+    <div class="media-body">
+      {{ q.short_description }}
+    </div>
+  </div>
+
+  <div id="quest-info-{{q.id}}" class="panel panel-primary panel-top">
+    <div class="panel-heading">
+      <h3 class="panel-title">Quest Info</h3>
+    </div>
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-sm-6">
+          <ul class="list-unstyled">
+            <li><h4>XP: {{q.xp}}{% if q.xp_can_be_entered_by_students %}+ <small>(student entered)</small>{% endif %}</h4></li>
+            <li>Campaign: {% if q.campaign %}{% if user.is_staff %}<a href="{% url 'quests:category_detail' q.campaign.id %}">{{ q.campaign }}</a>{% else %}{{ q.campaign }}{% endif %}{% else %}-{% endif %}</li>
+            <li>Expiry: {{q.date_expired}}</li>
+            <li>Repeatable: {% if q.max_repeats == 0 %}No
+                   {% else %}
+                     {% if q.max_repeats == -1 %} Unlimited
+                     {% else %} {{q.max_repeats}} time{{q.max_repeats|pluralize}} max
+                     {% endif %}
+                     {% if q.hours_between_repeats > 0 %}
+                     - every {{ q.hours_between_repeats}} hrs
+                     {% endif %}
+                  {% endif %}</li>
+          </ul>
+        </div>
+        <div class="col-sm-6">
+          <ul class="list-unstyled">
+            <li>Maps: {% include 'djcytoscape/snippets/map-list.html' %}</li>
+            {% if request.user.is_staff %}
+            <li>{% tag_name %}s: {% with q as object %}{% include 'tags/snippets/tag-list.html' %}{% endwith %}</li>
+            {% else %}
+            <li>{% tag_name %}s: {% with q as object %}{% include 'tags/snippets/tag-list.html' with user_obj=request.user %}{% endwith %}</li>
+            {% endif %}
+            {% if q.max_repeats != 0 %}
+            <li>Maximum total XP: {% if q.max_xp == -1 %} Unlimited
+                {% else %} {{q.max_xp}}
+                {% endif %}
+            </li>
+            {% endif %}
+            <li>Prerequisites:
+                  {% if request.user.is_staff and not dont_edit_prereqs %}<a class="btn btn-info btn-xs" href="{% url 'quests:quest_prereqs_update' q.id %}">Edit</a>{% endif %}
+                  {% with q as object %}{% include 'prerequisites/current_prereq_list.html' %}{% endwith %}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+  <h5>Status Breakdown</h5>
+  <table class="table" style="width: 350px;">
+      {% for stat in status_stats %}
+      <tr>
+          <td>{{ stat.status }}:</td>
+          <td>{{ stat.count }} ({{ stat.percent }})</td>
+      </tr>
+      {% endfor %}
+  </table>
+
+  {% if user_status_list %}
+    <table id="user-status-table"
+          class="user-status-table"
+          data-toggle="table"
+          data-classes="table table-striped table-bordered table-hover"
+          data-search="true"
+          data-trim-on-search="false">
+      <thead>
+        <tr>
+          <th data-field="user" data-sortable="true">User</th>
+          <th data-field="status">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in user_status_list %}
+        <tr>
+          <td>
+            <a href="{{ entry.user.profile.get_absolute_url }}">{{ entry.user.username }}</a>
+          </td>
+          <td>
+            {% if entry.submission %}
+              <a href="{{ entry.submission.get_absolute_url }}">{{ entry.status }}</a>
+            {% else %}
+              {{ entry.status }}
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p>No active students found.</p>
+  {% endif %}
+{% endblock %}

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -68,6 +68,7 @@ urlpatterns = [
     re_path(r'^(?P<pk>[0-9]+)/archive/$', views.QuestArchive.as_view(), name="quest_archive"),
     re_path(r'^(?P<quest_id>[0-9]+)/unarchive/', views.unarchive, name='unarchive'),
     re_path(r'^bulk-edit/$', views.QuestBulkEditView.as_view(), name='bulk_edit_quests'),
+    re_path(r'^(?P<quest_id>[0-9]+)/user-status/$', views.quest_user_status, name='quest_user_status'),
     re_path(r'^(?P<quest_id>[0-9]+)/start/$', views.start, name='start'),
     re_path(r'^(?P<quest_id>[0-9]+)/hide/$', views.hide, name='hide'),
     re_path(r'^(?P<quest_id>[0-9]+)/unhide/$', views.unhide, name='unhide'),


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Add a new "Quest User Status" view, URL route, and template to display the status of all active students for a given quest. The page shows each student's latest submission status—such as Not Started, Completed, Returned, Awaiting Approval, or In Progress—with links to submission details when available. Also add a button linking to this status page where appropriate.

### Why?
This feature provides teachers and staff a centralized view of student progress on quests, improving oversight and communication regarding quest submissions and statuses.

https://github.com/bytedeck/bytedeck/issues/918

### How?
- Added `quest_user_status` view decorated with `@staff_member_required` that fetches the quest, active student profiles, their latest submissions, and computes each user’s submission status.
- Created a URL route at `r'^(?P<quest_id>[0-9]+)/user-status/$'` named `quest_user_status` for accessing this view.
- Created the template `quest_user_status.html` extending `quest_manager/base.html`, displaying quest info and a sortable/searchable table of users with their statuses.
- Added a conditional button link to `quest_user_status` in quest-related templates, excluding the page itself to avoid redundant navigation.

### Testing

Added unit tests for the `quest_user_status` view.

Verified correct display of user submission statuses, including:

- Users with approved submissions show as **Approved**.  
- Users with returned submissions show as **Returned**.  
- Users with pending submissions show as **Awaiting Approval**.  
- Users with no submissions show as **Not Started**.

Ensured the view responds with HTTP 200 status for all cases tested.

Test coverage includes multiple users with different submission states.

### Screenshots (if front end is affected)

https://github.com/user-attachments/assets/c962ddcf-7a98-4afb-8bda-ff14bd2a17fc


### Anything Else?
Planning on adding the semester tracking like the Badge view, current semester and all semesters options. That might have to come later though.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff can open a "View status of all students" action from quest pages to see a completion dashboard with quest details (XP, campaign, expiry, repeatability), related maps and tags, prerequisites, max total XP, a status breakdown (counts & percentages), and a per-student table with links to submissions.

* **Tests**
  * Added tests for the status dashboard covering access, per-user statuses, "not started" cases, and latest-attempt selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->