### PR TITLE
Clean up Claude Code permission allow list for full trigger management

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,12 +2,11 @@
   "permissions": {
     "allow": [
       "mcp__Claude_Code_Remote__send_later",
-      "mcp__Claude_Code_Remote__read_file",
-      "mcp__Claude_Code_Remote__list_directory",
-      "mcp__Claude_Code_Remote__send_later",
       "mcp__Claude_Code_Remote__create_trigger",
-      "mcp__Claude_Code_Remote__remove_trigger",
-      "mcp__Claude_Code_Remote__delete_trigger"
+      "mcp__Claude_Code_Remote__update_trigger",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__Claude_Code_Remote__fire_trigger",
+      "mcp__Claude_Code_Remote__list_triggers"
     ]
   }
 }


### PR DESCRIPTION
### What?
Tidies the `permissions.allow` list in `.claude/settings.json` so Claude Code sessions have the full set of Claude_Code_Remote trigger-management tools pre-approved.

### Why?
The previous list had a duplicate `send_later` entry and three entries that don't match any real Claude_Code_Remote tool (`read_file`, `list_directory`, `remove_trigger`), so those rules never applied. It also lacked the rest of the trigger-management tools, meaning trigger updates/listing still required permission prompts.

### How?
Replaced the allow list with the actual tool set: `send_later`, `create_trigger`, `update_trigger`, `delete_trigger`, `fire_trigger`, and `list_triggers` — deduped and with the bogus entries removed.

### Testing?
Config-only change (JSON validated); no application code affected, so the test suite is untouched.

### Screenshots (if front end is affected)
N/A — no front-end changes.

### Anything Else?
Follow-up to #1918, which introduced this file.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_