### PR TITLE
Fix deck creation: restore schema after seeding, truncate long deck names

### DIFF
--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -117,8 +117,15 @@ def create_site_config_object():
     config = SiteConfig.objects.create()
     name = Tenant.get().name.replace("_", " ").replace("-", " ").title()
     if name:
-        config.site_name = f"{name} Deck"
-        config.site_name_short = name
+        # Tenant.name allows up to 62 chars (the Postgres schema-name limit), but the
+        # SiteConfig display fields are shorter (site_name=50, site_name_short=20), so
+        # truncate to each field's max_length. Without this, a long deck name raised
+        # "value too long for type character varying(20)" and aborted tenant creation.
+        # Both fields remain editable by the deck owner in Site Config afterwards.
+        site_name_max = SiteConfig._meta.get_field("site_name").max_length
+        site_name_short_max = SiteConfig._meta.get_field("site_name_short").max_length
+        config.site_name = f"{name} Deck"[:site_name_max]
+        config.site_name_short = name[:site_name_short_max]
         config.save()
 
 

--- a/src/tenant/signals.py
+++ b/src/tenant/signals.py
@@ -1,14 +1,25 @@
 from django.conf import settings
-from django.db import connection
 
-from django_tenants.utils import get_public_schema_name
+from django_tenants.utils import get_public_schema_name, tenant_context
 
 from .initialization import load_initial_tenant_data
 
 
 def initialize_tenant_with_data(sender, tenant, **kwargs):
-    connection.set_tenant(tenant)
-    load_initial_tenant_data()
+    """Seed a newly created tenant's schema with its initial data.
+
+    Runs the initialization inside the new tenant's schema via ``tenant_context``
+    so that the schema active before this handler ran is restored afterwards.
+
+    The previous version called ``connection.set_tenant(tenant)`` and never
+    switched back, leaving the connection pointed at the new tenant for the rest
+    of the request. Because deck creation is served from the public schema, the
+    later session write in ``SessionMiddleware`` then hit the *new* tenant's
+    empty ``django_session`` table, which Django reads as the session having been
+    deleted mid-request and raises ``SessionInterrupted``.
+    """
+    with tenant_context(tenant):
+        load_initial_tenant_data()
 
 
 def tenant_save_callback(sender, instance, **kwargs):

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -1,10 +1,13 @@
 from django_tenants.test.cases import TenantTestCase
+from django_tenants.utils import get_public_schema_name, schema_context, tenant_context
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from badges.models import Badge, BadgeRarity, BadgeType
 from courses.models import Block, Course, Grade, MarkRange, Rank
 from quest_manager.models import Category, Quest
+from siteconfig.models import SiteConfig
+from tenant.models import Tenant
 from utilities.models import MenuItem
 
 
@@ -165,8 +168,37 @@ class TenantInitializationTest(TenantTestCase):
     def test_site_config_created(self):
         """ Test that the SiteConfig object exists and the Deck name has expected defaults.
         """
-        from siteconfig.models import SiteConfig
         site_config = SiteConfig.get()
         self.assertTrue(site_config is not None)
         self.assertEqual(site_config.site_name, "My Byte Deck")
         self.assertEqual(site_config.site_name_short, "Deck")
+
+
+class CreateSiteConfigObjectTest(TenantTestCase):
+    """Tests for deriving a new tenant's SiteConfig display names from its deck name."""
+
+    def test_create_site_config__long_deck_name_does_not_overflow(self):
+        """A deck name longer than SiteConfig's display fields must not crash
+        tenant creation.
+
+        Tenant.name allows up to 62 chars (the Postgres schema-name limit), but
+        site_name_short is only 20 (and site_name 50), so a long name previously
+        raised "value too long for type character varying(20)" while seeding the
+        new tenant. The display names are truncated to fit and stay editable by
+        the owner afterwards.
+        """
+        # A realistic, valid deck name (subdomain) that is longer than the 20-char
+        # site_name_short field; creating it fires post_schema_sync, which seeds
+        # the new tenant via create_site_config_object. Tenants can only be created
+        # from the public schema.
+        deck_name = "timberline-secondary-hackerspace"  # 32 chars
+        with schema_context(get_public_schema_name()):
+            tenant = Tenant(schema_name="timberline_secondary_hackerspace", name=deck_name)
+            tenant.save()
+
+        with tenant_context(tenant):
+            config = SiteConfig.get()
+
+        expected_title = deck_name.replace("-", " ").title()  # "Timberline Secondary Hackerspace"
+        self.assertEqual(config.site_name_short, expected_title[:20])
+        self.assertEqual(config.site_name, f"{expected_title} Deck"[:50])

--- a/src/tenant/tests/test_signals.py
+++ b/src/tenant/tests/test_signals.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from django.db import connection
+
+from django_tenants.test.cases import TenantTestCase
+from django_tenants.utils import get_public_schema_name
+
+from tenant.models import Tenant
+from tenant.signals import initialize_tenant_with_data
+
+
+class InitializeTenantWithDataTest(TenantTestCase):
+    """Tests for the `post_schema_sync` handler that seeds a new tenant's schema."""
+
+    @patch("tenant.signals.load_initial_tenant_data")
+    def test_initialize_tenant_with_data__restores_previous_schema(self, mock_load):
+        """The handler seeds the new tenant's schema and then restores the schema
+        it started in.
+
+        It previously called ``connection.set_tenant(tenant)`` without switching
+        back, leaving the connection on the new tenant for the rest of the
+        request. Since deck creation is served from the public schema, the later
+        session write then hit the new schema's empty ``django_session`` table and
+        raised ``SessionInterrupted``. (``load_initial_tenant_data`` is mocked so
+        the test exercises only the schema handling, not the slow data seeding.)
+        """
+        tenant = Tenant.get()  # the current (non-public) test tenant
+
+        # Simulate a request being served from the public schema (as the deck
+        # creation view is) at the moment a new tenant is saved.
+        connection.set_schema_to_public()
+        try:
+            initialize_tenant_with_data(sender=Tenant, tenant=tenant)
+            # the connection must be back on the public schema, not left pointed
+            # at the tenant the handler just seeded
+            self.assertEqual(connection.schema_name, get_public_schema_name())
+        finally:
+            # restore the test schema for the remainder of the test / teardown
+            connection.set_tenant(tenant)
+
+        mock_load.assert_called_once()


### PR DESCRIPTION
### What?
Fixes two bugs hit while creating a deck through the public "Request a New Deck" flow:

1. **`SessionInterrupted` after a successful creation.** The new deck was created, but the final redirect raised `SessionInterrupted at /decks/new/`.
2. **`value too long for type character varying(20)`** — a 500 error when the deck name is longer than 20 characters, raised *after* the tenant schema had already been built.

### Why?
**Bug 1 — schema left switched after seeding.** The `post_schema_sync` handler in `tenant/signals.py` seeded the new tenant with `connection.set_tenant(tenant)` but never switched back:

```python
def initialize_tenant_with_data(sender, tenant, **kwargs):
    connection.set_tenant(tenant)   # switches to the new deck's schema…
    load_initial_tenant_data()      # …and never switches back
```

Deck creation is served from the **public** schema, so the rest of the request then ran against the new deck's schema. At the end of the request `SessionMiddleware` writes the session to `django_session` — but in the new schema that table is empty, so the `UPDATE` matches zero rows, which Django interprets as the session having been deleted concurrently and raises `SessionInterrupted`. The deck itself was fully created; only the redirect was lost. (This is the same wrong-schema class of bug as the owner-setup fix in #1903.)

**Bug 2 — display fields overflow.** `Tenant.name` allows up to 62 characters (the Postgres schema-name limit), but `create_site_config_object` copied it straight into `SiteConfig.site_name_short` (max 20) and `site_name` (max 50). Any deck name over 20 chars therefore passed form validation, spent ~a minute running `migrate_schemas`, then died at the database — leaving the requester's single-use verification nonce already consumed.

### How?
- **`tenant/signals.py`**: seed inside `tenant_context(tenant)`, which saves the schema active on entry and restores it on exit, so the connection is never left pointed at the new tenant.
- **`tenant/initialization.py`**: truncate the derived display names to each field's `max_length`. The deck name (subdomain) is unchanged, and both display fields remain editable by the owner in Site Config afterwards. Truncation is used rather than a hard form limit so valid long subdomain names (e.g. `timberline-secondary-hackerspace`) aren't rejected — happy to switch to an early form error instead if you'd prefer.

### Testing?
Both tests fail without the fix and pass with it:
- `tenant.tests.test_signals.InitializeTenantWithDataTest` — asserts the handler restores the public schema after seeding (fails as `'test' != 'public'` without the fix).
- `tenant.tests.test_initialization.CreateSiteConfigObjectTest` — creates a 32-char deck name and asserts the SiteConfig is seeded with truncated display names instead of raising `DataError`.

Full `tenant` app suite green (83 tests) and `flake8 src/tenant` clean. Verified against the develop dependency set (django-recaptcha 3), not the Phase-1 upgrade branch.

### Screenshots (if front end is affected)
N/A

### Anything Else?
The schema-restoration change makes *all* tenant creation restore the pre-creation schema; I checked the other creation paths (`initdb`'s library tenant, `TenantCreate.form_valid`) and they already re-enter their schema explicitly via `tenant_context`/`schema_context`, so none relied on the leak.

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_