### PR TITLE
Cut per-quest queries on the campaign detail page

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -713,6 +713,11 @@ class Quest(IsAPrereqMixin, HasPrereqsMixin, TagsModelMixin, XPItem):
         """Returns True if the quest has expired, False otherwise.
         See QuestQueryset.expired() for details.
         """
+        # If the queryset annotated ``is_expired`` (as the quest list and campaign
+        # detail views do), reuse it instead of issuing a query. Templates call
+        # this for every quest in a list, so per-row queries add up quickly.
+        if hasattr(self, "is_expired"):
+            return self.is_expired
         # utilize existing code in QuestQuerySet method not_expired()
         return not Quest.objects.filter(id=self.id).not_expired().exists()
 

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -571,3 +571,31 @@ class SubmissionTestModel(TenantTestCase):
         # the setup submission should not be completed yet, but make sure
         self.assertFalse(self.submission.is_completed, False)
         self.assertIsNone(self.submission.get_minutes_to_complete())
+
+
+class QuestExpiredAnnotationTest(TenantTestCase):
+    """Quest.expired() is called for every quest rendered in list templates, so
+    it reuses an ``is_expired`` annotation from the queryset when one is present
+    instead of issuing a query per call."""
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+
+    def test_expired__prefers_is_expired_annotation(self):
+        """When the instance carries an is_expired annotation, expired() returns
+        it without issuing a query."""
+        quest = baker.make(Quest)
+
+        quest.is_expired = True  # simulate the queryset annotation
+        with self.assertNumQueries(0):
+            self.assertTrue(quest.expired())
+
+        quest.is_expired = False
+        with self.assertNumQueries(0):
+            self.assertFalse(quest.expired())
+
+    def test_expired__falls_back_to_query_without_annotation(self):
+        """Without the annotation, expired() still computes the value from the DB;
+        a quest with no expiry date has not expired."""
+        quest = baker.make(Quest, date_expired=None)
+        self.assertFalse(quest.expired())

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -16,6 +16,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.http import JsonResponse
 from django.utils import timezone
@@ -2249,6 +2251,31 @@ class CategoryViewTests(ViewTestUtilsMixin, TenantTestCase):
         displayed_quests = response.context["category_displayed_quests"]
         intended_quests = Quest.objects.get_active().filter(campaign=view_test_campaign)
         self.assertQuerySetEqual(displayed_quests, intended_quests, ordered=False)
+
+    def test_CategoryDetail_view__query_count_flat_as_quests_grow(self):
+        """The campaign detail page prefetches tags and annotates is_expired, so
+        its query count does not grow with the number of quests in the campaign
+        (the template reads tags and calls quest.expired() for every quest)."""
+        self.client.force_login(self.test_teacher)
+        campaign = baker.make(Category)
+        url = reverse('quests:category_detail', kwargs={"pk": campaign.pk})
+
+        def make_quests(n):
+            for _ in range(n):
+                quest = baker.make(Quest, campaign=campaign)
+                quest.tags.add("shared-tag")
+
+        make_quests(2)
+        self.client.get(url)  # warm per-request caches (SiteConfig, content types)
+        with CaptureQueriesContext(connection) as few_queries:
+            self.client.get(url)
+
+        make_quests(4)  # 6 quests total
+        with CaptureQueriesContext(connection) as many_queries:
+            self.client.get(url)
+
+        # without the prefetch + annotation each extra quest adds several queries
+        self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
 
     def test_CategoryDetail_view__displays_published_status_when_false(self):
         """The Campaign Info panel must display "Published: False" for an unpublished

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -134,6 +134,19 @@ class CategoryDetail(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
             # students shouldn't be able to see inactive quests when they access this view
             quests = Quest.objects.get_active().filter(campaign=self.object)
 
+        # The template reads each quest's icon (which falls back to the campaign
+        # icon), tags, and calls quest.expired() (twice), so select_related the
+        # campaign, prefetch tags and annotate is_expired to avoid a handful of
+        # queries per quest. This mirrors the quest list view (see quest_list()).
+        quests = quests.select_related("campaign").prefetch_related("tags")
+        not_expired_subquery = quests.not_expired().values("id")
+        quests = quests.annotate(
+            is_expired=ExpressionWrapper(
+                ~Exists(not_expired_subquery.filter(id=OuterRef("id"))),
+                output_field=BooleanField(),
+            )
+        )
+
         kwargs['category_displayed_quests'] = quests
         kwargs['can_export'] = SiteConfig.get().can_user_export_to_library(self.request.user)
 


### PR DESCRIPTION
### What?
Reduce the campaign (Category) detail page from several queries per quest to a fixed number, regardless of how many quests are in the campaign.

### Why?
Rendering the quest table on the campaign detail page cost, per quest:
* `quest.expired()` runs an `EXISTS` query — and the template calls it **twice** per quest (once for the row, once for the collapsible panel);
* `quest.tags.all()` — one query per quest;
* `Quest.get_icon_url()` reads `quest.campaign` (a FK) when the quest has no icon of its own — one query per quest.

For a campaign with many quests this is a lot of avoidable queries on a page students and staff both open.

### How?
* `CategoryDetail.get_context_data` now `select_related("campaign")`, `prefetch_related("tags")`, and annotates `is_expired` on the quest queryset — the same `~Exists(not_expired…)` annotation the quest list view already uses.
* `Quest.expired()` reuses that annotation when the instance has it, and otherwise falls back to its existing query. This keeps every other caller working unchanged — importantly the shared `category_detail_content.html` partial is also rendered by the library import/export previews, which don't annotate; they simply take the (unchanged) fallback path, so no template change was needed and their behaviour is preserved.

### Testing?
`python src/manage.py test src` locally (Postgres + Redis). New tests:
* `quest_manager.tests.test_models.QuestExpiredAnnotationTest`: `expired()` returns a preset `is_expired` annotation with no query, and still falls back to a DB query when the annotation is absent.
* `quest_manager.tests.test_views.CategoryViewTests.test_CategoryDetail_view__query_count_flat_as_quests_grow`: the page's query count is the same for 2 quests and 6 quests.

Existing `CategoryViewTests` still pass. `flake8 src` clean.

### Screenshots (if front end is affected)
N/A — no visible changes; the expired/warning styling and quest list are identical.

### Anything Else?
Part of a small series of performance PRs from a query audit (one per app). Independent of the others.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_