### PR TITLE
Remove dead student quick_reply_form context + regression test (follow-up to #1886)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2050,6 +2050,34 @@ class QuestListViewTest(ViewTestUtilsMixin, TenantTestCase):
         response = self.client.get(reverse('quests:quest_active', args=[quest_avail_outside_course.id]))
         self.assertContains(response, f'id="heading-quest-{quest_avail_outside_course.id}')
 
+    def test_student_does_not_see_quick_reply_form(self):
+        """Regression for #1886 / #1759: the student quick reply form (which
+        404'd when resubmitting a returned quest) was removed. A returned
+        submission must still render on the quests page, but without the inline
+        quick reply form or its Re-Submit button — students resubmit via the
+        detailed view instead."""
+        self.client.force_login(self.test_student)
+
+        # a returned submission (completed once, then sent back by a teacher):
+        # is_completed is False but time_completed is set, so is_returned() is True
+        returned_sub = baker.make(
+            QuestSubmission,
+            user=self.test_student,
+            quest=self.quest1,
+            semester=SiteConfig.get().active_semester,
+            is_completed=False,
+            time_completed=timezone.now(),
+        )
+        self.assertTrue(returned_sub.is_returned())
+
+        response = self.client.get(reverse('quests:inprogress'))
+
+        # the returned submission is on the page ...
+        self.assertContains(response, f'id="heading-submission-{returned_sub.id}"')
+        # ... but the removed quick reply form and its button are not
+        self.assertNotContains(response, f'quick_reply{returned_sub.id}')
+        self.assertNotContains(response, 'Re-Submit Quest')
+
     def test_show_hidden(self):
         """ Test of:
         url(r'^available/all/$', views.quest_list, name='available_all'),

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -830,8 +830,6 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
         else available_quests.count()
     )
 
-    quick_reply_form = SubmissionQuickReplyFormStudent(request.POST or None)
-
     if view_type == QuestListViewTabTypes.IN_PROGRESS:
         in_progress_submissions = paginate(in_progress_submissions, page)
         # available_quests = []
@@ -875,7 +873,6 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
         "active_q_id": active_quest_id,
         "VIEW_TYPES": QuestListViewTabTypes,
         "view_type": view_type,
-        "quick_reply_form": quick_reply_form,
         "bulk_edit_mode": request.user.is_staff and 'bulk_edit' in request.GET,
     }
     return render(request, template, context)


### PR DESCRIPTION
### What?
Removes the now-dead student `quick_reply_form` from the `quest_list` view, and adds a regression test.

### Why?
#1886 (Closes #1759) removed the student quick reply form from the UI, including deleting its only template, `submission_buttons_form_student.html`. But `quest_list` in `quest_manager/views.py` still built that form and passed it into the template context on every quests-page render:

```python
quick_reply_form = SubmissionQuickReplyFormStudent(request.POST or None)
...
"quick_reply_form": quick_reply_form,
```

With the template gone, that context is dead — it constructs a form nothing consumes. This is the loose end left by #1886.

### How?
- Dropped the `quick_reply_form` construction and its context key from `quest_list`.
- **Kept** the `SubmissionQuickReplyFormStudent` import — it is still used as the text-only submission fallback in the submission-complete view (`views.py`, `form = SubmissionQuickReplyFormStudent(request.POST)`).
- Added `QuestListViewTest.test_student_does_not_see_quick_reply_form`: a *returned* submission still renders on the quests page, but without the inline quick reply form or its "Re-Submit Quest" button. Verified it fails if the form/context is restored.

### Testing?
- `QuestListViewTest` + `SubmissionCompleteViewTest` — 34 tests, 0 failures (run against the post-#1916 dependency set now on `develop`). The `SubmissionCompleteViewTest.test_complete_quick_reply_form*` cases exercise the retained import, confirming the complete-view fallback still works.
- `flake8 src/quest_manager/views.py src/quest_manager/tests/test_views.py` clean.

### Screenshots (if front end is affected)
N/A — no user-visible change; #1886 already removed the form from every rendered page. This only removes the orphaned server-side context.

### Anything Else?
Pure dead-code removal plus a regression test; no behavior change for students or staff.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_