### PR TITLE
Add regression tests for completing unavailable quests

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -841,16 +841,52 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
 
         self.assertErrorMessage(response)
 
-    def test_quest_not_available(self):
-        """ If a quest is not available to a student, they should not be able to complete it """
-        # TODO
-        # # Easy way to make unavailable, should probably patch the available quests lists instead though...
-        # self.quest.visibel_to_student = False
-        # self.quest.save()
+    def test_quest_not_available__unpublished(self):
+        """ If a quest is unpublished (moved to drafts) while a student's submission is
+        in progress, they should not be able to complete it by entering the completion
+        url directly. Regression test for issue #535.
+        """
+        self.quest.published = False
+        self.quest.save()
 
-        # response = self.post_complete(comment="")
-        # # Should redirect back to the submission with error message
-        # self.assertEqual(response.status_code, 404)
+        response = self.post_complete()
+        self.assertEqual(response.status_code, 404)
+        self.sub.refresh_from_db()
+        self.assertFalse(self.sub.is_completed)
+
+    def test_quest_not_available__archived(self):
+        """ If a quest is archived while a student's submission is in progress, they
+        should not be able to complete it by entering the completion url directly.
+        Regression test for issue #535.
+        """
+        self.quest.archived = True
+        self.quest.save()
+
+        response = self.post_complete()
+        self.assertEqual(response.status_code, 404)
+        self.sub.refresh_from_db()
+        self.assertFalse(self.sub.is_completed)
+
+    def test_quest_not_available__staff_also_404(self):
+        """ Staff also can't complete submissions of unpublished quests: the default
+        QuestSubmission queryset excludes unpublished/archived quests for everyone,
+        so the view's get_object_or_404 lookup fails.
+        """
+        self.client.force_login(self.test_teacher)
+        self.quest.published = False
+        self.quest.save()
+        draft_comment = baker.make(Comment, text="test draft comment")
+        staff_sub = baker.make(QuestSubmission, user=self.test_teacher, quest=self.quest,
+                               draft_comment=draft_comment, semester=self.semester)
+
+        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.test_teacher]):
+            response = self.client.post(
+                reverse('quests:complete', args=[staff_sub.id]),
+                data={'comment_text': "test comment", 'complete': True}
+            )
+        self.assertEqual(response.status_code, 404)
+        staff_sub.refresh_from_db()
+        self.assertFalse(staff_sub.is_completed)
 
     def test_notifications_own_student(self):
         """ Teacher should NOT be notified when their student complete's a quest, because it
@@ -966,18 +1002,6 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertFalse(self.sub.is_completed)
 
         self.assertErrorMessage(response)
-
-    # def test_quest_not_available(self):
-    #     """ If a quest is not available to a student, they should not be able to complete it """
-    #     # TODO
-    #     # # Easy way to make unavailable, should probably patch the available quests lists instead though...
-    #     # self.quest.visibel_to_student = False
-    #     # self.quest.save()
-
-    #     # response = self.post_complete(button="comment", comment="")
-    #     # # Should redirect back to the submission with error message
-    #     # self.assertEqual(response.status_code, 404)
-    #     pass
 
     def test_comment_button_notifications_own_student(self):
         """ Teacher should be notified when their student comments on an already complete's a quest


### PR DESCRIPTION
### What?
Fills in the `test_quest_not_available` TODO stub referenced in the issue with real regression tests, and removes a duplicate commented-out copy of the same stub.

Closes #535

### Why?
The scenario in the issue — a student with an in-progress submission completes a quest via the completion URL after the teacher withdraws it — **already returns 404** on develop: `QuestSubmissionManager.get_queryset()` excludes unpublished and archived quests by default, so the `complete` view's `get_object_or_404(QuestSubmission, ...)` lookup fails. But the test named in the issue was an empty TODO, so nothing pinned this behavior down and the issue stayed open.

### How?
Test-only change. Three new tests in `SubmissionCompleteViewTest`:
- `test_quest_not_available__unpublished` — 404, submission stays incomplete
- `test_quest_not_available__archived` — 404, submission stays incomplete
- `test_quest_not_available__staff_also_404` — documents that the manager-level exclusion applies to staff too (they can't complete submissions of draft quests either)

### Testing?
Full `SubmissionCompleteViewTest` class passes (26 tests); flake8 clean.

### Screenshots (if front end is affected)
N/A — tests only.

### Anything Else?
Two scoping notes for the reviewer:
- The issue also mentions "changes prereqs etc." — completing is *not* blocked when prereqs change mid-submission (only unpublish/archive trigger the 404, via the manager). Blocking on prereq changes would be debatable UX (a student who legitimately started could lose the ability to submit finished work), so it's left out; happy to follow up if you want it.
- The staff behavior these tests pin down (staff also 404) might be worth revisiting separately if teachers should be able to test-complete their own draft quests.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_