### PR TITLE
Use invisible reCAPTCHA widget on the deck request form

### DIFF
--- a/src/hackerspace_online/forms.py
+++ b/src/hackerspace_online/forms.py
@@ -77,8 +77,8 @@ class PublicContactForm(forms.Form):
         help_text='We will never share your email with anyone else.')
     message = forms.CharField(widget=forms.Textarea, required=True)
 
-    # Not using because our recaptcha key is currently set up for checkbox only
-    # and doesn't also support the invisible widget.
+    # The site's reCAPTCHA keys are for the v2 invisible widget; all captcha fields
+    # must use this widget type since a single key pair is configured globally.
     captcha = ReCaptchaField(
         label='',
         widget=ReCaptchaV2Invisible

--- a/src/tenant/forms.py
+++ b/src/tenant/forms.py
@@ -1,5 +1,5 @@
 from captcha.fields import ReCaptchaField
-from captcha.widgets import ReCaptchaV2Checkbox
+from captcha.widgets import ReCaptchaV2Invisible
 
 from django import forms
 from django.contrib.auth import get_user_model
@@ -145,4 +145,7 @@ class DeckRequestForm(forms.Form):
         label="Your Email",
         widget=forms.EmailInput(attrs={"placeholder": "you@example.com"})
     )
-    captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox)
+    # Must match the widget type of the site's reCAPTCHA keys: a single key pair is
+    # configured globally and Google's keys are widget-type specific, so use the same
+    # invisible widget as the public contact form (see hackerspace_online/forms.py).
+    captcha = ReCaptchaField(label='', widget=ReCaptchaV2Invisible)

--- a/src/tenant/tests/test_forms.py
+++ b/src/tenant/tests/test_forms.py
@@ -6,10 +6,25 @@ from django.contrib.auth import get_user_model
 
 from django_tenants.test.cases import TenantTestCase
 
-from tenant.forms import TenantForm
+from captcha.widgets import ReCaptchaV2Invisible
+
+from tenant.forms import DeckRequestForm, TenantForm
 from tenant.models import Tenant
 
 User = get_user_model()
+
+
+class DeckRequestFormTest(TenantTestCase):
+    """Tests for the public `DeckRequestForm`."""
+
+    def test_captcha_uses_invisible_recaptcha_widget(self):
+        """The deck request captcha must use the same reCAPTCHA widget type as the rest
+        of the site (v2 invisible). A single key pair is configured globally
+        (RECAPTCHA_PUBLIC_KEY/RECAPTCHA_PRIVATE_KEY) and Google's keys are widget-type
+        specific, so a checkbox widget can't validate with the site's invisible keys.
+        """
+        form = DeckRequestForm()
+        self.assertIsInstance(form.fields['captcha'].widget, ReCaptchaV2Invisible)
 
 
 class TenantFormTest(TenantTestCase):


### PR DESCRIPTION
### What?
Switches the deck request form's captcha from `ReCaptchaV2Checkbox` to `ReCaptchaV2Invisible` (with `label=''`), matching the widget the public contact form already uses.

Follow-up to #1903, fixing the broken captcha reported on bytedeck-staging.com.

### Why?
Google reCAPTCHA keys are widget-type specific, and the project configures a **single** key pair globally (`RECAPTCHA_PUBLIC_KEY`/`RECAPTCHA_PRIVATE_KEY`). The installed keys are for the **v2 invisible** widget — that's what the contact form (`hackerspace_online/forms.py`) uses — so the checkbox widget on the new deck request form can never render/validate with them. No second key pair can be plugged in, since the settings only hold one.

### How?
- `tenant/forms.py`: `DeckRequestForm.captcha` now uses `ReCaptchaV2Invisible` with a comment explaining the key-type constraint. django-recaptcha's invisible widget binds to the form's submit button automatically, so the plain `request_new_deck.html` template needs no changes.
- `hackerspace_online/forms.py`: corrected a stale comment that claimed the site keys were checkbox-type (the field right below it already uses the invisible widget).

### Testing?
New `DeckRequestFormTest.test_captcha_uses_invisible_recaptcha_widget` — failed before the change, passes after. Existing deck-request view tests (which patch `ReCaptchaField.clean`) are unaffected; full `tenant` suite passes (81 tests); flake8 clean.

Worth a quick manual check on staging after merge: submit the request-a-deck form and confirm the invisible badge appears bottom-right and the submission validates.

### Screenshots (if front end is affected)
The visible checkbox is replaced by the standard invisible-reCAPTCHA badge in the page corner, same as the contact form.

### Anything Else?
If separate checkbox keys are ever wanted, the widget/keys would need to become configurable per form — out of scope here.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_