### PR TITLE
added buttons to export campaigns, and restricted exporting to campaigns with published quests; Closes #1850

### DIFF
--- a/src/library/templates/library/confirm_export_campaign.html
+++ b/src/library/templates/library/confirm_export_campaign.html
@@ -13,6 +13,10 @@
     <div class="alert alert-danger">
       A campaign with the same import ID already exists in the shared library. Exporting again is not allowed.
     </div>
+  {% elif category_quest_count == 0 %}
+    <div class="alert alert-danger">
+      You cannot export a campaign with no published quests.
+    </div>
   {% else %}
     <p>Please read and agree to the following license before sharing this campaign:</p>
 
@@ -41,8 +45,11 @@
         </label>
       </div>
 
-      <button type="submit" class="btn btn-primary">Share Campaign to Library</button>
+      <button id="confirm-export-button" type="submit" class="btn btn-primary">
+        Share Campaign to Library
+      </button>
       <a href="{% url 'quests:categories' %}" class="btn btn-info">Cancel</a>
+
     </form>
     {% if library_quest_import_ids %}
         <div class="alert alert-danger panel-top">

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -833,6 +833,24 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
 
+    def test_export_get__disables_button_if_no_quests(self):
+        """
+        The confirmation page should disable the export button if the campaign has no quests.
+        """
+        self.config.allow_staff_export = True
+        self.config.full_clean()
+        self.config.save()
+        self.client.force_login(self.test_teacher)
+
+        empty_campaign = Category.objects.create(title="Empty Campaign")
+
+        url = reverse('library:export_category', args=[empty_campaign.import_id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        # Look for UI safeguard: button should be disabled
+        self.assertContains(response, 'You cannot export a campaign with no published quests.')
+
     def test_export_post__successful_export_and_notifications(self):
         """
         Test that a successful campaign export via POST:

--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -19,6 +19,22 @@
                 <i class="fa fa-edit"></i>
             </a>
 
+            {% if can_export %}
+              <a class="btn btn-default" role="button"
+                {% if object.quest_count != 0 %}
+                  href="{% url 'library:export_category' object.import_id %}"
+                  title="Export this Campaign to the Library"
+                {% else %}
+                  title="Cannot export without any published quests"
+                  disabled
+                  tabindex="-1"
+                  aria-disabled="true"
+                {% endif %}
+              >
+                <i class="fa fa-fw fa-upload"></i>
+              </a>
+            {% endif %}
+
             {% if not object.published %}
                 <form method="post" action="{% url 'quests:category_publish' object.id %}" class="preview-action-form">
                     {% csrf_token %}

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -45,6 +45,22 @@
               <i class="fa fa-edit"></i>
             </a>
 
+            {% if can_export %}
+              <a class="btn btn-default" role="button"
+                {% if object.quest_count != 0 %}
+                  href="{% url 'library:export_category' object.import_id %}"
+                  title="Export this Campaign to the Library"
+                {% else %}
+                  title="Cannot export without any published quests"
+                  disabled
+                  tabindex="-1"
+                  aria-disabled="true"
+                {% endif %}
+              >
+                <i class="fa fa-fw fa-upload"></i>
+              </a>
+            {% endif %}
+
               <a class="btn btn-danger"
                 {% if object.quest_count != 0 %}
                   disabled

--- a/src/siteconfig/models.py
+++ b/src/siteconfig/models.py
@@ -354,6 +354,29 @@ class SiteConfig(models.Model):
         social_app_clone.save()
         social_app_clone.sites.add(Site.objects.get_current())
 
+    def can_user_export_to_library(self, user):
+        """
+        Determine whether a given user can export quests or campaigns to the shared library.
+
+        Rules:
+            - Unauthenticated users cannot export.
+            - The deck owner can always export.
+            - Staff members can export only if `allow_staff_export` is True.
+
+        Args:
+            user (User): The user to check permissions for.
+
+        Returns:
+            bool: True if the user can export to the library, False otherwise.
+        """
+        if not user.is_authenticated:
+            return False
+
+        if user == self.deck_owner:
+            return True
+
+        return self.allow_staff_export and user.is_staff
+
     @classmethod
     def cache_key(cls):
         return f'{connection.schema_name}-siteconfig'


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Add buttons that lead to the export confirmation page. Much like importing, exporting a campaign that has no published quests is not allowed. The way we got around this with importing is not showing campaigns without published quests to decks other than the library. With exporting there's an explanation when hovering over the button.

### Why?
To allow users to get to the export confirmation page in ways that are explicitly protected and don't force url manipulation.

https://github.com/bytedeck/bytedeck/issues/1850

### How?
If the user is allowed to export (i.e. they are the owner or they are staff and `allow_staff_export=True`) the button is shown. If the campaign has no published quests then the button is disabled with help text explaining why.

### Testing?

- Wrote a test `test_export_get__disables_button_if_no_quests` that:
  - Creates a campaign with no published quests.
  - Renders the export confirmation page.
  - Confirms the page shows the alert message.
- Manually verified that campaigns with published quests display an **enabled export button** and navigate correctly to the confirmation page.

### Screenshots (if front end is affected)
<img width="1297" height="650" alt="image" src="https://github.com/user-attachments/assets/f0bd3dc6-7233-4fa9-adcc-9f17098185a4" />

<img width="1322" height="617" alt="image" src="https://github.com/user-attachments/assets/a785b961-86a8-486e-b7ca-f753bb00d496" />

<img width="1117" height="826" alt="image" src="https://github.com/user-attachments/assets/2ba76432-e3b7-4b0f-a4eb-31f3d5a57169" />


### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Export action for campaigns in the detail view and campaign list (visible when export is allowed); disabled and accessible when no published quests.  

* **Bug Fixes / UX**
  * Confirmation screen shows a red alert: "You cannot export a campaign with no published quests." Share button now has an explicit DOM id for client-side use.  

* **Permissions**
  * New site-config permission check controlling who can export to the library.  

* **Tests**
  * Added tests for empty-campaign export UI and export permission logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->