### PR TITLE
Fix exclude_NOT having no effect for inverted OR prerequisites

### DIFF
--- a/src/prerequisites/models.py
+++ b/src/prerequisites/models.py
@@ -267,11 +267,17 @@ class PrereqQuerySet(models.query.QuerySet):
         return qs
 
     def get_all_for_or_prereq_object(self, prereq_object, exclude_NOT=False):
+        """Return all Prereqs that have the given object as their alternate (OR) requirement.
+
+        :param prereq_object: the object to look for in the OR requirement slot
+        :param exclude_NOT: if True, omit Prereqs whose OR requirement is inverted (NOT)
+        :return: a queryset of matching Prereqs
+        """
         ct = ContentType.objects.get_for_model(prereq_object)
         qs = self.filter(or_prereq_content_type__pk=ct.id,
                          or_prereq_object_id=prereq_object.id)
         if exclude_NOT:
-            qs.exclude(or_prereq_invert=True)
+            qs = qs.exclude(or_prereq_invert=True)
         return qs
 
         # object matching sender, target or action object

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -176,6 +176,7 @@ class IsAPrereqMixinTest(TenantTestCase):
 
         # invert the OR requirement (NOT): the parent no longer relies on it
         self.prereq_with_or.or_prereq_invert = True
+        self.prereq_with_or.full_clean()
         self.prereq_with_or.save()
 
         reliant_objects = self.quest_or_prereq.get_reliant_objects(exclude_NOT=True)

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -163,6 +163,28 @@ class IsAPrereqMixinTest(TenantTestCase):
         reliant_objects = self.quest_prereq.get_reliant_objects(exclude_NOT=False)
         self.assertEqual(len(reliant_objects), 1)
 
+    def test_get_reliant_objects__exclude_NOT__inverted_or_prereq(self):
+        """An object that is only an inverted (NOT) alternate requirement of a
+        parent must not be reported as having reliant objects when
+        exclude_NOT=True. Regression test for issue #1900:
+        get_all_for_or_prereq_object discarded its exclude() result, so
+        exclude_NOT had no effect for the OR requirement slot."""
+        # from setUp: quest_or_prereq is the OR requirement of prereq_with_or,
+        # whose parent is quest_parent
+        reliant_objects = self.quest_or_prereq.get_reliant_objects(exclude_NOT=True)
+        self.assertListEqual(list(reliant_objects), [self.quest_parent])
+
+        # invert the OR requirement (NOT): the parent no longer relies on it
+        self.prereq_with_or.or_prereq_invert = True
+        self.prereq_with_or.save()
+
+        reliant_objects = self.quest_or_prereq.get_reliant_objects(exclude_NOT=True)
+        self.assertListEqual(list(reliant_objects), [])
+
+        # without exclude_NOT, the inverted OR relationship is still reported
+        reliant_objects = self.quest_or_prereq.get_reliant_objects(exclude_NOT=False)
+        self.assertListEqual(list(reliant_objects), [self.quest_parent])
+
     def test_get_reliant_objects__sort(self):
         """ Test that get_reliant_objects(sort=True) returns a list where the objects are sorted alphabetically by str() """
 


### PR DESCRIPTION
### What?
Fixes #1900: `PrereqQuerySet.get_all_for_or_prereq_object` called `qs.exclude(or_prereq_invert=True)` without assigning the result, so `exclude_NOT=True` was a silent no-op for the alternate (OR) requirement slot. One-line fix (`qs = qs.exclude(...)`), matching the sibling `get_all_for_prereq_object`, plus a docstring and a regression test that covers the OR slot with `or_prereq_invert=True`.

### Why?
Callers of `all_reliant_on(exclude_NOT=True)` / `get_reliant_objects(exclude_NOT=True)` still received Prereqs whose OR requirement is inverted (NOT). The production symptom is in CytoScape map generation (`djcytoscape/models.py:927`): an object that is only a NOT-OR requirement of a parent ("available if you *don't* have X") still got an edge drawn as though the parent relies on it. Found by CodeRabbit while reviewing an earlier revision of #1899 — full analysis in issue #1900.

### How?
Assign the excluded queryset back before returning. The new test was run against the unfixed code first and fails exactly as predicted (the inverted-OR parent is still reported reliant); with the fix it passes.

### Testing?
- New regression test `test_get_reliant_objects__exclude_NOT__inverted_or_prereq`: verified to FAIL on unfixed develop and pass with the fix.
- Full `prerequisites` + `djcytoscape` suites pass (97 tests).
- flake8 clean.

### Screenshots (if front end is affected)
No template changes. Maps generated after this fix will no longer draw reliant edges for inverted (NOT) OR prerequisites — that's the corrected behavior.

### Anything Else?
Existing maps are unaffected until regenerated. Closes #1900.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected filtering for inverted OR prerequisites when excluding NOT relationships.
  * Reliant-object results now accurately reflect inverted prerequisite relationships.

* **Tests**
  * Added coverage to verify expected results with and without excluded inverted relationships.

* **Documentation**
  * Expanded guidance for prerequisite query behavior and returned results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->