### PR TITLE
Handling of exporting a campaign with quest conflicts now copies quests to the library; Closes #1884

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -59,8 +59,11 @@ def export_quest_to_library(*, source_schema, quest_import_id):
 
 def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import_ids=None):
     """
-    Exports a campaign (Category) and all its quests from the given tenant schema
-    into the shared library schema.
+    Exports a campaign (Category) and its published quests from the given tenant
+    schema into the shared library schema. By default, all published quests in
+    the campaign are exported. If `skip_import_ids` is provided, any quests whose
+    `import_id` is in that set are excluded (e.g., when you plan to clone
+    conflicts separately).
 
     All exported quests and the campaign will be unpublished in the library by default.
     This ensures the shared library remains a neutral, reviewable repository.
@@ -68,20 +71,25 @@ def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import
     Args:
         source_schema (str): The tenant schema where the campaign currently resides.
         campaign_import_id (UUID): The import ID of the campaign to export.
+        skip_import_ids (Iterable[UUID] | None): Optional set of quest import_ids
+            to exclude from the export. When provided, the export will proceed
+            even if all quests are skipped
 
     Returns:
         ImportResult: The result of the import operation into the library schema.
 
     Raises:
         Category.DoesNotExist: If the campaign is not found in the source schema.
-        ValidationError: If no published quests exist for the campaign.
+        ValidationError: If no published quests exist for the campaign and
+            `skip_import_ids` was not provided.
     """
     with schema_context(source_schema):
         category = Category.objects.get(import_id=campaign_import_id)
         quests = Quest.objects.filter(published=True, campaign=category)
 
         # filter out conflicts (they'll be cloned and exported later)
-        quests = quests.exclude(import_id__in=skip_import_ids)
+        if skip_import_ids:
+            quests = quests.exclude(import_id__in=skip_import_ids)
 
         if not quests.exists() and not skip_import_ids:
             raise ValidationError("Cannot export a campaign without any published quests.")
@@ -116,14 +124,31 @@ def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import
 
 def export_campaign_and_copy_quests(source_schema, campaign_import_id):
     """
-    Exports a campaign and its quests to the library.
-    If any of the quests already exist in the library, copies are created
-    so the exported campaign has its own versions.
+    Export a campaign and its quests to the library, cloning conflicts.
+
+    Process:
+      - Detect quests in the target library that share an import_id with local quests.
+      - Export only the non-conflicting quests (unpublished) and the campaign.
+      - Ensure the campaign exists in the library.
+      - For each conflicting local quest, create a new unpublished copy in the
+        library campaign with a fresh import_id and a suffixed name to avoid
+        uniqueness issues.
+
+    Args:
+        source_schema (str): Tenant schema that contains the source campaign.
+        campaign_import_id (UUID): Import ID of the campaign to export.
+
+    Returns:
+        Category: The library campaign instance.
+
+    Raises:
+        Category.DoesNotExist: If the campaign is not found in the source schema.
     """
 
     # Step 1: get local campaign and quests first (in source schema)
-    local_campaign = Category.objects.get(import_id=campaign_import_id)
-    local_quests = list(local_campaign.current_quests())
+    with schema_context(source_schema):
+        local_campaign = Category.objects.get(import_id=campaign_import_id)
+        local_quests = list(local_campaign.current_quests())
 
     # detect which local quests already exist in the library before the export happens
     library_conflicting_ids = get_library_conflicting_quests(local_quests)
@@ -136,17 +161,19 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
 
     # Step 3: ensure the campaign exists in the library
     with library_schema_context():
-        library_campaign, _ = Category.objects.get_or_create(
-            import_id=campaign_import_id,
-            defaults={
-                'title': local_campaign.title,
-                'icon': local_campaign.icon,
-                'short_description': local_campaign.short_description,
-                'published': False,
-            }
-        )
-        library_campaign.full_clean()
-        library_campaign.save()
+        existing = Category.objects.filter(import_id=campaign_import_id).first()
+        if existing:
+            library_campaign = existing
+        else:
+            library_campaign = Category(
+                import_id=campaign_import_id,
+                title=local_campaign.title,
+                icon=local_campaign.icon,
+                short_description=local_campaign.short_description,
+                published=False,
+            )
+            library_campaign.full_clean()
+            library_campaign.save()
 
         # Step 4: clone only the conflicting quests
         for local_quest in local_quests:

--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -1,12 +1,13 @@
+from datetime import date
+from copy import deepcopy
+from uuid import uuid4
+
 from django_tenants.utils import schema_context
 from quest_manager.admin import QuestResource
 from quest_manager.models import Quest, Category
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
-from datetime import date
-from copy import deepcopy
-from uuid import uuid4
 from .utils import library_schema_context, get_library_conflicting_quests
 
 
@@ -186,12 +187,19 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
 
                 # make sure name fits max length
                 max_len = Quest._meta.get_field("name").max_length or 50
-                suffix = f" (Exported on {date.today()})"
+                base_suffix = f" (Exported on {date.today()})"
                 counter = 1
-                while Quest.objects.filter(name=local_quest.name[:max_len - len(suffix)] + suffix).exists():
-                    suffix = f"{suffix} #{counter}"
+                base_name = local_quest.name
+
+                # Try the base suffix first
+                potential_name = base_name[:max_len - len(base_suffix)] + base_suffix
+                while Quest.objects.filter(name=potential_name).exists():
+                    counter_suffix = f" #{counter}"
+                    full_suffix = base_suffix + counter_suffix
+                    potential_name = base_name[:max_len - len(full_suffix)] + full_suffix
                     counter += 1
-                clone.name = local_quest.name[:max_len - len(suffix)] + suffix
+
+                clone.name = potential_name
 
                 clone.full_clean()
                 clone.save()

--- a/src/library/templates/library/confirm_export_campaign.html
+++ b/src/library/templates/library/confirm_export_campaign.html
@@ -53,10 +53,9 @@
     </form>
     {% if library_quest_import_ids %}
         <div class="alert alert-danger panel-top">
-          {% comment %} TODO: Update this message to the new method of dealing with conflicts. {% endcomment %}
-            <strong>Warning:</strong> One or more quests in this campaign already exist in the library;
-            they are indicated with this icon <i class="icon-spacing fa fa-fw fa-exclamation-triangle"></i> in the quest list below.
-            Exporting this campaign will <strong>overwrite</strong> those existing quests with the local versions.
+          <strong>Warning:</strong> One or more quests in this campaign already exist in the library;
+          they are indicated with this icon <i class="icon-spacing fa fa-fw fa-exclamation-triangle"></i> in the quest list below.
+          Exporting this campaign will <strong>create duplicate copies</strong> of those quests in the library, linked to the exported campaign.
         </div>
     {% endif %}
     <h3>{{ campaign.name }}</h3>

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -945,6 +945,16 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
                     )
                     self.assertEqual(non_conflicting_quest.name, local_quests[1].name)
                     self.assertFalse(non_conflicting_quest.published)
+                else:
+                    # When all quests are conflicts, both should be clones
+                    self.assertEqual(cloned_quests.count(), len(local_quests))
+                    self.assertEqual(
+                        exported_campaign.quest_set.filter(
+                            import_id__in=[q.import_id for q in local_quests]
+                        ).count(),
+                        0,
+                        "Expected no original import_ids when all quests conflict",
+                    )
 
         # Step 3: First export (mix of conflict + non-conflict)
         run_export_and_assert(expect_non_conflicting=True)

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1,4 +1,5 @@
 import uuid
+from copy import deepcopy
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.db import connection
@@ -10,6 +11,7 @@ from django_tenants.utils import tenant_context
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
 from library.utils import get_library_schema_name, library_schema_context
 from library.importer import import_quest_to, import_campaign_to
+from library.exporter import export_campaign_and_copy_quests
 from model_bakery import baker
 from notifications.models import Notification
 from quest_manager.models import Category, Quest
@@ -887,6 +889,70 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
                     ).exists(),
                     f"Notification not found for {user.username}"
                 )
+
+    def test_export__campaign_with_conflicting_quests_clones_correctly(self):
+        """
+        Ensure that exporting a campaign where some quests already exist in the library:
+        - Clones conflicting quests
+        - Assigns new import_ids
+        - Appends a unique suffix to the quest name
+        - Sets published=False on the clones
+        - Works correctly when exporting more than once:
+            * First run: mix of conflicting + non-conflicting quests
+            * Second run: all quests are conflicts, all get cloned
+        """
+        self.client.force_login(self.test_teacher)
+
+        # Step 1: create a local campaign with quests
+        local_campaign = baker.make(Category, title="Local Campaign")
+        local_quests = [
+            baker.make(Quest, campaign=local_campaign, published=True, name="Quest 1"),
+            baker.make(Quest, campaign=local_campaign, published=True, name="Quest 2"),
+        ]
+
+        # Step 2: simulate a conflict in the library (one of the quests already exists)
+        with library_schema_context():
+            conflicting_quest = deepcopy(local_quests[0])
+            conflicting_quest.pk = None
+            conflicting_quest.import_id = local_quests[0].import_id
+            conflicting_quest.campaign = None
+            conflicting_quest.full_clean()
+            conflicting_quest.save()
+
+        def run_export_and_assert(expect_non_conflicting: bool):
+            """Helper to run export and validate clone naming/suffixing."""
+            export_campaign_and_copy_quests(
+                source_schema=self.tenant.schema_name,
+                campaign_import_id=local_campaign.import_id,
+            )
+            with library_schema_context():
+                exported_campaign = Category.objects.get(import_id=local_campaign.import_id)
+                self.assertEqual(exported_campaign.quest_set.count(), 2)
+
+                # One or more cloned quests should exist
+                cloned_quests = exported_campaign.quest_set.exclude(
+                    import_id__in=[q.import_id for q in local_quests]
+                )
+                self.assertTrue(cloned_quests.exists())
+                for cq in cloned_quests:
+                    self.assertFalse(cq.published)
+                    self.assertIn("(Exported on", cq.name)
+
+                if expect_non_conflicting:
+                    # Verify the non-conflicting quest was exported normally
+                    non_conflicting_quest = exported_campaign.quest_set.get(
+                        import_id=local_quests[1].import_id
+                    )
+                    self.assertEqual(non_conflicting_quest.name, local_quests[1].name)
+                    self.assertFalse(non_conflicting_quest.published)
+
+        # Step 3: First export (mix of conflict + non-conflict)
+        run_export_and_assert(expect_non_conflicting=True)
+
+        # Step 4: Delete campaign in library → re-run export (now all quests conflict)
+        with library_schema_context():
+            Category.objects.filter(import_id=local_campaign.import_id).delete()
+        run_export_and_assert(expect_non_conflicting=False)
 
 
 class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -28,17 +28,17 @@ library_schema_context = functools.partial(schema_context, get_library_schema_na
 
 def get_library_conflicting_quests(local_quests):
     """
-    Given a set of local quests, return any quests in the library
+    Given a list of local Quest objects, return any quests in the library
     that share the same import_id (i.e., conflicts).
 
     Args:
-        local_quests (Iterable[Quest]): Local quests to check.
+        local_quests (List[Quest]): Local quests to check.
 
     Returns:
         list[Quest]: List of conflicting Quest objects from the library.
     """
     from quest_manager.models import Quest
-    quest_import_ids = [q.import_id for q in local_quests if q.import_id]
+    quest_import_ids = [q.import_id for q in local_quests]
 
     with library_schema_context():
         conflicts = list(

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -425,6 +425,7 @@ class ExportCampaignView(View, ExportPermissionMixin):
         self._require_export_permission(request)
 
         campaign = get_object_or_404(Category, import_id=campaign_import_id)
+        # evaluate the queryset to render the quests properly and give proper context to get_library_conflicting_quests
         quests = list(campaign.current_quests())
 
         # Get existing campaign in library (if any)

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -81,8 +81,7 @@
               {% if local_quest_import_ids and q.import_id in local_quest_import_ids %}
                 <i title="This quest already exists in your deck and any local changes will be overwritten." class="icon-spacing fa fa-fw fa-exclamation-triangle"></i>
               {% elif library_quest_import_ids and q.import_id in library_quest_import_ids %}
-              {% comment %} TODO: Update this help text with more info on how this conflict will be handled {% endcomment %}
-                <i title="This quest already exists on the library." class="icon-spacing fa fa-fw fa-exclamation-triangle"></i>
+                <i title="This quest already exists in the library and will be copied as a new version during export." class="icon-spacing fa fa-fw fa-exclamation-triangle"></i>
               {% endif %}
             </td>
           </tr>

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -844,7 +844,6 @@ def ajax_quest_info(request, quest_id=None):
                 else:
                     quest = get_object_or_404(Quest, pk=quest_id)
 
-                template = 'quest_manager/preview_content_quests_avail.html'
                 quest_info_html = render_to_string(template,
                                                    {'q': quest, 'is_library_view': is_library_view, 'can_export': can_export},
                                                    request=request)


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
### What?
- Updated the export process to handle quests that already exist in the library by creating duplicate copies instead of overwriting or failing.
- Added `export_campaign_and_copy_quests` function to handle the export and copying of conflicting quests.
- Updated `export_campaign_to_library` to allow exports when all quests already exist in the library.
- Added `get_library_conflicting_quests` utility function to detect conflicts by `import_id`.
- Updated front-end warnings and tooltips to reflect the new behavior of creating duplicate copies.
- Implemented a safe naming mechanism for duplicate quests to avoid unique constraint violations.

### Why?
- Previously conflicting quests would be overwritten.
- With the new implementation of skipping conflicts, exporting a campaign would fail if all quests already existed in the library.
- Ensures that campaigns and their quests are always exportable, maintaining a copy in the library without overwriting existing content.
- Improves clarity for users through updated messages and icons in the UI.

https://github.com/bytedeck/bytedeck/issues/1884

### How?
- In `exporter.py`:
  - Added `export_campaign_and_copy_quests` function.
  - Modified `export_campaign_to_library` to skip conflicts and allow empty `quests` when `skip_import_ids` is not empty.
  - Used `deepcopy` and a counter-based suffix system to safely clone conflicting quests.
- In `utils.py`:
  - Added `get_library_conflicting_quests` to identify conflicting quests in the library by `import_id`.
- In `views.py`:
  - Updated the campaign export view to call `export_campaign_and_copy_quests` instead of `export_campaign_to_library`.
- In templates:
  - Updated warning message in campaign export UI.
  - Updated tooltip on the conflict icon to indicate quests will be copied.

### Testing?
- Verified exporting campaigns when some or all quests already exist in the library.
- Confirmed that duplicate quests are created with unique names and correct campaign associations.
- Checked that front-end warning messages and icons display correctly.
- Ensured the export still works for campaigns with no conflicting quests.
- Added test to make sure cloning functions correctly.
    - First export: mix of conflict + non-conflict
    - Second export: all quests conflict + second export of a conflicting quest

### Screenshots (if front end is affected)

<img width="1100" height="793" alt="image" src="https://github.com/user-attachments/assets/312153d1-59d1-4620-8788-d5571eb8cf32" />

<img width="1337" height="208" alt="image" src="https://github.com/user-attachments/assets/e33bdef2-16a4-4bcd-a30c-4fec00512150" />


### Anything Else?


https://github.com/user-attachments/assets/8f1e6533-8fe5-4ac8-bd3b-70fffaa88ee2



### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Campaign export is now conflict-aware: non-conflicting quests export immediately, while conflicting quests are copied as new unpublished versions linked to the campaign.
  - Ensures exported campaigns and cloned quests start unpublished.
- UI
  - Updated warning text to clarify that conflicts will be copied, not overwritten.
  - Revised tooltip to indicate conflicting quests will be copied during export.
- Tests
  - Added integration test validating cloning behavior for conflicting quests.
- Refactor
  - Centralized conflict detection logic and streamlined export flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->