### PR TITLE
Escape all HTML in plain-text comment forms to prevent stored XSS

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -11,6 +11,7 @@ from model_bakery import baker
 
 from announcements.forms import AnnouncementForm
 from announcements.models import Announcement
+from comments.models import Comment
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
 from siteconfig.models import SiteConfig
 
@@ -215,6 +216,27 @@ class AnnouncementViewTests(ViewTestUtilsMixin, TenantTestCase):
         #     data=form_data
         # )
         # self.assertRedirects(response, self.test_announcement.get_absolute_url())
+
+    def test_comment_on_announcement__escapes_html(self):
+        """HTML entered in the announcement comment form is completely escaped when
+        the comment is saved, so scripts can't execute when the comment is rendered.
+        Regression test for issue #1343.
+        """
+        success = self.client.login(username=self.test_student1.username, password=self.test_password)
+        self.assertTrue(success)
+
+        payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
+        response = self.client.post(
+            reverse('announcements:comment', args=[self.test_announcement.id]),
+            data={'comment_text': payload, 'comment_button': True}
+        )
+        self.assertRedirects(response, self.test_announcement.get_absolute_url())
+
+        comment = Comment.objects.all_with_target_object(self.test_announcement).first()
+        self.assertIsNotNone(comment)
+        self.assertNotIn('<script', comment.text)
+        self.assertNotIn('<img', comment.text)
+        self.assertIn('&lt;script&gt;', comment.text)
 
     def test_copy_announcement(self):
         # log in a teacher

--- a/src/comments/forms.py
+++ b/src/comments/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.html import escape
 
 from bytedeck_summernote.widgets import ByteDeckSummernoteSafeInplaceWidget
 
@@ -24,3 +25,13 @@ class CommentForm(forms.Form):
         self.fields['comment_text'].label = self.label
 
     comment_text = forms.CharField()
+
+    def clean_comment_text(self):
+        text = self.cleaned_data.get('comment_text', '')
+        if not self.wysiwyg:
+            # The plain-text (non-wysiwyg) comment field is accessible to all users,
+            # so no HTML at all is allowed in it, otherwise scripts can be injected
+            # and will execute when the comment is rendered (see issue #1343).
+            # The wysiwyg variant is sanitized by the safe summernote widget instead.
+            text = escape(text)
+        return text

--- a/src/comments/tests/test_forms.py
+++ b/src/comments/tests/test_forms.py
@@ -1,0 +1,29 @@
+from django_tenants.test.cases import TenantTestCase
+
+from comments.forms import CommentForm
+
+
+class CommentFormTest(TenantTestCase):
+    """The plain-text (non-wysiwyg) comment form is accessible to all users, so
+    all HTML entered in it must be completely escaped. Regression tests for
+    issue #1343 where scripts entered in plain-text comment fields would execute.
+    """
+
+    xss_payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
+    escaped_payload = ('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+                       '&lt;img src=x onerror=alert(1)&gt;')
+
+    def test_comment_form__escapes_html_when_not_wysiwyg(self):
+        """All HTML in the plain-text (default) comment form is escaped on cleaning."""
+        form = CommentForm(data={'comment_text': self.xss_payload})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+
+    def test_comment_form__wysiwyg_html_untouched_by_form(self):
+        """The wysiwyg variant leaves HTML alone at the form level: its content is
+        sanitized by the safe summernote widget and `clean_html()` on save instead.
+        """
+        html = '<p>some <b>formatted</b> text</p>'
+        form = CommentForm(data={'comment_text': html}, wysiwyg=True)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['comment_text'], html)

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
+from django.utils.html import escape
 
 from bootstrap_datepicker_plus.widgets import DatePickerInput, TimePickerInput
 from crispy_forms.bootstrap import Accordion, AccordionGroup
@@ -259,7 +260,19 @@ class SubmissionFormStaff(SubmissionForm):
         )
 
 
-class SubmissionReplyForm(forms.Form):
+class EscapeCommentTextMixin:
+    """Completely escapes HTML entered in a form's `comment_text` field.
+
+    Plain-text (non-wysiwyg) comment fields are accessible to all users, so no
+    HTML at all is allowed in them, otherwise scripts can be injected and will
+    execute when the comment is rendered (see issue #1343).
+    """
+
+    def clean_comment_text(self):
+        return escape(self.cleaned_data.get('comment_text', ''))
+
+
+class SubmissionReplyForm(EscapeCommentTextMixin, forms.Form):
     comment_text = forms.CharField(label='Reply', widget=forms.Textarea(attrs={'rows': 2}))
 
 
@@ -267,7 +280,7 @@ class BadgeModelChoiceField(BadgeLabel, forms.ModelChoiceField):
     pass
 
 
-class SubmissionQuickReplyForm(forms.Form):
+class SubmissionQuickReplyForm(EscapeCommentTextMixin, forms.Form):
     comment_text = forms.CharField(label='', required=False, widget=forms.Textarea(attrs={'rows': 2}))
     # Queryset needs to be set on creation in __init__(), otherwise bad stuff happens upon initial migration
     award = BadgeModelChoiceField(queryset=None, label='Grant an Award', required=False)
@@ -277,7 +290,7 @@ class SubmissionQuickReplyForm(forms.Form):
         self.fields['award'].queryset = Badge.objects.all_manually_granted()
 
 
-class SubmissionQuickReplyFormStudent(forms.Form):
+class SubmissionQuickReplyFormStudent(EscapeCommentTextMixin, forms.Form):
     comment_text = forms.CharField(label='', required=False, widget=forms.Textarea(attrs={'rows': 2}))
 
 

--- a/src/quest_manager/tests/test_forms.py
+++ b/src/quest_manager/tests/test_forms.py
@@ -2,7 +2,12 @@ from django.utils import timezone
 
 from django_tenants.test.cases import TenantTestCase
 
-from quest_manager.forms import QuestForm
+from quest_manager.forms import (
+    QuestForm,
+    SubmissionQuickReplyForm,
+    SubmissionQuickReplyFormStudent,
+    SubmissionReplyForm,
+)
 
 
 class QuestFormTest(TenantTestCase):
@@ -35,3 +40,32 @@ class QuestFormTest(TenantTestCase):
         form = QuestForm(data=form_data)
         self.assertFalse(form.is_valid())
         self.assertIn("Blocking quests cannot be Hideable.", form.errors['__all__'][0])
+
+
+class QuickReplyFormsEscapeHTMLTest(TenantTestCase):
+    """The plain-text (non-wysiwyg) reply forms are accessible to all users, so
+    all HTML entered in them must be completely escaped. Regression tests for
+    issue #1343 where scripts entered in the quick reply form would execute.
+    """
+
+    xss_payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
+    escaped_payload = ('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+                       '&lt;img src=x onerror=alert(1)&gt;')
+
+    def test_SubmissionQuickReplyFormStudent__escapes_html(self):
+        """All HTML in the student quick reply form is escaped on cleaning."""
+        form = SubmissionQuickReplyFormStudent(data={'comment_text': self.xss_payload})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+
+    def test_SubmissionQuickReplyForm__escapes_html(self):
+        """All HTML in the staff quick reply form is escaped on cleaning."""
+        form = SubmissionQuickReplyForm(data={'comment_text': self.xss_payload})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+
+    def test_SubmissionReplyForm__escapes_html(self):
+        """All HTML in the reply form is escaped on cleaning."""
+        form = SubmissionReplyForm(data={'comment_text': self.xss_payload})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -723,6 +723,21 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments[0].text, f'<p>{comment}</p>')
 
+    def test_complete_quick_reply_form__escapes_html(self):
+        """HTML entered in the quick reply form is completely escaped when the comment
+        is saved, so scripts can't execute when the comment is rendered. Regression
+        test for issue #1343.
+        """
+        payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
+        response = self.post_complete(submission_comment=payload)
+        self.assertRedirects(response, expected_url=reverse('quests:quests'))
+
+        comments = self.sub.get_comments()
+        self.assertEqual(comments.count(), 1)
+        self.assertNotIn('<script', comments[0].text)
+        self.assertNotIn('<img', comments[0].text)
+        self.assertIn('&lt;script&gt;', comments[0].text)
+
     def test_complete__no_verification(self):
         """ Checks if a student completing a submission that causes their XP to go over
         the threshold for 'Digital Novice' rank (60 XP) generates a notification


### PR DESCRIPTION
### What?
Completely escapes HTML entered in the plain-text (non-wysiwyg) comment forms: the quest submission quick-reply forms (student and staff), `SubmissionReplyForm`, and the announcement comment form.

Closes #1343

### Why?
Scripts entered in the quick reply form execute when the comment is rendered (stored XSS). Comment text is rendered with `|safe`, and `clean_html()` in `comments/models.py` only removes `<script>` *tags* — other elements and their attributes survive, so payloads like ``'&lt;img src=x onerror=alert(1)&gt;'`` execute for anyone viewing the comment (before the fix, the new tests captured exactly that: the stored comment was ``'&lt;img onerror="alert(1)" src="x"/&gt;'``). As the issue says, all users have access to these plain-text fields, so no HTML at all should be allowed in them.

### How?
- `quest_manager/forms.py`: new `EscapeCommentTextMixin` with a `clean_comment_text()` that escapes everything (`django.utils.html.escape`), applied to `SubmissionQuickReplyForm`, `SubmissionQuickReplyFormStudent`, and `SubmissionReplyForm`.
- `comments/forms.py`: `CommentForm.clean_comment_text()` escapes when `wysiwyg=False` (the default, used by announcement comments). The wysiwyg variant is untouched — it's sanitized by `ByteDeckSummernoteSafeWidget` instead.

Escaping at the **form** level (rather than in `clean_html()`) matters for two reasons: it leaves the wysiwyg comment paths and system-generated HTML (award notices, "XP requested" additions, blank-comment placeholders) intact, and it also covers the quest completion path that assigns `draft_comment.text` directly, bypassing `create_comment()`/`clean_html()` entirely.

Legitimate text is unaffected: escaped text is stored and rendered back as the literal characters the user typed, and `clean_html()`'s entity handling is idempotent for already-escaped text (BeautifulSoup decodes, then re-escapes).

### Testing?
7 new tests, 6 failing before the fix (the 7th pins the wysiwyg passthrough behavior):
- `QuickReplyFormsEscapeHTMLTest` — form-level escaping for all three quest_manager reply forms
- `CommentFormTest` — escaping for the plain `CommentForm`; wysiwyg variant left to the safe widget
- `SubmissionCompleteViewTest.test_complete_quick_reply_form__escapes_html` — end-to-end: student completes a quest with an XSS payload, stored comment contains no live tags
- `AnnouncementViewTests.test_comment_on_announcement__escapes_html` — end-to-end for announcement comments

Full `quest_manager`, `comments`, and `announcements` suites pass (278 tests); flake8 clean.

### Screenshots (if front end is affected)
Behavior change only: HTML typed into plain-text comment boxes now renders as literal text instead of markup.

### Anything Else?
`clean_html()` itself is unchanged; it still sanitizes the legacy/wysiwyg `create_comment()` paths. If you'd rather harden it too (e.g. attribute stripping via an allowlist sanitizer), that seems like a good follow-up, but it wasn't needed to close this hole.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_