### PR TITLE
Fix randomly-flaky CI: deterministic Prereq content types in tests

### DIFF
--- a/src/djcytoscape/tests/test_signals.py
+++ b/src/djcytoscape/tests/test_signals.py
@@ -99,3 +99,25 @@ class TestRegenerateMapSignals(TenantTestCase):
 
         prereq.save()
         self.assertEqual(task.call_count, 2)
+
+    def test_prereq_signal_handles_all_registered_parent_models(self, task):
+        """Saving a Prereq must not crash the map-regeneration signal for any
+        registered prereq model as the parent. Loops through every model that
+        implements IsAPrereqMixin — the only models that are supposed to be
+        used in a Prereq's generic foreign keys."""
+        from django.contrib.contenttypes.models import ContentType
+        from prerequisites.models import IsAPrereqMixin
+
+        quest = baker.make(Quest)
+        quest_ct = ContentType.objects.get_for_model(Quest)
+
+        for ct in IsAPrereqMixin.all_registered_content_types():
+            with self.subTest(parent_model=f'{ct.app_label}.{ct.model}'):
+                # A parent id that exists for no object also exercises the
+                # signal's DoesNotExist early-return (parent deleted case).
+                Prereq.objects.create(
+                    parent_content_type=ct,
+                    parent_object_id=2147480000,
+                    prereq_content_type=quest_ct,
+                    prereq_object_id=quest.pk,
+                )  # implicitly asserts the post_save signals raise nothing

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -188,8 +188,20 @@ class IsAPrereqMixinTest(TenantTestCase):
     def test_condition_met_as_prerequisite__is_implemented(self):
         """ All models that inherit from this mixin should implement the condition_met_as_prerequisite() method """
         for ct in IsAPrereqMixin.all_registered_content_types():
+            model_class = ct.model_class()
+            if model_class is Prereq:
+                # baker.make(Prereq) fills the generic foreign keys with a random
+                # content type — any installed model, even ones that can't be
+                # prereqs, like Portfolio (whose primary key isn't named 'id',
+                # crashing the map-regeneration signal on save). This made CI
+                # randomly flaky. Build a deterministic Prereq instead.
+                instance = Prereq.objects.create(
+                    parent_object=baker.make('quest_manager.Quest'),
+                    prereq_object=baker.make('quest_manager.Quest'),
+                )
+            else:
+                instance = baker.make(model_class)
             # If the method is not implemented, then NotImplementedError is thrown
-            instance = baker.make(ct.model_class())
             try:
                 instance.condition_met_as_prerequisite(user=baker.make(User), num_required=1)
             except UndefinedTable:
@@ -333,3 +345,31 @@ class PrereqAllConditionsMetModelTest(TenantTestCase):
         self.prereq_cache.remove_id(6)
         self.assertNotIn(6, self.prereq_cache.get_ids())
         self.assertEqual(len(self.prereq_cache.get_ids()), len(ids))
+
+
+class AddSimplePrereqAllRegisteredModelsTest(TenantTestCase):
+    """Prereq.add_simple_prereq must work for every registered prereq model —
+    the models that implement IsAPrereqMixin, which are the only models that
+    are supposed to be used in a Prereq's generic foreign keys."""
+
+    def test_add_simple_prereq_for_every_registered_model(self):
+        """Loops through all registered prereq models, using each as the
+        requirement of a new Prereq, and checks the stored generic ids."""
+        parent = baker.make('quest_manager.Quest')
+        for model_class in IsAPrereqMixin.all_registered_model_classes():
+            with self.subTest(prereq_model=model_class.__name__):
+                if model_class is Prereq:
+                    # baker.make(Prereq) would pick random content types;
+                    # build a deterministic one instead
+                    prereq_object = Prereq.add_simple_prereq(
+                        baker.make('quest_manager.Quest'), baker.make('quest_manager.Quest'))
+                elif model_class.__name__ == 'Rank':
+                    # a Rank prereq triggers map generation (see
+                    # prerequisites.signals), which requires a non-blank name
+                    prereq_object = baker.make(model_class, name='Test Rank')
+                else:
+                    prereq_object = baker.make(model_class)
+                new_prereq = Prereq.add_simple_prereq(parent, prereq_object)
+                self.assertEqual(new_prereq.parent_object_id, parent.pk)
+                self.assertEqual(new_prereq.prereq_object_id, prereq_object.pk)
+                self.assertEqual(new_prereq.get_prereq(), prereq_object)


### PR DESCRIPTION
### What?
Test-only fix for the randomly-flaky CI failures, plus regression tests that loop through all registered prereq models.

Root cause: `IsAPrereqMixinTest.test_condition_met_as_prerequisite__is_implemented` loops through every registered prereq model with `baker.make(ct.model_class())`. **`Prereq` itself is in that registry** (it implements `IsAPrereqMixin`), and `baker.make(Prereq)` fills the Prereq's generic foreign keys with a **random content type drawn from every installed model** — model-bakery's `gen_content_type()` is literally `ContentType.objects.get_for_model(random.choice(apps.get_models()))`. Whenever it drew a model whose primary key isn't named `id` — `portfolios.Portfolio` (pk `user`), `sessions.Session` (pk `session_key`), or `django_celery_beat.PeriodicTasks` (pk `ident`) — saving the Prereq crashed in the djcytoscape map-regeneration signal (`get(id=...)` → `FieldError: Cannot resolve keyword 'id' into field`) and the run went red.

Changes (2 test files, no production code):
- `test_condition_met_as_prerequisite__is_implemented` builds a deterministic `Prereq` (quest → quest) when its loop reaches `Prereq`, instead of letting baker pick random content types.
- New djcytoscape regression test: saving a `Prereq` with **every registered prereq model** as parent (via `IsAPrereqMixin.all_registered_content_types()`) must not crash the map signal — including the parent-deleted (`DoesNotExist`) path.
- New prerequisites regression test: `Prereq.add_simple_prereq` works for every registered prereq model as the requirement and stores the correct generic ids.

### Why?
This is the root cause of the random red CI runs — including the failed Build and Tests run on the #1897 merge commit ([run 29135884067](https://github.com/bytedeck/bytedeck/actions/runs/29135884067)), whose log shows this exact `FieldError` with Portfolio's field list. Which test died varied from run to run because the content type draw is random.

Only models implementing `IsAPrereqMixin` are supposed to appear in a Prereq's generic foreign keys, so the right fix is to make the tests respect that contract. (An earlier revision of this PR instead converted `.id` → `.pk` across the GFK-handling production code; reverted in favor of this test-level fix per review direction.)

### How?
Pinned the one nondeterministic `baker.make(Prereq)` call, and added registry-scoped loop tests so the contract ("any registered prereq model works") stays enforced.

### Testing?
- Full `prerequisites` + `djcytoscape` suites pass (98 tests).
- The fixed test is deterministic by construction — it no longer lets model-bakery choose content types.
- flake8 clean.

### Screenshots (if front end is affected)
No front-end changes.

### Anything Else?
- CodeRabbit's review of the earlier revision surfaced a real **pre-existing** bug, untouched here: `PrereqQuerySet.get_all_for_or_prereq_object` discards its `qs.exclude(or_prereq_invert=True)` result, so `exclude_NOT=True` has no effect for OR prereqs (this feeds `all_reliant_on()` / `get_reliant_objects(exclude_NOT=True)`, used by map generation). Happy to fix with a proper test in a separate PR.
- #1898 contains three `.id`→`.pk` conversions made while diagnosing this flake (map signal, `generate_selector_id`, `add_simple_prereq`). They're harmless no-ops for registered models, but no longer necessary once this merges — say the word if you'd like them reverted from #1898.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW