### PR TITLE
Group 1.28.0 changelog items by topic in their most significant category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,36 +8,31 @@ This file chronologically records all notable changes to this website, including
 * New Features:
   - Deck Requests:
     - New decks can now be requested directly from the public ByteDeck site instead of by contacting us. Visitors fill in a short reCAPTCHA-protected form (name and email), click the verification link emailed to them (valid for one hour, good for one deck), and are guided through creating their own deck. The new deck's owner then receives a welcome email with their initial login credentials [#1892](https://github.com/bytedeck/bytedeck/issues/1892) [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
+    - New deck owners now receive a secure random initial password (generated once and emailed) instead of a guessable one, and deck-request verification links are opaque single-use nonces that keep the requester's name and email out of the URL [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
+    - Creating a new deck no longer silently fails to set up the deck owner's account (the setup ran in the wrong database schema, which made it a no-op in production), and verification / welcome emails are now sent in the background so the signup pages don't hang while mail goes out [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
   - Library:
     - Campaigns can now be exported to the shared Library: a new export button on the campaign detail page (enabled once the campaign has published quests) leads to a confirmation page that lists all of the campaign's quests and flags any that already exist in the Library [#1849](https://github.com/bytedeck/bytedeck/issues/1849) [#1850](https://github.com/bytedeck/bytedeck/issues/1850)
     - Exporting a campaign whose quests already exist in the Library now copies those quests into the exported campaign instead of blocking the export, so a campaign can be exported even when every quest in it is already in the Library [#1884](https://github.com/bytedeck/bytedeck/issues/1884)
+    - When importing a single quest that already exists on your deck, the confirmation page now shows a prominent red warning explaining that overwriting existing quests individually is not yet supported. (Previously the notice was easy to miss and contradicted the campaign-import message, which says existing quests get overwritten.) [#1876](https://github.com/bytedeck/bytedeck/issues/1876) [#1878](https://github.com/bytedeck/bytedeck/issues/1878)
+    - Importing from the Library now also checks your archived quests for duplicates, so you can no longer end up with a second copy of a quest you had archived [#1877](https://github.com/bytedeck/bytedeck/issues/1877)
+    - Export-to-Library options are no longer offered while browsing the shared Library deck itself [#1888](https://github.com/bytedeck/bytedeck/issues/1888)
   - Campaigns:
     - Publish a campaign and all of the quests inside it in one click with the new publish button on the campaign detail page, instead of publishing each quest one at a time. (Handy before exporting to the Library, since only campaigns with published quests can be exported.) [#1843](https://github.com/bytedeck/bytedeck/issues/1843)
+    - The campaign detail, campaign delete, and badge-type delete pages now show the reason something can't be deleted in a red alert well, instead of only in a tooltip on the disabled delete button [#1861](https://github.com/bytedeck/bytedeck/issues/1861)
   - Quests:
     - New "Student Statuses" page for teachers: a new button among a quest's action buttons opens a table showing every student's status on that quest — including students who haven't started it — with links to their submissions [#918](https://github.com/bytedeck/bytedeck/issues/918)
+    - Archived quests can now be deleted directly — the delete page previously returned "Not Found" for them, forcing you to unarchive first [#1874](https://github.com/bytedeck/bytedeck/issues/1874)
 * Tweaks:
-  - Library:
-    - When importing a single quest that already exists on your deck, the confirmation page now shows a prominent red warning explaining that overwriting existing quests individually is not yet supported. (Previously the notice was easy to miss and contradicted the campaign-import message, which says existing quests get overwritten.) [#1876](https://github.com/bytedeck/bytedeck/issues/1876) [#1878](https://github.com/bytedeck/bytedeck/issues/1878)
   - Quest Approvals:
     - Search on the Approvals tab now also matches the Group, User, and Status columns, so it behaves the same as search on the other submission tables [#1875](https://github.com/bytedeck/bytedeck/issues/1875)
-  - Campaigns & Badges:
-    - The campaign detail, campaign delete, and badge-type delete pages now show the reason something can't be deleted in a red alert well, instead of only in a tooltip on the disabled delete button [#1861](https://github.com/bytedeck/bytedeck/issues/1861)
 * Refactor/Optimizations:
   - Django 5.2 preparation: removed APIs dropped between Django 4.2 and 5.2, and fixed two broken unpinned dependencies (namegenerator, redis-py) [#1897](https://github.com/bytedeck/bytedeck/issues/1897)
   - Eliminated the worst N+1 query patterns across approvals, badge lists, profile pages, the campaigns list, badge detail, ranks list, and popover counts [#1898](https://github.com/bytedeck/bytedeck/issues/1898)
   - Further N+1 reductions on the profile detail page and the notifications list [#1902](https://github.com/bytedeck/bytedeck/issues/1902)
   - Hardened rank and rarity caches against signal-less ORM writes [#1898](https://github.com/bytedeck/bytedeck/issues/1898)
-  - New deck owners now receive a secure random initial password (generated once and emailed) instead of a guessable one, and deck-request verification links are opaque single-use nonces that keep the requester's name and email out of the URL [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
 * Bugfixes:
-  - Deck Requests:
-    - Creating a new deck no longer silently fails to set up the deck owner's account (the setup ran in the wrong database schema, which made it a no-op in production), and verification / welcome emails are now sent in the background so the signup pages don't hang while mail goes out [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
   - Quest Maps:
     - Maps no longer draw connections for inverted ("NOT") OR-prerequisites: the exclude-NOT option was silently ignored for the OR slot of a prerequisite, so a map could include quests whose only link was a NOT condition [#1900](https://github.com/bytedeck/bytedeck/issues/1900) [#1901](https://github.com/bytedeck/bytedeck/issues/1901)
-  - Library:
-    - Importing from the Library now also checks your archived quests for duplicates, so you can no longer end up with a second copy of a quest you had archived [#1877](https://github.com/bytedeck/bytedeck/issues/1877)
-    - Export-to-Library options are no longer offered while browsing the shared Library deck itself [#1888](https://github.com/bytedeck/bytedeck/issues/1888)
-  - Quests:
-    - Archived quests can now be deleted directly — the delete page previously returned "Not Found" for them, forcing you to unarchive first [#1874](https://github.com/bytedeck/bytedeck/issues/1874)
 * Devops:
   - Fixed the randomly-flaky CI failures in the prerequisites signal tests (`Rank.DoesNotExist` and missing-map errors):
     - Tests that create `Prereq` objects now use deterministic content types instead of random ones [#1899](https://github.com/bytedeck/bytedeck/issues/1899)


### PR DESCRIPTION
### What?
Reorganizes the `1.28.0` (Marcus III) changelog section so each topic's items are grouped together under one heading in the topic's most significant category (New Features > Tweaks > Bugfixes), instead of being distributed across categories. Documentation only.

Moves:
- **Deck Requests** (New Features) absorbs the secure-password/nonce item from Refactor/Optimizations and the owner-schema/async-email item from Bugfixes — all [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
- **Library** (New Features) absorbs the single-quest-import warning tweak [#1876](https://github.com/bytedeck/bytedeck/issues/1876) [#1878](https://github.com/bytedeck/bytedeck/issues/1878) and the archived-duplicates [#1877](https://github.com/bytedeck/bytedeck/issues/1877) / export-options [#1888](https://github.com/bytedeck/bytedeck/issues/1888) bugfixes
- **Campaigns** (New Features) absorbs the delete-reason alert tweak [#1861](https://github.com/bytedeck/bytedeck/issues/1861)
- **Quests** (New Features) absorbs the archived-quest delete fix [#1874](https://github.com/bytedeck/bytedeck/issues/1874)

Cross-cutting refactors (Django 5.2 prep, N+1 eliminations, cache hardening), Quest Approvals, Quest Maps, and Devops stay where they were.

### Why?
Requested by @tylerecouture: reading everything about one feature area in one place is more useful than hunting for it across New Features / Tweaks / Bugfixes.

### How?
Pure reshuffle of existing lines within the 1.28.0 section — item wording and every issue link are unchanged (verified the issue-reference multiset is identical before/after). Net −5 lines from removing the now-empty sub-headings. Everything from `[1.27.0]` down is byte-identical.

### Testing?
No code changes; verified GitHub markdown nesting renders correctly (2-space topic headings, 4-space items) and that no bare `[#N]` references were introduced.

### Screenshots (if front end is affected)
N/A

### Anything Else?
Follow-up to [#1926](https://github.com/bytedeck/bytedeck/issues/1926) (formatting/links pass over the same sections).

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_