### PR TITLE
Add Completion Statuses button to the submission button set; Closes #1934

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission_buttons_other.html
+++ b/src/quest_manager/templates/quest_manager/submission_buttons_other.html
@@ -10,6 +10,9 @@
     <a title="View past submissions of this quest from other students" class="btn btn-default" role="button"
         target="_blank" href="{% url 'quests:approved_for_quest' s.quest.id %}">
         <i class="fa fa-fw fa-folder-o"></i></a>
+    <a title="View status of all students for this quest" class="btn btn-default" role="button"
+        target="_blank" href="{% url 'quests:quest_user_status' s.quest.id %}">
+        <i class="fa fa-fw fa-users"></i></a>
     <a title="View summary data for this quest" class="btn btn-default" role="button"
         target="_blank" href="{% url 'quests:summary' s.quest.id %}">
         <i class="fa fa-fw fa-bar-chart"></i></a>

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -437,6 +437,21 @@ class SubmissionViewTests(TenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[s4_pk]))
         self.assertEqual(response.status_code, 200)
 
+    def test_submission_view__staff_buttons_include_completion_statuses_link(self):
+        """The staff quick-link button group on the submission detail page must include
+        a link to the quest's Completion Statuses page, like it does for past submissions
+        and summary data (issue #1934). Students must not see the link.
+        """
+        status_url = reverse('quests:quest_user_status', args=[self.quest1.id])
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
+        self.assertContains(response, status_url)
+
+        self.client.force_login(self.test_student1)
+        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
+        self.assertNotContains(response, status_url)
+
     def test_student_can_drop_completed_submission_when_hidden(self):
         """
         Make sure student can drop a submission from a quest when an admin decides


### PR DESCRIPTION
### What?
Adds the Completion Statuses button (fa-users, "View status of all students for this quest") to the staff submission button set. Closes #1934.

### Why?
The Completion Statuses page from #918 was only reachable from the quest preview buttons. The submission button group — shown on each submission in the Quest Approvals tab and on the submission detail page — already quick-links the quest's past submissions and summary pages, so the statuses page belongs alongside them: while approving a submission, "who else has/hasn't done this quest" was two navigations away.

### How?
One template addition in `submission_buttons_other.html`, between the past-submissions and summary buttons, matching their style (`target="_blank"`, `btn-default`) and reusing the fa-users icon from the quest preview button set.

### Testing?
Test-driven: new `test_submission_view__staff_buttons_include_completion_statuses_link` failed before the template change and passes after. It asserts staff see the `quests:quest_user_status` link on the submission detail page and students don't (the button group is staff-only). Full `quest_manager.tests.test_views` module passes; flake8 clean.

### Screenshots (if front end is affected)
A new fa-users button appears in the submission quick-link button group, between the past-submissions folder icon and the summary bar-chart icon.

### Anything Else?
No migrations. The Approvals tab uses the same include, so it gets the button automatically.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staff-only quick link on quest submission pages to view completion status for all students.

* **Bug Fixes**
  * Ensured the completion-status link is hidden from students.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->