### PR TITLE
Point sidebar Quest Approvals button at the Submitted tab

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -10,6 +10,8 @@ or they could be moved into a `test_urls.py` module.
 
 """
 
+import re
+
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
@@ -168,6 +170,21 @@ class QuestViewQuickTests(ViewTestUtilsMixin, TenantTestCase):
             HTTP_X_REQUESTED_WITH='XMLHttpRequest',  # Ajax
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_sidebar_approvals_link__points_to_default_submitted_tab(self):
+        """The sidebar 'Quest Approvals' menu button links to the default approvals view
+        (the Submitted tab), not the In Progress tab. Regression test for issue #1895.
+        """
+        success = self.client.login(username=self.test_teacher.username, password=self.test_password)
+        self.assertTrue(success)
+
+        response = self.client.get(reverse('quests:quests'))
+        content = response.content.decode()
+
+        # grab the href of the anchor inside the sidebar's approvals menu
+        match = re.search(r'id="lg-menu-approvals".*?href="([^"]+)"', content, re.DOTALL)
+        self.assertIsNotNone(match, "Sidebar approvals menu not found in the rendered page")
+        self.assertEqual(match.group(1), reverse('quests:approvals'))
 
     def test_start(self):
         # log in a student from setUp

--- a/src/templates/sidebar.html
+++ b/src/templates/sidebar.html
@@ -19,7 +19,7 @@
   {% if request.user.is_staff %}
     <div class="nav list-group hidden-xs sidebar-menu" id="lg-menu-approvals">
       <a class="list-group-item {% if '/approvals/' in request.path_info %}active{% endif %}"
-         href="{% url 'quests:in_progress' %}">
+         href="{% url 'quests:approvals' %}">
         <i class="fa fa-shield fa-fw fa-rotate-180"></i>&nbsp;
         <span class="visible-sm-inline visible-xs-inline visible-md-inline">Approvals</span>
         <span class="hidden-sm hidden-xs hidden-md">Quest Approvals</span>


### PR DESCRIPTION
### What?
Changes the sidebar "Quest Approvals" menu button to link to `quests:approvals` (which defaults to the **Submitted** tab) instead of `quests:in_progress`.

Closes #1895

### Why?
Teachers land on the In Progress tab when they click Quest Approvals, so approving quests requires extra clicks. As confirmed in the issue discussion, the button should point to the Submitted tab by default. The link was changed to In Progress as a side effect of PR #1860 (which was about merging Returned into the In Progress tab and reordering tabs, not about the sidebar's default destination).

### How?
One-line change in `src/templates/sidebar.html`: the anchor in `#lg-menu-approvals` now uses `{% url 'quests:approvals' %}`. The tab reordering from #1860 (In Progress listed first) is untouched.

### Testing?
Added `QuestViewQuickTests.test_sidebar_approvals_link__points_to_default_submitted_tab`, which fails against the previous template (it resolved to `/quests/approvals/in-progress/`) and passes with the fix. Full `QuestViewQuickTests` class passes; flake8 clean.

### Screenshots (if front end is affected)
No visual change — only the link destination changes.

### Anything Else?
Part of a batch of bug fixes working through the open `bug`-labelled issues.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “Quest Approvals” sidebar link so it opens the default Submitted approvals view instead of the In Progress view.
  * Added regression coverage to help prevent the navigation issue from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->