### PR TITLE
Restructure 1.28.0 changelog: feature areas as top-level, type-tagged items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,34 +5,33 @@ This file chronologically records all notable changes to this website, including
 [Changelogs](http://keepachangelog.com/en/0.3.0/) | [Versioning](http://semver.org/) | [Branch model](https://nvie.com/posts/a-successful-git-branching-model/)
 
 ### [1.28.0] 2026-07-12 Marcus III
-* New Features:
-  - Deck Requests:
-    - New decks can now be requested directly from the public ByteDeck site instead of by contacting us. Visitors fill in a short reCAPTCHA-protected form (name and email), click the verification link emailed to them (valid for one hour, good for one deck), and are guided through creating their own deck. The new deck's owner then receives a welcome email with their initial login credentials [#1892](https://github.com/bytedeck/bytedeck/issues/1892) [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
-    - New deck owners now receive a secure random initial password (generated once and emailed) instead of a guessable one, and deck-request verification links are opaque single-use nonces that keep the requester's name and email out of the URL [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
-    - Creating a new deck no longer silently fails to set up the deck owner's account (the setup ran in the wrong database schema, which made it a no-op in production), and verification / welcome emails are now sent in the background so the signup pages don't hang while mail goes out [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
-  - Library:
-    - Campaigns can now be exported to the shared Library: a new export button on the campaign detail page (enabled once the campaign has published quests) leads to a confirmation page that lists all of the campaign's quests and flags any that already exist in the Library [#1849](https://github.com/bytedeck/bytedeck/issues/1849) [#1850](https://github.com/bytedeck/bytedeck/issues/1850)
-    - Exporting a campaign whose quests already exist in the Library now copies those quests into the exported campaign instead of blocking the export, so a campaign can be exported even when every quest in it is already in the Library [#1884](https://github.com/bytedeck/bytedeck/issues/1884)
-    - When importing a single quest that already exists on your deck, the confirmation page now shows a prominent red warning explaining that overwriting existing quests individually is not yet supported. (Previously the notice was easy to miss and contradicted the campaign-import message, which says existing quests get overwritten.) [#1876](https://github.com/bytedeck/bytedeck/issues/1876) [#1878](https://github.com/bytedeck/bytedeck/issues/1878)
-    - Importing from the Library now also checks your archived quests for duplicates, so you can no longer end up with a second copy of a quest you had archived [#1877](https://github.com/bytedeck/bytedeck/issues/1877)
-    - Export-to-Library options are no longer offered while browsing the shared Library deck itself [#1888](https://github.com/bytedeck/bytedeck/issues/1888)
-  - Campaigns:
-    - Publish a campaign and all of the quests inside it in one click with the new publish button on the campaign detail page, instead of publishing each quest one at a time. (Handy before exporting to the Library, since only campaigns with published quests can be exported.) [#1843](https://github.com/bytedeck/bytedeck/issues/1843)
-    - The campaign detail, campaign delete, and badge-type delete pages now show the reason something can't be deleted in a red alert well, instead of only in a tooltip on the disabled delete button [#1861](https://github.com/bytedeck/bytedeck/issues/1861)
-  - Quests:
-    - New "Student Statuses" page for teachers: a new button among a quest's action buttons opens a table showing every student's status on that quest — including students who haven't started it — with links to their submissions [#918](https://github.com/bytedeck/bytedeck/issues/918)
-    - Archived quests can now be deleted directly — the delete page previously returned "Not Found" for them, forcing you to unarchive first [#1874](https://github.com/bytedeck/bytedeck/issues/1874)
+* Deck Requests:
+  - [New Feature] New decks can now be requested directly from the public ByteDeck site instead of by contacting us. Visitors fill in a short reCAPTCHA-protected form (name and email), click the verification link emailed to them (valid for one hour, good for one deck), and are guided through creating their own deck. The new deck's owner then receives a welcome email with their initial login credentials [#1892](https://github.com/bytedeck/bytedeck/issues/1892) [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
+  - [Tweak] New deck owners now receive a secure random initial password (generated once and emailed) instead of a guessable one, and deck-request verification links are opaque single-use nonces that keep the requester's name and email out of the URL [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
+  - [Bugfix] Creating a new deck no longer silently fails to set up the deck owner's account (the setup ran in the wrong database schema, which made it a no-op in production), and verification / welcome emails are now sent in the background so the signup pages don't hang while mail goes out [#1903](https://github.com/bytedeck/bytedeck/issues/1903)
+  - [Bugfix] Fixed two more errors when creating a deck through the request form: a deck name longer than 20 characters no longer aborts setup at the database, and completing the request no longer fails with a "SessionInterrupted" error after the deck has already been created [#1938](https://github.com/bytedeck/bytedeck/issues/1938)
+  - [Bugfix] Links in deck-request verification, welcome, and account email-confirmation messages now use https:// instead of http:// [#1939](https://github.com/bytedeck/bytedeck/issues/1939)
+* Library:
+  - [New Feature] Campaigns can now be exported to the shared Library: a new export button on the campaign detail page (enabled once the campaign has published quests) leads to a confirmation page that lists all of the campaign's quests and flags any that already exist in the Library [#1849](https://github.com/bytedeck/bytedeck/issues/1849) [#1850](https://github.com/bytedeck/bytedeck/issues/1850)
+  - [New Feature] Exporting a campaign whose quests already exist in the Library now copies those quests into the exported campaign instead of blocking the export, so a campaign can be exported even when every quest in it is already in the Library [#1884](https://github.com/bytedeck/bytedeck/issues/1884)
+  - [Tweak] When importing a single quest that already exists on your deck, the confirmation page now shows a prominent red warning explaining that overwriting existing quests individually is not yet supported. (Previously the notice was easy to miss and contradicted the campaign-import message, which says existing quests get overwritten.) [#1876](https://github.com/bytedeck/bytedeck/issues/1876) [#1878](https://github.com/bytedeck/bytedeck/issues/1878)
+  - [Bugfix] Importing from the Library now also checks your archived quests for duplicates, so you can no longer end up with a second copy of a quest you had archived [#1877](https://github.com/bytedeck/bytedeck/issues/1877)
+  - [Bugfix] Export-to-Library options are no longer offered while browsing the shared Library deck itself [#1888](https://github.com/bytedeck/bytedeck/issues/1888)
+* Campaigns:
+  - [New Feature] Publish a campaign and all of the quests inside it in one click with the new publish button on the campaign detail page, instead of publishing each quest one at a time. (Handy before exporting to the Library, since only campaigns with published quests can be exported.) [#1843](https://github.com/bytedeck/bytedeck/issues/1843)
+  - [Tweak] The campaign detail, campaign delete, and badge-type delete pages now show the reason something can't be deleted in a red alert well, instead of only in a tooltip on the disabled delete button [#1861](https://github.com/bytedeck/bytedeck/issues/1861)
+* Quests:
+  - [New Feature] New "Student Statuses" page for teachers: a new button among a quest's action buttons opens a table showing every student's status on that quest — including students who haven't started it — with links to their submissions [#918](https://github.com/bytedeck/bytedeck/issues/918)
+  - [Bugfix] Archived quests can now be deleted directly — the delete page previously returned "Not Found" for them, forcing you to unarchive first [#1874](https://github.com/bytedeck/bytedeck/issues/1874)
 * Tweaks:
-  - Quest Approvals:
-    - Search on the Approvals tab now also matches the Group, User, and Status columns, so it behaves the same as search on the other submission tables [#1875](https://github.com/bytedeck/bytedeck/issues/1875)
+  - Search on the Approvals tab now also matches the Group, User, and Status columns, so it behaves the same as search on the other submission tables [#1875](https://github.com/bytedeck/bytedeck/issues/1875)
 * Refactor/Optimizations:
   - Django 5.2 preparation: removed APIs dropped between Django 4.2 and 5.2, and fixed two broken unpinned dependencies (namegenerator, redis-py) [#1897](https://github.com/bytedeck/bytedeck/issues/1897)
   - Eliminated the worst N+1 query patterns across approvals, badge lists, profile pages, the campaigns list, badge detail, ranks list, and popover counts [#1898](https://github.com/bytedeck/bytedeck/issues/1898)
   - Further N+1 reductions on the profile detail page and the notifications list [#1902](https://github.com/bytedeck/bytedeck/issues/1902)
   - Hardened rank and rarity caches against signal-less ORM writes [#1898](https://github.com/bytedeck/bytedeck/issues/1898)
 * Bugfixes:
-  - Quest Maps:
-    - Maps no longer draw connections for inverted ("NOT") OR-prerequisites: the exclude-NOT option was silently ignored for the OR slot of a prerequisite, so a map could include quests whose only link was a NOT condition [#1900](https://github.com/bytedeck/bytedeck/issues/1900) [#1901](https://github.com/bytedeck/bytedeck/issues/1901)
+  - Maps no longer draw connections for inverted ("NOT") OR-prerequisites: the exclude-NOT option was silently ignored for the OR slot of a prerequisite, so a map could include quests whose only link was a NOT condition [#1900](https://github.com/bytedeck/bytedeck/issues/1900) [#1901](https://github.com/bytedeck/bytedeck/issues/1901)
 * Devops:
   - Fixed the randomly-flaky CI failures in the prerequisites signal tests (`Rank.DoesNotExist` and missing-map errors):
     - Tests that create `Prereq` objects now use deterministic content types instead of random ones [#1899](https://github.com/bytedeck/bytedeck/issues/1899)


### PR DESCRIPTION
### What?
Restructures the `1.28.0` (Marcus III) changelog so each major feature area is its own top-level point, with every item prefixed by its type. Also documents the two deck-creation hotfixes cherry-picked into this release. Documentation only.

Before, items were grouped under category headings (New Features / Tweaks / …) with feature areas nested inside. Now:
- **Deck Requests, Library, Campaigns, Quests** are top-level points, and each item under them is tagged `[New Feature]` / `[Tweak]` / `[Bugfix]` — so a whole feature area reads together in one place regardless of change type.
- **Standalone / cross-cutting** work keeps the plain category sections: `Tweaks` (the Approvals search change), `Refactor/Optimizations` (Django prep, N+1s, caches), `Bugfixes` (the quest-map NOT fix), and `Devops`.
- The `New Features` category section is dropped because every new-feature item now lives under a feature area — nothing was left in it. (Say the word if you'd rather keep an empty placeholder or handle the leftovers differently.)

### Why?
Requested: for the major grouped features, promote them to their own main point with type-annotated subpoints, e.g. `[New Feature] …`, `[Tweak] …`, `[Bugfix] …`.

### How?
Reshuffle + inline type tags within the 1.28.0 section only. Existing item wording and every issue link are unchanged. Two new entries added under **Deck Requests** for the cherry-picked hotfixes:
- `[Bugfix] … a deck name longer than 20 characters no longer aborts setup … no longer fails with a "SessionInterrupted" error …` [#1938](https://github.com/bytedeck/bytedeck/issues/1938)
- `[Bugfix] Links in deck-request verification, welcome, and account email-confirmation messages now use https://` [#1939](https://github.com/bytedeck/bytedeck/issues/1939)

> **Note on the second PR number:** your message said "#1938 and #9128" — #9128 isn't a valid PR number for this repo, so I've assumed you meant **#1939** (the proxy-SSL / https-links hotfix, the other of the two deck-creation fixes). If you meant a different PR, tell me and I'll swap the reference.

### Testing?
No code changes. Verified: no bare `[#N]` references remain, the full set of issue links is intact (plus the two new ones), markdown nesting renders correctly (top-level `*` feature areas, 2-space items, 4-space Devops sub-bullets), and everything from `[1.27.0]` down is byte-identical.

### Screenshots (if front end is affected)
N/A

### Anything Else?
Follow-up to [#1926](https://github.com/bytedeck/bytedeck/issues/1926) and [#1936](https://github.com/bytedeck/bytedeck/issues/1936) (earlier formatting / grouping passes over the same section).

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deck request handling for deck names longer than 20 characters.
  * Resolved failures caused by interrupted sessions during deck creation.
  * Updated email links to use secure HTTPS connections.

* **Documentation**
  * Reorganized the 1.28.0 changelog into clearer feature and fix categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->