### PR TITLE
Prevent campaign name line breaks in quest maps; Closes #1289

### DIFF
--- a/src/djcytoscape/static/djcytoscape/js/maps.js
+++ b/src/djcytoscape/static/djcytoscape/js/maps.js
@@ -59,7 +59,11 @@ cy.style()
         "text-rotation": "-90deg",
         "text-halign": "left",
         "text-margin-x": -10,
-        "text-margin-y": -40
+        "text-margin-y": -40,
+        // Campaign labels run vertically along the node's edge, so the generic node
+        // `text-max-width` wraps long names onto stacked lines (see issue #1289).
+        // Disable wrapping here to keep each campaign name on a single line.
+        "text-wrap": "none"
       })
     .selector('edge.repeat-edge')
       .style({


### PR DESCRIPTION
### What?
Stops long campaign names from wrapping onto multiple stacked lines in the quest map. Closes #1289.

### Why?
Campaign (compound) node labels are rotated to run vertically along the node's edge. They inherited the generic `node` style's `text-max-width: 147`, so a longer campaign name wrapped into two side-by-side vertical lines (see the screenshot in #1289).

### How?
Added `"text-wrap": "none"` to the `$node > node` (compound node) selector in `maps.js`, which overrides the generic node wrapping for campaigns only. Quest nodes keep their existing wrapping.

### Testing?
This is a client-side cytoscape.js style change with no server-side behavior to unit-test (the djcytoscape model tests cover the DB `node_styles` default, which is a separate style string and is unaffected). Recommend a visual check on a deck with a long campaign name in a map to confirm the label stays on one line and fits its node.

### Screenshots (if front end is affected)
Before: campaign name wraps to two vertical lines (per #1289). After: single vertical line.

### Anything Else?
Only affects campaign compound-node labels in maps. No migrations. `maps-dark.js` only overrides colours and is unaffected.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compound and campaign label positioning.
  * Campaign names now remain on a single line for clearer readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->