### PR TITLE
Avoid a profile query per student in the mark distribution chart

### DIFF
--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -398,7 +398,11 @@ class Semester(models.Model):
         Profile.objects.bulk_update(profiles, ['xp_cached'])
 
     def get_student_mark_list(self, students_only=False):
-        students = CourseStudent.objects.all_users_for_active_semester(students_only=students_only)
+        # select_related the profile since we read profile.mark_cached for every
+        # student below; without it that is a query per student.
+        students = CourseStudent.objects.all_users_for_active_semester(
+            students_only=students_only
+        ).select_related('profile')
         mark_list = []
         for student in students:
             mark_list.append(student.profile.mark_cached)

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.db import connection
 from django.shortcuts import reverse
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from django_tenants.test.cases import TenantTestCase
@@ -1015,6 +1017,27 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, TenantTestCase):
         user.profile.save()
 
         return baker.make(CourseStudent, user=user, semester=self.semester, course=self.course, block=self.block)
+
+    def test_get_student_mark_list__query_count_flat_as_students_grow(self):
+        """get_student_mark_list select_relates each student's profile, so its
+        query count does not grow with the number of students (it reads
+        student.profile.mark_cached for every student)."""
+        self.create_student_course(50)
+        self.create_student_course(60)
+        # warm SiteConfig/content-type caches so only the student marks matter
+        Semester.get_student_mark_list(Semester, students_only=True)
+
+        with CaptureQueriesContext(connection) as few_queries:
+            Semester.get_student_mark_list(Semester, students_only=True)
+
+        for _ in range(4):
+            self.create_student_course(70)
+
+        with CaptureQueriesContext(connection) as many_queries:
+            Semester.get_student_mark_list(Semester, students_only=True)
+
+        # without select_related('profile') each extra student adds a query
+        self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
 
     def test_non_ajax_status_code(self):
         self.assert403('courses:mark_distribution_chart', args=[self.teacher.pk])


### PR DESCRIPTION
### What?
`Semester.get_student_mark_list()` now `select_related('profile')` on its student queryset.

### Why?
The method reads `student.profile.mark_cached` for every student in the active semester (it builds the mark distribution chart on the course page). Because the profile wasn't select_related, that was one extra query per student — a class of 30 meant ~30 avoidable queries every time the chart loads.

### How?
One-line change: `.select_related('profile')` on the `all_users_for_active_semester()` result inside `get_student_mark_list()`. The select_related is applied here (at the point of use) rather than in the shared `all_users_for_active_semester()` manager method, so callers that don't need the profile aren't forced to join it.

### Testing?
`python src/manage.py test src` locally (Postgres + Redis). New test `TestAjax_MarkDistributionChart.test_get_student_mark_list__query_count_flat_as_students_grow` asserts the method's query count is the same for 2 students and 6 students. Existing `TestAjax_MarkDistributionChart` tests still pass. `flake8 src` clean.

### Screenshots (if front end is affected)
N/A — the chart output is unchanged.

### Anything Else?
Part of a small series of performance PRs from a query audit (one per app). Independent of the others.

The tag progress chart (`Ajax_TagChart.get_quest_dataset`) has its own, deeper N+1s (a per-row `COUNT`, plus per-row `quest`/`tags` loads inside the XP-capping logic); untangling it safely touches the user-facing XP totals, so I've left it out of this PR rather than risk that in a "quick win."

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_