### PR TITLE
Campaign publish UX tweaks: redirects, list-view button, distinct icons; Closes #1931

### DIFF
--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -39,7 +39,7 @@
                 <form method="post" action="{% url 'quests:category_publish' object.id %}" class="preview-action-form">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-success" title="Publish Campaign and all its Quests">
-                        <i class="fa fa-upload"></i>
+                        <i class="fa fa-fw fa-eye"></i>
                     </button>
                 </form>
             {% endif %}

--- a/src/quest_manager/templates/quest_manager/category_form.html
+++ b/src/quest_manager/templates/quest_manager/category_form.html
@@ -6,7 +6,7 @@
 {% block content %}
 <form method="post" enctype="multipart/form-data">{% csrf_token %}
   {{ form | crispy }}
- <a href="{% url 'quests:categories' %}" role="button" class="btn btn-danger">Cancel</a>
+ <a href="{{ cancel_url }}" role="button" class="btn btn-danger">Cancel</a>
   <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success">
 </form>
 {% endblock %}

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -61,6 +61,17 @@
               </a>
             {% endif %}
 
+            {% if not object.published %}
+              <form method="post" action="{% url 'quests:category_publish' object.id %}" class="preview-action-form">
+                {% csrf_token %}
+                {% comment %} return to this list after publishing, instead of the campaign detail default {% endcomment %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit" class="btn btn-success" title="Publish Campaign and all its Quests">
+                  <i class="fa fa-fw fa-eye"></i>
+                </button>
+              </form>
+            {% endif %}
+
               <a class="btn btn-danger"
                 {% if object.quest_count != 0 %}
                   disabled

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -19,11 +19,11 @@
     <div class="mb-3">
       {% if "/drafts/" in request.path %}
         <a href="#" class="btn btn-primary" onclick="submitBulkAction('publish')">
-          <i class="fa fa-upload"></i> Publish All Selected
+          <i class="fa fa-eye"></i> Publish All Selected
         </a>
       {% elif "/available/" in request.path %}
         <a href="#" class="btn btn-primary" onclick="submitBulkAction('unpublish')">
-          <i class="fa fa-upload"></i> Unpublish All Selected
+          <i class="fa fa-eye-slash"></i> Unpublish All Selected
         </a>
       {% endif %}
       {% if "/archived/" in request.path %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2461,16 +2461,32 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
             data={'next': 'https://evil.example.com/'})
         self.assertRedirects(response, reverse('quests:category_detail', args=[campaign.id]))
 
+    def test_CategoryPublish_view__ignores_http_next_url_on_secure_request(self):
+        """A `next` parameter that would downgrade a secure (https) request to plain
+        http must be ignored, falling back to the campaign's detail view.
+        """
+        campaign = baker.make(Category, published=False)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('quests:category_publish', args=[campaign.id]),
+            data={'next': 'http://testserver/quests/campaigns/inactive/'},
+            secure=True)
+        self.assertRedirects(response, reverse('quests:category_detail', args=[campaign.id]))
+
     def test_CategoryList_view__publish_button_on_inactive_tab(self):
         """The inactive campaigns list must show the publish button for unpublished
-        campaigns; the available tab (published campaigns) must not show it (issue #1931).
+        campaigns, with a hidden `next` field returning to the list after publishing;
+        the available tab (published campaigns) must not show the button (issue #1931).
         """
         unpublished_campaign = baker.make(Category, published=False)
         published_campaign = baker.make(Category, published=True)
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('quests:categories_inactive'))
+        inactive_url = reverse('quests:categories_inactive')
+        response = self.client.get(inactive_url)
         self.assertContains(response, reverse('quests:category_publish', args=[unpublished_campaign.id]))
+        self.assertContains(response, f'name="next" value="{inactive_url}"')
 
         response = self.client.get(reverse('quests:categories'))
         self.assertNotContains(response, reverse('quests:category_publish', args=[published_campaign.id]))

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2264,17 +2264,33 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(course.title, data['title'])
 
     def test_CategoryUpdate_view(self):
-        """ Admin should be able to update a course """
+        """ Admin should be able to update a course. Saving returns to the campaign's
+        detail view (the page the edit was started from), not the campaigns list
+        (issue #1931). """
         self.client.force_login(self.test_teacher)
         data = {
             'title': 'My Updated Title',
             'published': False,
         }
         response = self.client.post(reverse('quests:category_update', args=[1]), data=data)
-        self.assertRedirects(response, reverse('quests:categories'))
+        self.assertRedirects(response, reverse('quests:category_detail', args=[1]))
         course = Category.objects.get(id=1)
         self.assertEqual(course.title, data['title'])
         self.assertEqual(course.published, data['published'])
+
+    def test_CategoryUpdate_view__cancel_button_returns_to_detail(self):
+        """The cancel button on the campaign update form must link back to the
+        campaign's detail view, not the campaigns list (issue #1931)."""
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:category_update', args=[1]))
+        self.assertContains(response, f'href="{reverse("quests:category_detail", args=[1])}"')
+
+    def test_CategoryCreate_view__cancel_button_returns_to_list(self):
+        """The cancel button on the campaign create form must link back to the
+        campaigns list, since a new campaign has no detail view to return to."""
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:category_create'))
+        self.assertContains(response, f'href="{reverse("quests:categories")}"')
 
     def test_CategoryDelete_view(self):
         """
@@ -2363,7 +2379,7 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         Test CategoryPublish end-to-end:
         - Staff can see the "Publish Campaign and all its Quests" button on an unpublished campaign.
         - Posting to the publish URL as staff sets published=True on the campaign and all related quests,
-            and redirects back to the categories list.
+            and redirects back to the campaign's detail view (issue #1931).
         - After publishing, the button is no longer shown to staff.
         - Non-staff POST to the publish URL is forbidden (403) and does not change publish states.
         """
@@ -2381,8 +2397,8 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         publish_url = reverse('quests:category_publish', args=[campaign.id])
         response = self.client.post(publish_url)
 
-        # Should redirect after successful publish
-        self.assertRedirects(response, reverse('quests:categories'))
+        # Should redirect back to the campaign's detail view after successful publish
+        self.assertRedirects(response, reverse('quests:category_detail', args=[campaign.id]))
 
         campaign.refresh_from_db()
         quest_1.refresh_from_db()
@@ -2420,6 +2436,62 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertFalse(quest_1.published)
         self.assertFalse(quest_2.published)
         self.assertFalse(archived_quest.published)
+
+    def test_CategoryPublish_view__redirects_to_next_url(self):
+        """Publishing with a safe `next` parameter (e.g. from the campaigns list view)
+        must redirect back to that page instead of the campaign's detail view (issue #1931).
+        """
+        campaign = baker.make(Category, published=False)
+        self.client.force_login(self.test_teacher)
+
+        next_url = reverse('quests:categories_inactive')
+        response = self.client.post(
+            reverse('quests:category_publish', args=[campaign.id]), data={'next': next_url})
+        self.assertRedirects(response, next_url)
+
+    def test_CategoryPublish_view__ignores_unsafe_next_url(self):
+        """A `next` parameter pointing off-site must be ignored (open redirect protection),
+        falling back to the campaign's detail view.
+        """
+        campaign = baker.make(Category, published=False)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('quests:category_publish', args=[campaign.id]),
+            data={'next': 'https://evil.example.com/'})
+        self.assertRedirects(response, reverse('quests:category_detail', args=[campaign.id]))
+
+    def test_CategoryList_view__publish_button_on_inactive_tab(self):
+        """The inactive campaigns list must show the publish button for unpublished
+        campaigns; the available tab (published campaigns) must not show it (issue #1931).
+        """
+        unpublished_campaign = baker.make(Category, published=False)
+        published_campaign = baker.make(Category, published=True)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:categories_inactive'))
+        self.assertContains(response, reverse('quests:category_publish', args=[unpublished_campaign.id]))
+
+        response = self.client.get(reverse('quests:categories'))
+        self.assertNotContains(response, reverse('quests:category_publish', args=[published_campaign.id]))
+
+    def test_CategoryDetail_view__staff_see_unpublished_quests_of_unpublished_campaign(self):
+        """Staff must see a campaign's unpublished quests on the campaign detail page
+        regardless of whether the campaign itself is published; only archived quests
+        are hidden. Guards the staff quest list of inactive campaigns (issue #1931).
+        """
+        campaign = baker.make(Category, published=False)
+        published_quest = baker.make(Quest, campaign=campaign, published=True)
+        unpublished_quest = baker.make(Quest, campaign=campaign, published=False)
+        archived_quest = baker.make(Quest, campaign=campaign, published=False, archived=True)
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:category_detail', args=[campaign.id]))
+
+        displayed_quests = list(response.context['category_displayed_quests'])
+        self.assertIn(published_quest, displayed_quests)
+        self.assertIn(unpublished_quest, displayed_quests)
+        self.assertNotIn(archived_quest, displayed_quests)
 
 
 class AjaxSubmissionCountTest(ViewTestUtilsMixin, TenantTestCase):

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.utils.decorators import method_decorator
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic.list import ListView
 
 import numpy as np
@@ -149,6 +150,8 @@ class CategoryCreate(NonPublicOnlyViewMixin, CreateView):
     def get_context_data(self, **kwargs):
         kwargs["heading"] = "Create New Campaign"
         kwargs["submit_btn_value"] = "Create"
+        # a new campaign has no detail view to return to yet, so cancel goes to the list
+        kwargs["cancel_url"] = reverse("quests:categories")
 
         return super().get_context_data(**kwargs)
 
@@ -157,11 +160,13 @@ class CategoryCreate(NonPublicOnlyViewMixin, CreateView):
 class CategoryUpdate(NonPublicOnlyViewMixin, UpdateView):
     fields = ("title", "short_description", "icon", "published")
     model = Category
-    success_url = reverse_lazy("quests:categories")
+    # no success_url: UpdateView falls back to the object's get_absolute_url(), returning
+    # the user to the campaign detail view they started the edit from (issue #1931)
 
     def get_context_data(self, **kwargs):
         kwargs["heading"] = "Update Campaign"
         kwargs["submit_btn_value"] = "Update"
+        kwargs["cancel_url"] = self.object.get_absolute_url()
 
         return super().get_context_data(**kwargs)
 
@@ -218,21 +223,27 @@ class CategoryPublish(View):
         with all related quests using the model method `publish_with_quests()`. On success,
         adds a success message linking to the campaign detail. On failure, adds an error message.
 
-        Finally, redirects the user to the campaigns list view.
+        Finally, redirects the user back to the page the publish button was clicked on: the
+        `next` POST parameter if it is a safe local URL (the campaigns list view provides it),
+        otherwise the campaign's detail view (issue #1931).
 
         Args:
             request: The HTTP request object.
             pk: Primary key of the campaign to publish.
 
         Returns:
-            HttpResponseRedirect to the campaigns list page.
+            HttpResponseRedirect to the `next` URL or the campaign detail page.
         """
         category = get_object_or_404(Category, pk=pk)
         category.publish_with_quests()
         link = f'<a href="{category.get_absolute_url()}">{category.title}</a>'
         messages.success(request, f'Campaign "{link}" and all quests published.')
 
-        return redirect("quests:categories")
+        # only follow `next` if it stays on this host, to prevent open redirects
+        next_url = request.POST.get('next')
+        if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+            return redirect(next_url)
+        return redirect(category)
 
 
 class QuestDelete(NonPublicOnlyViewMixin, UserPassesTestMixin, UpdateMapMessageMixin, DeleteView):

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -148,9 +148,18 @@ class CategoryCreate(NonPublicOnlyViewMixin, CreateView):
     success_url = reverse_lazy("quests:categories")
 
     def get_context_data(self, **kwargs):
+        """Add the campaign creation form context.
+
+        Args:
+            **kwargs: extra context passed through to the template.
+
+        Returns:
+            dict: template context including the form heading, submit button label,
+            and `cancel_url` — the campaigns list, since a new campaign has no
+            detail view to return to yet.
+        """
         kwargs["heading"] = "Create New Campaign"
         kwargs["submit_btn_value"] = "Create"
-        # a new campaign has no detail view to return to yet, so cancel goes to the list
         kwargs["cancel_url"] = reverse("quests:categories")
 
         return super().get_context_data(**kwargs)
@@ -164,6 +173,16 @@ class CategoryUpdate(NonPublicOnlyViewMixin, UpdateView):
     # the user to the campaign detail view they started the edit from (issue #1931)
 
     def get_context_data(self, **kwargs):
+        """Add the campaign update form context.
+
+        Args:
+            **kwargs: extra context passed through to the template.
+
+        Returns:
+            dict: template context including the form heading, submit button label,
+            and `cancel_url` — the campaign's detail view, so cancelling returns
+            to the page the edit was started from (issue #1931).
+        """
         kwargs["heading"] = "Update Campaign"
         kwargs["submit_btn_value"] = "Update"
         kwargs["cancel_url"] = self.object.get_absolute_url()
@@ -239,9 +258,11 @@ class CategoryPublish(View):
         link = f'<a href="{category.get_absolute_url()}">{category.title}</a>'
         messages.success(request, f'Campaign "{link}" and all quests published.')
 
-        # only follow `next` if it stays on this host, to prevent open redirects
+        # only follow `next` if it stays on this host (and keeps https when the
+        # request came in over https), to prevent open redirects and downgrades
         next_url = request.POST.get('next')
-        if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts={request.get_host()}):
+        if next_url and url_has_allowed_host_and_scheme(
+                next_url, allowed_hosts={request.get_host()}, require_https=request.is_secure()):
             return redirect(next_url)
         return redirect(category)
 


### PR DESCRIPTION
### What?
Follow-ups to the campaign publish feature (#1843 / #1862), from testing on staging. Closes #1931.

1. **Redirects return to where you came from.** Saving a campaign edit (and its Cancel button) now returns to the campaign's detail view instead of the campaigns list. Publishing returns to the campaign detail view, or back to the campaigns list when the button was clicked there (via a `next` parameter).
2. **Publish button on the campaigns list.** The Inactive tab's Action column now includes the green "Publish Campaign and all its Quests" button for unpublished campaigns.
3. **Distinct icons.** Publish actions now use `fa-eye` (bulk Unpublish uses `fa-eye-slash`) instead of `fa-upload`, which is kept for "Export to the Library" — previously an unpublished campaign showed two identical upload icons meaning different things.
4. **Regression test for staff quest visibility.** A report that an unpublished campaign's detail page hides its unpublished quests could **not** be reproduced: staff see all non-archived quests regardless of campaign state (only archived quests are hidden). A test now locks this behavior in.

### Why?
Getting dumped back on the campaigns list after each edit/publish breaks the editing flow; the list view had no way to publish without a detour through the detail page; and the duplicate `fa-upload` icons made publish vs export ambiguous. `fa-eye`/`fa-eye-slash` match the existing conventions (badge "UNPUBLISHED" markers, unhide/hide quest buttons) and the meaning of published = visible to students.

### How?
- `CategoryUpdate` drops its `success_url`, so `UpdateView` falls back to `Category.get_absolute_url()` (the detail view); both form views pass a `cancel_url` to the template (`CategoryCreate` keeps the list as its cancel target since a new campaign has no detail page yet).
- `CategoryPublish.post()` follows a `next` POST parameter when it is a safe local URL (checked with `url_has_allowed_host_and_scheme` to prevent open redirects), otherwise redirects to the campaign detail view. The campaigns list form supplies `next`; the detail-view form uses the default.
- `tab_campaigns_list.html` renders the publish form for unpublished campaigns in the non-library branch (the list view is staff-only).
- Icon swaps in `category_detail.html`, `tab_campaigns_list.html`, and `tab_quests_available.html`.

### Testing?
Test-driven: 6 tests failed before the implementation, all pass after.
- `test_CategoryUpdate_view` / `test_CategoryPublish_view` updated for the new redirect targets.
- New: `test_CategoryUpdate_view__cancel_button_returns_to_detail`, `test_CategoryCreate_view__cancel_button_returns_to_list`, `test_CategoryPublish_view__redirects_to_next_url`, `test_CategoryPublish_view__ignores_unsafe_next_url`, `test_CategoryList_view__publish_button_on_inactive_tab`.
- New regression test: `test_CategoryDetail_view__staff_see_unpublished_quests_of_unpublished_campaign` (passes on unmodified develop — see item 4).
- Full `quest_manager` suite (233 tests) passes on a fresh test DB; flake8 clean.

### Screenshots (if front end is affected)
The campaigns list Inactive tab gains a green eye-icon publish button per unpublished campaign; the campaign detail publish button's icon changes from an upload arrow to an eye.

### Anything Else?
No migrations. If the missing-quests report from staging (item 4 in #1931) turns out to involve a non-archived quest, that needs a fresh look with the specific quest's state.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publish action for unpublished campaigns directly from the campaigns list.
  * Added safe return navigation after publishing, keeping staff on the page where they started.
  * Updated cancel links to return to the relevant campaign or campaign list.

* **Bug Fixes**
  * Corrected publish and update redirects.
  * Improved visibility of unpublished, non-archived quests on campaign details.
  * Updated action icons to better represent publish and unpublish actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->