### PR TITLE
Update Dockerfile to install libpcre2-8-0 and libpcre2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get install -y libicu[0-9][0-9]
 RUN apt-get install -y build-essential
 
 #https://stackoverflow.com/questions/21669354/rebuild-uwsgi-with-pcre-support
-RUN apt-get install -y libpcre3 libpcre3-dev
+RUN apt-get update && \
+    apt-get install -y libpcre2-8-0 libpcre2-dev
 
 RUN python3 -m pip install --upgrade pip
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Update the Dockerfile to install the current PCRE2 libraries:
```
RUN apt-get update && \
    apt-get install -y libpcre2-8-0 libpcre2-dev
```

This replaces the old `libpcre3` and `libpcre3-dev` packages.

### Why?
`libpcre3` has been end-of-life for several years and is no longer maintained.  
Using `libpcre2` ensures compatibility with modern dependencies that rely on the updated PCRE2 API.  
It also prevents potential security issues and keeps the development environment up to date.

### How?
The Dockerfile was modified to:

1. Run `apt-get update` before installing packages.
2. Install `libpcre2-8-0` (runtime library) and `libpcre2-dev` (development headers) instead of the outdated `libpcre3` packages.

### Testing?
- This change has been included in other branches that have successfully built and passed CI, indicating the updated PCRE2 packages do not break the build.
- Existing dependencies that rely on PCRE (e.g., Python packages like `regex`) appear to continue to function correctly in those branches.

### Screenshots (if front end is affected)
N/A

### Anything Else?
This update ensures the development environment is modern and avoids relying on deprecated libraries. No other code changes are needed.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the build environment to use PCRE2 for regular expression support, improving compatibility and long-term maintenance.
  * Refreshed package installation steps to ensure reliable dependency setup during image builds.
  * No changes to user-facing features or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->