### PR TITLE
Batch 3: eliminate per-badge N+1 queries on profile detail and notifications

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -357,9 +357,22 @@ class BadgeAssertionManager(models.Manager):
         return sorted_qs
 
     def badge_assertions_dict_items(self, user):
-        earned_assertions = self.all_for_user_distinct(user)
+        earned_assertions = list(self.all_for_user_distinct(user))
+
+        # Group all of the user's assertions by badge in one query, so each
+        # badge's get_duplicate_assertions() (rendered in every popover) is
+        # served from memory instead of a query per badge.
+        duplicates_by_badge = defaultdict(list)
+        for assertion in self.get_queryset(False).get_user(user):
+            duplicates_by_badge[assertion.badge_id].append(assertion)
+
+        # Prefetch every displayed badge's prerequisites in one query (the
+        # popover lists them) instead of a query per badge.
+        Prereq.objects.prefetch_for_parents([a.badge for a in earned_assertions])
+
         assertion_dict = defaultdict(list)
         for assertion in earned_assertions:
+            assertion._duplicate_assertions_cache = duplicates_by_badge[assertion.badge_id]
             assertion_dict[assertion.badge.badge_type].append(assertion)
 
         return assertion_dict.items()
@@ -475,7 +488,12 @@ class BadgeAssertion(models.Model):
         return count
 
     def get_duplicate_assertions(self):
-        """A qs of all assertions of this badge for this user"""
+        """A qs (or a pre-populated list) of all assertions of this badge for this user.
+
+        badge_assertions_dict_items() can populate _duplicate_assertions_cache so
+        the profile page serves this from memory instead of a query per badge."""
+        if hasattr(self, '_duplicate_assertions_cache'):
+            return self._duplicate_assertions_cache
         return BadgeAssertion.objects.all_for_user_badge(self.user, self.badge, False)
 
 

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -357,6 +357,17 @@ class BadgeAssertionManager(models.Manager):
         return sorted_qs
 
     def badge_assertions_dict_items(self, user):
+        """Group a user's earned badges by badge type for the profile page.
+
+        Returns one assertion per earned badge (via all_for_user_distinct),
+        grouped into dict items keyed by BadgeType. Each returned assertion
+        has its duplicate assertions and its badge's prerequisites
+        pre-populated in one query each, so the per-badge popovers render
+        without issuing a query per badge.
+
+        :param user: the user whose earned badges are grouped
+        :return: dict_items of {BadgeType: [BadgeAssertion, ...]}
+        """
         earned_assertions = list(self.all_for_user_distinct(user))
 
         # Group all of the user's assertions by badge in one query, so each

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -266,6 +266,27 @@ class BadgeAssertionTestModel(TenantTestCase):
         qs = badge_assertion.get_duplicate_assertions()
         self.assertQuerySetEqual(list(qs), values, )
 
+    def test_badge_assertions_dict_items_prefetches_duplicates(self):
+        """badge_assertions_dict_items pre-populates each distinct badge's
+        duplicate assertions, so get_duplicate_assertions() serves them from
+        memory with no query per badge (the profile page renders one popover
+        per badge)."""
+        badge_a = Recipe(Badge, name='Badge A').make()
+        badge_b = Recipe(Badge, name='Badge B').make()
+        baker.make(BadgeAssertion, user=self.student, badge=badge_a, _quantity=2)
+        baker.make(BadgeAssertion, user=self.student, badge=badge_b, _quantity=3)
+
+        items = BadgeAssertion.objects.badge_assertions_dict_items(self.student)
+        distinct_assertions = [a for _badge_type, assertions in items for a in assertions]
+
+        duplicate_counts = {}
+        with self.assertNumQueries(0):
+            for assertion in distinct_assertions:
+                duplicate_counts[assertion.badge_id] = len(list(assertion.get_duplicate_assertions()))
+
+        self.assertEqual(duplicate_counts[badge_a.id], 2)
+        self.assertEqual(duplicate_counts[badge_b.id], 3)
+
     def test_badge_assertion_manager_create_assertion(self):
 
         # no semester

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -17,7 +17,12 @@ from .models import Notification
 @non_public_only_view
 @login_required
 def list(request):
-    notifications_list = Notification.objects.all_for_user(request.user)
+    # each rendered notification reads its sender/target/action generic FK
+    # objects; prefetch them so the page issues a few grouped queries instead
+    # of several per notification
+    notifications_list = Notification.objects.all_for_user(request.user).prefetch_related(
+        'sender_object', 'target_object', 'action_object',
+    )
 
     paginator = Paginator(notifications_list, 15)
     page = request.GET.get('page', 1)

--- a/src/prerequisites/models.py
+++ b/src/prerequisites/models.py
@@ -321,6 +321,12 @@ class PrereqManager(models.Manager):
         if not parent_objects:
             return parent_objects
 
+        # all parents share one content type; a mixed list would silently drop
+        # the prereqs of every object whose model isn't the first one's
+        model = type(parent_objects[0])
+        if any(type(obj) is not model for obj in parent_objects):
+            raise ValueError("prefetch_for_parents requires all parent_objects to be the same model")
+
         ct = ContentType.objects.get_for_model(parent_objects[0])
         prereqs_by_parent = defaultdict(list)
         matching_prereqs = self.get_queryset().filter(

--- a/src/prerequisites/models.py
+++ b/src/prerequisites/models.py
@@ -1,4 +1,6 @@
 import json
+from collections import defaultdict
+
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
@@ -12,7 +14,13 @@ class HasPrereqsMixin:
     """
 
     def prereqs(self):
-        """ A queryset of all the object's prerequisites """
+        """ A queryset (or a pre-populated list) of all the object's prerequisites.
+
+        PrereqManager.prefetch_for_parents() can populate _prereqs_cache to serve
+        this from memory instead of a query per object (e.g. when rendering many
+        badge popovers on the profile page)."""
+        if hasattr(self, '_prereqs_cache'):
+            return self._prereqs_cache
         return Prereq.objects.all_parent(self)
 
     def add_simple_prereqs(self, prereq_objects_list):
@@ -298,6 +306,33 @@ class PrereqManager(models.Manager):
 
     def all_parent(self, parent_object):
         return self.get_queryset().get_all_for_parent_object(parent_object)
+
+    def prefetch_for_parents(self, parent_objects):
+        """Populate each parent object's prereqs() cache in a single query.
+
+        All parents must be instances of the same model (they share one
+        content type). Each object gets a ``_prereqs_cache`` list that
+        HasPrereqsMixin.prereqs() returns, avoiding a query per object.
+
+        :param parent_objects: an iterable of same-model objects to populate
+        :return: the parent objects as a list
+        """
+        parent_objects = list(parent_objects)
+        if not parent_objects:
+            return parent_objects
+
+        ct = ContentType.objects.get_for_model(parent_objects[0])
+        prereqs_by_parent = defaultdict(list)
+        matching_prereqs = self.get_queryset().filter(
+            parent_content_type=ct,
+            parent_object_id__in=[obj.pk for obj in parent_objects],
+        )
+        for prereq in matching_prereqs:
+            prereqs_by_parent[prereq.parent_object_id].append(prereq)
+
+        for obj in parent_objects:
+            obj._prereqs_cache = prereqs_by_parent[obj.pk]
+        return parent_objects
 
     def all_reliant_on(self, prereq_object, exclude_NOT=False):
         qs = self.get_queryset().get_all_for_prereq_object(prereq_object, exclude_NOT=exclude_NOT)

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -396,3 +396,41 @@ class AddSimplePrereqAllRegisteredModelsTest(TenantTestCase):
                 self.assertEqual(new_prereq.parent_object_id, parent.pk)
                 self.assertEqual(new_prereq.prereq_object_id, prereq_object.pk)
                 self.assertEqual(new_prereq.get_prereq(), prereq_object)
+
+
+class PrereqPrefetchTest(TenantTestCase):
+    """PrereqManager.prefetch_for_parents batches prereqs() for many same-model
+    objects into a single query (used by the profile page's badge popovers)."""
+
+    def setUp(self):
+        self.parent1 = baker.make('quest_manager.Quest')
+        self.parent2 = baker.make('quest_manager.Quest')
+        self.requirement = baker.make('quest_manager.Quest')
+        Prereq.add_simple_prereq(self.parent1, self.requirement)
+        Prereq.add_simple_prereq(self.parent2, self.requirement)
+
+    def test_prereqs_without_prefetch_returns_queryset(self):
+        """Objects that were not prefetched keep the normal queryset API."""
+        from quest_manager.models import Quest
+        quest = Quest.objects.get(pk=self.parent1.pk)
+        self.assertEqual(quest.prereqs().count(), 1)
+        self.assertTrue(quest.prereqs().exists())
+
+    def test_prefetch_for_parents_serves_prereqs_without_per_object_queries(self):
+        """After prefetch_for_parents, each object's prereqs() is served from
+        its cache with no further per-object query."""
+        from quest_manager.models import Quest
+        quests = list(Quest.objects.filter(pk__in=[self.parent1.pk, self.parent2.pk]))
+
+        Prereq.objects.prefetch_for_parents(quests)
+
+        with self.assertNumQueries(0):
+            for quest in quests:
+                prereqs = quest.prereqs()
+                self.assertEqual(len(list(prereqs)), 1)
+                self.assertEqual(prereqs[0].parent_object_id, quest.pk)
+
+    def test_prefetch_for_parents_empty_input(self):
+        """Empty input is a no-op returning an empty list (no query)."""
+        with self.assertNumQueries(0):
+            self.assertEqual(Prereq.objects.prefetch_for_parents([]), [])

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -434,3 +434,10 @@ class PrereqPrefetchTest(TenantTestCase):
         """Empty input is a no-op returning an empty list (no query)."""
         with self.assertNumQueries(0):
             self.assertEqual(Prereq.objects.prefetch_for_parents([]), [])
+
+    def test_prefetch_for_parents_rejects_mixed_models(self):
+        """Mixed-model input is rejected: all parents must share one content
+        type, or the query would silently drop some objects' prereqs."""
+        badge = baker.make('badges.Badge')
+        with self.assertRaises(ValueError):
+            Prereq.objects.prefetch_for_parents([self.parent1, badge])

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -184,11 +184,13 @@ class ProfileDetail(NonPublicOnlyViewMixin, DetailView):
         context['courses_old'] = CourseStudent.objects.all_for_user_active(profile.user, False)
         context['in_progress_submissions'] = QuestSubmission.objects.all_not_completed(profile.user, blocking=True)
         context['completed_submissions'] = QuestSubmission.objects.all_completed(profile.user)
-        context['badge_assertions_by_type'] = BadgeAssertion.objects.get_by_type_for_user(profile.user)
+        # get_by_type_for_user() was called only for its side effect of granting
+        # any newly-earned badges; its returned list was never used in the
+        # template. Call that side effect directly and skip building the list.
+        BadgeAssertion.objects.check_for_new_assertions(profile.user)
         context['completed_past_submissions'] = QuestSubmission.objects.all_completed_past(profile.user)
         context['xp_per_course'] = profile.xp_per_course()
         context['badge_assertions_dict_items'] = BadgeAssertion.objects.badge_assertions_dict_items(profile.user)
-        context['tags'] = get_user_tags_and_xp(profile.user)
 
         tags_xp = get_user_tags_and_xp(profile.user)
 


### PR DESCRIPTION
### What?
Third batch of query-efficiency fixes, targeting the profile detail page (the worst remaining offender) and the notifications list. Measured by profiling the seeded tenant (100 students, 800 submissions, 300 badge assertions) with per-view SQL capture:

| View | Real queries before | Real queries after |
|---|---|---|
| Student profile detail (own) | 65 | **45** |
| Student profile detail (staff view) | 65 | **41** |
| Notifications list | 21 | **17** |

The changes:
1. **Profile badge popovers ran a query per badge for duplicate assertions.** The profile page renders one popover per earned badge, and each called `assertion.get_duplicate_assertions()` → one query per badge (x15 on the profiled student). `badge_assertions_dict_items` now fetches all of the user's assertions once, groups them by badge in Python, and populates a per-assertion cache that `get_duplicate_assertions()` reads.
2. **Each badge popover also ran a query for its prerequisites** (`badge.prereqs`, x10). Added `PrereqManager.prefetch_for_parents()`, which loads the prerequisites of many same-model objects in a single query and populates a `_prereqs_cache` that `HasPrereqsMixin.prereqs()` reads; `badge_assertions_dict_items` calls it for the displayed badges. Non-prefetched callers are unchanged — `prereqs()` still returns a normal queryset, so existing `.count()`/`.exists()`/`.delete()` call sites are unaffected.
3. **Notifications rendered each row's generic-FK objects one query at a time.** The list view now `prefetch_related`s `sender_object`, `target_object`, and `action_object`, collapsing the per-row sender/target/action lookups into a few grouped queries.
4. **Dead work removed on the profile page:** `badge_assertions_by_type` was computed for the context but never rendered in any template — its only real effect was the badge-granting side effect of `check_for_new_assertions()`, which is now called directly. The profile view also called `get_user_tags_and_xp()` twice (the first result was immediately overwritten); the redundant call is removed.

### Why?
The profile detail page is the most query-heavy student-facing page and scales with the number of badges a student has earned (a popover per badge, each doing 2+ queries). The notifications list scaled with the number of notifications per page. Both are frequently visited.

### How?
Profiled with Django's `CaptureQueriesContext` against the generated tenant, ranked the remaining repeated query shapes, and eliminated the per-row ones with a Python-side grouping (duplicate assertions), a batched generic-FK prefetch helper (badge prereqs), and standard `prefetch_related` (notification GFKs). The remaining profile-page prereq queries come from the preserved `check_for_new_assertions()` badge-granting path, which is correctness-critical and out of scope here.

### Testing?
- New regression tests, each asserting the batched path issues **no** per-object query (`assertNumQueries(0)`):
  - `badges`: `test_badge_assertions_dict_items_prefetches_duplicates`
  - `prerequisites`: `PrereqPrefetchTest` (prefetch serves `prereqs()` with no per-object query; unprefetched objects still return a queryset; empty input is a no-op)
- Full `badges`, `prerequisites`, `profile_manager`, and `notifications` suites pass.
- flake8 clean.
- Before/after query counts re-measured with cold caches (table above).

### Screenshots (if front end is affected)
No template or rendered-output changes — the profile page and notifications render identically (verified by the existing view/template tests).

### Anything Else?
Remaining smaller offenders noted for a possible follow-up: the per-badge tag lists on the profile popovers (a few `taggit` queries) and the notifications list's `get_root_url()` (a tenant + domain query per notification), which would benefit from a schema-scoped cache like the ranks/rarities caches — deferred here because it touches multi-tenancy internals and the win is modest. The prerequisites recalculation engine remains the big architectural item.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Faster badge and prerequisite loading by reducing repeated database requests.
  * Improved notification list rendering, especially for pages with many notifications.
  * Badge duplicate information is now loaded efficiently for smoother profile and badge views.

* **Bug Fixes**
  * Profile pages continue granting newly earned badges while displaying the expected badge and submission information.

* **Tests**
  * Added coverage confirming correct badge duplicates, prerequisite results, and notification-related query efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->