### PR TITLE
update dockerfile for the debian update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ STOPSIGNAL SIGINT
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
+    && apt-get -y install --no-install-recommends apt
 
 RUN pip install pylint
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?

Update the Dockerfile to replace the installation of `apt-utils` (which is no longer available in Debian trixie) with a supported package (`apt`), ensuring build compatibility with the latest base image.

### Why?

The build was failing due to `apt-utils` having no installation candidate in Debian trixie. This change resolves the error and ensures the image builds successfully on current Debian-based slim images.

### How?

- Removed:  
  RUN apt-get update && apt-get -y install --no-install-recommends apt-utils
- Added:  
  RUN apt-get update && apt-get -y install --no-install-recommends apt
- No other changes were made to the Dockerfile.

### Testing?


### Screenshots (if front end is affected)

N/A (backend build process only).

### Anything Else?
Debian had an update on August 9th.
https://www.debian.org/News/2025/20250809
They have a list of known issues but I didn't find anything referencing apt-utils
https://www.debian.org/releases/trixie/release-notes/issues.html

As to why this is only being affected now, it seems that the CI might have had a cached version for the tests between August 9th and now, and so it wasn't affected until now.

Also after looking through their documentation they referenced pcre2 so that might have been affected by Debian as well.
https://github.com/bytedeck/bytedeck/pull/1870

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system package installation in the build pipeline to improve container build reliability and surface build-time errors more clearly.
  * General build configuration cleanup to ensure consistent environments across builds.

* **Notes**
  * No user-facing changes; application behavior and features remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->