### PR TITLE
Remove per-row COUNT queries from the student tag detail view

### DIFF
--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -3,6 +3,8 @@ import json
 from django import forms
 from django.core import signing
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from django.utils.text import slugify
@@ -12,6 +14,7 @@ from django_tenants.test.client import TenantClient
 
 from model_bakery import baker
 from tags.forms import TagForm
+from tags.views import TagDetailStudent
 from tags.widgets import TaggitSelect2Widget
 from taggit.forms import TagField
 from taggit.models import Tag
@@ -240,6 +243,67 @@ class TagCRUDViewTests(ViewTestUtilsMixin, TenantTestCase):
         self.assertContains(response, f'{repeatable_quest.name} ({repeatable_quest.xp} XP)', html=True)
         for i in range(2, num_subs, 1):
             self.assertContains(response, f'{repeatable_quest.name} ({i}) ({repeatable_quest.xp} XP)', html=True)
+
+    def test_get_quest_submissions__query_count_flat_as_submissions_grow(self):
+        """get_quest_submissions counts submissions per quest in memory and
+        select_relates the quest, so its query count does not grow with the
+        number of submissions (it previously ran a COUNT and loaded the quest
+        per submission)."""
+        repeatable_quest = baker.make('quest_manager.quest', max_repeats=-1, xp=1)
+        repeatable_quest.tags.add(self.tag.name)
+
+        def add_submissions(n):
+            for _ in range(n):
+                baker.make(
+                    'quest_manager.questsubmission',
+                    quest=repeatable_quest, user=self.test_student,
+                    is_completed=True, is_approved=True,
+                    semester=SiteConfig.get().active_semester,
+                )
+
+        view = TagDetailStudent()
+        view.user = self.test_student
+        view.object = self.tag
+
+        add_submissions(2)
+        view.get_quest_submissions()  # warm caches
+        with CaptureQueriesContext(connection) as few_queries:
+            view.get_quest_submissions()
+
+        add_submissions(4)
+        with CaptureQueriesContext(connection) as many_queries:
+            view.get_quest_submissions()
+
+        self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
+
+    def test_get_badge_assertions__query_count_flat_as_assertions_grow(self):
+        """get_badge_assertions counts assertions per badge in memory and
+        select_relates the badge, so its query count does not grow with the
+        number of assertions."""
+        badge = baker.make('badges.badge', xp=1)
+        badge.tags.add(self.tag.name)
+
+        def add_assertions(n):
+            for _ in range(n):
+                baker.make(
+                    'badges.badgeassertion', badge=badge, user=self.test_student,
+                    semester=SiteConfig.get().active_semester,
+                )
+
+        view = TagDetailStudent()
+        view.user = self.test_student
+        view.object = self.tag
+
+        add_assertions(2)
+        view.get_badge_assertions()  # warm caches
+        with CaptureQueriesContext(connection) as few_queries:
+            view.get_badge_assertions()
+
+        add_assertions(4)
+        with CaptureQueriesContext(connection) as many_queries:
+            view.get_badge_assertions()
+
+        self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
 
     def test_CreateView(self):
         """Make sure create view can create tags"""

--- a/src/tags/views.py
+++ b/src/tags/views.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from django.urls import reverse_lazy
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
@@ -106,26 +108,38 @@ class TagDetailStudent(TagDetail):
         return super().get(*args, **kwargs)
 
     def get_quest_submissions(self):
-        submissions = get_quest_submission_by_tag(self.user, [self.object.name]).order_by('quest', 'ordinal')
+        # select_related the quest since the template reads submission.quest, and
+        # evaluate the queryset once so we can count submissions per quest in
+        # memory instead of a COUNT query per row.
+        submissions = list(
+            get_quest_submission_by_tag(self.user, [self.object.name]).order_by('quest', 'ordinal').select_related('quest')
+        )
+        quest_counts = Counter(submission.quest_id for submission in submissions)
 
         # inject 'is_multiple' var into QuestSubmission object (basically the same as annotate)
         # conditional if there are multiple submissions pointing to quest
         for submission in submissions:
             ordinal_check = submission.ordinal > 1
-            multiple = submissions.filter(quest__id=submission.quest.id).count() > 1
+            multiple = quest_counts[submission.quest_id] > 1
 
             submission.is_multiple = ordinal_check or multiple
 
         return submissions
 
     def get_badge_assertions(self):
-        assertions = get_badge_assertion_by_tags(self.user, [self.object.name]).order_by('badge', 'ordinal')
+        # select_related the badge since the template reads assertion.badge, and
+        # evaluate the queryset once so we can count assertions per badge in
+        # memory instead of a COUNT query per row.
+        assertions = list(
+            get_badge_assertion_by_tags(self.user, [self.object.name]).order_by('badge', 'ordinal').select_related('badge')
+        )
+        badge_counts = Counter(assertion.badge_id for assertion in assertions)
 
         # inject 'is_multiple' var into BadgeAssertion object (basically the same as annotate)
         # conditional if there are multiple assertions pointing to badge
         for assertion in assertions:
             ordinal_check = assertion.ordinal > 1
-            multiple = assertions.filter(badge__id=assertion.badge.id).count() > 1
+            multiple = badge_counts[assertion.badge_id] > 1
 
             assertion.is_multiple = ordinal_check or multiple
 

--- a/src/tags/views.py
+++ b/src/tags/views.py
@@ -108,6 +108,18 @@ class TagDetailStudent(TagDetail):
         return super().get(*args, **kwargs)
 
     def get_quest_submissions(self):
+        """Return this user's approved quest submissions for the current tag,
+        each with an ``is_multiple`` attribute set.
+
+        The queryset is evaluated once (with the quest select_related) and the
+        number of submissions per quest is counted in memory, rather than
+        running a COUNT query for every submission, to determine whether a
+        submission's name needs an ordinal suffix.
+
+        Returns:
+            list[QuestSubmission]: the evaluated submissions, each annotated in
+            Python with a boolean ``is_multiple`` attribute.
+        """
         # select_related the quest since the template reads submission.quest, and
         # evaluate the queryset once so we can count submissions per quest in
         # memory instead of a COUNT query per row.
@@ -127,6 +139,18 @@ class TagDetailStudent(TagDetail):
         return submissions
 
     def get_badge_assertions(self):
+        """Return this user's badge assertions for the current tag, each with an
+        ``is_multiple`` attribute set.
+
+        The queryset is evaluated once (with the badge select_related) and the
+        number of assertions per badge is counted in memory, rather than running
+        a COUNT query for every assertion, to determine whether an assertion's
+        name needs an ordinal suffix.
+
+        Returns:
+            list[BadgeAssertion]: the evaluated assertions, each annotated in
+            Python with a boolean ``is_multiple`` attribute.
+        """
         # select_related the badge since the template reads assertion.badge, and
         # evaluate the queryset once so we can count assertions per badge in
         # memory instead of a COUNT query per row.


### PR DESCRIPTION
### What?
Make `TagDetailStudent.get_quest_submissions()` and `get_badge_assertions()` issue a fixed number of queries instead of a handful per row.

### Why?
Both methods looped over the student's submissions/assertions for a tag and, for **each** one, ran a `COUNT` query (`submissions.filter(quest__id=…).count() > 1`) to decide whether to append an ordinal to the name. They also read `submission.quest` / `assertion.badge` per row — another query per row here and again in the template. On a tag the student has engaged with a lot, that's several queries per submission/assertion.

### How?
* Evaluate each queryset once with `select_related('quest')` / `select_related('badge')` (the template reads those relations too).
* Count per quest / per badge in memory with `collections.Counter` instead of a `COUNT` query per row.

The counts are derived from the same distinct rows the old `.filter(...).count()` counted, so the `"(ordinal)"` labelling is unchanged — the existing `test_DetailView__student_view_ordinal` test still passes. The methods now return a list rather than a queryset; the only consumers (`get_context_data` and the template) just take `len()` and iterate, so that's transparent.

### Testing?
`python src/manage.py test src` locally (Postgres + Redis). New tests assert each method's query count is the same for 2 vs 6 submissions/assertions. The existing `TagCRUDViewTests` (including the ordinal display test) still pass. `flake8 src` clean.

### Screenshots (if front end is affected)
N/A — the rendered tag detail page is unchanged.

### Anything Else?
Part of a small series of performance PRs from a query audit (one per app). Independent of the others.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved tag detail pages to load quest submissions and badge assertions more efficiently.
  * Reduced repeated database queries when displaying multiple related submissions or assertions.

* **Tests**
  * Added coverage to ensure query counts remain consistent as related records increase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->