### PR TITLE
added individually to the message; Closes #1876

### DIFF
--- a/src/library/templates/library/confirm_import_quest.html
+++ b/src/library/templates/library/confirm_import_quest.html
@@ -4,9 +4,9 @@
 {% block content %}
   {% if local_quest %}
     <div class="alert alert-danger">
-      Your deck already contains a quest with a matching Import ID.  Overwriting existing quests is not yet supported.
+      Your deck already contains a quest with a matching Import ID. Overwriting existing quests individually is not yet supported.
       If you still want to import this quest from the Library, you need to delete the existing quest from your deck
-      or change it's Import ID:
+      or change its Import ID:
     </div>
     <div class="well">
       <p>


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
Just added the word "individually" to the warning message displayed by quests.
### Why?
I identified an inconsistency between warning messages when importing a campaign and importing a quest. When importing a quest it says that overwriting is not currently supported. Then when importing a campaign when you already have a quest in that campaign, it says that the quest may be overwritten. Which could lead to confusion.

for more details see this issue https://github.com/bytedeck/bytedeck/issues/1876
### How?
Changed this 
"Your deck already contains a quest with a matching Import ID.  Overwriting existing quests is not yet supported."
To this
"Your deck already contains a quest with a matching Import ID.  Overwriting existing quests **individually** is not yet supported."
### Testing?
Just an html change
### Screenshots (if front end is affected)
<img width="1079" height="109" alt="image" src="https://github.com/user-attachments/assets/66e31b24-8f92-4dbd-a84e-95c596e030dd" />

### Anything Else?
Let me know if you'd rather a different wording, or change the warning message more.

### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the alert in the quest import confirmation to state that overwriting existing quests individually is not supported, improving guidance during the import flow.
  * Fixed wording/typo in the import prompt from “it's” to the correct “its.” No behavioral or functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->