### PR TITLE
Fix deck creation crash: truncate Site.name for long deck domains

### DIFF
--- a/src/hackerspace_online/signals.py
+++ b/src/hackerspace_online/signals.py
@@ -52,4 +52,10 @@ def handle_tenant_site_domain_update(tenant, **kwargs):
 
     with tenant_context(tenant):
         domain = tenant.get_primary_domain().domain
-        Site.objects.update(name=domain, domain=domain)
+        # Site.name is varchar(50) but Site.domain is varchar(100); a long deck
+        # subdomain can exceed 50 chars, so cap the human-readable name to the
+        # field's max_length. allauth builds URLs from Site.domain (not name), so
+        # truncating the label is harmless. Without this, creating a deck with a
+        # long name raised "value too long for type character varying(50)".
+        name_max = Site._meta.get_field("name").max_length
+        Site.objects.update(name=domain[:name_max], domain=domain)

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -39,6 +39,7 @@ class SignalTest(ViewTestUtilsMixin, TenantTestCase):
         long_name = "a" * 55
         with schema_context(get_public_schema_name()):
             tenant = Tenant(schema_name="longsitename", name=long_name)
+            tenant.full_clean()
             tenant.save()
 
         with tenant_context(tenant):

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -1,9 +1,12 @@
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
+from django_tenants.utils import get_public_schema_name, schema_context, tenant_context
 
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
+from tenant.models import Tenant
 
 # from django.shortcuts import reverse
 # from django.test import RequestFactory
@@ -19,3 +22,30 @@ class SignalTest(ViewTestUtilsMixin, TenantTestCase):
     def change_domain_urls_signal(self):
         # TODO
         pass
+
+    def test_handle_tenant_site_domain_update__long_domain_truncates_site_name(self):
+        """A tenant whose full domain exceeds Site.name's 50-char limit is still
+        created successfully.
+
+        The post_schema_sync handler sets the tenant's Site from its domain; it
+        previously did Site.objects.update(name=domain, ...), which raised
+        "value too long for type character varying(50)" for a long deck subdomain
+        because Site.name is varchar(50). The name label is now truncated to fit,
+        while Site.domain (varchar(100), used by allauth to build URLs) keeps the
+        full value.
+        """
+        # A valid subdomain longer than Site.name's 50-char max, so the derived
+        # "<name>.<ROOT_DOMAIN>" domain overflows Site.name without the fix.
+        long_name = "a" * 55
+        with schema_context(get_public_schema_name()):
+            tenant = Tenant(schema_name="longsitename", name=long_name)
+            tenant.save()
+
+        with tenant_context(tenant):
+            site = Site.objects.first()
+            full_domain = tenant.get_primary_domain().domain
+            name_max = Site._meta.get_field("name").max_length
+            # domain (100) keeps the full value; name (50) is truncated to fit
+            self.assertEqual(site.domain, full_domain)
+            self.assertEqual(site.name, full_domain[:name_max])
+            self.assertLessEqual(len(site.name), name_max)

--- a/src/tenant/forms.py
+++ b/src/tenant/forms.py
@@ -9,6 +9,14 @@ from .models import Tenant
 
 User = get_user_model()
 
+# The deck name is used verbatim as SiteConfig.site_name_short (max_length 20)
+# and also seeds the other name-derived display fields (site_name, the Site
+# name). Capping the name here — at the shortest of those limits — means the
+# user gets a clear error at form time instead of a valid-looking long name
+# being silently truncated when the deck is created. (The creation code still
+# truncates defensively for non-form paths like the admin / management commands.)
+MAX_DECK_NAME_LENGTH = 20
+
 
 class TenantBaseForm(ModelForm):
     """
@@ -21,7 +29,13 @@ class TenantBaseForm(ModelForm):
 
     def clean_name(self):
         name = self.cleaned_data["name"]
-        # has already validated the model field at this point
+        # has already validated the model field (format, uniqueness) at this point
+        if len(name) > MAX_DECK_NAME_LENGTH:
+            raise forms.ValidationError(
+                f"Deck names can be at most {MAX_DECK_NAME_LENGTH} characters "
+                "(your deck name is also shown as your site's short name). "
+                "Please choose a shorter name for your deck."
+            )
         if name == "public":
             raise forms.ValidationError("The public tenant is restricted and cannot be used.")
         else:

--- a/src/tenant/forms.py
+++ b/src/tenant/forms.py
@@ -28,6 +28,19 @@ class TenantBaseForm(ModelForm):
         fields = ["name"]
 
     def clean_name(self):
+        """Validate the deck name.
+
+        Enforces the deck-name length cap (``MAX_DECK_NAME_LENGTH``), rejects the
+        reserved ``public`` name, and rejects a name whose schema already exists in
+        the database without a matching tenant object.
+
+        Returns:
+            str: The cleaned deck name.
+
+        Raises:
+            forms.ValidationError: If the name is too long, is reserved, or collides
+                with an existing orphaned schema.
+        """
         name = self.cleaned_data["name"]
         # has already validated the model field (format, uniqueness) at this point
         if len(name) > MAX_DECK_NAME_LENGTH:

--- a/src/tenant/tests/test_forms.py
+++ b/src/tenant/tests/test_forms.py
@@ -136,7 +136,7 @@ class TenantFormTest(TenantTestCase):
         form = TenantForm(data)
         self.assertFalse(form.is_valid())
 
-    def test_deck_name_too_long(self):
+    def test_clean_name__deck_name_too_long(self):
         """A deck name longer than MAX_DECK_NAME_LENGTH is rejected on the form with a
         clear error, so the user gets feedback instead of the name being silently
         truncated (into SiteConfig.site_name_short etc.) when the deck is created.
@@ -155,7 +155,7 @@ class TenantFormTest(TenantTestCase):
         form = TenantForm({**base, "name": at_limit})
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_duplicate_deck_name_is_rejected(self):
+    def test_clean_name__duplicate_deck_name_is_rejected(self):
         """A deck name that already exists is rejected on the form (via the unique
         constraint), so the user is warned before the deck is created rather than
         hitting an error afterwards.

--- a/src/tenant/tests/test_forms.py
+++ b/src/tenant/tests/test_forms.py
@@ -8,7 +8,7 @@ from django_tenants.test.cases import TenantTestCase
 
 from captcha.widgets import ReCaptchaV2Invisible
 
-from tenant.forms import DeckRequestForm, TenantForm
+from tenant.forms import MAX_DECK_NAME_LENGTH, DeckRequestForm, TenantForm
 from tenant.models import Tenant
 
 User = get_user_model()
@@ -135,3 +135,41 @@ class TenantFormTest(TenantTestCase):
         # trying to create new tenant, with name of existing schema
         form = TenantForm(data)
         self.assertFalse(form.is_valid())
+
+    def test_deck_name_too_long(self):
+        """A deck name longer than MAX_DECK_NAME_LENGTH is rejected on the form with a
+        clear error, so the user gets feedback instead of the name being silently
+        truncated (into SiteConfig.site_name_short etc.) when the deck is created.
+        """
+        base = {"first_name": "John", "last_name": "Doe", "email": "john.doe@example.com"}
+
+        # one over the limit: rejected with a message that names the limit
+        too_long = "a" * (MAX_DECK_NAME_LENGTH + 1)
+        form = TenantForm({**base, "name": too_long})
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+        self.assertIn(str(MAX_DECK_NAME_LENGTH), form.errors["name"][0])
+
+        # exactly at the limit: accepted
+        at_limit = "a" * MAX_DECK_NAME_LENGTH
+        form = TenantForm({**base, "name": at_limit})
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_duplicate_deck_name_is_rejected(self):
+        """A deck name that already exists is rejected on the form (via the unique
+        constraint), so the user is warned before the deck is created rather than
+        hitting an error afterwards.
+        """
+        # Add an existing tenant with a known (short) name. bulk_create avoids the
+        # slow schema build and the post_save signals — we only need the row so the
+        # form's uniqueness check has something to collide with.
+        Tenant.objects.bulk_create([Tenant(schema_name="dupedeck", name="dupedeck")])
+        data = {
+            "name": "dupedeck",
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john.doe@example.com",
+        }
+        form = TenantForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)


### PR DESCRIPTION
### What?
Fixes a `DataError at /decks/new/` — **`value too long for type character varying(50)`** — raised during `TenantCreate` when a deck is created with a long name.

### Why?
The `post_schema_sync` handler `handle_tenant_site_domain_update` (`src/hackerspace_online/signals.py`) sets the new tenant's django `Site` from its domain:

```python
domain = tenant.get_primary_domain().domain      # e.g. "a-long-deck-name.bytedeck-staging.com"
Site.objects.update(name=domain, domain=domain)
```

`Site.name` is `varchar(50)` but `Site.domain` is `varchar(100)`. Assigning the **full domain** to `name` overflows the 50-char column once the subdomain is long enough (with the `.bytedeck-staging.com` suffix, a deck name over ~29 chars is enough), aborting deck creation after the schema has already been built.

This is the same varchar-overflow class as #1938, but a different field #1938 didn't cover — that fix truncated `SiteConfig.site_name` / `site_name_short`; this is the `django.contrib.sites` `Site.name`.

### How?
Truncate the `name` label to `Site.name`'s `max_length`. `Site.domain` still stores the full value, and allauth builds its URLs from `Site.domain` (not `name`), so truncating the human-readable label has no functional effect.

```python
name_max = Site._meta.get_field("name").max_length
Site.objects.update(name=domain[:name_max], domain=domain)
```

### Testing?
New test in `hackerspace_online.tests.test_signals.SignalTest` (fails without the fix, passes with it): creating a tenant with a 55-char name seeds a truncated `Site.name` without raising `DataError`, while `Site.domain` keeps the full domain. `flake8` clean. Verified against the develop dependency set.

### Screenshots (if front end is affected)
N/A

### Anything Else?
Follow-up to #1938 — with this, all three deck-name-derived columns touched during deck creation (`SiteConfig.site_name`, `SiteConfig.site_name_short`, and `Site.name`) are bounded to their field limits.

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to limit deck names to 20 characters.
  * Deck names that exceed the limit or duplicate an existing deck are now rejected with clear form errors.

* **Bug Fixes**
  * Long primary domains are now handled successfully while preserving the full domain and safely limiting the displayed site name.

* **Tests**
  * Added coverage for deck-name length, duplicate-name validation, and long-domain handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->