### PR TITLE
Add export campaign feature; Closes #1849

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -1,6 +1,6 @@
 from django_tenants.utils import schema_context
 from quest_manager.admin import QuestResource
-from quest_manager.models import Quest
+from quest_manager.models import Quest, Category
 
 from .utils import library_schema_context
 from django.core.exceptions import ValidationError
@@ -50,5 +50,58 @@ def export_quest_to_library(*, source_schema, quest_import_id):
         imported_quest.published = False
         imported_quest.full_clean()
         imported_quest.save()
+
+    return result
+
+
+def export_campaign_to_library(*, source_schema, campaign_import_id):
+    """
+    Exports a campaign (Category) and all its quests from the given tenant schema
+    into the shared library schema.
+
+    All exported quests and the campaign will be unpublished in the library by default.
+    This ensures the shared library remains a neutral, reviewable repository.
+
+    Args:
+        source_schema (str): The tenant schema where the campaign currently resides.
+        campaign_import_id (UUID): The import ID of the campaign to export.
+
+    Returns:
+        ImportResult: The result of the import operation into the library schema.
+
+    Raises:
+        Category.DoesNotExist: If the campaign is not found in the source schema.
+        ValidationError: If no published quests exist for the campaign.
+    """
+    with schema_context(source_schema):
+        category = Category.objects.get(import_id=campaign_import_id)
+        quests = Quest.objects.filter(published=True, campaign=category)
+        if not quests.exists():
+            raise ValidationError("Cannot export a campaign without any published quests.")
+        export_data = QuestResource().export(quests)
+
+    # Prepare visibility map for library: all quests unpublished
+    exported_visibility_map = {str(q.import_id): False for q in quests}
+
+    with library_schema_context():
+        try:
+            result = QuestResource().import_data(
+                export_data,
+                dry_run=False,
+                raise_errors=True,
+                use_transactions=True,
+                import_campaign=True,
+                local_visibility_map=exported_visibility_map,
+            )
+        except (ValidationError, IntegrityError) as e:
+            # Raise a clearer validation error with context
+            raise ValidationError(f"Failed to import campaign to library schema: {e}") from e
+
+        # Explicitly unpublish imported campaign
+        imported_category = Category.objects.filter(import_id=campaign_import_id).first()
+        if imported_category:
+            imported_category.published = False
+            imported_category.full_clean()
+            imported_category.save(update_fields=['published'])
 
     return result

--- a/src/library/templates/library/confirm_export_campaign.html
+++ b/src/library/templates/library/confirm_export_campaign.html
@@ -1,0 +1,59 @@
+{% extends "quest_manager/base.html" %}
+
+{% block head_title %}Library | Export Campaign to Shared Library{% endblock %}
+
+{% block heading %}
+  <i class="fa fa-book pull-right"></i>
+  {% block heading_inner %}Export Campaign to Library{% endblock %}
+{% endblock %}
+
+{% block content %}
+
+  {% if existing_campaign %}
+    <div class="alert alert-danger">
+      A campaign with the same import ID already exists in the shared library. Exporting again is not allowed.
+    </div>
+  {% else %}
+    <p>Please read and agree to the following license before sharing this campaign:</p>
+
+    <div class="alert alert-info">
+      This campaign and its quests will be shared under the
+      <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">
+        Creative Commons Attribution-ShareAlike 4.0 International License.
+      </a>
+    </div>
+
+    <p class="text-muted">
+      Want to share more about this campaign or start a discussion?
+      Join the conversation on the
+      <a href="https://github.com/bytedeck/bytedeck/discussions" target="_blank" rel="noopener noreferrer">
+        ByteDeck Library Discussions.
+      </a>
+    </p>
+
+    <form method="post" id="export-form">
+      {% csrf_token %}
+
+      <div class="form-check mb-3">
+        <input type="checkbox" class="form-check-input" id="agreeLicense" name="agreeLicense" required />
+        <label class="form-check-label" for="agreeLicense">
+          I agree to share this campaign and all its quests under the Creative Commons Attribution-ShareAlike 4.0 International License.*
+        </label>
+      </div>
+
+      <button type="submit" class="btn btn-primary">Share Campaign to Library</button>
+      <a href="{% url 'quests:categories' %}" class="btn btn-info">Cancel</a>
+    </form>
+    {% if library_quest_import_ids %}
+        <div class="alert alert-danger panel-top">
+          {% comment %} TODO: Update this message to the new method of dealing with conflicts. {% endcomment %}
+            <strong>Warning:</strong> One or more quests in this campaign already exist in the library;
+            they are indicated with this icon <i class="icon-spacing fa fa-fw fa-exclamation-triangle"></i> in the quest list below.
+            Exporting this campaign will <strong>overwrite</strong> those existing quests with the local versions.
+        </div>
+    {% endif %}
+    <h3>{{ campaign.name }}</h3>
+    {% include "quest_manager/category_detail_content.html" %}
+  {% endif %}
+
+{% endblock %}

--- a/src/library/urls.py
+++ b/src/library/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('quests-list/', views.LibraryQuestListView.as_view(), name='quest_list'),
     path('campaign-list/', views.LibraryCampaignListView.as_view(), name='category_list'),
     path('import-campaign/<uuid:campaign_import_id>/', views.ImportCampaignView.as_view(), name='import_category'),
+    path('export-campaign/<uuid:campaign_import_id>/', views.ExportCampaignView.as_view(), name='export_category'),
     path('campaigns/<uuid:campaign_import_id>/view/', views.CategoryDetailView.as_view(), name='category_detail_view'),
     path('import-quest/<uuid:quest_import_id>/', views.ImportQuestView.as_view(), name='import_quest'),
     path('export-quest/<uuid:quest_import_id>/', views.ExportQuestView.as_view(), name='export_quest'),

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -78,8 +78,11 @@
               <small>{{ q.tags.all|join:", "|default:"-" }}</small>
             </td>
             <td id="status-icon-{{ q.id }}" class="col-xs-2 hidden-xs text-muted">
-              {% if q.import_id in local_quest_import_ids %}
-                <i title="This quest already exists in your deck and any local changes will be overwritten." class="icon-spacing fa fa-fw fa-exclamation-triangle">
+              {% if local_quest_import_ids and q.import_id in local_quest_import_ids %}
+                <i title="This quest already exists in your deck and any local changes will be overwritten." class="icon-spacing fa fa-fw fa-exclamation-triangle"></i>
+              {% elif library_quest_import_ids and q.import_id in library_quest_import_ids %}
+              {% comment %} TODO: Update this help text with more info on how this conflict will be handled {% endcomment %}
+                <i title="This quest already exists on the library." class="icon-spacing fa fa-fw fa-exclamation-triangle"></i>
               {% endif %}
             </td>
           </tr>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Add the ability to export a full campaign (category) and all its quests from a tenant schema to the shared library schema, including confirmation views and permission checks.

### Why?
This feature enables users to share campaigns and their quests centrally in the shared library, improving content reuse and management across tenants. 

https://github.com/bytedeck/bytedeck/issues/1849

### How?
- Implement `ExportCampaignView` with GET confirmation and POST export logic.
- Add permission checks to restrict export to deck owners or staff if `allow_staff_export=True`.
- Use import/export logic with `QuestResource` to transfer campaigns and quests.
- Notify staff users after a successful export.
- Add tests covering permission enforcement, export success, and error cases.

### Testing?
- Unit tests verify export permission scenarios for deck owners and staff.
- Tests ensure forbidden access when a campaign already exists in the library.
- Tests confirm successful export redirects and notifications are sent.
- Manual testing of confirmation pages and export flows in UI.

### Screenshots (if front end is affected)

#### With no Conflicts
<img width="825" height="747" alt="image" src="https://github.com/user-attachments/assets/b345b08b-0aff-4f88-9f2e-d21cc4686b08" />

#### One or more Quests exist in the Library already
<img width="841" height="805" alt="image" src="https://github.com/user-attachments/assets/72fe541d-6879-4fcd-8478-735340a4f4b9" />

#### Campaign already exists in the Library already
<img width="1128" height="292" alt="image" src="https://github.com/user-attachments/assets/7bbe1973-3339-4e63-9e55-c106547ab0c9" />

#### Success notification displayed on Library
<img width="740" height="162" alt="image" src="https://github.com/user-attachments/assets/820ab3e0-9667-4e6d-9a4a-86ff9cb19a82" />

> The success notification uses the same format as the quests, Library `deck_ai`, user who exported, the deck it was exported from, and finally the name of the campaign. Clicking the notification will send you to the Campaign detail page

### Anything Else?
- Future improvements include handling duplicate quests in library by creating copies.


### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Export entire campaigns (category + published quests) to the shared library with a confirmation page, license acceptance, conflict warnings, routing, and post-export notifications.

- Improvements
  - Centralized export permission checks; clearer conflict warnings and library indicators in lists; exported items are created unpublished in the library; isolated cross-tenant operations; refined redirects and success messaging.

- Tests
  - Expanded coverage for permissions, conflict handling, successful quest/campaign exports, notifications, and cross-tenant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->