### PR TITLE
Fix blank "Published:" line for unpublished campaigns

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -20,7 +20,12 @@
         <ul class="list-unstyled">
           <li>Published quests in this campaign: {% firstof category_quest_count category.quest_count "0" %}</li>
           <li>Total XP available: {% firstof category_total_xp_available category.xp_sum "0" %}</li>
-          <li>Published: {% firstof category_published category.published %}</li>
+          {% comment %}
+            `firstof` outputs nothing when all values are falsy, so pipe the result
+            through `yesno` to render False as "False" instead of a blank.
+          {% endcomment %}
+          {% firstof category_published category.published as category_is_published %}
+          <li>Published: {{ category_is_published|yesno:"True,False" }}</li>
         </ul>
       </div>
     </div>

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2250,6 +2250,26 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         intended_quests = Quest.objects.get_active().filter(campaign=view_test_campaign)
         self.assertQuerySetEqual(displayed_quests, intended_quests, ordered=False)
 
+    def test_CategoryDetail_view__displays_published_status_when_false(self):
+        """The Campaign Info panel must display "Published: False" for an unpublished
+        campaign. Regression test for the `{% firstof %}` template tag swallowing
+        falsy values, which left the "Published:" line blank when the campaign
+        was unpublished.
+        """
+        campaign = baker.make(Category, published=False)
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:category_detail', kwargs={"pk": campaign.pk}))
+        self.assertContains(response, "Published: False")
+
+    def test_CategoryDetail_view__displays_published_status_when_true(self):
+        """The Campaign Info panel must display "Published: True" for a published campaign."""
+        campaign = baker.make(Category, published=True)
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:category_detail', kwargs={"pk": campaign.pk}))
+        self.assertContains(response, "Published: True")
+
     def test_CategoryCreate_view(self):
         """ Admin should be able to create a course """
         self.client.force_login(self.test_teacher)


### PR DESCRIPTION
### What?
Fixes the Campaign Info panel showing a blank value after "Published:" when a campaign is unpublished. It now renders `Published: False`.

### Why?
The campaign detail page displayed the status with `{% firstof category_published category.published %}`. The `firstof` tag outputs the first *truthy* value — and nothing at all when every value is falsy — so `published=False` rendered as an empty string. Discovered while testing the campaign publish button from #1862: after unpublishing a campaign, the "Published:" line went blank.

### How?
Capture the `firstof` result with `as` and pipe it through `yesno:"True,False"`, so `False` (or a missing value) renders as "False" instead of a blank. The other `firstof` uses in the template are unaffected: the count lines already fall back to a literal `"0"`, and the icon/id values are always truthy.

This template is shared by the campaign detail view and three library views (which pass an explicit `category_published`); both contexts derive the value from the same object, so behaviour is consistent in both.

### Testing?
- New regression test `test_CategoryDetail_view__displays_published_status_when_false` — fails without the fix (blank output), passes with it.
- Companion test `test_CategoryDetail_view__displays_published_status_when_true` locks in the existing True rendering.
- Full `CategoryViewTests` class and all 41 `library` tests pass; flake8 clean.

### Screenshots (if front end is affected)
Before: `Published:` (blank) on an unpublished campaign.
After: `Published: False`

### Anything Else?
No migrations. Template-only change plus tests.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_