### PR TITLE
Fix broken dotted test-label examples in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ You can run tests either locally, or through the web container:
    * Quit after the first error or failure, and also by running th tests in parallel to take advantage of multi-core processors:
      `python src/manage.py test src --parallel --failfast`
    * Only run tests from a single app, for example: `python src/manage.py test src/announcements`
-   * Only run tests from a single test class: `python src/manage.py test src.announcements.tests.test_views.AnnouncementViewTests`
-   * Only run a single test: `python src/manage.py test src.announcements.tests.test_views.AnnouncementViewTests.test_teachers_have_archive_button`
+   * Only run tests from a single test class: `python src/manage.py test announcements.tests.test_views.AnnouncementViewTests`
+   * Only run a single test: `python src/manage.py test announcements.tests.test_views.AnnouncementViewTests.test_teachers_have_archive_button`
 1. This project uses git pre-commit hooks, set up with the Python "[pre-commit](https://pre-commit.com/)" module. These hooks trigger a series of checks every time a new commit is made. They ensure that the code is formatted correctly, and some even auto-correct certain simple issues. However, we don't have pre-commit hooks for running our Django tests, so the full test suite must still be ran separately. All pre-commit hooks are defined in the [.pre-commit-config.yaml](.pre-commit-config.yaml) file. Note that if auto-corrections are made, the commit won't complete, and you'll need to run the commit command again. It can also be helpful to run these hooks manually to ensure you have everything setup correctly:
 
    * using venv: `pre-commit run`


### PR DESCRIPTION
### What?
Corrects the two single-class / single-test examples in CONTRIBUTING.md's "Running Tests and Checking Code Style" section, which used `src.`-prefixed dotted test labels that don't actually work.

### Why?
`python src/manage.py test src.announcements.tests.test_views.AnnouncementViewTests` fails with `ModuleNotFoundError: No module named 'src'`: the `src/` directory has no `__init__.py` (it isn't a package), and the repo root is never on `sys.path` — running `python src/manage.py` puts `src/` itself on the path, so apps are importable only as top-level packages (`announcements`, `quest_manager`, ...). Anyone copy-pasting these examples hits an immediate error.

### How?
Changed the two examples to the working app-package form:
* `python src/manage.py test announcements.tests.test_views.AnnouncementViewTests`
* `python src/manage.py test announcements.tests.test_views.AnnouncementViewTests.test_teachers_have_archive_button`

This matches the labels documented in CLAUDE.md (fixed there during #1918's review). The directory-path form on the line above (`test src/announcements`) works as-is and is untouched.

### Testing?
Docs-only change. Verified the corrected labels resolve (and the old ones don't) against manage.py's actual `sys.path` behavior.

### Screenshots (if front end is affected)
N/A

### Anything Else?
Follow-up to the CLAUDE.md review discussion in #1918.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_