### PR TITLE
Grant badges to qualifying students via a teacher-confirmed flow

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -239,24 +239,36 @@ class Badge(IsAPrereqMixin, HasPrereqsMixin, TagsModelMixin, models.Model):
     def get_absolute_url(self):
         return reverse('badges:badge_detail', kwargs={'badge_id': self.id})
 
+    def student_qualifies_ungranted(self, user):
+        """Return True if `user` meets this badge's prerequisites but hasn't been granted it
+        yet; otherwise False.
+
+        Badges with no prerequisites are manual-grant-only, hence `no_prereq_means=False`
+        (matching BadgeManager.get_conditions_met). Shared by the grant-check preview
+        (students_who_qualify_ungranted) and the grant task, so both apply the same rule.
+        """
+        from prerequisites.models import Prereq
+
+        return (
+            not BadgeAssertion.objects.all_for_user_badge(user, self, False).exists()
+            and Prereq.objects.all_conditions_met(self, user, no_prereq_means=False)
+        )
+
     def students_who_qualify_ungranted(self):
-        """Return current-semester students who meet this badge's prerequisites but have
-        not been granted it yet.
+        """Return the current-semester students who meet this badge's prerequisites but have
+        not been granted it yet, as a list of User objects (empty when none qualify).
 
         Used to preview and confirm a teacher-initiated grant-check (issue #1157): rather
         than auto-granting on every prereq edit (which risks granting a badge before it is
-        finished), the teacher runs this check on demand. Badges with no prerequisites are
-        manual-grant-only, hence `no_prereq_means=False` (matching BadgeManager.get_conditions_met).
+        finished), the teacher runs this check on demand.
+
+        Returns:
+            list[User]: e.g. ``[<User: ada>, <User: grace>]``
         """
         from courses.models import CourseStudent
-        from prerequisites.models import Prereq
 
         students = CourseStudent.objects.all_users_for_active_semester()
-        return [
-            user for user in students
-            if not BadgeAssertion.objects.all_for_user_badge(user, self, False).exists()
-            and Prereq.objects.all_conditions_met(self, user, no_prereq_means=False)
-        ]
+        return [user for user in students if self.student_qualifies_ungranted(user)]
 
     def get_icon_url(self):
         if self.icon and hasattr(self.icon, 'url'):

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -239,6 +239,25 @@ class Badge(IsAPrereqMixin, HasPrereqsMixin, TagsModelMixin, models.Model):
     def get_absolute_url(self):
         return reverse('badges:badge_detail', kwargs={'badge_id': self.id})
 
+    def students_who_qualify_ungranted(self):
+        """Return current-semester students who meet this badge's prerequisites but have
+        not been granted it yet.
+
+        Used to preview and confirm a teacher-initiated grant-check (issue #1157): rather
+        than auto-granting on every prereq edit (which risks granting a badge before it is
+        finished), the teacher runs this check on demand. Badges with no prerequisites are
+        manual-grant-only, hence `no_prereq_means=False` (matching BadgeManager.get_conditions_met).
+        """
+        from courses.models import CourseStudent
+        from prerequisites.models import Prereq
+
+        students = CourseStudent.objects.all_users_for_active_semester()
+        return [
+            user for user in students
+            if not BadgeAssertion.objects.all_for_user_badge(user, self, False).exists()
+            and Prereq.objects.all_conditions_met(self, user, no_prereq_means=False)
+        ]
+
     def get_icon_url(self):
         if self.icon and hasattr(self.icon, 'url'):
             return self.icon.url

--- a/src/badges/templates/badges/badge_grant_qualifying_confirm.html
+++ b/src/badges/templates/badges/badge_grant_qualifying_confirm.html
@@ -1,0 +1,49 @@
+{% extends "badges/base.html" %}
+
+{% block heading_inner %}Grant {{ config.custom_name_for_badge }}: {{ badge.name }}{% endblock %}
+
+{% block content %}
+  <div class="media">
+    <div class="media-left">
+      <img class="media-object icon-lg img-rounded" src="{{ badge.get_icon_url }}" alt="icon" />
+    </div>
+    <div class="media-body">
+      {{ badge.short_description|safe }}
+    </div>
+  </div>
+  <p></p>
+
+  {% if qualifying_students %}
+    <div class="well">
+      <p>
+        <strong>{{ qualifying_students|length }}</strong>
+        student{{ qualifying_students|length|pluralize }} currently
+        {{ qualifying_students|length|pluralize:"meets,meet" }} this
+        {{ config.custom_name_for_badge|lower }}'s prerequisites but
+        {{ qualifying_students|length|pluralize:"has,have" }} not been granted it yet:
+      </p>
+      <ul>
+        {% for student in qualifying_students %}
+          <li><a href="{{ student.profile.get_absolute_url }}">{{ student.profile }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+    <form action="" method="post">{% csrf_token %}
+      <p>
+        Grant this {{ config.custom_name_for_badge|lower }} to the
+        {{ qualifying_students|length }} student{{ qualifying_students|length|pluralize }} above?
+        Their teachers will be notified.
+      </p>
+      <a href="{{ badge.get_absolute_url }}" role="button" class="btn btn-info">Cancel</a>
+      <input type="submit" value="Grant to qualifying students" class="btn btn-success" />
+    </form>
+  {% else %}
+    <div class="well">
+      <p>
+        No current students meet this {{ config.custom_name_for_badge|lower }}'s prerequisites
+        without already having it, so there is nothing to grant.
+      </p>
+    </div>
+    <a href="{{ badge.get_absolute_url }}" role="button" class="btn btn-info">Back to {{ config.custom_name_for_badge|lower }}</a>
+  {% endif %}
+{% endblock %}

--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -43,7 +43,7 @@
             {% if badge.published %}
             <a class="btn btn-success" title="Grant to all students who meet this {{ config.custom_name_for_badge|lower }}'s prerequisites"
                href="{% url 'badges:grant_qualifying' badge.id %}">
-              <i class="fa fa-check-circle-o"></i>
+              <i class="fa fa-fw fa-users"></i>
             </a>
             {% endif %}
           </div>

--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -40,6 +40,12 @@
             <a class="btn btn-success" title="Bulk grant to multiple student" href="{% url 'badges:bulk_grant_badge' badge.id %}">
               <i class="fa fa-users"></i>
             </a>
+            {% if badge.published %}
+            <a class="btn btn-success" title="Grant to all students who meet this {{ config.custom_name_for_badge|lower }}'s prerequisites"
+               href="{% url 'badges:grant_qualifying' badge.id %}">
+              <i class="fa fa-check-circle-o"></i>
+            </a>
+            {% endif %}
           </div>
         </div>
         {% endif %}

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -301,6 +301,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         """
         self.client.force_login(self.test_teacher)
         self.test_badge.published = False
+        self.test_badge.full_clean()
         self.test_badge.save()
 
         url = reverse('badges:grant_qualifying', args=[self.test_badge.id])
@@ -341,6 +342,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         """
         self.client.force_login(self.test_teacher)
         self.test_badge.published = False
+        self.test_badge.full_clean()
         self.test_badge.save()
 
         prereq_quest = baker.make(Quest)

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -296,16 +296,16 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
 
     @patch('badges.views.grant_badge_assertions_for_badge.apply_async')
     def test_badge_grant_qualifying__unpublished_badge_does_not_grant(self, task):
-        """An unpublished badge can't be granted: the view redirects with a warning and
-        never queues the grant task.
+        """An unpublished badge can't be granted: both GET and POST redirect with a warning
+        and never queue the grant task.
         """
         self.client.force_login(self.test_teacher)
         self.test_badge.published = False
         self.test_badge.save()
 
-        response = self.client.post(reverse('badges:grant_qualifying', args=[self.test_badge.id]))
-
-        self.assertRedirects(response, self.test_badge.get_absolute_url())
+        url = reverse('badges:grant_qualifying', args=[self.test_badge.id])
+        self.assertRedirects(self.client.get(url), self.test_badge.get_absolute_url())
+        self.assertRedirects(self.client.post(url), self.test_badge.get_absolute_url())
         task.assert_not_called()
 
     def test_badge_prereqs_update__prompts_to_grant_qualifying(self):

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -1,6 +1,9 @@
 import uuid
 
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
 from django_tenants.test.cases import TenantTestCase
@@ -9,6 +12,8 @@ from model_bakery import baker
 
 from badges.models import Badge, BadgeAssertion, BadgeType
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
+from prerequisites.models import Prereq
+from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
 from djcytoscape.models import CytoScape
 from notifications.models import Notification
@@ -57,6 +62,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertRedirectsLogin('badges:bulk_grant_badge', args=[b_pk])
         self.assertRedirectsLogin('badges:bulk_grant')
         self.assertRedirectsLogin('badges:revoke', args=[a_pk])
+        self.assertRedirectsLogin('badges:grant_qualifying', args=[b_pk])
 
     def test_all_badge_page_status_codes_for_students(self):
 
@@ -81,6 +87,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert403('badges:bulk_grant_badge', args=[b_pk])
         self.assert403('badges:bulk_grant')
         self.assert403('badges:revoke', args=[s_pk])
+        self.assert403('badges:grant_qualifying', args=[b_pk])
 
         self.assertEqual(self.client.get(reverse('badges:badge_prereqs_update', args=[b_pk])).status_code, 403)
 
@@ -104,6 +111,7 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assert200('badges:bulk_grant')
         self.assert200('badges:revoke', args=[a_pk])
         self.assert200('badges:badge_prereqs_update', args=[a_pk])
+        self.assert200('badges:grant_qualifying', args=[b_pk])
 
     def test_badge_create(self):
         # log in a teacher
@@ -252,6 +260,108 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         # we just bulk granted 2 badges, so there should be two more than before!
         badge_assertions_after = BadgeAssertion.objects.all().count()
         self.assertEqual(badge_assertions_after, badge_assertions_before + 2)
+
+    def test_badge_grant_qualifying__GET_lists_qualifying_students(self):
+        """The grant-qualifying page lists current students who meet the badge's prereqs
+        but haven't been granted it yet, and offers a confirm button (issue #1157).
+        """
+        self.client.force_login(self.test_teacher)
+
+        # a published badge with a single prereq, and a current student who has met it
+        quest = baker.make(Quest)
+        Prereq.add_simple_prereq(self.test_badge, quest)
+        baker.make('courses.CourseStudent', user=self.test_student1, semester=self.sem)
+        baker.make(QuestSubmission, user=self.test_student1, quest=quest,
+                   is_completed=True, is_approved=True, semester=self.sem)
+
+        response = self.client.get(reverse('badges:grant_qualifying', args=[self.test_badge.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.test_student1, response.context['qualifying_students'])
+        self.assertContains(response, 'Grant to qualifying students')
+
+    @patch('badges.views.grant_badge_assertions_for_badge.apply_async')
+    def test_badge_grant_qualifying__POST_queues_task_and_redirects(self, task):
+        """Confirming the grant queues the grant task for the badge and redirects to its
+        detail page.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(reverse('badges:grant_qualifying', args=[self.test_badge.id]))
+
+        self.assertRedirects(response, self.test_badge.get_absolute_url())
+        task.assert_called_once_with(
+            kwargs={'badge_id': self.test_badge.id, 'start_from_user_id': 1}, queue='default'
+        )
+
+    @patch('badges.views.grant_badge_assertions_for_badge.apply_async')
+    def test_badge_grant_qualifying__unpublished_badge_does_not_grant(self, task):
+        """An unpublished badge can't be granted: the view redirects with a warning and
+        never queues the grant task.
+        """
+        self.client.force_login(self.test_teacher)
+        self.test_badge.published = False
+        self.test_badge.save()
+
+        response = self.client.post(reverse('badges:grant_qualifying', args=[self.test_badge.id]))
+
+        self.assertRedirects(response, self.test_badge.get_absolute_url())
+        task.assert_not_called()
+
+    def test_badge_prereqs_update__prompts_to_grant_qualifying(self):
+        """After a teacher saves a badge's prerequisites they are prompted (via a message
+        linking to the grant-qualifying page) to run a grant-check, rather than the badge
+        being auto-granted on prereq changes (issue #1157).
+        """
+        self.client.force_login(self.test_teacher)
+
+        prereq_quest = baker.make(Quest)
+        ct = ContentType.objects.get_for_model(prereq_quest)
+        form_prefix = "prerequisites-prereq-parent_content_type-parent_object_id"
+        formset_data = {
+            f"{form_prefix}-TOTAL_FORMS": "1",
+            f"{form_prefix}-INITIAL_FORMS": "0",
+            f"{form_prefix}-MAX_NUM_FORMS": "1000",
+            f"{form_prefix}-0-prereq_object": f"{ct.id}-{prereq_quest.id}",
+            f"{form_prefix}-0-prereq_count": "1",
+            f"{form_prefix}-0-or_prereq_count": "1",
+        }
+        response = self.client.post(
+            reverse('badges:badge_prereqs_update', args=[self.test_badge.id]), data=formset_data
+        )
+
+        self.assertRedirects(response, self.test_badge.get_absolute_url())
+        grant_url = reverse('badges:grant_qualifying', args=[self.test_badge.id])
+        messages = [str(m) for m in response.wsgi_request._messages]
+        self.assertTrue(any(grant_url in m for m in messages))
+
+    def test_badge_prereqs_update__unpublished_badge_not_prompted_to_grant(self):
+        """Saving prerequisites on an unpublished badge does NOT show the grant-check
+        prompt, since an unpublished badge can't be granted (issue #1157).
+        """
+        self.client.force_login(self.test_teacher)
+        self.test_badge.published = False
+        self.test_badge.save()
+
+        prereq_quest = baker.make(Quest)
+        ct = ContentType.objects.get_for_model(prereq_quest)
+        form_prefix = "prerequisites-prereq-parent_content_type-parent_object_id"
+        formset_data = {
+            f"{form_prefix}-TOTAL_FORMS": "1",
+            f"{form_prefix}-INITIAL_FORMS": "0",
+            f"{form_prefix}-MAX_NUM_FORMS": "1000",
+            f"{form_prefix}-0-prereq_object": f"{ct.id}-{prereq_quest.id}",
+            f"{form_prefix}-0-prereq_count": "1",
+            f"{form_prefix}-0-or_prereq_count": "1",
+        }
+        response = self.client.post(
+            reverse('badges:badge_prereqs_update', args=[self.test_badge.id]), data=formset_data
+        )
+
+        self.assertRedirects(response, self.test_badge.get_absolute_url())
+        grant_url = reverse('badges:grant_qualifying', args=[self.test_badge.id])
+        messages = [str(m) for m in response.wsgi_request._messages]
+        self.assertFalse(any(grant_url in m for m in messages))
 
     def test_scape_update_message_on_update_delete(self):
         """ Checks if delete and update function gives a success message when a badge is related to map """

--- a/src/badges/urls.py
+++ b/src/badges/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     path('<int:badge_id>/all/', views.detail_all, name='badge_detail_all'),  # show assertions of all students
     re_path(r'^(?P<pk>[0-9]+)/edit/$', views.BadgeUpdate.as_view(), name='badge_update'),
     re_path(r'^(?P<pk>[0-9]+)/prereqs/edit/$', views.BadgePrereqsUpdate.as_view(), name='badge_prereqs_update'),
-    path('<int:badge_id>/grant-qualifying/', views.badge_grant_qualifying, name='grant_qualifying'),
+    path('<int:badge_id>/grant-qualifying/', views.BadgeGrantQualifying.as_view(), name='grant_qualifying'),
     re_path(r'^(?P<badge_id>[0-9]+)/copy/$', views.badge_copy, name='badge_copy'),
     re_path(r'^(?P<pk>[0-9]+)/delete/$', views.BadgeDelete.as_view(), name='badge_delete'),
 

--- a/src/badges/urls.py
+++ b/src/badges/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('<int:badge_id>/all/', views.detail_all, name='badge_detail_all'),  # show assertions of all students
     re_path(r'^(?P<pk>[0-9]+)/edit/$', views.BadgeUpdate.as_view(), name='badge_update'),
     re_path(r'^(?P<pk>[0-9]+)/prereqs/edit/$', views.BadgePrereqsUpdate.as_view(), name='badge_prereqs_update'),
+    path('<int:badge_id>/grant-qualifying/', views.badge_grant_qualifying, name='grant_qualifying'),
     re_path(r'^(?P<badge_id>[0-9]+)/copy/$', views.badge_copy, name='badge_copy'),
     re_path(r'^(?P<pk>[0-9]+)/delete/$', views.BadgeDelete.as_view(), name='badge_delete'),
 

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -7,8 +7,9 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404, redirect, render
 from django.http import JsonResponse
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
+from django.utils.safestring import mark_safe
 from django.views import View
 from django.views.generic import RedirectView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
@@ -26,6 +27,8 @@ from djcytoscape.models import CytoScape
 from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 from djcytoscape.views import UpdateMapMessageMixin
 
+
+from prerequisites.tasks import grant_badge_assertions_for_badge
 
 from .forms import BadgeAssertionForm, BadgeForm, BulkBadgeAssertionForm
 from .models import Badge, BadgeAssertion, BadgeType
@@ -66,6 +69,61 @@ def badge_list(request):
 
 class BadgePrereqsUpdate(ObjectPrereqsFormView):
     model = Badge
+
+    def form_valid(self, form):
+        """After a teacher saves a badge's prerequisites, prompt them to run a grant-check
+        (rather than auto-granting on every edit, which could grant a badge before it is
+        ready — issue #1157). The prompt links to badge_grant_qualifying, which confirms
+        the count before granting. Only published badges can be auto-granted.
+        """
+        response = super().form_valid(form)
+        if self.object.published:
+            badge_name = SiteConfig.get().custom_name_for_badge.lower()
+            grant_url = reverse('badges:grant_qualifying', args=[self.object.id])
+            messages.info(
+                self.request,
+                mark_safe(
+                    f'Prerequisites changed. '
+                    f'<a href="{grant_url}">Check and grant this {badge_name} to qualifying students?</a>'
+                )
+            )
+        return response
+
+
+@non_public_only_view
+@staff_member_required
+def badge_grant_qualifying(request, badge_id):
+    """Teacher-initiated grant-check for a badge (issue #1157).
+
+    GET shows how many current students currently meet the badge's prerequisites but
+    haven't been granted it, and asks the teacher to confirm. POST queues
+    grant_badge_assertions_for_badge, which grants the badge to those students (in bunches)
+    and notifies their teachers. Badges are auto-granted on demand this way rather than
+    automatically on prereq changes, so a badge is never granted while still being built.
+    """
+    badge = get_object_or_404(Badge, pk=badge_id)
+    badge_name = SiteConfig.get().custom_name_for_badge
+
+    if not badge.published:
+        messages.warning(request, f"This {badge_name.lower()} is not published, so it cannot be granted to students.")
+        return redirect(badge.get_absolute_url())
+
+    if request.method == 'POST':
+        grant_badge_assertions_for_badge.apply_async(
+            kwargs={'badge_id': badge.id, 'start_from_user_id': 1}, queue='default')
+        messages.success(
+            request,
+            f"Granting {badge_name.lower()} \"{badge}\" to all qualifying students. "
+            "This may take a moment to complete."
+        )
+        return redirect(badge.get_absolute_url())
+
+    context = {
+        "heading": f"Grant {badge_name}: {badge.name}",
+        "badge": badge,
+        "qualifying_students": badge.students_who_qualify_ungranted(),
+    }
+    return render(request, "badges/badge_grant_qualifying_confirm.html", context)
 
 
 class BadgeDelete(NonPublicOnlyViewMixin, UpdateMapMessageMixin, DeleteView):

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -9,7 +9,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.http import JsonResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
-from django.utils.html import format_html
 from django.views import View
 from django.views.generic import RedirectView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
@@ -80,14 +79,13 @@ class BadgePrereqsUpdate(ObjectPrereqsFormView):
         if self.object.published:
             badge_name = SiteConfig.get().custom_name_for_badge.lower()
             grant_url = reverse('badges:grant_qualifying', args=[self.object.id])
-            # format_html escapes the interpolated values (badge_name comes from SiteConfig)
+            # Messages render with |safe (messages-snippet.html), matching how the rest of the
+            # project builds message links; both values here are trusted (a reversed URL and the
+            # staff-set badge label). Project-wide escaping of message HTML is tracked separately.
             messages.info(
                 self.request,
-                format_html(
-                    'Prerequisites changed. <a href="{}">Check and grant this {} to qualifying students?</a>',
-                    grant_url,
-                    badge_name,
-                )
+                f'Prerequisites changed. '
+                f'<a href="{grant_url}">Check and grant this {badge_name} to qualifying students?</a>'
             )
         return response
 

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.http import JsonResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.views import View
 from django.views.generic import RedirectView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
@@ -80,11 +80,13 @@ class BadgePrereqsUpdate(ObjectPrereqsFormView):
         if self.object.published:
             badge_name = SiteConfig.get().custom_name_for_badge.lower()
             grant_url = reverse('badges:grant_qualifying', args=[self.object.id])
+            # format_html escapes the interpolated values (badge_name comes from SiteConfig)
             messages.info(
                 self.request,
-                mark_safe(
-                    f'Prerequisites changed. '
-                    f'<a href="{grant_url}">Check and grant this {badge_name} to qualifying students?</a>'
+                format_html(
+                    'Prerequisites changed. <a href="{}">Check and grant this {} to qualifying students?</a>',
+                    grant_url,
+                    badge_name,
                 )
             )
         return response

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -90,40 +90,53 @@ class BadgePrereqsUpdate(ObjectPrereqsFormView):
         return response
 
 
-@non_public_only_view
-@staff_member_required
-def badge_grant_qualifying(request, badge_id):
+@method_decorator(staff_member_required, name='dispatch')
+class BadgeGrantQualifying(NonPublicOnlyViewMixin, View):
     """Teacher-initiated grant-check for a badge (issue #1157).
 
-    GET shows how many current students currently meet the badge's prerequisites but
-    haven't been granted it, and asks the teacher to confirm. POST queues
-    grant_badge_assertions_for_badge, which grants the badge to those students (in bunches)
-    and notifies their teachers. Badges are auto-granted on demand this way rather than
-    automatically on prereq changes, so a badge is never granted while still being built.
+    GET shows how many current students meet the badge's prerequisites but haven't been
+    granted it, and asks the teacher to confirm. POST queues grant_badge_assertions_for_badge,
+    which grants the badge to those students (in bunches) and notifies their teachers.
+    Granting happens on demand this way rather than automatically on prereq changes, so a
+    badge is never granted while it is still being built. Published badges only.
     """
-    badge = get_object_or_404(Badge, pk=badge_id)
-    badge_name = SiteConfig.get().custom_name_for_badge
+    template_name = "badges/badge_grant_qualifying_confirm.html"
 
-    if not badge.published:
-        messages.warning(request, f"This {badge_name.lower()} is not published, so it cannot be granted to students.")
-        return redirect(badge.get_absolute_url())
+    def get(self, request, badge_id):
+        badge = get_object_or_404(Badge, pk=badge_id)
+        if not badge.published:
+            return self._unpublished_redirect(request, badge)
 
-    if request.method == 'POST':
+        context = {
+            "heading": f"Grant {SiteConfig.get().custom_name_for_badge}: {badge.name}",
+            "badge": badge,
+            "qualifying_students": badge.students_who_qualify_ungranted(),
+        }
+        return render(request, self.template_name, context)
+
+    def post(self, request, badge_id):
+        badge = get_object_or_404(Badge, pk=badge_id)
+        if not badge.published:
+            return self._unpublished_redirect(request, badge)
+
         grant_badge_assertions_for_badge.apply_async(
             kwargs={'badge_id': badge.id, 'start_from_user_id': 1}, queue='default')
         messages.success(
             request,
-            f"Granting {badge_name.lower()} \"{badge}\" to all qualifying students. "
-            "This may take a moment to complete."
+            f'Granting {SiteConfig.get().custom_name_for_badge.lower()} "{badge}" to all '
+            'qualifying students. This may take a moment to complete.'
         )
         return redirect(badge.get_absolute_url())
 
-    context = {
-        "heading": f"Grant {badge_name}: {badge.name}",
-        "badge": badge,
-        "qualifying_students": badge.students_who_qualify_ungranted(),
-    }
-    return render(request, "badges/badge_grant_qualifying_confirm.html", context)
+    @staticmethod
+    def _unpublished_redirect(request, badge):
+        """An unpublished badge can't be granted; warn and send the teacher back to it."""
+        messages.warning(
+            request,
+            f"This {SiteConfig.get().custom_name_for_badge.lower()} is not published, "
+            "so it cannot be granted to students."
+        )
+        return redirect(badge.get_absolute_url())
 
 
 class BadgeDelete(NonPublicOnlyViewMixin, UpdateMapMessageMixin, DeleteView):

--- a/src/prerequisites/signals.py
+++ b/src/prerequisites/signals.py
@@ -6,7 +6,6 @@ from django.dispatch import receiver
 from badges.models import Badge
 from prerequisites.models import Prereq, HasPrereqsMixin
 from prerequisites.tasks import (
-    grant_badge_assertions_for_badge,
     update_conditions_for_quest,
     update_quest_conditions_all_users,
     update_quest_conditions_for_user,
@@ -88,16 +87,16 @@ def update_cache_triggered_by_prereq(sender, instance, *args, **kwargs):
     """ Update the cache of available quests (PreqAllConditionsMet) for relevant users when Prereq objects are changed,
     If the parent of the Prereq object is a quest. (i.e a quest's prereqs were changed)
 
-    If the parent is a badge, check whether the badge should now be auto-granted to
-    students who meet its changed conditions (issue #1157).
+    Badge prereq changes are intentionally NOT auto-granted here: a teacher may tweak a
+    badge's prerequisites several times while building it, and auto-granting on each change
+    could grant the badge before it is ready. Instead the teacher runs a grant-check on
+    demand from the badge page (see badges.views.badge_grant_qualifying, issue #1157).
     """
     if isinstance(instance.parent_object, Quest):
         # # The parent_object itself being deleted could have cascaded to delete the sender Prereq, so it parent might not exist.
         # Cover this instance in a post_delete signal receiver for Quest objects.
         if instance.parent_object:
             update_conditions_for_quest.apply_async(kwargs={'quest_id': instance.parent_object.id, 'start_from_user_id': 1}, queue='default')
-    elif isinstance(instance.parent_object, Badge):
-        grant_badge_assertions_for_badge.apply_async(kwargs={'badge_id': instance.parent_object.id, 'start_from_user_id': 1}, queue='default')
 
 
 @receiver(post_save, sender=Prereq)

--- a/src/prerequisites/signals.py
+++ b/src/prerequisites/signals.py
@@ -5,7 +5,12 @@ from django.dispatch import receiver
 
 from badges.models import Badge
 from prerequisites.models import Prereq, HasPrereqsMixin
-from prerequisites.tasks import update_conditions_for_quest, update_quest_conditions_all_users, update_quest_conditions_for_user
+from prerequisites.tasks import (
+    grant_badge_assertions_for_badge,
+    update_conditions_for_quest,
+    update_quest_conditions_all_users,
+    update_quest_conditions_for_user,
+)
 from quest_manager.models import Quest, QuestSubmission
 from djcytoscape.models import CytoScape
 
@@ -82,12 +87,17 @@ def update_cache_triggered_by_quests_available_outside_course(sender, instance, 
 def update_cache_triggered_by_prereq(sender, instance, *args, **kwargs):
     """ Update the cache of available quests (PreqAllConditionsMet) for relevant users when Prereq objects are changed,
     If the parent of the Prereq object is a quest. (i.e a quest's prereqs were changed)
+
+    If the parent is a badge, check whether the badge should now be auto-granted to
+    students who meet its changed conditions (issue #1157).
     """
     if isinstance(instance.parent_object, Quest):
         # # The parent_object itself being deleted could have cascaded to delete the sender Prereq, so it parent might not exist.
         # Cover this instance in a post_delete signal receiver for Quest objects.
         if instance.parent_object:
             update_conditions_for_quest.apply_async(kwargs={'quest_id': instance.parent_object.id, 'start_from_user_id': 1}, queue='default')
+    elif isinstance(instance.parent_object, Badge):
+        grant_badge_assertions_for_badge.apply_async(kwargs={'badge_id': instance.parent_object.id, 'start_from_user_id': 1}, queue='default')
 
 
 @receiver(post_save, sender=Prereq)

--- a/src/prerequisites/tasks.py
+++ b/src/prerequisites/tasks.py
@@ -110,8 +110,10 @@ def update_conditions_for_quest(self, quest_id, start_from_user_id):
 
 @app.task(base=TransactionAwareTask, bind=True, name='prerequisites.tasks.grant_badge_assertions_for_badge', max_retries=settings.CELERY_TASK_MAX_RETRIES)  # noqa
 def grant_badge_assertions_for_badge(self, badge_id, start_from_user_id):
-    """When a badge's prerequisites change, grant the badge to all current students who
-    now meet its conditions, and notify their teachers of each auto-grant (issue #1157).
+    """Grant a badge to all current students who meet its conditions, and notify their
+    teachers of each grant (issue #1157). This is triggered on demand by a teacher from
+    the badge page (badges.views.badge_grant_qualifying) rather than automatically on
+    prereq changes, so a badge is never granted while it is still being built.
     This is done in bunches of users (CELERY_TASKS_BUNCH_SIZE), recursively, like
     update_conditions_for_quest.
 
@@ -128,8 +130,8 @@ def grant_badge_assertions_for_badge(self, badge_id, start_from_user_id):
         # If the badge is deleted or unpublished while this task is running/queued.
         return f"Badge {badge_id} no longer exists or is not published."
 
-    # check if this already started recently, if so, don't need to start a new one.
-    # for example, when prereqs are updated, one might be deleted and two more added, that will result in 3 signals!
+    # check if this already started recently, if so, don't need to start a new one
+    # (e.g. a teacher double-clicking the grant button).
     cache_key = f'grant_badge_assertions_for_badge_{badge_id}_wait'
     if start_from_user_id == 1 and cache.get(cache_key):
         return f"Skipping task for badge {badge_id}, already started."

--- a/src/prerequisites/tasks.py
+++ b/src/prerequisites/tasks.py
@@ -108,6 +108,72 @@ def update_conditions_for_quest(self, quest_id, start_from_user_id):
     return quest.name
 
 
+@app.task(base=TransactionAwareTask, bind=True, name='prerequisites.tasks.grant_badge_assertions_for_badge', max_retries=settings.CELERY_TASK_MAX_RETRIES)  # noqa
+def grant_badge_assertions_for_badge(self, badge_id, start_from_user_id):
+    """When a badge's prerequisites change, grant the badge to all current students who
+    now meet its conditions, and notify their teachers of each auto-grant (issue #1157).
+    This is done in bunches of users (CELERY_TASKS_BUNCH_SIZE), recursively, like
+    update_conditions_for_quest.
+
+    Args:
+        badge_id (int): The badge with updated prerequisites (i.e. this badge is the parent_object of an updated Prereq),
+        start_from_user_id (int): user_id to start with for the next bunch of calculations
+    """
+    from badges.models import Badge, BadgeAssertion
+    from notifications.signals import notify
+    from siteconfig.models import SiteConfig
+
+    badge = Badge.objects.filter(id=badge_id).first()
+    if not badge or not badge.published:
+        # If the badge is deleted or unpublished while this task is running/queued.
+        return f"Badge {badge_id} no longer exists or is not published."
+
+    # check if this already started recently, if so, don't need to start a new one.
+    # for example, when prereqs are updated, one might be deleted and two more added, that will result in 3 signals!
+    cache_key = f'grant_badge_assertions_for_badge_{badge_id}_wait'
+    if start_from_user_id == 1 and cache.get(cache_key):
+        return f"Skipping task for badge {badge_id}, already started."
+    cache.set(cache_key, True, 1)
+
+    users = CourseStudent.objects.all_users_for_active_semester()
+    users = users.order_by('id').filter(id__gte=start_from_user_id)[:settings.CELERY_TASKS_BUNCH_SIZE]
+
+    user = None
+    for user in users:
+        # badges with no prereqs are manually granted only, hence no_prereq_means=False
+        # (matches BadgeManager.get_conditions_met)
+        if (
+            not BadgeAssertion.objects.all_for_user_badge(user, badge, False).exists()
+            and Prereq.objects.all_conditions_met(badge, user, no_prereq_means=False)
+        ):
+            assertion = BadgeAssertion.objects.create_assertion(user, badge)
+
+            # let the student's teachers know the badge was granted automatically
+            deck_ai = SiteConfig.get().deck_ai
+            notify.send(
+                deck_ai,
+                action=assertion,
+                target=badge,
+                recipient=deck_ai,
+                affected_users=list(user.profile.current_teachers()),
+                verb=f"auto-granted {user.get_username()} the badge:",
+                icon="<i class='fa fa-lg fa-certificate text-warning'></i>",
+            )
+
+    if user:
+        # user is the last user that was updated, so continue from the next one.
+        minimum_user_id = user.id + 1
+        if User.objects.filter(id__gte=minimum_user_id).exists():
+            # there are more users, so keep going with the next bunch.
+            self.apply_async(
+                queue='default',
+                countdown=1,  # delay a bit to give some time for the last group to finish, so we don't hog all the resources.
+                kwargs={'badge_id': badge.id, 'start_from_user_id': minimum_user_id}
+            )
+    # Return value is displayed at the end of the celery log
+    return badge.name
+
+
 @app.task(base=TransactionAwareTask, bind=True, name='prerequisites.tasks.update_quest_conditions_for_user', max_retries=settings.CELERY_TASK_MAX_RETRIES)  # noqa
 def update_quest_conditions_for_user(self, user_id):
     user = User.objects.filter(id=user_id).first()

--- a/src/prerequisites/tasks.py
+++ b/src/prerequisites/tasks.py
@@ -142,12 +142,8 @@ def grant_badge_assertions_for_badge(self, badge_id, start_from_user_id):
 
     user = None
     for user in users:
-        # badges with no prereqs are manually granted only, hence no_prereq_means=False
-        # (matches BadgeManager.get_conditions_met)
-        if (
-            not BadgeAssertion.objects.all_for_user_badge(user, badge, False).exists()
-            and Prereq.objects.all_conditions_met(badge, user, no_prereq_means=False)
-        ):
+        # same qualification rule as the grant-check preview (Badge.students_who_qualify_ungranted)
+        if badge.student_qualifies_ungranted(user):
             assertion = BadgeAssertion.objects.create_assertion(user, badge)
 
             # let the student's teachers know the badge was granted automatically

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -137,21 +137,18 @@ class PrerequisitesSignalsTest(TenantTestCase):
         prereq.save()  # update
         self.assertEqual(task.call_count, 0)
 
-    @patch('prerequisites.signals.grant_badge_assertions_for_badge.apply_async')
-    def test_badge_granting_triggered_by_badge_prereq_changes(self, task):
-        """Creation, update and deletion of a prereq where the parent is a badge should
-        each trigger the badge-granting task, so students who meet the badge's new
-        conditions are granted it automatically. Regression test for issue #1157.
+    @patch('prerequisites.tasks.grant_badge_assertions_for_badge.apply_async')
+    def test_badge_prereq_changes_do_not_auto_grant(self, task):
+        """Creating, updating or deleting a prereq whose parent is a badge must NOT trigger
+        the badge-granting task: a teacher may tweak a badge's prereqs while building it,
+        so granting is teacher-initiated from the badge page instead (issue #1157).
         """
         badge = baker.make(Badge)
         prereq = baker.make(Prereq, prereq_invert=True, parent_object=badge)  # creation
         prereq.prereq_invert = False
         prereq.save()  # update
-        self.assertEqual(task.call_count, 2)
-        task.assert_called_with(kwargs={'badge_id': badge.id, 'start_from_user_id': 1}, queue='default')
-
-        prereq.delete()  # deletion (removing a prereq can also make more users meet conditions)
-        self.assertEqual(task.call_count, 3)
+        prereq.delete()  # deletion
+        self.assertEqual(task.call_count, 0)
 
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
     def test_update_cache_triggered_by_quest_prereq_changes(self, task):

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -144,8 +144,10 @@ class PrerequisitesSignalsTest(TenantTestCase):
         so granting is teacher-initiated from the badge page instead (issue #1157).
         """
         badge = baker.make(Badge)
-        prereq = baker.make(Prereq, prereq_invert=True, parent_object=badge)  # creation
+        quest = baker.make('quest_manager.quest')
+        prereq = baker.make(Prereq, prereq_invert=True, parent_object=badge, prereq_object=quest)  # creation
         prereq.prereq_invert = False
+        prereq.full_clean()
         prereq.save()  # update
         prereq.delete()  # deletion
         self.assertEqual(task.call_count, 0)

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -137,6 +137,22 @@ class PrerequisitesSignalsTest(TenantTestCase):
         prereq.save()  # update
         self.assertEqual(task.call_count, 0)
 
+    @patch('prerequisites.signals.grant_badge_assertions_for_badge.apply_async')
+    def test_badge_granting_triggered_by_badge_prereq_changes(self, task):
+        """Creation, update and deletion of a prereq where the parent is a badge should
+        each trigger the badge-granting task, so students who meet the badge's new
+        conditions are granted it automatically. Regression test for issue #1157.
+        """
+        badge = baker.make(Badge)
+        prereq = baker.make(Prereq, prereq_invert=True, parent_object=badge)  # creation
+        prereq.prereq_invert = False
+        prereq.save()  # update
+        self.assertEqual(task.call_count, 2)
+        task.assert_called_with(kwargs={'badge_id': badge.id, 'start_from_user_id': 1}, queue='default')
+
+        prereq.delete()  # deletion (removing a prereq can also make more users meet conditions)
+        self.assertEqual(task.call_count, 3)
+
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
     def test_update_cache_triggered_by_quest_prereq_changes(self, task):
         """Creation and Update of a prereq where the parent IS a quest should both trigger a cache update

--- a/src/prerequisites/tests/test_tasks.py
+++ b/src/prerequisites/tests/test_tasks.py
@@ -6,6 +6,7 @@ from django.core.cache import cache
 from django.test import override_settings
 
 from django_tenants.test.cases import TenantTestCase
+from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
 from badges.models import Badge, BadgeAssertion
@@ -25,6 +26,8 @@ class GrantBadgeAssertionsForBadgeTest(TenantTestCase):
     """
 
     def setUp(self):
+        """Set up a teacher, a current-semester student who has completed a quest, and a badge."""
+        self.client = TenantClient(self.tenant)
         self.teacher = baker.make(User, is_staff=True)
         self.student = baker.make(User)
         baker.make('courses.CourseStudent', user=self.student,
@@ -92,6 +95,7 @@ class GrantBadgeAssertionsForBadgeTest(TenantTestCase):
         """An unpublished badge is never auto-granted."""
         Prereq.add_simple_prereq(self.badge, self.quest)
         self.badge.published = False
+        self.badge.full_clean()
         self.badge.save()
 
         self.run_task()

--- a/src/prerequisites/tests/test_tasks.py
+++ b/src/prerequisites/tests/test_tasks.py
@@ -111,7 +111,7 @@ class GrantBadgeAssertionsForBadgeTest(TenantTestCase):
 
     def test_grant_badge_assertions_for_badge__skips_if_already_started(self):
         """The task skips itself when another run for the same badge started recently
-        (multiple prereq-change signals can fire for a single form save).
+        (e.g. a teacher double-clicking the grant button).
         """
         Prereq.add_simple_prereq(self.badge, self.quest)
         cache.set(f'grant_badge_assertions_for_badge_{self.badge.id}_wait', True, 1)

--- a/src/prerequisites/tests/test_tasks.py
+++ b/src/prerequisites/tests/test_tasks.py
@@ -2,11 +2,14 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import override_settings
 
 from django_tenants.test.cases import TenantTestCase
 from model_bakery import baker
 
 from badges.models import Badge, BadgeAssertion
+from courses.models import CourseStudent
 from notifications.models import Notification
 from prerequisites.models import Prereq
 from prerequisites.tasks import grant_badge_assertions_for_badge
@@ -96,3 +99,56 @@ class GrantBadgeAssertionsForBadgeTest(TenantTestCase):
         self.assertFalse(
             BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
         )
+
+    def test_grant_badge_assertions_for_badge__deleted_badge(self):
+        """The task bails out gracefully if the badge was deleted while it was queued."""
+        deleted_badge_id = self.badge.id
+        self.badge.delete()
+
+        result = grant_badge_assertions_for_badge(badge_id=deleted_badge_id, start_from_user_id=1)
+
+        self.assertIn("no longer exists", result)
+
+    def test_grant_badge_assertions_for_badge__skips_if_already_started(self):
+        """The task skips itself when another run for the same badge started recently
+        (multiple prereq-change signals can fire for a single form save).
+        """
+        Prereq.add_simple_prereq(self.badge, self.quest)
+        cache.set(f'grant_badge_assertions_for_badge_{self.badge.id}_wait', True, 1)
+
+        result = self.run_task()
+
+        self.assertIn("already started", result)
+        self.assertFalse(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
+        )
+
+    def test_grant_badge_assertions_for_badge__no_current_students(self):
+        """The task completes without granting anything when there are no students
+        registered in a course in the active semester.
+        """
+        Prereq.add_simple_prereq(self.badge, self.quest)
+        CourseStudent.objects.all().delete()
+
+        result = self.run_task()
+
+        self.assertEqual(result, self.badge.name)
+        self.assertFalse(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
+        )
+
+    @override_settings(CELERY_TASKS_BUNCH_SIZE=1)
+    def test_grant_badge_assertions_for_badge__processes_users_in_bunches(self):
+        """When there are more users than the bunch size, the task re-queues itself to
+        continue with the next bunch of users.
+        """
+        Prereq.add_simple_prereq(self.badge, self.quest)
+        # a second student, so the first bunch (of 1) doesn't cover everyone
+        student2 = baker.make(User)
+        baker.make('courses.CourseStudent', user=student2,
+                   semester=SiteConfig.get().active_semester)
+
+        with patch.object(grant_badge_assertions_for_badge, 'apply_async') as recursive_call:
+            self.run_task()
+
+        self.assertEqual(recursive_call.call_count, 1)

--- a/src/prerequisites/tests/test_tasks.py
+++ b/src/prerequisites/tests/test_tasks.py
@@ -1,1 +1,98 @@
 # When prereq is changed, id is added/removed from cache
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+
+from django_tenants.test.cases import TenantTestCase
+from model_bakery import baker
+
+from badges.models import Badge, BadgeAssertion
+from notifications.models import Notification
+from prerequisites.models import Prereq
+from prerequisites.tasks import grant_badge_assertions_for_badge
+from quest_manager.models import Quest, QuestSubmission
+from siteconfig.models import SiteConfig
+
+User = get_user_model()
+
+
+class GrantBadgeAssertionsForBadgeTest(TenantTestCase):
+    """Tests for the `grant_badge_assertions_for_badge` task, which grants a badge to
+    all current students who meet its (changed) prerequisite conditions. Issue #1157.
+    """
+
+    def setUp(self):
+        self.teacher = baker.make(User, is_staff=True)
+        self.student = baker.make(User)
+        baker.make('courses.CourseStudent', user=self.student,
+                   semester=SiteConfig.get().active_semester)
+
+        self.quest = baker.make(Quest)
+        self.badge = baker.make(Badge)
+        # the student has already completed the quest
+        baker.make(QuestSubmission, user=self.student, quest=self.quest,
+                   is_completed=True, is_approved=True,
+                   semester=SiteConfig.get().active_semester)
+
+    def run_task(self):
+        """Run the task synchronously, with the student's teacher patched in."""
+        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.teacher]):
+            return grant_badge_assertions_for_badge(badge_id=self.badge.id, start_from_user_id=1)
+
+    def test_grant_badge_assertions_for_badge__grants_and_notifies(self):
+        """A student who already meets a badge's new prereq conditions is granted the
+        badge, and their teacher is notified of the auto-grant.
+        """
+        Prereq.add_simple_prereq(self.badge, self.quest)
+        notifications_before = Notification.objects.all_for_user(self.teacher).count()
+
+        self.run_task()
+
+        self.assertTrue(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
+        )
+        self.assertEqual(
+            Notification.objects.all_for_user(self.teacher).count(), notifications_before + 1
+        )
+
+    def test_grant_badge_assertions_for_badge__conditions_not_met(self):
+        """A student who doesn't meet the badge's prereq conditions is not granted it."""
+        other_quest = baker.make(Quest)  # not completed by the student
+        Prereq.add_simple_prereq(self.badge, other_quest)
+
+        self.run_task()
+
+        self.assertFalse(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
+        )
+
+    def test_grant_badge_assertions_for_badge__no_prereqs(self):
+        """A badge with no prereqs is manually granted only, so the task grants nothing."""
+        self.run_task()
+
+        self.assertFalse(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
+        )
+
+    def test_grant_badge_assertions_for_badge__already_granted(self):
+        """A student who already has the badge is not granted a duplicate."""
+        Prereq.add_simple_prereq(self.badge, self.quest)
+        BadgeAssertion.objects.create_assertion(self.student, self.badge)
+
+        self.run_task()
+
+        self.assertEqual(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).count(), 1
+        )
+
+    def test_grant_badge_assertions_for_badge__unpublished_badge(self):
+        """An unpublished badge is never auto-granted."""
+        Prereq.add_simple_prereq(self.badge, self.quest)
+        self.badge.published = False
+        self.badge.save()
+
+        self.run_task()
+
+        self.assertFalse(
+            BadgeAssertion.objects.all_for_user_badge(self.student, self.badge, False).exists()
+        )


### PR DESCRIPTION
### What?
Lets a teacher grant a badge, on demand, to all current students who meet its prerequisites, and notifies those students' teachers of each grant.

Closes #1157

### Why?
Badges are only auto-granted lazily — `BadgeAssertion.objects.check_for_new_assertions()` runs when a student's profile page is viewed or when they complete a quest. So when a teacher adds a prereq to a badge, students who already meet the new condition get nothing until they happen to load their profile.

We deliberately do **not** grant automatically on every prereq change: a teacher building a badge may tweak its prerequisites several times (add one, then another), and auto-granting in between could grant the badge before it's ready. Instead the teacher triggers a grant-check when they're done, and confirms the count first.

### How?
- **`prerequisites/tasks.py`**: `grant_badge_assertions_for_badge(badge_id, start_from_user_id)` — grants the badge to every current-semester student who has no assertion and meets its conditions (`no_prereq_means=False`, so no-prereq badges stay manual-only), processing users in `CELERY_TASKS_BUNCH_SIZE` bunches recursively and notifying each student's current teachers. Bails if the badge was deleted/unpublished meanwhile; a short debounce guards against a double-clicked button.
- **`badges/views.py`**: `badge_grant_qualifying` view — GET shows how many current students qualify but don't have the badge yet and asks the teacher to confirm; POST queues the task and redirects. Published badges only.
- **Two entry points** (per review): a persistent "grant to qualifying students" button on the badge detail page, and a prompt (a message linking to the confirmation page) shown after a teacher saves the badge's prerequisites (`BadgePrereqsUpdate.form_valid`).
- **`badges/models.py`**: `Badge.students_who_qualify_ungranted()` powers the confirmation preview.
- **`prerequisites/signals.py`**: the `Prereq` post_save/post_delete receiver no longer queues the grant task for badge parents (quest behaviour unchanged).

### Testing?
- `test_tasks.py::GrantBadgeAssertionsForBadgeTest` — grants + teacher notification; skips users not meeting conditions; skips no-prereq badges; no duplicate assertions; unpublished badges never granted; deleted-badge and already-started guards; bunching.
- `test_signals.py::test_badge_prereq_changes_do_not_auto_grant` — badge prereq create/update/delete must NOT queue the grant task.
- `badges/tests/test_views.py` — grant-qualifying page lists qualifying students (GET), POST queues the task and redirects, unpublished-badge guard, and the post-prereq-save prompt is shown for published badges and hidden for unpublished ones.

Full `prerequisites` + `badges` suites pass; flake8 clean; no new migrations.

### Screenshots (if front end is affected)
New: a "grant to qualifying students" button on the badge detail page, and a confirmation page that lists the qualifying students before granting.

### Anything Else?
The task still covers the campaign→badge case noted previously for #1286, but only when a badge's own prereq rows change; campaign-membership changes still need a separate signal and are left for #1286.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staff-only “grant qualifying” review and confirmation flow for published badges.
  * Added an endpoint and confirmation page to list eligible students and grant badge assertions in bulk.
  * Introduced an async background task to grant qualifying badges and notify affected students’ teachers.
  * After saving prerequisites on a published badge, staff are prompted to review eligible students.

* **Bug Fixes**
  * Badge grant/review actions are hidden and blocked for unpublished badges.
  * Prevented duplicate badge grants and ensured prerequisites changes do not auto-grant badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->