### PR TITLE
Trust X-Forwarded-Proto so absolute URLs use https behind nginx

### DIFF
--- a/nginx/uwsgi_params
+++ b/nginx/uwsgi_params
@@ -11,3 +11,8 @@ uwsgi_param REMOTE_PORT $remote_port;
 uwsgi_param SERVER_ADDR $server_addr;
 uwsgi_param SERVER_PORT $server_port;
 uwsgi_param SERVER_NAME $server_name;
+# Forward the original request scheme (http/https) so Django can build correct
+# absolute URLs when TLS is terminated here. Paired with SECURE_PROXY_SSL_HEADER
+# in settings.py; set from nginx's own $scheme, so client-supplied values can't
+# spoof it.
+uwsgi_param HTTP_X_FORWARDED_PROTO $scheme;

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -40,6 +40,15 @@ if not ALLOWED_HOSTS:
 
 CSRF_TRUSTED_ORIGINS = env('CSRF_TRUSTED_ORIGINS', default=[])
 
+# In production TLS is terminated at nginx, which then forwards to uWSGI over
+# plain HTTP. Trust the forwarded scheme so request.is_secure() — and every
+# absolute URL built from it, e.g. the verification/welcome email links from
+# request.build_absolute_uri() — reflects the original https request instead of
+# the internal http hop. nginx sets this from its own $scheme (see
+# nginx/uwsgi_params), overwriting any client-supplied value, so it can't be
+# spoofed in the standard deployment. Harmless in dev (runserver never sends it).
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 WSGI_APPLICATION = 'hackerspace_online.wsgi.application'
 
 # Application definition

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.test import RequestFactory, SimpleTestCase
+
+
+class SecureProxySSLHeaderTest(SimpleTestCase):
+    """The app runs behind an nginx/uWSGI front end that terminates TLS and
+    forwards to Django over plain HTTP, so Django must trust the forwarded scheme
+    to recognize secure requests and build https:// URLs (e.g. in email links)."""
+
+    def test_secure_proxy_ssl_header_is_configured(self):
+        """SECURE_PROXY_SSL_HEADER must name the X-Forwarded-Proto header nginx sets."""
+        self.assertEqual(settings.SECURE_PROXY_SSL_HEADER, ("HTTP_X_FORWARDED_PROTO", "https"))
+
+    def test_forwarded_https_request_is_secure(self):
+        """A request forwarded with X-Forwarded-Proto: https is treated as secure,
+        so build_absolute_uri produces https:// links instead of http://."""
+        request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="https")
+        self.assertTrue(request.is_secure())
+        self.assertTrue(request.build_absolute_uri("/decks/new/").startswith("https://"))
+
+    def test_forwarded_http_request_is_not_secure(self):
+        """Without the https forwarded scheme, the request stays plain HTTP so the
+        header can't be used to fake a secure request."""
+        request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="http")
+        self.assertFalse(request.is_secure())


### PR DESCRIPTION
### What?
Makes Django-generated absolute URLs use `https://` in production. Right now the deck-request verification email (and allauth's email-confirmation links) go out with `http://` links.

### Why?
In production, nginx terminates TLS and forwards to uWSGI over plain HTTP. But `nginx/uwsgi_params` forwarded **no** scheme information, and settings had no `SECURE_PROXY_SSL_HEADER`, so Django saw every request as plain HTTP. Anything built with `request.build_absolute_uri()` — the deck-request verification link (`tenant/utils.py`) and allauth's confirmation emails among them — therefore got an `http://` scheme.

### How?
- **`nginx/uwsgi_params`**: forward the original request scheme as `HTTP_X_FORWARDED_PROTO`, set from nginx's own `$scheme`. Because it's set from nginx (not passed through from the client), a client can't spoof it.
- **`src/hackerspace_online/settings.py`**: `SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')`, so `request.is_secure()` and every URL built from it reflect the original TLS request. This is safe only because nginx always overwrites the header (see above). It's harmless in development, where `runserver` never sends it.

### Testing?
New `hackerspace_online.tests.test_settings.SecureProxySSLHeaderTest` (fails without the setting, passes with it):
- a request carrying `X-Forwarded-Proto: https` is recognized as secure and `build_absolute_uri` returns an `https://` URL;
- without the `https` forwarded scheme the request stays plain HTTP, so the header can't be used to fake a secure request.

`flake8` clean on both changed Python files. `test_auth`/`test_middleware`/`test_settings` pass. (One unrelated, pre-existing failure in `PublicContactFormTest.test_valid_data` occurs only in this sandbox — its reCAPTCHA verification makes a real outbound HTTPS call that the sandbox proxy rejects with a self-signed cert; it passes on CI, which has network access, and is untouched by this change.)

### Screenshots (if front end is affected)
N/A

### Anything Else?
The `uwsgi_params` change is deploy-side config — it takes effect when the nginx image is rebuilt/redeployed (`nginx/Dockerfile` copies this file to `/etc/nginx/uwsgi_params`, and the prod vhost `include`s it). This also fixes `http://` links in any other email or redirect that builds absolute URLs, not just the deck-request flow.

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_