### PR TITLE
add archived quests to the delete view queryset and test it; Closes #1874

### DIFF
--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -24,6 +24,11 @@
         </button>
       </form>
 
+      <a class="btn btn-danger" href="{% url 'quests:quest_delete' q.id %}" role="button"
+        title = "Delete this quest" >
+        <i class="fa fa-trash-o"></i>
+      </a>
+
     {% elif  request.user.is_staff or request.user == q.editor %}
         {% if is_library_view %}
           <a href="{% url 'library:import_quest' q.import_id %}"

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1434,6 +1434,16 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, TenantTestCase):
         with self.assertRaises(Quest.DoesNotExist):
             Quest.objects.get(id=new_quest.id)
 
+        # now test deletion of an archived quest
+        archived_quest = Quest.objects.create(**self.minimal_valid_form_data, archived=True)
+        self.assertTrue(Quest.objects.all_including_archived().filter(id=archived_quest.id).exists())
+
+        # delete archived quest
+        response = self.client.post(reverse('quests:quest_delete', args=[archived_quest.id]))
+        self.assertRedirects(response, reverse('quests:quests'))
+        with self.assertRaises(Quest.DoesNotExist):
+            Quest.objects.get(id=archived_quest.id)
+
     def test_TA_can_create_draft_quests_and_delete_own(self):
         # simulate a logged in TA (teaching assistant = a student with extra permissions)
         test_ta = User.objects.create_user('test_ta')

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -225,6 +225,12 @@ class QuestDelete(NonPublicOnlyViewMixin, UserPassesTestMixin, UpdateMapMessageM
     def test_func(self):
         return self.get_object().is_editable(self.request.user)
 
+    def get_queryset(self):
+        """
+        Include archived quests so that archived quests can be deleted using this views.
+        """
+        return Quest.objects.all_including_archived()
+
     model = Quest
     success_url = reverse_lazy("quests:quests")
 


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?  
- Updated the `QuestDelete` view to include archived quests in its queryset by using `Quest.objects.all_including_archived()`.  
- Added test coverage to ensure teachers can delete archived quests.  

### Why?  
- Previously, archived quests were excluded from the queryset by default, so attempting to delete them would raise `404`.  
- This ensures that `QuestDelete` works correctly for both active and archived quests, matching expected behavior.  


[#1874](https://github.com/bytedeck/bytedeck/issues/1874)  

### How?  
- Overrode `get_queryset()` in `QuestDelete` to call `Quest.objects.all_including_archived()`.  
- Added a section in `test_teacher_can_create_and_delete_quests` to create an archived quest and verify it can be deleted.  

### Testing?  
- Unit test confirms that teachers can delete both active and archived quests.  
- Existing tests for permission checks and deletion of active quests remain unaffected.  

### Screenshots (if front end is affected)  
<img width="1052" height="796" alt="image" src="https://github.com/user-attachments/assets/7613610c-97e1-4d00-be1e-fe9315a3e4d1" />

<img width="1132" height="717" alt="image" src="https://github.com/user-attachments/assets/86805582-af1a-429f-b870-29ee7f61d6c7" />

### Anything Else?  
- Ensures consistency between manager methods and CBV behavior.  

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff can now delete archived quests from the quest management interface; archived quests show a Delete option matching the active-quest workflow and redirect appropriately after confirmation.

* **Tests**
  * Test coverage expanded to create and delete archived quests, verifying archived-quest visibility and successful removal via the delete view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->