### PR TITLE
added conditional to debug to remove it from testing

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -773,9 +773,26 @@ DJANGORESIZED_DEFAULT_FORCE_FORMAT = None
 TAGGIT_CASE_INSENSITIVE = True
 
 
+# TESTING ##################################################
+
+TESTING = 'test' in sys.argv
+if TESTING:
+    # Use weaker password hasher for speeding up tests
+    PASSWORD_HASHERS = [
+        'django.contrib.auth.hashers.MD5PasswordHasher',
+    ]
+
+    # django.test.override_settings does not simply work as expected.
+    # overriding settings here instead
+    CACHES['default'] = {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'test-loc'
+    }
+
+
 # DEBUG / DEVELOPMENT SPECIFIC SETTINGS #################################
 
-if DEBUG:
+if DEBUG and not TESTING:
 
     import socket
     INTERNAL_IPS = ['127.0.0.1', '0.0.0.0']
@@ -822,20 +839,3 @@ if DEBUG:
     # DEBUG_TOOLBAR_CONFIG = {
     #     'SHOW_TOOLBAR_CALLBACK': lambda request: not request.is_ajax()
     # }
-
-
-# TESTING ##################################################
-
-TESTING = 'test' in sys.argv
-if TESTING:
-    # Use weaker password hasher for speeding up tests
-    PASSWORD_HASHERS = [
-        'django.contrib.auth.hashers.MD5PasswordHasher',
-    ]
-
-    # django.test.override_settings does not simply work as expected.
-    # overriding settings here instead
-    CACHES['default'] = {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'test-loc'
-    }


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?  
Reordered and updated settings so that testing configuration is applied before debug/development configuration, and ensured that `DEBUG`-only settings (e.g., debug toolbar) are not loaded when running tests.  

### Why?  
Previously, the debug toolbar and related middleware/apps could still be added when running tests in `DEBUG` mode. This caused noise in the test environment, potential conflicts, and unnecessary overhead. By explicitly checking `if DEBUG and not TESTING`, the debug-only setup is skipped during tests, keeping the test environment clean and consistent.  

### How?  
- Moved the **TESTING** block above the **DEBUG/DEV** block.  
- Changed condition from `if DEBUG:` → `if DEBUG and not TESTING:`.  
- Left debug/development configuration unchanged otherwise.  

### Testing?   
- Confirmed that when running the dev server with `DEBUG=True` (and not in test mode), debug toolbar and panels are still loaded as expected.  

### Screenshots (if front end is affected)  
N/A  

### Anything Else?  
This change reduces test overhead and ensures debug-only dependencies don’t leak into the test environment.  

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Introduced a dedicated testing mode to speed up and stabilize test runs (faster hashing, in-memory caching).
  - Prevents debug tooling from loading during tests for cleaner output and fewer side effects.
  - Improves CI performance and consistency across environments.

- Refactor
  - Consolidated testing configuration into a single source to eliminate duplication and reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->