### PR TITLE
Treat max_repeats=-1 as unlimited for repeat-per-semester quests

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -674,11 +674,11 @@ class Quest(IsAPrereqMixin, HasPrereqsMixin, TagsModelMixin, XPItem):
         if not time_of_last:
             return False
 
-        # if haven't maxed out repeats
+        # if haven't maxed out repeats (max_repeats = -1 means unlimited repeats)
         if self.repeat_per_semester:
             # get all completed this semester
             qs = QuestSubmission.objects.all_completed(user=user).filter(quest=self)
-            if qs.count() > self.max_repeats:
+            if qs.count() > self.max_repeats and self.max_repeats != -1:
                 return False
         elif latest_sub.ordinal > self.max_repeats and self.max_repeats != -1:
             return False

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -370,6 +370,31 @@ class QuestTestModel(TenantTestCase):
         # No repeat left this semester
         self.assertFalse(quest_semester.is_repeat_available(student))
 
+    @freeze_time('2018-10-12 00:54:00', tz_offset=0)
+    def test_is_repeat_available__infinite_repeats_per_semester(self):
+        """A quest with unlimited repeats (max_repeats=-1) that is also set to repeat
+        per semester is repeatable after each completion. Regression test for issue
+        #1531 where this combination made the quest never repeatable, causing 404s
+        for returning students.
+        """
+        baker.make(User, is_staff=True)  # need a teacher or student creation will fail.
+        student = baker.make(User)
+        quest = baker.make(Quest, name="quest-infinite-semester-repeatable", max_repeats=-1,
+                           repeat_per_semester=True)
+
+        # in progress, shouldn't be available.
+        sub = QuestSubmission.objects.create_submission(student, quest)
+        self.assertFalse(quest.is_repeat_available(student))
+
+        # available again after completion
+        sub.mark_completed()
+        self.assertTrue(quest.is_repeat_available(student))
+
+        # and still available after more completions this semester (unlimited repeats)
+        sub2 = QuestSubmission.objects.create_submission(student, quest)
+        sub2.mark_completed()
+        self.assertTrue(quest.is_repeat_available(student))
+
     def test_correct_ordinal_submission(self):
         student = baker.make('user')
         quest = baker.make(Quest, max_repeats=-1)


### PR DESCRIPTION
### What?
Fixes `Quest.is_repeat_available()` so that `max_repeats = -1` (unlimited) works when `repeat_per_semester` is also enabled.

Closes #1531

### Why?
The issue reported 404s for students on their 3rd repeat of a course when a quest had "repeat per semester" enabled together with max repeats of -1. Root cause in `is_repeat_available()`: the per-semester branch checks `qs.count() > self.max_repeats`, and any count is greater than -1, so the quest was **never** repeat-available in that configuration — students who'd completed it in a previous semester couldn't access it again, producing the 404. The non-semester branch already special-cased `-1`; the per-semester branch didn't.

### How?
One-line change in `src/quest_manager/models.py`: the per-semester repeat check now skips the limit when `max_repeats == -1`, matching the other branch's semantics. (This answers the issue's question about which value should win: `-1` consistently means "unlimited repeats" in both modes, so no form validation conflict is needed.)

### Testing?
New test `QuestTestModel.test_is_repeat_available__infinite_repeats_per_semester` — fails before the fix (`is_repeat_available()` returns False after completion) and passes after. Full `quest_manager` suite passes (221 tests); flake8 clean.

### Screenshots (if front end is affected)
N/A — model logic fix.

### Anything Else?
Part of a batch of bug fixes working through the open `bug`-labelled issues.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_