### PR TITLE
Django 5.2 prep: remove APIs dropped between 4.2 and 5.2, fix two broken unpinned dependencies

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -33,4 +33,5 @@ pytz # required by django-redis which uses pickle, even though django-redis chan
 
 # subdependencies
 psycopg2-binary>=2.8.6,<2.10  # since our backend is PostgreSQL, Django and django-tenants use this to interact with the db
+redis>=4.0.2,<8  # pulled in via django-redis/celery; redis-py 8+ speaks RESP3 (HELLO) which the redis 5.0 server in docker-compose doesn't support
 pillow>=10.3,<11.0  # used implicitly by django_resized (does not exist as an extra package either)

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -19,7 +19,6 @@ django-summernote>=0.8,<0.9
 django-taggit>=2.1,<5.0
 django-tenants>=3.5,<3.6  # latest version that supports python 3.8 (but now using 3.10 so can update it?)
 django-url-or-relative-url-field>=0.2.0,<0.3.0
-django-utils-six==2.0  # only 2.0 exists. Previous version was removed back in Django 3.0
 tenant-schemas-celery>=2.2,<3.1
 
 # non django

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ pre-commit
 freezegun>=0.3.12
 mock>=2.0,<6.0
 model_bakery>=1.1,<2.0
-namegenerator
 names

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -176,7 +176,7 @@ class BadgeAssertionManagerTest(TenantTestCase):
         # this should only return three, not the duplicate badge_assertion of badge1
         # and they should be sorted by badge.sort_order
         qs = BadgeAssertion.objects.all_for_user_distinct(user=self.student)
-        self.assertQuerysetEqual(qs, [badge_assertion, badge_assertion2, badge_assertion3])
+        self.assertQuerySetEqual(qs, [badge_assertion, badge_assertion2, badge_assertion3])
 
     def test_all_for_user_distinct__badge_type_order_correct(self):
         """
@@ -200,7 +200,7 @@ class BadgeAssertionManagerTest(TenantTestCase):
         badge_assertion3 = baker.make(BadgeAssertion, user=self.student, badge=badge3)
 
         qs = BadgeAssertion.objects.all_for_user_distinct(user=self.student)
-        self.assertQuerysetEqual(qs, [badge_assertion3, badge_assertion2, badge_assertion])
+        self.assertQuerySetEqual(qs, [badge_assertion3, badge_assertion2, badge_assertion])
 
 
 class BadgeAssertionTestModel(TenantTestCase):
@@ -264,7 +264,7 @@ class BadgeAssertionTestModel(TenantTestCase):
             values.append(badge_assertion)
 
         qs = badge_assertion.get_duplicate_assertions()
-        self.assertQuerysetEqual(list(qs), values, )
+        self.assertQuerySetEqual(list(qs), values, )
 
     def test_badge_assertion_manager_create_assertion(self):
 

--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -175,11 +175,11 @@ class CommentModelTest(TenantTestCase):
         "Test that method returns a queryset including all children"
         parent = baker.make(Comment)
 
-        self.assertQuerysetEqual(parent.get_children(), [])
+        self.assertQuerySetEqual(parent.get_children(), [])
 
         child = baker.make(Comment, parent=parent)
         self.assertIsNone(child.get_children())
 
         child2 = baker.make(Comment, parent=parent)
         children = parent.get_children()
-        self.assertQuerysetEqual(children, [child, child2], ordered=False)
+        self.assertQuerySetEqual(children, [child, child2], ordered=False)

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -138,7 +138,7 @@ class SemesterModelManagerTest(TenantTestCase):
 
     def test_get_current_as_queryset(self):
         """ Get's the current semester object in a quesryset  """
-        self.assertQuerysetEqual(Semester.objects.get_current(as_queryset=True), [SiteConfig.get().active_semester])
+        self.assertQuerySetEqual(Semester.objects.get_current(as_queryset=True), [SiteConfig.get().active_semester])
 
     def test_complete_active_semester(self):
         """ set current semester to closed and do lots of stuff..  """
@@ -352,7 +352,7 @@ class CourseStudentManagerTest(TenantTestCase):
 
         course_students = CourseStudent.objects.all_for_user_semester(self.student, semester_to_check)
         self.assertEqual(course_students.count(), 2)
-        self.assertQuerysetEqual(course_students, [sc1, sc2], ordered=False)
+        self.assertQuerySetEqual(course_students, [sc1, sc2], ordered=False)
 
     @patch('profile_manager.models.Profile.xp_per_course')
     def test_calc_semester_grades(self, xp_per_course):

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -613,7 +613,7 @@ class MarkRangeViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         # get response from list view and assert all default existing MarkRanges are displayed
         response = self.client.get(reverse('courses:markranges'))
-        self.assertQuerysetEqual(response.context['object_list'], MarkRange.objects.all())
+        self.assertQuerySetEqual(response.context['object_list'], MarkRange.objects.all())
 
     def test_MarkRangeCreate_view(self):
         """Staff users can create new MarkRange objects through the create view form"""

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -209,7 +209,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, TenantTestCase):
         CytoScape.generate_map(questA, "A")
         all_maps = CytoScape.objects.all()  # Main is included in this list
         # A queryset created from all objects is ordered correctly by default
-        self.assertQuerysetEqual(all_maps, all_maps.order_by('name'))
+        self.assertQuerySetEqual(all_maps, all_maps.order_by('name'))
 
     def test_generate_map(self):
         quest = baker.make('quest_manager.Quest')

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -334,7 +334,6 @@ SELECT2_THEME = 'bootstrap'  # This doesn't actually work, why?
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'America/Vancouver'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 
@@ -425,14 +424,20 @@ if USE_S3:
     # S3 Static Files
     STATICFILES_LOCATION = 'static'
     STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{STATICFILES_LOCATION}/'
-    STATICFILES_STORAGE = 'storage.custom_storages.StaticStorage'
 
     # Media Files
 
     # S3 public media files
     PUBLIC_MEDIAFILES_LOCATION = 'public_media'
     MEDIA_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{PUBLIC_MEDIAFILES_LOCATION}/'
-    DEFAULT_FILE_STORAGE = 'storage.custom_storages.PublicMediaStorage'
+
+    # STORAGES replaces the STATICFILES_STORAGE and DEFAULT_FILE_STORAGE settings,
+    # which are removed in Django 5.1. When STORAGES is not defined (the non-S3
+    # branch below), Django's defaults apply: FileSystemStorage + StaticFilesStorage.
+    STORAGES = {
+        "default": {"BACKEND": "storage.custom_storages.PublicMediaStorage"},
+        "staticfiles": {"BACKEND": "storage.custom_storages.StaticStorage"},
+    }
 
     # S3 private media files
     # For any implementation in future, Refer https://testdriven.io/blog/storing-django-static-and-media-files-on-amazon-s3/

--- a/src/hackerspace_online/shell_utils.py
+++ b/src/hackerspace_online/shell_utils.py
@@ -1,5 +1,4 @@
 import names
-import namegenerator
 import random
 
 from django.contrib.auth import get_user_model
@@ -8,6 +7,23 @@ from quest_manager.models import Quest, Category
 from badges.models import Badge
 
 User = get_user_model()
+
+
+def random_name():
+    """ Generates a random adjective-noun-number name for fake quests/campaigns,
+    e.g. 'fuzzy-otter-42'. Replaces the `namegenerator` package, which was
+    deleted from PyPI. """
+    adjectives = [
+        'ancient', 'brave', 'clever', 'daring', 'eager', 'fuzzy', 'gentle', 'hidden',
+        'icy', 'jolly', 'keen', 'lucky', 'mighty', 'noble', 'proud', 'quick',
+        'rusty', 'silent', 'tiny', 'wild',
+    ]
+    nouns = [
+        'badger', 'comet', 'dragon', 'falcon', 'glacier', 'harbor', 'island', 'jungle',
+        'lantern', 'meadow', 'nebula', 'otter', 'prairie', 'quartz', 'river', 'summit',
+        'tundra', 'valley', 'willow', 'zephyr',
+    ]
+    return f"{random.choice(adjectives)}-{random.choice(nouns)}-{random.randint(0, 9999)}"
 
 
 def generate_students(num=100, quiet=False):
@@ -59,14 +75,14 @@ def generate_quests(num_quest_per_campaign=10, num_campaigns=5, quiet=False):
 
         # create campaign
         new_campaign = Category.objects.create(
-            title=f'Campaign-{namegenerator.gen()}',
+            title=f'Campaign-{random_name()}',
         )
         if not quiet:
             print(new_campaign)
 
         # create initial quest with a prerequisite
         initial_quest = Quest.objects.create(
-            name=namegenerator.gen(),
+            name=random_name(),
             xp=random.randint(0, 20),
             campaign=new_campaign
         )
@@ -79,7 +95,7 @@ def generate_quests(num_quest_per_campaign=10, num_campaigns=5, quiet=False):
         # create each subsequent quest using initial_quest as prereq
         for _j in range(num_quest_per_campaign - 1):
             quest = Quest.objects.create(
-                name=namegenerator.gen(),
+                name=random_name(),
                 xp=random.randint(0, 20),
                 campaign=new_campaign
             )

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -1,6 +1,5 @@
 # from mock import patch
 
-from django.utils.six import text_type
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -202,7 +201,7 @@ class IsAPrereqMixinTest(TenantTestCase):
         """ All models implementing this Mixin, also implement this method if the default doesn't suffice """
         prereq_models = IsAPrereqMixin.all_registered_model_classes()
         for model in prereq_models:
-            assert all(isinstance(x, text_type) for x in model.gfk_search_fields())
+            assert all(isinstance(x, str) for x in model.gfk_search_fields())
 
     def test_static_content_type_is_registered(self):
         """A content_type representing a model that implements the IsAPrereqMixin returns True

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -103,10 +103,10 @@ class ProfileTestModel(TenantTestCase):
         self.assertFalse(self.profile.current_courses().exists())
         # add one and test
         course_registration = self.create_active_course_registration()
-        self.assertQuerysetEqual(self.profile.current_courses(), [course_registration])
+        self.assertQuerySetEqual(self.profile.current_courses(), [course_registration])
         # add a second
         course_registration2 = self.create_active_course_registration()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.profile.current_courses(),
             [course_registration, course_registration2]
         )

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -490,7 +490,7 @@ class ProfileViewTests(ViewTestUtilsMixin, TenantTestCase):
         testblock_queryset = response.context['object_list']
         self.assertEqual(testblock_queryset.count(), 2)
         # queryset specifications: profile objects that are: part of active semester, a part of a coursestudent object that's in the desired block
-        self.assertQuerysetEqual(testblock_queryset, Profile.objects.all_for_active_semester().filter(user__coursestudent__block=testblock))
+        self.assertQuerySetEqual(testblock_queryset, Profile.objects.all_for_active_semester().filter(user__coursestudent__block=testblock))
 
     def test_profile_update_email(self):
         """

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -401,7 +401,7 @@ class QuestManagerTest(TenantTestCase):
         baker.make(Quest, name='Quest-available-without-course', available_outside_course=True)
         baker.make(Quest, name='Quest-not-available-without-course', available_outside_course=False)
         qs = Quest.objects.all().available_without_course().values_list('name', flat=True)
-        self.assertQuerysetEqual(qs, ['Quest-available-without-course', 'Send your teacher a Message'], ordered=False)
+        self.assertQuerySetEqual(qs, ['Quest-available-without-course', 'Send your teacher a Message'], ordered=False)
 
     def test_quest_qs_editable(self):
         """
@@ -512,7 +512,7 @@ class QuestManagerTest(TenantTestCase):
         # complete the blocking quest to make others available
         blocking_sub.mark_completed()
         qs = Quest.objects.get_available(self.student)
-        self.assertQuerysetEqual(list(qs.values_list('name', flat=True)), ['Quest-not-started', 'Welcome to ByteDeck!'], ordered=False)
+        self.assertQuerySetEqual(list(qs.values_list('name', flat=True)), ['Quest-not-started', 'Welcome to ByteDeck!'], ordered=False)
 
         ########################################
         # 2. Quests that are not published to students or archived
@@ -543,7 +543,7 @@ class QuestManagerTest(TenantTestCase):
         # move 1 hour out and the cooldown quest should now appear:
         with freeze_time(localtime() + timedelta(hours=1, minutes=1)):
             qs = Quest.objects.get_available(self.student)
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 list(qs.values_list('name', flat=True)),
                 ['Quest-1hr-cooldown', 'Quest-not-started', 'Welcome to ByteDeck!'],
                 ordered=False
@@ -559,7 +559,7 @@ class QuestManagerTest(TenantTestCase):
             # increment time another hour just be sure it doesn't appear (max repeats of 1 reached)
             with freeze_time(localtime() + timedelta(hours=1, minutes=1)):
                 qs = Quest.objects.get_available(self.student)
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     list(qs.values_list('name', flat=True)),
                     ['Quest-not-started', 'Welcome to ByteDeck!'],
                     ordered=False
@@ -720,19 +720,19 @@ class QuestSubmissionQuerysetTest(TenantTestCase):
         qs = QuestSubmission.objects.all()
 
         # Currently contains the submission from setup.
-        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [self.sub])
+        self.assertQuerySetEqual(qs.for_teacher_only(self.teacher), [self.sub])
 
         # Add another submission from a different block, with a different teacher
         baker.make(QuestSubmission, quest=self.quest, semester=self.active_semester)
         # Should still only have the originally submission
         qs = QuestSubmission.objects.all()
-        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [self.sub])
+        self.assertQuerySetEqual(qs.for_teacher_only(self.teacher), [self.sub])
 
         # Add another submission from a different block, but this time the quest should notify the teacher
         sub2 = baker.make(QuestSubmission, semester=self.active_semester, quest__specific_teacher_to_notify=self.teacher)
         # print(qs.for_teacher_only(self.teacher))
         qs = QuestSubmission.objects.all()
-        self.assertQuerysetEqual(qs.for_teacher_only(self.teacher), [self.sub, sub2], ordered=False)
+        self.assertQuerySetEqual(qs.for_teacher_only(self.teacher), [self.sub, sub2], ordered=False)
 
     def test_for_teachers_only__with_deleted_quest(self):
         """for_teachers_only QuestSubmissions should be deleted for that quest if it is deleted"""
@@ -766,11 +766,11 @@ class QuestSubmissionManagerTest(TenantTestCase):
     def test_get_queryset_default(self):
         """QuestSubmissionManager.get_queryset by default should return all published, not archived quest submissions"""
         qs = QuestSubmission.objects.get_queryset()
-        self.assertQuerysetEqual(qs, [self.sub1, self.sub2], ordered=False)
+        self.assertQuerySetEqual(qs, [self.sub1, self.sub2], ordered=False)
 
     def test_get_queryset_for_active_semester(self):
         qs = QuestSubmission.objects.get_queryset(active_semester_only=True)
-        self.assertQuerysetEqual(qs, [self.sub1])
+        self.assertQuerySetEqual(qs, [self.sub1])
 
     def test_get_queryset_for_all_quests(self):
         qs = QuestSubmission.objects.get_queryset(
@@ -785,7 +785,7 @@ class QuestSubmissionManagerTest(TenantTestCase):
         quest = self.sub1.quest
         first = baker.make(QuestSubmission, user=self.student, quest=quest, semester=self.active_semester)
         qs = QuestSubmission.objects.all_for_user_quest(self.student, quest, True)
-        self.assertQuerysetEqual(qs, [first])
+        self.assertQuerySetEqual(qs, [first])
 
     def make_test_submissions_stack(self):
         """Generate 7 submissions, 3 from one semester and 4 from a different semester, each with different settings

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -419,7 +419,7 @@ class SubmissionManagerTest(TenantTestCase):
 
         # Default parameters, all submissions this semester, as would be shown in staff "Approved" tab
         all_approved = QuestSubmission.objects.all_approved()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             all_approved,
             [sub_approved, sub_approved_no_xp, sub_approved_different_quest, sub_approved_user],
             ordered=False
@@ -427,7 +427,7 @@ class SubmissionManagerTest(TenantTestCase):
 
         # active_semester_only=False should include sub_approved_other_semester
         all_approved = QuestSubmission.objects.all_approved(active_semester_only=False)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             all_approved,
             [sub_approved, sub_approved_different_quest, sub_approved_other_semester, sub_approved_no_xp, sub_approved_user],
             ordered=False
@@ -435,7 +435,7 @@ class SubmissionManagerTest(TenantTestCase):
 
         # quest=quest should not include sub_approved_different_quest
         all_approved = QuestSubmission.objects.all_approved(quest=quest)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             all_approved,
             [sub_approved, sub_approved_no_xp, sub_approved_user],
             ordered=False
@@ -443,7 +443,7 @@ class SubmissionManagerTest(TenantTestCase):
 
         # user=test_user should only include sub_approved_user
         all_approved = QuestSubmission.objects.all_approved(user=user)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             all_approved,
             [sub_approved_user],
             ordered=False

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2038,7 +2038,7 @@ class QuestListViewTest(ViewTestUtilsMixin, TenantTestCase):
             intended_order = displayed_order.order_by(*XPItem._meta.ordering)
 
             # assert ordered view is unchanged from displayed view
-            self.assertQuerysetEqual(displayed_order, intended_order)
+            self.assertQuerySetEqual(displayed_order, intended_order)
 
     def test_context_correct_tab_types(self):
         """ Checks each possible tab for student and teacher individually if it can be activated
@@ -2182,7 +2182,7 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         # Admin should be able to see every quest assigned to the viewed campaign
         displayed_quests = response.context["category_displayed_quests"]
         intended_quests = Quest.objects.filter(campaign=view_test_campaign)
-        self.assertQuerysetEqual(displayed_quests, intended_quests, ordered=False)
+        self.assertQuerySetEqual(displayed_quests, intended_quests, ordered=False)
 
         # Students should be able to access view
         self.client.force_login(self.test_student1)
@@ -2192,7 +2192,7 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         # Students should only be able to see active quests assigned to the viewed campaign
         displayed_quests = response.context["category_displayed_quests"]
         intended_quests = Quest.objects.get_active().filter(campaign=view_test_campaign)
-        self.assertQuerysetEqual(displayed_quests, intended_quests, ordered=False)
+        self.assertQuerySetEqual(displayed_quests, intended_quests, ordered=False)
 
     def test_CategoryCreate_view(self):
         """ Admin should be able to create a course """

--- a/src/tags/tests/test_widgets.py
+++ b/src/tags/tests/test_widgets.py
@@ -1,4 +1,3 @@
-from django.utils.six import text_type
 
 from tags.widgets import TaggitSelect2Widget
 
@@ -9,7 +8,7 @@ class TestTaggitSelect2Widget(TenantTestCase):
 
     def test_get_url(self):
         widget = TaggitSelect2Widget()
-        assert isinstance(widget.get_url(), text_type)
+        assert isinstance(widget.get_url(), str)
 
     def test_tag_attrs(self):
         widget = TaggitSelect2Widget()

--- a/src/utilities/tests/test_widgets.py
+++ b/src/utilities/tests/test_widgets.py
@@ -8,7 +8,6 @@ from django.db.models import Q
 from django.core import signing
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-from django.utils.six import text_type
 from django.urls import reverse
 
 from django_tenants.test.cases import TenantTestCase
@@ -62,7 +61,7 @@ class TestGFKSelect2Widget(TenantTestCase):
     def test_initial_data(self):
         group = self.groups[0]
         form = self.form.__class__(initial={'f': group})
-        assert text_type(group) in form.as_p()
+        assert str(group) in form.as_p()
 
     def test_label_from_instance_initial(self):
         group = self.groups[0]
@@ -122,7 +121,7 @@ class TestGFKSelect2Widget(TenantTestCase):
 
         widget.search_fields = {'auth': {'group': ['name__icontains']}}
         assert isinstance(widget.get_search_fields(Group), collections.abc.Iterable)
-        assert all(isinstance(x, text_type) for x in widget.get_search_fields(Group))
+        assert all(isinstance(x, str) for x in widget.get_search_fields(Group))
 
     def test_filter_queryset(self):
         widget = CustomGFKSelect2Widget()
@@ -181,12 +180,12 @@ class TestGFKSelect2Widget(TenantTestCase):
         assert dict(cached_widget['search_fields']) == widget.search_fields
         qs = widget.get_queryset()
         assert isinstance(cached_widget['queryset'][0][0], qs.get_querysets()[0].__class__)
-        assert text_type(cached_widget['queryset'][0][1]) == text_type(qs.get_querysets()[0].query)
+        assert str(cached_widget['queryset'][0][1]) == str(qs.get_querysets()[0].query)
 
     def test_get_url(self):
         widget = GFKSelect2Widget(
             queryset=QuerySetSequence(Group.objects.all()), search_fields={'auth': {'group': ['name__icontains']}})
-        assert isinstance(widget.get_url(), text_type)
+        assert isinstance(widget.get_url(), str)
 
     def test_order(self):
         """ Tests if there isn't any unexpected ordering issues when getting the queryset. """
@@ -198,5 +197,5 @@ class TestGFKSelect2Widget(TenantTestCase):
             search_fields={'quest_manager': {'quest': ['name__icontains']}}
         )
 
-        self.assertQuerysetEqual(widget.get_queryset(), queryset_expected)
-        self.assertQuerysetEqual(widget.filter_queryset(None, ''), queryset_expected)
+        self.assertQuerySetEqual(widget.get_queryset(), queryset_expected)
+        self.assertQuerySetEqual(widget.filter_queryset(None, ''), queryset_expected)


### PR DESCRIPTION
### What?
Phase 0 of the Django 4.2 → 5.2 LTS upgrade plan: remove every in-code usage of APIs that Django drops between 4.2 and 5.2, while staying fully compatible with the current Django 4.2. Also fixes two dependency breakages (unrelated to the upgrade) that currently prevent any fresh `pip install -r requirements.txt` from producing a working environment.

- Replace `STATICFILES_STORAGE` / `DEFAULT_FILE_STORAGE` (removed in Django 5.1) with the `STORAGES` dict in the `USE_S3` settings branch. The non-S3 branch keeps Django's defaults.
- Rename `assertQuerysetEqual` → `assertQuerySetEqual` (removed in Django 5.1) at all 31 call sites across 11 test files.
- Remove `USE_L10N = True` (setting removed in Django 5.0; it has been a no-op default since 4.0).
- Drop the `django-utils-six` shim and replace its 3 `text_type` usages in tests with plain `str`.
- Remove `namegenerator` from `requirements.txt` — **the package has been deleted from PyPI** (404 on the index), so every fresh install fails. Its single usage (naming fake quests/campaigns in `shell_utils.py`) is replaced with a small local generator.
- Pin `redis>=4.0.2,<8` — redis-py is an unpinned transitive dep (django-redis, celery), and version 8 negotiates RESP3 via a `HELLO` command the `redis:5.0-alpine` server in docker-compose doesn't understand, producing ~25 test errors on any fresh install.

### Why?
Django 4.2's extended support has ended, so the app is on an unpatched framework version. The upgrade plan stages all risk while still on 4.2: this PR clears the removed-API surface so later dependency bumps and the eventual `Django>=5.2,<5.3` pin flip stay small and individually green. The two dependency fixes are included because without them CI cannot build a fresh image at all — the breakage exists on `develop` today.

### How?
All changes are mechanical and backward-compatible on Django 4.2: `STORAGES` and the new assert casings have existed since 4.2, `USE_L10N=True` matches the hardcoded default, and the `str`/`text_type` swap is behavior-identical on Python 3.

### Testing?
Verified in a Python 3.10 container against the docker-compose Postgres 16 + Redis 5.0 (mirroring CI):
- `python src/manage.py check` — no issues
- `python src/manage.py makemigrations --check --dry-run` — no migration drift
- `flake8` clean on all changed files
- `manage.py test` across all nine affected apps (utilities, tags, prerequisites, comments, badges, djcytoscape, courses, profile_manager, quest_manager): **675 tests, OK**
- The redis pin was confirmed empirically: the same test errors reproduce with redis-py 8.0.1 in files this PR doesn't touch, and disappear with redis-py 7.4.1.

### Screenshots (if front end is affected)
No front-end changes.

### Anything Else?
This is Phase 0 of a staged upgrade plan. Next phases (separate PRs): dependency cluster bumps on 4.2 (django-tenants 3.10, allauth 65.x, import-export 4.x, crispy-forms 2.x + crispy-bootstrap3, django-recaptcha 4.x, taggit/redis/celery-beat), then a deprecation-warnings-as-errors pass, then the `Django>=5.2,<5.3` flip. The Redis 5.0 server itself (EOL) should be upgraded eventually, which would let the `redis<8` pin be lifted.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Redis support for production deployments.
  - Updated cloud storage configuration for compatibility with newer Django versions.
  - Added built-in random naming for generated campaigns and quests.

- **Bug Fixes**
  - Corrected queryset comparison assertions across the test suite.
  - Updated text type checks for modern Python compatibility.
  - Replaced obsolete naming functionality and removed outdated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->