### PR TITLE
new deck request model and form to automate process

### DIFF
--- a/src/templates/account/login.html
+++ b/src/templates/account/login.html
@@ -9,6 +9,12 @@
 {% block heading %}{% trans "Sign In" %}<i class="pull-right fa fa-sign-in"></i>{% endblock %}
 
 {% block content %}
+  {% if request.GET.created %}
+  <div class="alert alert-success" role="alert">
+    Deck created! Check your email for login credentials.
+  </div>
+  {% endif %}
+
   {% comment %}
     Conditions are setup this way because checking socialaccount_providers returns a list of strings based on the INSTALLED_APPS
     If you look at the get_providers tag, it returns all social account providers whether it is configured or not

--- a/src/templates/public/base.html
+++ b/src/templates/public/base.html
@@ -33,7 +33,7 @@
     <!-- Messages -->
 
     {% if messages %}{% for message in messages %}
-    <div class="alert alert-warning alert-dismissible fade show text-center lead {% if message.tags %}{{ message.tags }}{% endif %}" role="alert"}>
+    <div class="alert alert-warning alert-dismissible fade show text-center lead {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">
         <b>{{ message|safe }}</b>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
           <span aria-hidden="true">&times;</span>
@@ -86,7 +86,7 @@
           </a>
         </li> -->
         <li class="nav-item">
-          <a class="nav-link" href="/pages/request-a-deck/">Try it</a>
+          <a class="nav-link" href="{% url 'decks:request_new_deck' %}">Try it</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/pages/subscribe/">Pricing</a>

--- a/src/templates/public/snippets/footer.html
+++ b/src/templates/public/snippets/footer.html
@@ -5,7 +5,7 @@
            <h1-BD>ByteDeck</h1-BD>
            <hr style="width:100px">
            <ul class="BD-footer-links">
-            <li><a href="/pages/request-a-deck/">Try it</a></li>
+            <li><a href="{% url 'decks:request_new_deck' %}">Try it</a></li>
             <li><a href="/pages/subscribe/">Pricing</a></li>
             <li><a href="https://github.com/bytedeck/bytedeck/discussions">Help Forum</a></li>
 

--- a/src/tenant/forms.py
+++ b/src/tenant/forms.py
@@ -1,7 +1,11 @@
+from captcha.fields import ReCaptchaField
+from captcha.widgets import ReCaptchaV2Checkbox
+
 from django import forms
 from django.contrib.auth import get_user_model
 from django.forms import ModelForm
 
+from siteconfig.models import SiteConfig
 from .models import Tenant
 
 User = get_user_model()
@@ -55,3 +59,91 @@ class TenantForm(TenantBaseForm):
 
     class Meta(TenantBaseForm.Meta):
         fields = TenantBaseForm.Meta.fields + ["first_name", "last_name", "email"]
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the TenantForm.
+
+        If `verified_data` is provided in kwargs, pre-fill the form fields
+        from it and disable the email field so that it cannot be modified.
+
+        Args:
+            *args: Positional arguments passed to the parent form.
+            **kwargs: Keyword arguments passed to the parent form. Can include:
+                verified_data (dict, optional): Dictionary containing pre-verified
+                    user data with keys 'deck_name', 'first_name', 'last_name', 'email'.
+        """
+        # Pop verified data from kwargs (if any)
+        self.verified_data = kwargs.pop('verified_data', None)
+        super().__init__(*args, **kwargs)
+        if self.verified_data:
+            # Pre-fill fields from verified session
+            self.fields["first_name"].initial = self.verified_data.get("first_name", "")
+            self.fields["last_name"].initial = self.verified_data.get("last_name", "")
+            self.fields["email"].initial = self.verified_data.get("email", "")
+
+            # Email is already verified so make it immutable
+            self.fields["email"].disabled = True
+
+    def clean_email(self):
+        """
+        Ensure the email field has a valid value during form cleaning.
+
+        Returns the initial verified email if the field is disabled,
+        otherwise returns the cleaned data from user input.
+
+        Returns:
+            str: The email address for the tenant owner.
+        """
+        if self.fields["email"].disabled:
+            email = (self.verified_data or {}).get("email") or self.initial.get("email")
+            if not email:
+                raise forms.ValidationError("Verified e-mail address is required.")
+            return email
+        return self.cleaned_data.get("email")
+
+    def save(self, commit=True):
+        """
+        Save the Tenant and ensure the deck owner User has the correct email and names.
+        """
+        tenant = super().save(commit=False)
+
+        email = self.cleaned_data.get("email") or self.initial.get("email")
+        first_name = self.cleaned_data.get("first_name")
+        last_name = self.cleaned_data.get("last_name")
+
+        if commit:
+            tenant.full_clean()
+            tenant.save()
+
+            # Optionally update owner only when in a tenant schema (non-public)
+            config = SiteConfig.get()
+            if config:
+                owner = config.deck_owner
+                owner.email = email
+                owner.first_name = first_name
+                owner.last_name = last_name
+                owner.full_clean()
+                owner.save()
+
+        return tenant
+
+
+class DeckRequestForm(forms.Form):
+    """Public form to request a new deck; protected by reCAPTCHA."""
+
+    first_name = forms.CharField(
+        max_length=150,
+        label="First Name",
+        widget=forms.TextInput(attrs={"placeholder": "Your first name"})
+    )
+    last_name = forms.CharField(
+        max_length=150,
+        label="Last Name",
+        widget=forms.TextInput(attrs={"placeholder": "Your last name"})
+    )
+    email = forms.EmailField(
+        label="Your Email",
+        widget=forms.EmailInput(attrs={"placeholder": "you@example.com"})
+    )
+    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox)

--- a/src/tenant/templates/tenant/deck_request_denied.html
+++ b/src/tenant/templates/tenant/deck_request_denied.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content_outer %}
+<h1>Deck Request Required</h1>
+<p>You need to submit a deck request and verify your email before creating a new deck.</p>
+<p><a href="{% url 'decks:request_new_deck' %}">Return to deck request form</a></p>
+{% endblock %}

--- a/src/tenant/templates/tenant/email/verify_deck_request.txt
+++ b/src/tenant/templates/tenant/email/verify_deck_request.txt
@@ -1,0 +1,11 @@
+Hello {{ first_name }},
+
+Thank you for requesting a new deck.
+
+Please verify your email within 1 hour by clicking this link:
+{{ verification_link }}
+
+If you did not request a deck, you can safely ignore this email.
+
+Thank you,
+Bytedeck Team

--- a/src/tenant/templates/tenant/request_new_deck.html
+++ b/src/tenant/templates/tenant/request_new_deck.html
@@ -1,0 +1,16 @@
+{% extends "public/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="container my-5">
+    <h1 class="mb-4">Request a New Deck</h1>
+
+    <form method="post">
+        {% csrf_token %}
+        {{ form|crispy }}
+
+        <button type="submit" class="btn btn-primary mt-3">Submit Request</button>
+    </form>
+</div>
+{% endblock %}

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1,24 +1,22 @@
-from unittest.mock import patch
-from freezegun import freeze_time
-from datetime import datetime
+from unittest.mock import PropertyMock, Mock, patch
 
 from django.conf import settings
-from django.core import mail
+from django.views import View
 from django.http import Http404, HttpResponse
 from django.contrib.auth import get_user_model
 from django.shortcuts import reverse
-from django.test import RequestFactory
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
 
-from allauth.account.models import EmailAddress, EmailConfirmationHMAC
-from allauth.account.adapter import get_adapter
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name
 from django_tenants.utils import tenant_context
 
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
-from tenant.views import non_public_only_view, public_only_view, email_confirmed_handler
+from tenant.views import non_public_only_view, public_only_view, TenantCreate, TenantForm, EmailVerificationRequiredMixin
 from tenant.models import Tenant
+from tenant.utils import DeckRequestService
 from siteconfig.models import SiteConfig
 
 User = get_user_model()
@@ -72,7 +70,9 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
     """Various tests for `TenantCreate` view class."""
 
     def setUp(self):
-        # create the public schema
+        self.factory = RequestFactory()
+
+        # Create the public schema
         self.public_tenant = Tenant(schema_name="public", name="public")
         with tenant_context(self.public_tenant):
             # create superuser account
@@ -85,101 +85,139 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
             # django signals (post_save and pre_save) can save us a lot of time.
             Tenant.objects.bulk_create([self.public_tenant])
             self.public_tenant.refresh_from_db()
-            # create domain object manually, since we avoided triggering the signals
-            self.public_tenant.domains.create(domain="localhost", is_primary=True)
+            # Use 'testserver' as the domain for environment-agnostic testing
+            self.public_tenant.domains.create(domain="testserver", is_primary=True)
 
-        self.client = TenantClient(self.public_tenant)
+        # Create client for the tenant
+        self.client = TenantClient(self.public_tenant, host="testserver")
 
-    def test_default(self):
-        """
-        Creating new tenant object with valid data, should pass without errors.
-        """
-        # first case, access /decks/new/ page as anonymous user
-        # should returns 302 (login required, note: it's admin/login/ page)
-        response = self.client.get(reverse("tenant:new"))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual("{}?next={}".format(reverse("admin:login"), reverse("tenant:new")), response.url)
-
-        self.client.force_login(self.superuser)
-
-        # second case, forgot to enter "first" and "last" names
-        # should returns 200 (same page, but with errors)
-        form_data = {
-            "name": "default",
-            "email": "john.doe@example.com",
-        }
-        response = self.client.post(reverse("tenant:new"), data=form_data)
-        self.assertEqual(response.status_code, 200)
-
-        # third case, incorrect email address
-        # should returns 200 (same page, but with errors)
-        form_data = {
+        self.form_data = {
             "name": "default",
             "first_name": "John",
             "last_name": "Doe",
-            "email": "john.doe@example",  # incorrect email address
+            "email": "john.doe@example.com",
+            "captcha": "dummy",
         }
-        response = self.client.post(reverse("tenant:new"), data=form_data)
-        self.assertEqual(response.status_code, 200)
+
+    def test_anonymous_denied_without_verified_deck_request(self):
+        """Anonymous users without a verified deck request are denied access."""
+        response = self.client.get(reverse("tenant:new"))
+        self.assertEqual(response.status_code, 403)
+        self.assertTemplateUsed(response, "tenant/deck_request_denied.html")
+
+    def test_form__errors_for_missing_fields(self):
+        """Form errors occur if first_name, last_name, or invalid email are missing."""
+        self.client.force_login(self.superuser)
+
+        # Missing first_name / last_name
+        form_data = {"name": "default", "email": "john.doe@example.com"}
+        response = self.client.post(reverse("tenant:new"), data=form_data, follow=True)
+        # Check that the error message for required fields is present
+        self.assertContains(response, "This field is required", count=2)
+
+        # Invalid email
+        form_data.update({"first_name": "John", "last_name": "Doe", "email": "john.doe@example"})
+        response = self.client.post(reverse("tenant:new"), data=form_data, follow=True)
+        # Check for invalid email error
         self.assertContains(response, "Enter a valid email address")
 
-        # fourth (final) case, and finally trying to submit with all required (non-blank) fields
-        # should returns 302 (redirect to newly created tenant)
-        # need to freeze_time as signer keys are timestamped. Without it will fail the confirmation_link test
-        with freeze_time(datetime(2024, 3, 3)):
-            form_data = {
-                "name": "default",
-                "first_name": "John",
-                "last_name": "Doe",
-                "email": "john.doe@example.com",
-            }
-            response = self.client.post(reverse("tenant:new"), data=form_data)
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(response.url, "http://default.localhost:8000")
+    @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
+    @patch.object(DeckRequestService, "send_verification_email")
+    def test_successful_deck_request_sends_email_and_shows_message(self, mock_send_email, mock_captcha):
+        """
+        Ensure that submitting a valid deck request triggers the verification
+        email to be sent and returns a redirect response.
+        """
+        form_data = {
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john.doe@example.com",
+            "captcha": "dummy",
+        }
+        response = self.client.post(reverse("decks:request_new_deck"), data=form_data)
+        mock_send_email.assert_called_once()
+        mock_captcha.assert_called()
+        self.assertEqual(response.status_code, 302)
 
-            # check mailbox after submitting form
-            self.assertEqual(len(mail.outbox), 1)
-            self.assertIn("Please Confirm Your Email Address", mail.outbox[0].subject)
-            # expecting to see john.doe@example.com as recipient
-            self.assertEqual(mail.outbox[0].to, ['john.doe@example.com'])
-            # expecting to see correct domain name in confirmation link and make sure link is correct
-            email_address = EmailAddress.objects.get(email="john.doe@example.com")
-            key = EmailConfirmationHMAC(email_address).key
-            confirmation_link = "".join(["http://default.localhost:8000", reverse("account_confirm_email", args=[key])])
+    @patch("tenant.models.Tenant.full_clean")
+    def test_tenant_form_saves_owner_correctly(self, mock_full_clean):
+        """TenantForm should save tenant and create deck owner from verified data."""
+        form = TenantForm(data=self.form_data, verified_data=self.form_data)
+        self.assertTrue(form.is_valid(), form.errors)
 
-            self.assertIn(confirmation_link, mail.outbox[0].body)
+        tenant = form.save()
 
-            owner = SiteConfig.get().deck_owner or None
-            self.assertEqual(owner.get_full_name(), "John Doe")  # should be equal and prove the case
+        with tenant_context(tenant):
+            site_config = SiteConfig.objects.get()
+            owner = site_config.deck_owner
+
+            self.assertEqual(owner.first_name, "John")
+            self.assertEqual(owner.last_name, "Doe")
             self.assertEqual(owner.email, "john.doe@example.com")
 
-            # check that the username was set to firstname.lastname (instead of "owner")
-            self.assertEqual(owner.username, "john.doe")  # should be equal and prove the case
-            # check that the  password was set to firstname-deckname-lastname (instead of "password")
-            self.assertEqual(owner.check_password("john-default-doe"), True)
+    @patch("tenant.models.Tenant.full_clean")
+    def test_form_valid_creates_tenant_and_redirects(self, mock_full_clean):
+        """TenantCreate.form_valid should save tenant, assign deck owner, and redirect."""
+        request = self.factory.post(reverse("tenant:new"), data=self.form_data)
+        request.session = {"verified_deck_request": self.form_data}
 
-            # manually verify email
-            email_address_obj = owner.emailaddress_set.get(email="john.doe@example.com")
-            get_adapter(response.wsgi_request).confirm_email(response.wsgi_request, email_address_obj)
+        view = TenantCreate()
+        view.setup(request)
 
-            # clear the outbox from outdated messages
-            mail.outbox.clear()
+        form = TenantForm(data=self.form_data, verified_data=self.form_data)
+        self.assertTrue(form.is_valid(), form.errors)
 
-            # confirming the email/account and receiving welcome email
-            email_confirmed_handler(email_address=email_address_obj)
+        response = view.form_valid(form)
+        self.assertEqual(response.status_code, 302)
 
-            self.assertEqual(len(mail.outbox), 1)
-            self.assertIn("Instructions to sign in to default", mail.outbox[0].subject)
-            # expecting to see the same john.doe@example.com as recipient
-            self.assertEqual(mail.outbox[0].to, ['john.doe@example.com'])
+        tenant = form.instance
 
-            # ... make sure only non-logged users receives "welcome" email
-            self.client.force_login(owner)
+        with tenant_context(tenant):
+            site_config = SiteConfig.objects.get()
+            self.assertIsInstance(site_config.deck_owner, User)
+            self.assertEqual(site_config.deck_owner.email, "john.doe@example.com")
 
-            # clear the outbox from outdated messages
-            mail.outbox.clear()
 
-            # trying to confirm email after being logged into app...
-            email_confirmed_handler(email_address=email_address_obj)
-            # expect to receive nothing...
-            self.assertEqual(len(mail.outbox), 0)
+class DummyView(EmailVerificationRequiredMixin, View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("ok")
+
+
+class EmailVerificationRequiredMixinTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User(username="regular")
+        self.fake_profile = Mock()
+        self.fake_profile.id = 123
+        patcher = patch.object(User, "profile", new_callable=PropertyMock, return_value=self.fake_profile)
+        self.mock_profile = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.view = DummyView.as_view()
+
+    @patch("tenant.views.render")  # patch render to avoid template DB queries
+    def test_verified_at_allows_or_denies_access(self, mock_render):
+        # make render() just return a dummy response
+        mock_render.side_effect = lambda request, template_name, context=None, status=None: HttpResponse(status=status or 200)
+
+        fixed_now = timezone.now()
+
+        def make_request(ts):
+            request = self.factory.get("/dummy/")
+            request.user = self.user
+            request.session = {
+                "verified_deck_request": {"email": "john.doe@example.com", "verified_at": ts}
+            }
+            return request
+
+        # Recent timestamp allowed
+        recent_ts = fixed_now.timestamp()
+        request = make_request(recent_ts)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+
+        # Stale timestamp denied
+        stale_ts = fixed_now.timestamp() - (DeckRequestService.TOKEN_MAX_AGE + 1)
+        request = make_request(stale_ts)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 403)

--- a/src/tenant/urls.py
+++ b/src/tenant/urls.py
@@ -6,4 +6,6 @@ app_name = 'tenant'
 
 urlpatterns = [
     path('new/', views.TenantCreate.as_view(), name='new'),
+    path("request-new-deck/", views.RequestNewDeck.as_view(), name="request_new_deck"),
+    path("request-new-deck/verify/<path:token>/", views.verify_deck_request, name="verify_deck_request"),
 ]

--- a/src/tenant/utils.py
+++ b/src/tenant/utils.py
@@ -1,4 +1,10 @@
+from django.core import signing
+from django.core.signing import BadSignature, SignatureExpired
+from django.template.loader import get_template
+
+from siteconfig.models import SiteConfig
 from .models import Tenant
+from .tasks import send_email_message
 
 
 def get_root_url():
@@ -17,3 +23,150 @@ def get_root_url():
 
 def generate_schema_name(tenant_name):
     return tenant_name.replace('-', '_').lower()
+
+
+def generate_default_owner_password(user, tenant):
+    """Generate a default password for a new deck's owner to
+    firstname-deckname-lastname
+    """
+    return "-".join([user.first_name, tenant.name, user.last_name]).lower()
+
+
+class DeckRequestService:
+    """Handles deck request token generation, validation, and email sending."""
+
+    TOKEN_MAX_AGE = 3600  # 1 hour
+
+    @staticmethod
+    def generate_token(first_name, last_name, email):
+        """
+        Generate a signed token encoding the user's first name, last name, and email.
+
+        The token is timestamped and can later be validated to confirm the user's
+        identity during deck creation.
+
+        Args:
+            first_name (str): User's first name.
+            last_name (str): User's last name.
+            email (str): User's email address.
+
+        Returns:
+            str: A signed, timestamped token containing the user info.
+        """
+        payload = {
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email
+        }
+        return signing.dumps(payload, salt="deck-request", compress=True)
+
+    @staticmethod
+    def decode_token(token):
+        """
+        Decode and verify a signed deck request token.
+
+        Validates the token's signature and ensures it is not older than TOKEN_MAX_AGE.
+        Returns the decoded user data if valid, otherwise returns None.
+
+        Args:
+            token (str): A signed deck request token.
+
+        Returns:
+            dict or None: Decoded user data with keys 'first_name', 'last_name', 'email',
+            or None if the token is invalid or expired.
+        """
+        try:
+            return signing.loads(
+                token,
+                salt="deck-request",
+                max_age=DeckRequestService.TOKEN_MAX_AGE
+            )
+        except (BadSignature, SignatureExpired):
+            return None
+
+    @staticmethod
+    def build_verification_link(request, token):
+        """
+        Construct a full URL for verifying a deck request token.
+
+        Args:
+            request (HttpRequest): The current request object, used to build absolute URI.
+            token (str): The signed deck request token.
+
+        Returns:
+            str: A fully-qualified URL that the user can visit to verify their deck request.
+        """
+        from django.urls import reverse
+        path = reverse("decks:verify_deck_request", args=[token])
+        return request.build_absolute_uri(path)
+
+    @staticmethod
+    def send_verification_email(first_name, email, token, request=None):
+        """
+        Send a verification email containing a deck request token.
+
+        If `request` is provided, builds an absolute URL using the request context.
+        Otherwise, uses a relative URL.
+
+        Args:
+            first_name (str): User's first name.
+            email (str): User's email address.
+            token (str): Signed deck request token.
+            request (HttpRequest, optional): The current request, used for building absolute URL.
+
+        Returns:
+            None
+        """
+        from django.urls import reverse
+        if request:
+            verification_link = request.build_absolute_uri(
+                reverse("decks:verify_deck_request", args=[token])
+            )
+        else:
+            verification_link = f"/decks/request-new-deck/verify/{token}/"
+
+        message = get_template("tenant/email/verify_deck_request.txt").render({
+            "first_name": first_name,
+            "verification_link": verification_link,
+        })
+
+        send_email_message(
+            subject="Verify your email to confirm your deck request",
+            message=message,
+            recipient_list=[email],
+        )
+
+    @staticmethod
+    def send_welcome_email(user, tenant):
+        """
+        Send a welcome email to a newly created tenant owner.
+
+        The email contains information about the new tenant and the default
+        owner password. It is sent asynchronously via Celery.
+
+        Args:
+            user (User): The newly created deck owner.
+            tenant (Tenant): The newly created tenant instance.
+
+        Returns:
+            None
+        """
+        subject = get_template("tenant/email/welcome_subject.txt").render({
+            "config": SiteConfig.get(),
+            "tenant": tenant,
+            "user": user,
+        })
+        subject = "".join(subject.splitlines())
+
+        message = get_template("tenant/email/welcome_message.txt").render({
+            "config": SiteConfig.get(),
+            "tenant": tenant,
+            "user": user,
+            "password": generate_default_owner_password(user, tenant),
+        })
+
+        send_email_message(
+            subject=subject,
+            message=message,
+            recipient_list=[user.email],
+        )

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -1,28 +1,28 @@
 import functools
 
-from django.core.mail import EmailMultiAlternatives
-from django.template.loader import get_template
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.sites.models import Site
+from django.contrib import messages
+from django.shortcuts import redirect, render
 from django.db import connection
-from django.dispatch import receiver
 from django.http import Http404, HttpResponseRedirect
 from django.utils.decorators import method_decorator
+from django.utils.text import slugify
+from django.utils import timezone
 from django.views.generic.edit import CreateView
+from django.views.generic import FormView
 from django.urls import reverse_lazy
 
 from django_tenants.utils import get_public_schema_name
 from django_tenants.utils import tenant_context
 
-from allauth.account.utils import user_username, send_email_confirmation
-from allauth.account.signals import email_confirmed
-from allauth.account.models import EmailConfirmationHMAC
+from allauth.account.utils import user_username
+from allauth.account.models import EmailAddress
 
 from siteconfig.models import SiteConfig
-from utilities.html import textify
 
-from .forms import TenantForm
+from .forms import TenantForm, DeckRequestForm
 from .models import Tenant
+from .utils import DeckRequestService, generate_default_owner_password
 
 
 def public_only_view(f):
@@ -59,27 +59,89 @@ class NonPublicOnlyViewMixin:
         return super().dispatch(*args, **kwargs)
 
 
-def generate_default_owner_password(user, tenant):
-    """Generate a default password for a new deck's owner to"
-    firstname-deckname-lastname
+class EmailVerificationRequiredMixin:
     """
-    return "-".join([user.first_name, tenant.name, user.last_name]).lower()
+    Restricts access to views unless:
+    - The user is staff (always allowed), OR
+    - The session has a verified_deck_request.
+
+    Does NOT require authentication if the user has a verified_deck_request.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        # staff always allowed
+        if request.user.is_authenticated and request.user.is_staff:
+            return super().dispatch(request, *args, **kwargs)
+
+        # allow if session has verified token
+        verified = request.session.get("verified_deck_request")
+        if verified:
+            verified_at = verified.get("verified_at")
+            if verified_at is not None:
+                now_ts = timezone.now().timestamp()
+                if now_ts - float(verified_at) <= DeckRequestService.TOKEN_MAX_AGE:
+                    return super().dispatch(request, *args, **kwargs)
+            # stale or malformed so clear it
+            request.session.pop("verified_deck_request", None)
+
+        # deny otherwise
+        return render(request, "tenant/deck_request_denied.html", status=403)
 
 
-class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
+class TenantCreate(PublicOnlyViewMixin, EmailVerificationRequiredMixin, CreateView):
+    """
+    View to create a new tenant (deck) in the system.
+
+    Collects tenant name, owner first and last name, and email.
+    Automatically creates or updates the deck owner, sets a default password,
+    verifies the owner's email, and sends a welcome email via DeckRequestService.
+    """
     model = Tenant
     form_class = TenantForm
     template_name = 'tenant/tenant_form.html'
     login_url = reverse_lazy('admin:login')
 
-    def form_valid(self, form):
-        """ Copy the tenant name to the schema_name and the domain_url fields."""
-        # TODO: this is duplication of code in admin.py.  Move this into the Tenant model?  Perhaps as a pre-save hook?
-        form.instance.schema_name = form.instance.name.replace('-', '_')
-        form.instance.domain_url = f'{form.instance.name}.{Site.objects.get(id=1).domain}'
+    def get_form_kwargs(self):
+        """
+        Returns the keyword arguments for instantiating the form.
 
-        # save the form and get the response (HttpResponseRedirect)
-        response = super().form_valid(form)
+        If there is a verified deck request stored in the session, it is
+        passed to the form under the 'verified_data' key.
+
+        Returns:
+            dict: Form keyword arguments, possibly including 'verified_data'.
+        """
+        kwargs = super().get_form_kwargs()
+        verified_data = self.request.session.get("verified_deck_request")
+        kwargs['verified_data'] = verified_data
+        return kwargs
+
+    def form_valid(self, form):
+        """
+        Called when the submitted form is valid.
+
+        Creates the tenant instance and updates the deck owner's information.
+        Sets a default password, marks the email as verified, and sends a
+        welcome email to the owner. Finally, redirects to the tenant's login
+        page with a 'created=1' query parameter.
+
+        Args:
+            form (TenantForm): The validated form instance.
+
+        Returns:
+            HttpResponseRedirect: Redirect to the tenant's login page.
+        """
+        # Normalize: valid Postgres schema and subdomain
+        name_slug = slugify(form.instance.name)
+        schema = name_slug.replace("-", "_")[:63]
+        if not schema or not schema[0].isalpha():
+            schema = f"t_{schema}"[:63]
+        form.instance.schema_name = schema
+        current_domain = Site.objects.get_current().domain
+        form.instance.domain_url = f"{name_slug}.{current_domain}"
+
+        # Save tenant
+        self.object = form.save()
 
         # saved object (tenant) can be accessed via `object` attribute
         cleaned_data = form.cleaned_data
@@ -89,7 +151,6 @@ class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
             # otherwise save first / last name
             owner.first_name = cleaned_data['first_name']
             owner.last_name = cleaned_data['last_name']
-            owner.save()
 
             # set the owner's username to firstname.lastname (instead of "owner")
             user_username(owner, f"{owner.first_name}.{owner.last_name}")
@@ -97,82 +158,112 @@ class TenantCreate(PublicOnlyViewMixin, LoginRequiredMixin, CreateView):
             # set the owner's password to firstname-deckname-lastname
             owner.set_password(generate_default_owner_password(owner, self.object))
 
-            # save email address
-            email = cleaned_data['email']
-            owner.email = email
+            # Email is immutable but assign for completeness
+            owner.email = cleaned_data.get("email")
+            owner.full_clean()
             owner.save()
 
-            return HttpResponseRedirect(self.get_success_url())
+            # Mark email as verified and primary
+            email_address, created = EmailAddress.objects.get_or_create(
+                user=owner,
+                email=owner.email,
+                defaults={'verified': True, 'primary': True}
+            )
+            if not created:
+                email_address.verified = True
+                email_address.primary = True
+                email_address.full_clean()
+                email_address.save()
 
-        return response
+            DeckRequestService.send_welcome_email(owner, self.object)
 
-    def post(self, request, *args, **kwargs):
-        """
-        Handle POST requests: instantiate a form instance with the passed
-        POST variables and then check if it's valid.
-        """
-        self.object = None
-
-        form = self.get_form()
-        if form.is_valid():
-            # get the response (HttpResponseRedirect)...
-            response = self.form_valid(form)
-            # ...and send email confirmation message
-            with tenant_context(self.object):
-                owner = SiteConfig.get().deck_owner
-                send_email_confirmation(
-                    request=request,
-                    user=owner,
-                    signup=False,
-                    email=owner.email,
-                )
-
-            return response
-        else:
-            return self.form_invalid(form)
-
-    def get_success_url(self):
-        """ Redirect to the newly created tenant."""
-        return self.object.get_root_url()
+        login_url = f"{self.object.get_root_url().rstrip('/')}/accounts/login/?created=1"
+        # clear the verified deck request so the next visit gets a clean form
+        self.request.session.pop("verified_deck_request", None)
+        return HttpResponseRedirect(login_url)
 
 
-@receiver(email_confirmed, sender=EmailConfirmationHMAC)
-def email_confirmed_handler(email_address, **kwargs):
-    """Send a welcome email to the deck owner after their email has been verified.
-    Include instructions for how to log in with the username and password.
+class RequestNewDeck(PublicOnlyViewMixin, FormView):
     """
-    user = email_address.user
-    config = SiteConfig.get()
-    tenant = Tenant.get()
+    View to handle requests for creating a new deck.
 
-    # just verified email for a first time and never been logged into app before
-    if user.last_login is not None:
-        return
-    # somehow user is not a deck owner
-    if not (user.pk == config.deck_owner.pk):
-        return
+    Renders a form to collect first name, last name, and email. Upon valid
+    submission, it sends a verification email containing a time-limited token
+    to confirm the user's email address before creating a new deck.
 
-    subject = get_template("tenant/email/welcome_subject.txt").render(context={
-        "config": config,
-        "tenant": tenant,
-        "user": user,
-    })
-    # email subject *must not* contain newlines
-    subject = "".join(subject.splitlines())
+    Inherits:
+        PublicOnlyViewMixin: restricts access to the public schema only.
+        FormView: standard Django form handling.
+    """
 
-    # generate "welcome" email for new user
-    msg = get_template("tenant/email/welcome_message.txt").render(context={
-        "config": config,
-        "tenant": tenant,
-        "user": user,
-        "password": generate_default_owner_password(user, tenant),
-    })
+    form_class = DeckRequestForm
+    template_name = "tenant/request_new_deck.html"
+    success_url = reverse_lazy("decks:request_new_deck")
 
-    # sending a text and HTML content combination
-    email = EmailMultiAlternatives(
-        subject,
-        body=textify(msg),  # convert msg to plain text, using textify utility
-        to=[user.email],
-    )
-    email.attach_alternative(msg, "text/html")
-    email.send()
+    def form_valid(self, form):
+        """
+        Handle valid deck request form submissions.
+
+        Extracts the user's first name, last name, and email from the form.
+        Generates a signed verification token and sends an email containing
+        the verification link. A success message is displayed prompting the
+        user to check their inbox.
+
+        Args:
+            form (DeckRequestForm): The validated form instance containing
+                the user's information.
+
+        Returns:
+            HttpResponse: Redirect to the success URL as defined by FormView.
+        """
+        first_name = form.cleaned_data["first_name"]
+        last_name = form.cleaned_data["last_name"]
+        email = form.cleaned_data["email"]
+
+        token = DeckRequestService.generate_token(first_name, last_name, email)
+        DeckRequestService.send_verification_email(first_name, email, token, request=self.request)
+
+        messages.success(self.request, "Check your email to verify your request!")
+        return super().form_valid(form)
+
+
+def verify_deck_request(request, token):
+    """
+    Verify a deck creation request via a signed token.
+
+    Attempts to decode the provided verification token. If valid, the
+    decoded data is stored in the session under `verified_deck_request`
+    so it can be prefilled during deck creation.
+    If invalid or expired, an error message is shown and the user is
+    redirected back to the request form.
+
+    Args:
+        request (HttpRequest): The current request object.
+        token (str): The signed token received from the verification email.
+
+    Returns:
+        HttpResponseRedirect: Redirects to either the deck request form if
+        verification fails, or the deck creation form if verification succeeds.
+    """
+    data = DeckRequestService.decode_token(token)
+    if not data:
+        messages.error(
+            request,
+            "Your verification link is invalid or has expired. "
+            "Please request a new deck verification email."
+        )
+        return redirect("decks:request_new_deck")
+
+    # stash verification in session
+    request.session["verified_deck_request"] = {
+        "deck_name": data.get("deck_name", ""),
+        "first_name": data.get("first_name", ""),
+        "last_name": data.get("last_name", ""),
+        "email": data.get("email", ""),
+        "verified_at": timezone.now().timestamp(),
+    }
+
+    messages.success(request, "Email verified! Now create your deck.")
+
+    # redirect to deck creation form
+    return redirect("decks:new")


### PR DESCRIPTION
Please ensure you are familiar with our Pull Request Description expectations described here: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/
## What?
Refactored the deck request and tenant creation flow to use a centralized, stateless `DeckRequestService` for token generation, verification, and email handling.


- Added `DeckRequestService` class:

  - `generate_token(first_name, last_name, email)`: Creates a signed, timestamped token.
  - `decode_token(token)`: Validates and decodes token; returns user data if valid, `None` otherwise.
  - `build_verification_link(request, token)`: Builds a full verification URL.
  - `send_verification_email(first_name, email, token, request=None)`: Sends an email containing the verification token.
  - `send_welcome_email(user, tenant)`: Sends the welcome email to a newly created tenant owner.
  - `TOKEN_MAX_AGE = 3600` (1 hour expiration for tokens).

### Why?
The old deck request process relied on manual input and was less secure. Moving to a token-based system ensures that:

- Only verified requests can create new tenants.
- The email associated with the deck owner is guaranteed to be verified.
- Staff/admins can still bypass verification and created tenants normally.
- Session data doesn't persist past its intended use.

https://github.com/bytedeck/bytedeck/issues/1730

### How?
- Deck request submission now generates a signed, timestamped token with first name, last name, and email.
- The token is sent via email and must be used within 1 hour.
- When verified, the decoded payload is stored in `session["verified_deck_request"]`.
- `TenantCreateView` access is controlled via `EmailVerificationRequiredMixin`:
    - Staff can always access.
    - Non-staff must have a valid session token.
- Once the form is completed, session data is cleared.

### Testing?  
- Form validations, including email immutability when pre-verified  
- DeckRequestForm triggers verification email correctly  
- TenantCreate correctly saves owner and tenant, sets username/password, and marks email verified  
- Access restrictions enforced for public/non-public tenants and verified/non-verified users

### Screenshots (if front end is affected)
<img width="1837" height="813" alt="image" src="https://github.com/user-attachments/assets/03d7533e-4141-4f69-a6df-875bd68b090c" />

Message displayed after submitting a valid deck request.
<img width="1903" height="72" alt="image" src="https://github.com/user-attachments/assets/ed74ee7e-44ee-4972-8449-6b48953a48a1" />

Clicking the verification link verifies the email and redirects to the create new deck form with pre filled in values and immutable email field.
<img width="1224" height="610" alt="image" src="https://github.com/user-attachments/assets/cf52ddc9-e652-464b-9b0f-52156ad10d01" />

Verification link only lasts an hour, if you wait longer than an hour this message gets displayed when you click the link after at least an hour has passed.
<img width="1897" height="75" alt="image" src="https://github.com/user-attachments/assets/118984bf-253f-48fd-a355-468f5bdcc78c" />


### Anything Else?
### Review request
@tylerecouture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public "Request a New Deck" page with CAPTCHA, email verification link (1‑hour expiry) and welcome email containing initial login info; successful creation redirects to login and shows a "Deck created! Check your email for login credentials." alert.
  * "Deck request denied" page shown when verification is required.

* **Bug Fixes**
  * Fixed stray brace in messages alert.
  * Navbar/footer "Try it" links now use dynamic URL resolution.

* **Tests**
  * Tests updated for the new request/verification/onboarding flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->