### PR TITLE
added alert alert-danger to the warning message

### DIFF
--- a/src/library/templates/library/confirm_import_quest.html
+++ b/src/library/templates/library/confirm_import_quest.html
@@ -3,11 +3,11 @@
 {% block heading_inner %}Import Quest from Library{% endblock %}
 {% block content %}
   {% if local_quest %}
-    <p>
+    <div class="alert alert-danger">
       Your deck already contains a quest with a matching Import ID.  Overwriting existing quests is not yet supported.
       If you still want to import this quest from the Library, you need to delete the existing quest from your deck
       or change it's Import ID:
-    </p>
+    </div>
     <div class="well">
       <p>
         Existing Quest: <a href="{{ local_quest.get_absolute_url }}">{{ local_quest.name }}</a>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Highlighted the warning message displayed by `confirm_import_quest.html` when the quest already exists locally.
 
### Why?
The rest of the confirmation pages use alert wells to display the warning messages. The message didn't feel like a warning and wasn't very visible before.

https://github.com/bytedeck/bytedeck/issues/1878
### How?
```html
    <div class="alert alert-danger">
      Your deck already contains a quest with a matching Import ID.  Overwriting existing quests is not yet supported.
      If you still want to import this quest from the Library, you need to delete the existing quest from your deck
      or change it's Import ID:
    </div>
```
the div used to be <p>

### Testing?
Manually tested that it showed up as a red well.

### Screenshots (if front end is affected)
<img width="1100" height="449" alt="image" src="https://github.com/user-attachments/assets/ca1cc668-b549-4511-87df-1f98cf512e21" />


### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the warning message on the quest import confirmation page to use a Bootstrap danger alert for clearer visual emphasis.
  - Improves readability and consistency with the app’s UI components, making critical warnings more noticeable to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->