### PR TITLE
Fail-fast on insecure production config; harden .env.example.aws defaults

### DIFF
--- a/.env.example.aws
+++ b/.env.example.aws
@@ -1,9 +1,14 @@
 # https://docs.docker.com/compose/environment-variables/
 # https://django-environ.readthedocs.io/en/latest/#django-environ
 
+# REQUIRED: generate a unique, random key per deployment, e.g.
+#   python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+# The app refuses to start on a real (non-localhost) domain while this is left
+# as the 'Change.Me!' default.
 SECRET_KEY=Change.Me!
 
-DEBUG=True
+# Must be False for any real (non-localhost) deployment; the app enforces this.
+DEBUG=False
 
 ## ROOT DOMAIN ################################
 #
@@ -68,19 +73,21 @@ REDIS_PORT=6379
 
 ## POSTGRES ############################################
 
-# Only used for local development with `python src/manage.py runserver`
-# When running web service in a container with `docker compose up web`
-#  the app will read POSTGRES_HOST=db from docker-compose.yml
-#  similarly with the celery-beat service
-POSTGRES_HOST=127.0.0.1
+# Point this at the managed database endpoint (e.g. the AWS RDS endpoint) in
+# production/staging.
+POSTGRES_HOST=your-db.xxxxxxxxxxxx.region.rds.amazonaws.com
 
 POSTGRES_PORT=5432
 POSTGRES_DB_NAME=postgres
 POSTGRES_USER=postgres
 
-# No password needed in development
-#POSTGRES_PASSWORD=
-POSTGRES_HOST_AUTH_METHOD=trust
+# REQUIRED in production: the password for the Postgres user above.
+POSTGRES_PASSWORD=
+
+# POSTGRES_HOST_AUTH_METHOD=trust is a *local-dev* convenience for the
+# containerized postgres (see .env.example); it does not apply to a managed DB
+# like RDS. Never enable passwordless trust auth in production.
+#POSTGRES_HOST_AUTH_METHOD=trust
 
 
 ## PUBLIC TENANT  ######################################
@@ -109,8 +116,9 @@ TENANT_DEFAULT_OWNER_PASSWORD=password
 
 
 # STATIC AND MEDIA FILES
-# set below to 1 only when using AWS
-USE_S3=0
+# 1 = serve static & media from S3/CloudFront (the production/staging setup).
+# Set to 0 only if you intend to serve them locally from nginx instead.
+USE_S3=1
 
 # AWS
 

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -40,6 +40,38 @@ if not ALLOWED_HOSTS:
 
 CSRF_TRUSTED_ORIGINS = env('CSRF_TRUSTED_ORIGINS', default=[])
 
+
+def _validate_deployment_settings(root_domain, debug, secret_key):
+    """Refuse to boot a real deployment that is still using the shipped example
+    defaults, so a miscopied .env (e.g. from .env.example.aws) can't silently
+    expose the site.
+
+    A real deployment is anything whose ROOT_DOMAIN is not ``localhost``
+    (production, staging, etc.). Local development (``localhost``) is never
+    blocked, and the caller skips this entirely during tests. Raises
+    ``ImproperlyConfigured`` on an unsafe configuration.
+    """
+    from django.core.exceptions import ImproperlyConfigured
+
+    if root_domain == 'localhost':
+        return
+    if debug:
+        raise ImproperlyConfigured(
+            f"DEBUG must be False for a real deployment (ROOT_DOMAIN={root_domain!r}). "
+            "Set DEBUG=False in the environment."
+        )
+    if secret_key == 'Change.Me!':
+        raise ImproperlyConfigured(
+            "SECRET_KEY is still the example default ('Change.Me!'). Generate a "
+            "unique, random SECRET_KEY in the environment before deploying."
+        )
+
+
+# Fail fast on insecure example defaults in a real deployment. Skipped during
+# tests, where DEBUG/SECRET_KEY are intentionally weak.
+if 'test' not in sys.argv:
+    _validate_deployment_settings(ROOT_DOMAIN, DEBUG, SECRET_KEY)
+
 # In production TLS is terminated at nginx, which then forwards to uWSGI over
 # plain HTTP. Trust the forwarded scheme so request.is_secure() — and every
 # absolute URL built from it, e.g. the verification/welcome email links from

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -68,8 +68,10 @@ def _validate_deployment_settings(root_domain, debug, secret_key):
 
 
 # Fail fast on insecure example defaults in a real deployment. Skipped during
-# tests, where DEBUG/SECRET_KEY are intentionally weak.
-if 'test' not in sys.argv:
+# tests, where DEBUG/SECRET_KEY are intentionally weak. This bootstrap line is
+# excluded from coverage because it only runs outside the test harness; the
+# logic itself is covered directly by DeploymentSettingsGuardTest.
+if 'test' not in sys.argv:  # pragma: no cover
     _validate_deployment_settings(ROOT_DOMAIN, DEBUG, SECRET_KEY)
 
 # In production TLS is terminated at nginx, which then forwards to uWSGI over

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -1,5 +1,8 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, SimpleTestCase
+
+from hackerspace_online.settings import _validate_deployment_settings
 
 
 class SecureProxySSLHeaderTest(SimpleTestCase):
@@ -23,3 +26,29 @@ class SecureProxySSLHeaderTest(SimpleTestCase):
         header can't be used to fake a secure request."""
         request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="http")
         self.assertFalse(request.is_secure())
+
+
+class DeploymentSettingsGuardTest(SimpleTestCase):
+    """A real (non-localhost) deployment must not boot with the shipped example
+    defaults; `_validate_deployment_settings` raises to prevent it, while leaving
+    local development untouched."""
+
+    def test_local_development_is_never_blocked(self):
+        """localhost is local dev, so the example DEBUG=True + default SECRET_KEY are allowed."""
+        # Should not raise.
+        _validate_deployment_settings("localhost", True, "Change.Me!")
+
+    def test_real_deployment_rejects_debug_true(self):
+        """DEBUG=True on a real domain is refused, so debug pages can't leak in production."""
+        with self.assertRaises(ImproperlyConfigured):
+            _validate_deployment_settings("bytedeck.com", True, "a-real-random-secret-key")
+
+    def test_real_deployment_rejects_default_secret_key(self):
+        """The example 'Change.Me!' SECRET_KEY is refused on a real domain."""
+        with self.assertRaises(ImproperlyConfigured):
+            _validate_deployment_settings("bytedeck.com", False, "Change.Me!")
+
+    def test_properly_configured_deployment_is_allowed(self):
+        """DEBUG=False with a unique SECRET_KEY on a real domain passes the guard."""
+        # Should not raise.
+        _validate_deployment_settings("bytedeck.com", False, "a-real-random-secret-key")


### PR DESCRIPTION
### What?
Adds a startup guard that refuses to boot a **real deployment** using the shipped example defaults, and flips `.env.example.aws` to safe production values.

- `settings.py`: new `_validate_deployment_settings()` raises `ImproperlyConfigured` at import time if `ROOT_DOMAIN` is not `localhost` (i.e. production/staging) **and** either `DEBUG=True` or `SECRET_KEY='Change.Me!'`.
- `.env.example.aws`: `DEBUG=False`, `USE_S3=1`, `SECRET_KEY` documented as must-regenerate.
- `.env.example.aws`: require `POSTGRES_PASSWORD` and disable the passwordless `POSTGRES_HOST_AUTH_METHOD=trust` default (addresses the Postgres trust-auth finding).

### Why?
The AWS env template shipped `DEBUG=True`, `SECRET_KEY=Change.Me!`, `USE_S3=0`, and Postgres `trust` auth — so copying it verbatim to a server would silently expose debug pages, use a publicly-known secret key, and allow passwordless DB access. There was nothing to stop that. The guard turns a dangerous silent misconfiguration into a hard, obvious boot failure, and the template now defaults to the safe production posture.

### How?
- The guard keys off `ROOT_DOMAIN`: `localhost` = local dev (never blocked); anything else = a real deployment that must have `DEBUG=False` and a non-default `SECRET_KEY`. The call is skipped during tests (`'test' in sys.argv`), where weak values are intentional.
- The logic lives in a small pure helper so it's unit-testable; `test_settings.py` covers all four branches (local dev allowed, `DEBUG=True` blocked, default key blocked, proper prod allowed).

### Testing?
- Added `DeploymentSettingsGuardTest` (4 cases) in `src/hackerspace_online/tests/test_settings.py`, covering every branch of the guard.
- Verified locally that the guard's branch logic is correct and that `settings.py` / `test_settings.py` compile.
- The guard is a no-op for local dev and CI (`ROOT_DOMAIN=localhost`), so it doesn't affect the existing `check` / `check --deploy` / test steps.

### Screenshots (if front end is affected)
n/a — configuration/security only.

### Anything Else?
- No behaviour change for local development or existing deployments that are already correctly configured — it only blocks *insecure* real-domain configs.
- Independent of PR #1950 (nginx templating); either can merge first.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_