### PR TITLE
Ignore irrelevant UndefinedTable errors in IsAPrereqMixin tests; Closes #1868

### DIFF
--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -10,6 +10,8 @@ from model_bakery import baker
 
 from prerequisites.models import IsAPrereqMixin, Prereq, PrereqAllConditionsMet
 
+from psycopg2.errors import UndefinedTable
+
 User = get_user_model()
 
 
@@ -189,7 +191,12 @@ class IsAPrereqMixinTest(TenantTestCase):
         for ct in IsAPrereqMixin.all_registered_content_types():
             # If the method is not implemented, then NotImplementedError is thrown
             instance = baker.make(ct.model_class())
-            instance.condition_met_as_prerequisite(user=baker.make(User), num_required=1)
+            try:
+                instance.condition_met_as_prerequisite(user=baker.make(User), num_required=1)
+            except UndefinedTable:
+                # Ignore unrelated missing table errors from debug toolbar
+                # https://github.com/bytedeck/bytedeck/issues/1868
+                pass
 
     def test_gfk_search_fields__is_implemented(self):
         """ All models implementing this Mixin, also implement this method if the default doesn't suffice """


### PR DESCRIPTION
Update Dockerfile to install PCRE2 instead of PCRE3

Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Ignore unrelated missing table errors from debug toolbar

### Why?
https://github.com/bytedeck/bytedeck/issues/1868
### How?
### Testing?
### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build dependencies to use PCRE2-based regex libraries for improved compatibility; no user-facing behavior changes expected.

* **Tests**
  * Adjusted tests to catch and ignore environment-specific missing-table errors from external tooling, reducing flaky failures while preserving detection of real issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->