### PR TITLE
include archived quests in the check on the library for duplicates; Closes #1877

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -347,13 +347,25 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
 
     def test_export_get__shows_error_if_quest_already_in_library(self):
         """
-        Test that the export confirmation view shows an error if the quest already exists in the library.
+        Test that the export confirmation view shows an error if the quest already exists in the library,
+        whether the existing library quest is archived or not. Exporting again should not be allowed
+        in either case.
         """
         self.config.allow_staff_export = True
         self.config.full_clean()
         self.config.save()
 
         self.client.force_login(self.test_teacher)
+
+        url = reverse('library:export_quest', args=[self.shared_quest.import_id])
+        response = self.client.get(url)
+        self.assertContains(response, "A quest with the same import ID already exists in the shared library. Exporting again is not allowed.")
+
+        # Archive the quest to test it again but against an archived quest
+        with library_schema_context():
+            self.shared_quest.archived = True
+            self.shared_quest.full_clean()
+            self.shared_quest.save()
 
         url = reverse('library:export_quest', args=[self.shared_quest.import_id])
         response = self.client.get(url)

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -326,10 +326,10 @@ class ExportQuestView(View):
         """
         self._require_export_permission(request)
 
-        quest = get_object_or_404(Quest.objects.all_including_archived(), import_id=quest_import_id)
+        quest = get_object_or_404(Quest.objects.all(), import_id=quest_import_id)
 
         with library_schema_context():
-            library_quest = Quest.objects.filter(import_id=quest.import_id).first()
+            library_quest = Quest.objects.all_including_archived().filter(import_id=quest.import_id).first()
 
         return render(request, self.template_name, {
             'quest': quest,
@@ -359,12 +359,12 @@ class ExportQuestView(View):
         """
         self._require_export_permission(request)
 
-        quest = get_object_or_404(Quest.objects.all_including_archived(), import_id=quest_import_id)
+        quest = get_object_or_404(Quest.objects.all(), import_id=quest_import_id)
 
         source_schema = connection.schema_name
 
         with library_schema_context():
-            if Quest.objects.filter(import_id=quest.import_id).exists():
+            if Quest.objects.all_including_archived().filter(import_id=quest.import_id).exists():
                 raise PermissionDenied(f"A quest with import_id {quest.import_id} already exists in the shared library.")
 
             # Perform export


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Add `all_including_archived()` to the check on the library so that even if the quest is archived it won't let you export.
Add testing so that this gets caught.

### Why?
Before if the quest was archived on the library you could try to export it again, this lead to a failure as duplicate import-ids can't exist so django caught it. However you shouldn't even be able to try.

https://github.com/bytedeck/bytedeck/issues/1877
### How?
Added `all_including_archived()` to the check on the library schema. I also removed `all_including_archived()` to the queryset on the local schema since that's redundant. When making the views I must have gotten the two mixed up.

Also added/modified tests to include an archived quest so this gets caught in testing in for future.

### Testing?
Manual testing + modified a test to make sure archived quests still get detected.

### Screenshots (if front end is affected)
### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents re-exporting a quest if a matching entry already exists in the shared library, including archived entries. Users now see the same “already exists” error for both archived and active duplicates.

* **Tests**
  * Expanded test coverage to validate export behavior when a duplicate exists in the library, including archived cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->