### PR TITLE
Batch notification/quest queries to cut N+1s and per-row writes

### DIFF
--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -48,14 +48,16 @@ class NotificationQuerySet(models.query.QuerySet):
     #         qs_no_target.update(unread=False)
 
     def mark_all_read(self, recipient):
-        qs = self.get_unread().get_user(recipient)
-        qs.update(unread=False)
-        qs.update(time_read=timezone.now())
+        # Update unread and time_read in a single query. This must be one
+        # update: doing it as two (update(unread=False) then
+        # update(time_read=...)) makes the second update re-evaluate the
+        # unread=True filter, which now matches nothing, so time_read never
+        # gets set.
+        self.get_unread().get_user(recipient).update(unread=False, time_read=timezone.now())
 
     def mark_all_unread(self, recipient):
-        qs = self.get_read().get_user(recipient)
-        qs.update(unread=True)
-        qs.update(time_read=None)
+        # Single update for the same reason as mark_all_read above.
+        self.get_read().get_user(recipient).update(unread=True, time_read=None)
 
     def get_unread(self):
         return self.filter(unread=True)
@@ -327,30 +329,36 @@ def new_notification(sender, **kwargs):
     if affected_users is None:
         affected_users = [recipient, ]
 
+    notes = []
     for u in affected_users:
         # don't send a notification to yourself/themself
         if u == sender:
-            pass
-        else:
-            new_note = Notification(
-                recipient=u,
-                verb=verb,
-                sender_content_type=ContentType.objects.get_for_model(sender),
-                sender_object_id=sender.id,
-                font_icon=icon,
-            )
-            # Set the target if provided.
-            for option in ("target", "action"):
-                # obj = kwargs.pop(option, None) #don't want to remove option with pop
-                try:
-                    obj = kwargs[option]
-                    if obj is not None:
-                        setattr(new_note, "%s_content_type" % option, ContentType.objects.get_for_model(obj))
-                        setattr(new_note, "%s_object_id" % option, obj.id)
-                except:  # noqa
-                    # TODO make this except explicit, don't remember what it's doing
-                    pass
-            new_note.save()
+            continue
+
+        new_note = Notification(
+            recipient=u,
+            verb=verb,
+            sender_content_type=ContentType.objects.get_for_model(sender),
+            sender_object_id=sender.id,
+            font_icon=icon,
+        )
+        # Set the target if provided.
+        for option in ("target", "action"):
+            # obj = kwargs.pop(option, None) #don't want to remove option with pop
+            try:
+                obj = kwargs[option]
+                if obj is not None:
+                    setattr(new_note, "%s_content_type" % option, ContentType.objects.get_for_model(obj))
+                    setattr(new_note, "%s_object_id" % option, obj.id)
+            except:  # noqa
+                # TODO make this except explicit, don't remember what it's doing
+                pass
+        notes.append(new_note)
+
+    # Create every recipient's notification in a single bulk INSERT rather
+    # than one save() per user (a class-wide notification was N INSERTs).
+    # Safe: nothing is connected to Notification's post_save signal.
+    Notification.objects.bulk_create(notes)
 
 
 notify.connect(new_notification)

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -1,4 +1,7 @@
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
 from django_tenants.test.cases import TenantTestCase
 from django.contrib.contenttypes.models import ContentType
@@ -7,6 +10,8 @@ from model_bakery import baker
 from model_bakery.recipe import Recipe
 
 from notifications.models import Notification, new_notification
+
+User = get_user_model()
 
 
 class NotificationModelTest(TenantTestCase):
@@ -72,6 +77,76 @@ class NotificationModelTest(TenantTestCase):
 
         notes_unread = Notification.objects.all_unread(self.student)
         self.assertEqual(notes_unread.count(), 1)
+
+    def test_new_notification__bulk_creates_one_insert_for_many_recipients(self):
+        """new_notification writes every recipient's notification in a single bulk
+        INSERT instead of one save() per recipient."""
+        recipients = baker.make(User, _quantity=5)
+
+        with CaptureQueriesContext(connection) as ctx:
+            new_notification(
+                self.teacher,
+                recipient=self.student,  # required kwarg, unused when affected_users given
+                affected_users=recipients,
+                verb="tested",
+            )
+
+        # a single bulk INSERT covers all recipients (was one INSERT per recipient)
+        inserts = [q for q in ctx.captured_queries if 'insert into "notifications_notification"' in q['sql'].lower()]
+        self.assertEqual(len(inserts), 1)
+        self.assertEqual(Notification.objects.filter(recipient__in=recipients).count(), 5)
+
+    def test_new_notification__skips_sender(self):
+        """A user does not get notified about their own action, even when listed
+        in affected_users (regression guard for the bulk_create refactor)."""
+        # clear notifications created as a side effect of user creation in setUp
+        Notification.objects.all().delete()
+
+        new_notification(
+            self.teacher,
+            recipient=self.student,
+            affected_users=[self.teacher, self.student],
+            verb="tested",
+        )
+        # only the student (not the sender/teacher) should have a notification
+        self.assertEqual(Notification.objects.filter(recipient=self.teacher).count(), 0)
+        self.assertEqual(Notification.objects.filter(recipient=self.student).count(), 1)
+
+    def test_mark_all_read__single_update_sets_unread_and_time_read(self):
+        """mark_all_read marks every unread notification read and stamps time_read
+        in one UPDATE (the previous two-update version left time_read unset)."""
+        baker.make(Notification, recipient=self.student, unread=True, time_read=None, _quantity=3)
+        self.assertEqual(Notification.objects.all_unread(self.student).count(), 3)
+
+        with CaptureQueriesContext(connection) as ctx:
+            Notification.objects.all().mark_all_read(self.student)
+
+        updates = [q for q in ctx.captured_queries if q['sql'].lstrip().upper().startswith('UPDATE')]
+        self.assertEqual(len(updates), 1)
+
+        self.assertEqual(Notification.objects.all_unread(self.student).count(), 0)
+        # time_read must actually be set now, not left None
+        for note in Notification.objects.filter(recipient=self.student):
+            self.assertIsNotNone(note.time_read)
+
+    def test_mark_all_unread__single_update_sets_unread_and_clears_time_read(self):
+        """mark_all_unread marks read notifications unread and clears time_read in
+        one UPDATE (the previous two-update version left time_read set)."""
+        baker.make(
+            Notification, recipient=self.student, unread=False, time_read=timezone.now(), _quantity=3,
+        )
+        self.assertEqual(Notification.objects.all_read(self.student).count(), 3)
+
+        with CaptureQueriesContext(connection) as ctx:
+            Notification.objects.all().mark_all_unread(self.student)
+
+        updates = [q for q in ctx.captured_queries if q['sql'].lstrip().upper().startswith('UPDATE')]
+        self.assertEqual(len(updates), 1)
+
+        self.assertEqual(Notification.objects.all_read(self.student).count(), 0)
+        for note in Notification.objects.filter(recipient=self.student):
+            self.assertTrue(note.unread)
+            self.assertIsNone(note.time_read)
 
     def test_url_correct_comment_hash(self):
         """ Checks if instances where an url is given. There is a corresponding comment hash with it

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -1,11 +1,15 @@
 from django.contrib.auth import get_user_model
+from django.db import connection
 from django.shortcuts import reverse
+from django.test.utils import CaptureQueriesContext
 
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
+from notifications.models import Notification
+from notifications.signals import notify
 
 User = get_user_model()
 
@@ -119,3 +123,58 @@ class NotificationViewTests(ViewTestUtilsMixin, TenantTestCase):
             HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_ajax__query_count_does_not_grow_with_notifications(self):
+        """The dropdown AJAX prefetches each notification's sender/target/action
+        generic FKs, so its query count stays flat as unread notifications grow
+        (get_link() reads three generic FKs per row)."""
+        self.client.force_login(self.test_student1)
+        url = reverse('notifications:ajax')
+
+        # every notification shares the same sender (a User) and target (a Quest)
+        # content types, so prefetching collapses their generic-FK reads to a
+        # fixed number of queries regardless of the notification count
+        target = baker.make('quest_manager.Quest')
+
+        def notify_student(times):
+            for _ in range(times):
+                notify.send(
+                    self.test_teacher,
+                    target=target,
+                    recipient=self.test_student1,
+                    affected_users=[self.test_student1],
+                    verb="did",
+                )
+
+        # warm per-request caches (SiteConfig, content types, session) so the two
+        # measurements below differ only by the number of notifications rendered
+        notify_student(2)
+        self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        with CaptureQueriesContext(connection) as few_queries:
+            self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        notify_student(5)  # 7 unread total, still under the 15-item cap
+        with CaptureQueriesContext(connection) as many_queries:
+            self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        # without the prefetch each extra notification adds several generic-FK queries
+        self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
+
+    def test_read_all__marks_all_read_and_sets_time_read(self):
+        """The read_all view marks every unread notification read and stamps
+        time_read, then redirects to the notifications list."""
+        self.client.force_login(self.test_student1)
+        baker.make(
+            Notification, recipient=self.test_student1, unread=True, time_read=None, _quantity=3,
+        )
+        self.assertEqual(Notification.objects.all_unread(self.test_student1).count(), 3)
+
+        response = self.client.get(reverse('notifications:read_all'))
+        # don't fetch the target: baker-made notifications have random generic FKs
+        # that the list template would try to render
+        self.assertRedirects(response, reverse('notifications:list'), fetch_redirect_response=False)
+
+        self.assertEqual(Notification.objects.all_unread(self.test_student1).count(), 0)
+        for note in Notification.objects.filter(recipient=self.test_student1):
+            self.assertIsNotNone(note.time_read)

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -54,13 +54,9 @@ def list_unread(request):
 @non_public_only_view
 @login_required
 def read_all(request):
-    notifications = Notification.objects.all_unread(request.user)
-
-    for note in notifications:
-        note.unread = False
-        note.time_read = timezone.now()
-        note.save()
-
+    # mark every unread notification read in a single UPDATE instead of
+    # saving each row individually.
+    Notification.objects.all().mark_all_read(request.user)
     return redirect('notifications:list')
 
 
@@ -94,7 +90,12 @@ def ajax(request):
     if request.method == "POST":
 
         limit = 15
-        notifications = Notification.objects.all_unread(request.user)
+        # get_link() reads the sender/action/target generic FKs of each
+        # notification, so prefetch them to avoid 3 extra queries per row
+        # (this endpoint fires on essentially every authenticated page load).
+        notifications = Notification.objects.all_unread(request.user).prefetch_related(
+            'sender_object', 'target_object', 'action_object',
+        )
         count = notifications.count()
         # limit number of items else the list in the menu will go off
         # the bottom of the screen and can't get the links at the bottom...

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -554,7 +554,12 @@ class QuestManager(models.Manager):
             Returns:
                 QuerySet of draft quests if the user is staff or a TA with editable draft quests, empty otherwise.
         """
-        qs = self.get_queryset().filter(published=False)
+        # These quests render the same template rows as the staff "available"
+        # tab, which reads each quest's campaign, editor profile and tags, so
+        # prefetch them here too (the available queryset already does).
+        qs = self.get_queryset().filter(published=False).select_related(
+            "campaign", "editor__profile"
+        ).prefetch_related("tags")
 
         if user.is_staff:
             return qs
@@ -572,7 +577,11 @@ class QuestManager(models.Manager):
             QuerySet of archived quests if user is staff, empty list otherwise
         """
         if user.is_staff:
-            qs = self.get_queryset(include_archived=True).filter(archived=True)
+            # Same template as the "available" tab (see all_drafts), so
+            # prefetch campaign, editor profile and tags to avoid per-row queries.
+            qs = self.get_queryset(include_archived=True).filter(archived=True).select_related(
+                "campaign", "editor__profile"
+            ).prefetch_related("tags")
             return qs
         return self.get_queryset().none()
 

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -571,3 +571,55 @@ class SubmissionTestModel(TenantTestCase):
         # the setup submission should not be completed yet, but make sure
         self.assertFalse(self.submission.is_completed, False)
         self.assertIsNone(self.submission.get_minutes_to_complete())
+
+
+class QuestManagerPrefetchTest(TenantTestCase):
+    """The Drafts and Archived staff tabs render the same template rows as the
+    'Available' tab, which reads each quest's campaign, editor profile and tags.
+    all_drafts() and all_archived() must prefetch those relations so a page of
+    quests does not issue a query per row."""
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+        # a teacher is needed both as staff caller and as each quest's editor
+        self.teacher = User.objects.create_user('teacher', is_staff=True)
+        self.campaign = baker.make(Category, title="Test Campaign")
+
+    def _make_quests(self, **kwargs):
+        """Create three quests with a campaign, editor and tags set, so the
+        related-object accessors exercised by the template have data to read."""
+        quests = []
+        for i in range(3):
+            quest = baker.make(Quest, campaign=self.campaign, editor=self.teacher, **kwargs)
+            quest.tags.add(f'tag-{i}')
+            quests.append(quest)
+        return quests
+
+    def test_all_drafts__prefetches_related_objects(self):
+        """all_drafts() prefetches campaign, editor profile and tags, so reading
+        them for every draft quest issues no additional queries."""
+        self._make_quests(published=False)
+
+        drafts = list(Quest.objects.all_drafts(self.teacher))
+        self.assertEqual(len(drafts), 3)
+
+        with self.assertNumQueries(0):
+            for quest in drafts:
+                self.assertEqual(quest.campaign.title, "Test Campaign")
+                # editor__profile is select_related; profile is the reverse 1-1
+                self.assertIsNotNone(quest.editor.profile)
+                self.assertEqual(len(quest.tags.all()), 1)
+
+    def test_all_archived__prefetches_related_objects(self):
+        """all_archived() prefetches campaign, editor profile and tags, so reading
+        them for every archived quest issues no additional queries."""
+        self._make_quests(archived=True)
+
+        archived = list(Quest.objects.all_archived(self.teacher))
+        self.assertEqual(len(archived), 3)
+
+        with self.assertNumQueries(0):
+            for quest in archived:
+                self.assertEqual(quest.campaign.title, "Test Campaign")
+                self.assertIsNotNone(quest.editor.profile)
+                self.assertEqual(len(quest.tags.all()), 1)


### PR DESCRIPTION
### What?
Four small, independent database optimizations on hot paths, each covered by a query-count test:

1. **Notifications dropdown AJAX (`notifications/views.py` `ajax`)** — prefetch each notification's `sender`, `target` and `action` generic FKs so `get_link()` no longer issues three queries per row. This endpoint fires on essentially every authenticated page load. (The sibling `list()` view already did this.)
2. **`read_all` view** — mark every unread notification read with a single `UPDATE` (via the existing `mark_all_read()`) instead of looping and calling `.save()` per row.
3. **`mark_all_read()` / `mark_all_unread()` querysets** — collapse the two `update()` calls into one. This also fixes a latent bug (see Why).
4. **`new_notification` signal** — build the recipients' notifications and `bulk_create()` them in one `INSERT` instead of one `save()` per recipient.
5. **`Quest.all_drafts()` / `all_archived()`** — `select_related("campaign", "editor__profile")` and `prefetch_related("tags")`, matching the sibling "available" queryset, since the Drafts and Archived staff tabs render the same template rows.

### Why?
These are among the easiest, highest-traffic wins from a query audit of the codebase:

* The notification dropdown polls on every page; without the prefetch each unread notification costs ~3 extra queries.
* Posting one announcement to a class was one `INSERT` per student; `bulk_create` makes it one statement.
* The Drafts/Archived tabs reused the "available" template but not its prefetch, so each quest row re-queried campaign, editor profile and tags.

While collapsing `mark_all_read()`/`mark_all_unread()` into a single `update()`, this also fixes a **latent correctness bug**: they previously ran two updates — e.g. `update(unread=False)` then `update(time_read=...)` — where the second re-evaluated the `unread=True` filter, which by then matched no rows, so `time_read` was never stamped (and symmetrically never cleared). The single combined `update()` sets both columns.

### How?
* Added `.prefetch_related('sender_object', 'target_object', 'action_object')` to the `ajax` queryset.
* Routed `read_all` through `Notification.objects.all().mark_all_read(user)`.
* Rewrote the two queryset methods as one `update(unread=..., time_read=...)`.
* Accumulated the per-recipient `Notification` objects into a list and `bulk_create()`d them (safe: nothing is connected to `Notification`'s `post_save`).
* Chained `select_related`/`prefetch_related` onto the draft and archived querysets.

### Testing?
`python src/manage.py test src` locally (Postgres + Redis). New tests, all passing:
* `notifications.tests.test_models`: `mark_all_read`/`mark_all_unread` each issue a single `UPDATE` and correctly set/clear `time_read`; `new_notification` issues a single bulk `INSERT` for many recipients and still skips the sender.
* `notifications.tests.test_views`: the dropdown AJAX query count no longer grows with the number of unread notifications; `read_all` marks all read, stamps `time_read` and redirects.
* `quest_manager.tests.test_models`: `all_drafts()`/`all_archived()` read campaign, editor profile and tags for every quest with no per-row queries (`assertNumQueries(0)`).

Existing `mark_all_read` callers in `badges` and `courses`, and the quest-list view tests, still pass. `flake8 src` clean.

### Screenshots (if front end is affected)
N/A — no user-visible changes.

### Anything Else?
This is the first of a few small performance PRs from the same audit; later ones (campaign detail page, tag XP widgets, chart AJAX endpoints, comment threads) are scoped per app and will follow separately.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_