### PR TITLE
added alert wells where can't delete pops up; Closes #1861

### DIFF
--- a/src/badges/templates/badges/badgetype_confirm_delete.html
+++ b/src/badges/templates/badges/badgetype_confirm_delete.html
@@ -6,15 +6,18 @@
 {% block content %}
   {% if not has_badges %}
     <form action="" method="post">{% csrf_token %}
-      <p>Are you sure you want to delete this {{ config.custom_name_for_badge }} type? You can't delete types that have {{ config.custom_name_for_badge }} assigned to them.<p>
+      <p>Are you sure you want to delete this {{ config.custom_name_for_badge }} type? You can't delete types that have {{ config.custom_name_for_badge }} assigned to them.</p>
       <div class="well">
-        <p>{{ config.custom_name_for_badge }} Type Name: {{object.name}}</p>
-        <p>{{ config.custom_name_for_badge }} Type ID: {{object.id}}</p>
+        <p>{{ config.custom_name_for_badge }} Type Name: {{ object.name }}</p>
+        <p>{{ config.custom_name_for_badge }} Type ID: {{ object.id }}</p>
       </div>
       <a href="{% url 'badges:badge_types' %}" role="button" class="btn btn-info">Cancel</a>
       <input type="submit" value="Delete" class="btn btn-danger" />
     </form>
   {% else %}
-    <p>Unable to delete {{ config.custom_name_for_badge|lower }} type '{{ object.name }}' as it still has {{ config.custom_name_for_badge }}s assigned to it. See a list of current {{ config.custom_name_for_badge }}s <a href="{% url 'badges:list' %}">here.</a></p>
+    <div class="alert alert-danger">
+      Unable to delete {{ config.custom_name_for_badge|lower }} type '{{ object.name }}' as it still has {{ config.custom_name_for_badge }}s assigned to it.
+      See a list of current {{ config.custom_name_for_badge }}s <a href="{% url 'badges:list' %}">here</a>.
+    </div>
   {% endif %}
 {% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_confirm_delete.html
+++ b/src/quest_manager/templates/quest_manager/category_confirm_delete.html
@@ -7,10 +7,17 @@
 <form action="{% url 'quests:category_delete' object.id %}" method="post">{% csrf_token %}
   <p>Are you sure you want to delete this campaign?</p>
   <div class="well">
-    <p>Campaign Name: {{object.title}}</p>
-    <p>Campaign ID: {{object.id}}</p>
+    <p>Campaign Name: {{ object.title }}</p>
+    <p>Campaign ID: {{ object.id }}</p>
   </div>
-  <a href="{% url 'quests:categories'%}" role="button" class="btn btn-info">Cancel</a>
+
+  {% if object.quest_count != 0 %}
+    <div class="alert alert-danger">
+      Can't delete a campaign that has published quests; you must unpublish or delete all quests in the campaign first.
+    </div>
+  {% endif %}
+
+  <a href="{% url 'quests:categories' %}" role="button" class="btn btn-info">Cancel</a>
   <input
     type="submit"
     value="Delete"

--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -6,11 +6,17 @@
 {% block heading %}<i class="fa fa-compass pull-right"></i>{% block heading_inner %} {{ object.title }} Campaign{% endblock %}{% endblock %}
 
 {% block content %}
+    {% if object.quest_count != 0 and request.user.is_staff %}
+        <div class="alert alert-danger mb-3">
+            Can't delete a campaign that has published quests; you must unpublish or delete all quests in the campaign first.
+        </div>
+    {% endif %}
+
     {% if request.user.is_staff %}
         <div class="pull-right">
             <a class="btn btn-warning" href="{% url 'quests:category_update' object.id %}" role="button"
-                title = "Edit this campaign" >
-            <i class="fa fa-edit"></i>
+                title="Edit this campaign">
+                <i class="fa fa-edit"></i>
             </a>
 
             <a class="btn btn-danger"
@@ -20,14 +26,15 @@
                     aria-disabled="true"
                     title="Can't delete a campaign that has published quests; you must unpublish or delete all quests in the campaign first"
                 {% else %}
-                    href="{% url 'quests:category_delete' object.id %}" title="Delete this campaign"
+                    href="{% url 'quests:category_delete' object.id %}"
                     title="Delete this campaign"
                 {% endif %}
                 role="button">
-            <i class="fa fa-trash-o"></i>
+                <i class="fa fa-trash-o"></i>
             </a>
         </div>
     {% endif %}
+
     {% if object.published or request.user.is_staff %}
         {% with object as category %}
             {% include "quest_manager/category_detail_content.html" %}
@@ -37,6 +44,6 @@
     {% endif %}
 {% endblock %}
 
-{% block js%}
+{% block js %}
   {{ block.super }}
 {% endblock %}

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -15,6 +15,7 @@
 {% endblock %}
 {% block content %}
   <p>This page is visible to staff only.</p>
+
   <ul id="campaign-tabs" class="nav nav-tabs nav-justified" role="tablist">
     <li role="presentation"
         class="{% if available_tab_active %}active{% endif %}">


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Added an alert well for the message that's shown when you can't delete something.

### Why?

https://github.com/bytedeck/bytedeck/issues/1861
### How?
Added this code for campaigns
```html
  {% if object.quest_count != 0 %}
    <div class="alert alert-danger">
      Can't delete a campaign that has published quests; you must unpublish or delete all quests in the campaign first.
    </div>
  {% endif %}
```
And this for the badge type
```html
    <div class="alert alert-danger">
            The message was pre-existing
    </div>
```
### Testing?
Manually made sure they only appear when there are published quests in the Campaign.
In the case of the Badge Type I made sure that it only appeared when there were no Badges assigned to the type.
### Screenshots (if front end is affected)

### Anything Else?
No well in the main campaign list
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevents deleting campaigns with published quests by disabling delete actions and showing explanatory tooltips.
  * Displays clear danger alerts when deletion is blocked.
  * Conditionally shows campaign details only when published or for staff.

* **Bug Fixes**
  * Corrected an unclosed HTML tag and minor template syntax issues.
  * Standardized attribute text and spacing for improved accessibility and readability.

* **Style**
  * Minor layout and whitespace adjustments for clearer spacing and button placement.
  * Ensured consistent formatting and trailing newline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->