### PR TITLE
Reject unlimited repeats combined with repeat-per-semester in the quest form

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -206,6 +206,21 @@ class QuestForm(forms.ModelForm):
                 "either turn Hidable off or turn Blocking off."
             )
 
+        # make sure repeat_per_semester isn't combined with unlimited repeats (issue #1531):
+        # unlimited repeats never run out, so a per-semester reset would do nothing, and the
+        # combination made the quest never repeatable, causing 404s for returning students.
+        max_repeats = cleaned_data.get('max_repeats')
+        repeat_per_semester = cleaned_data.get('repeat_per_semester')
+
+        if max_repeats == -1 and repeat_per_semester:
+            raise ValidationError(
+                "A quest with unlimited repeats (Max Repeats = -1) cannot also use "
+                "'Repeat per semester', because unlimited repeats never run out and a "
+                "new semester would have nothing to reset. Either set Max Repeats to "
+                "the number of repeats allowed each semester, or turn off 'Repeat per "
+                "semester' (in the Advanced section) to keep unlimited repeats."
+            )
+
 
 class TAQuestForm(QuestForm):
     """ Modified QuestForm that removes some fields TAs should not be able to set. """

--- a/src/quest_manager/tests/test_forms.py
+++ b/src/quest_manager/tests/test_forms.py
@@ -41,6 +41,40 @@ class QuestFormTest(TenantTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("Blocking quests cannot be Hideable.", form.errors['__all__'][0])
 
+    def test_repeat_per_semester_with_unlimited_repeats(self):
+        """A quest with unlimited repeats (max_repeats=-1) should not validate if it
+        also has repeat_per_semester: unlimited repeats never run out, so there is
+        nothing for a new semester to reset, and the combination previously caused
+        404 errors for returning students (issue #1531).
+        """
+        form_data = self.minimal_valid_data
+
+        form_data["max_repeats"] = -1
+        form_data["repeat_per_semester"] = True
+
+        form = QuestForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("unlimited repeats", form.errors['__all__'][0])
+
+    def test_repeat_per_semester_with_limited_repeats(self):
+        """A quest with a limited number of repeats can use repeat_per_semester."""
+        form_data = self.minimal_valid_data
+
+        form_data["max_repeats"] = 2
+        form_data["repeat_per_semester"] = True
+
+        form = QuestForm(data=form_data)
+        self.assertTrue(form.is_valid())
+
+    def test_unlimited_repeats_without_repeat_per_semester(self):
+        """A quest with unlimited repeats is valid as long as repeat_per_semester is off."""
+        form_data = self.minimal_valid_data
+
+        form_data["max_repeats"] = -1
+
+        form = QuestForm(data=form_data)
+        self.assertTrue(form.is_valid())
+
 
 class QuickReplyFormsEscapeHTMLTest(TenantTestCase):
     """The plain-text (non-wysiwyg) reply forms are accessible to all users, so


### PR DESCRIPTION
### What?
`QuestForm` now rejects the combination `max_repeats = -1` (unlimited) with `repeat_per_semester = True`, with an error message explaining why and how to fix it.

Closes #1531

Replaces #1923 per review feedback there: the combination is a configuration error, so the form should refuse it with useful feedback rather than the runtime silently reinterpreting it.

### Why?
The issue reported 404s for returning students on a quest mistakenly configured with both settings. Root cause: in `is_repeat_available()`, the per-semester branch checks `completions_this_semester > max_repeats`, and any count is greater than -1, so the quest is never repeat-available. Unlimited repeats never run out, so a per-semester reset does nothing — the settings contradict each other and the user should be told at save time.

### How?
Added to `QuestForm.clean()` (same pattern as the existing blocking/hideable check, and inherited by `TAQuestForm`):

> "A quest with unlimited repeats (Max Repeats = -1) cannot also use 'Repeat per semester', because unlimited repeats never run out and a new semester would have nothing to reset. Either set Max Repeats to the number of repeats allowed each semester, or turn off 'Repeat per semester' (in the Advanced section) to keep unlimited repeats."

### Testing?
Three new tests in `QuestFormTest`:
- `test_repeat_per_semester_with_unlimited_repeats` — the invalid combination is rejected (failed before the fix)
- `test_repeat_per_semester_with_limited_repeats` — per-semester with a real limit still validates
- `test_unlimited_repeats_without_repeat_per_semester` — unlimited repeats alone still validates

Full `quest_manager` suite passes (230 tests); flake8 clean.

### Screenshots (if front end is affected)
Standard form error rendering — no layout change.

### Anything Else?
Existing quests already saved with the invalid combination will still 404 for repeats until edited (the form will then require fixing the two fields). If you'd like, a follow-up data migration could repair existing rows (e.g. turn off `repeat_per_semester` on quests with `max_repeats=-1`), but that changes teacher-authored data, so I left it out pending your call.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_