### PR TITLE
Fix deleting users on the public schema (schema-aware delete cascade)

### DIFF
--- a/src/hackerspace_online/admin.py
+++ b/src/hackerspace_online/admin.py
@@ -67,24 +67,67 @@ class CustomUserAdmin(UserAdmin):
     """
 
     def _on_public_schema(self):
+        """Return ``True`` when the current connection is on the public schema.
+
+        The schema-aware deletion paths below only diverge from Django's default
+        on the public schema; on tenant schemas every table exists so the
+        default behaviour is correct.
+
+        :returns: bool -- whether the active schema is the public schema.
+        """
         return connection.schema_name == get_public_schema_name()
 
     def get_deleted_objects(self, objs, request):
+        """Build the admin delete-confirmation data (schema-aware on public).
+
+        On tenant schemas, defer to Django's default.  On the public schema,
+        use :func:`schema_aware_get_deleted_objects` so the confirmation page
+        doesn't query tenant-only tables that don't exist there (issue #691).
+
+        :param objs: the objects queued for deletion.
+        :param request: the current admin request.
+        :returns: ``(to_delete, model_count, perms_needed, protected)`` -- the
+            same 4-tuple Django's ``get_deleted_objects`` returns.
+        """
         if not self._on_public_schema():
             return super().get_deleted_objects(objs, request)
         return schema_aware_get_deleted_objects(objs, request, self.admin_site)
 
     def delete_model(self, request, obj):
+        """Delete a single user (schema-aware cascade on the public schema).
+
+        On tenant schemas, defer to Django's default ``delete_model``.  On the
+        public schema, delete via :class:`SchemaAwareCollector` so absent
+        tenant-app tables are skipped instead of raising (issue #691).
+        ``origin=obj`` mirrors ``Model.delete()`` so ``pre_delete``/
+        ``post_delete`` receivers still see the triggering object.
+
+        :param request: the current admin request.
+        :param obj: the ``User`` instance to delete.
+        """
         if not self._on_public_schema():
             return super().delete_model(request, obj)
-        collector = SchemaAwareCollector(using=router.db_for_write(obj.__class__, instance=obj))
+        collector = SchemaAwareCollector(
+            using=router.db_for_write(obj.__class__, instance=obj), origin=obj,
+        )
         collector.collect([obj])
         collector.delete()
 
     def delete_queryset(self, request, queryset):
+        """Bulk-delete users (schema-aware cascade on the public schema).
+
+        On tenant schemas, defer to Django's default ``delete_queryset``.  On
+        the public schema, delete via :class:`SchemaAwareCollector` so absent
+        tenant-app tables are skipped instead of raising (issue #691).
+        ``using=queryset.db`` and ``origin=queryset`` mirror ``QuerySet.delete()``
+        so routing and ``pre_delete``/``post_delete`` receivers behave as usual.
+
+        :param request: the current admin request.
+        :param queryset: the ``User`` queryset selected for deletion.
+        """
         if not self._on_public_schema():
             return super().delete_queryset(request, queryset)
-        collector = SchemaAwareCollector(using=router.db_for_write(queryset.model))
+        collector = SchemaAwareCollector(using=queryset.db, origin=queryset)
         collector.collect(queryset)
         collector.delete()
 

--- a/src/hackerspace_online/admin.py
+++ b/src/hackerspace_online/admin.py
@@ -1,9 +1,12 @@
 from allauth.socialaccount.admin import SocialAccountAdmin, SocialAppAdmin
 
 from django.contrib import admin
-from django.contrib.auth.models import Group
-from django.contrib.auth.admin import GroupAdmin
+from django.contrib.auth.models import Group, User
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.sites.models import Site
+from django.db import connection, router
+
+from django_tenants.utils import get_public_schema_name
 
 from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
 from allauth.account.models import EmailAddress
@@ -11,6 +14,7 @@ from allauth.account.models import EmailAddress
 from django_summernote.models import Attachment
 
 from tenant.admin import PublicSchemaOnlyAdminAccessMixin
+from tenant.deletion import SchemaAwareCollector, schema_aware_get_deleted_objects
 
 
 class SiteCustomAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
@@ -50,6 +54,43 @@ class SocialAccountCustomAdmin(PublicSchemaOnlyAdminAccessMixin, SocialAccountAd
 
 admin.site.unregister(SocialAccount)
 admin.site.register(SocialAccount, SocialAccountCustomAdmin)
+
+
+class CustomUserAdmin(UserAdmin):
+    """Django's default UserAdmin, but with schema-aware deletion.
+
+    On the public schema, tenant-app tables (e.g. quest_manager_questsubmission)
+    don't exist, so the default delete cascade fails with
+    ``relation "..." does not exist`` (issue #691).  On the public schema we use
+    the schema-aware collector, which skips those absent tables; on tenant
+    schemas nothing changes (every table is present, so it's a no-op).
+    """
+
+    def _on_public_schema(self):
+        return connection.schema_name == get_public_schema_name()
+
+    def get_deleted_objects(self, objs, request):
+        if not self._on_public_schema():
+            return super().get_deleted_objects(objs, request)
+        return schema_aware_get_deleted_objects(objs, request, self.admin_site)
+
+    def delete_model(self, request, obj):
+        if not self._on_public_schema():
+            return super().delete_model(request, obj)
+        collector = SchemaAwareCollector(using=router.db_for_write(obj.__class__, instance=obj))
+        collector.collect([obj])
+        collector.delete()
+
+    def delete_queryset(self, request, queryset):
+        if not self._on_public_schema():
+            return super().delete_queryset(request, queryset)
+        collector = SchemaAwareCollector(using=router.db_for_write(queryset.model))
+        collector.collect(queryset)
+        collector.delete()
+
+
+admin.site.unregister(User)
+admin.site.register(User, CustomUserAdmin)
 
 
 # Remove a few more models from admin for now to simplify

--- a/src/tenant/deletion.py
+++ b/src/tenant/deletion.py
@@ -28,11 +28,29 @@ class SkipMissingSchemaTablesMixin:
 
     @cached_property
     def _visible_tables(self):
-        # Tables visible on the current search_path.  On the public schema this
-        # excludes the TENANT_APPS tables.
+        """Return the set of table names visible on the current Postgres schema.
+
+        ``connection.introspection.table_names()`` respects the active
+        ``search_path`` (via ``pg_table_is_visible``), so on the public schema
+        this set excludes the ``TENANT_APPS`` tables.  Cached because a single
+        collect walks many related models and the set is stable for the life of
+        the collector.
+        """
         return set(connection.introspection.table_names())
 
     def related_objects(self, related_model, related_fields, objs):
+        """Collect related objects, skipping models whose table isn't visible.
+
+        Overrides ``Collector.related_objects``.  If ``related_model``'s table
+        is absent from the current schema (e.g. a ``TENANT_APPS`` table on the
+        public schema), return an empty queryset so no query is issued and
+        nothing is cascaded for it; otherwise defer to the default behaviour.
+
+        :param related_model: the model on the far side of the reverse relation.
+        :param related_fields: the fields linking ``related_model`` to ``objs``.
+        :param objs: the objects whose related rows are being collected.
+        :returns: a queryset of related objects (empty when the table is absent).
+        """
         if related_model._meta.db_table not in self._visible_tables:
             # Empty queryset -- no DB hit, nothing to cascade for this model.
             return related_model._base_manager.none()

--- a/src/tenant/deletion.py
+++ b/src/tenant/deletion.py
@@ -1,0 +1,95 @@
+"""Schema-aware deletion collectors.
+
+On the public schema, ``TENANT_APPS`` tables (e.g. ``quest_manager_questsubmission``)
+do not exist.  When Django's deletion collector walks a ``User``'s reverse
+relations to build the delete cascade, it queries those tables and raises
+``relation "..." does not exist`` -- which is why a user could not be deleted on
+the public schema (issue #691; the original ``account_emailaddress`` error was
+just the first missing table it hit).
+
+The collectors below skip any related model whose DB table is not visible in the
+current Postgres schema.  On a tenant schema every table is present, so this is a
+no-op and cascades behave exactly as before; on the public schema the tenant-only
+tables are skipped (a public user has no rows in them anyway -- those FKs point at
+each *tenant's* ``auth_user``, not the public one).
+"""
+from django.contrib.admin.utils import NestedObjects, quote
+from django.db import connection, router
+from django.db.models.deletion import Collector
+from django.urls import NoReverseMatch, reverse
+from django.utils.functional import cached_property
+from django.utils.html import format_html
+from django.utils.text import capfirst
+
+
+class SkipMissingSchemaTablesMixin:
+    """Deletion-collector mixin: skip related models whose table isn't visible
+    in the current schema (see module docstring)."""
+
+    @cached_property
+    def _visible_tables(self):
+        # Tables visible on the current search_path.  On the public schema this
+        # excludes the TENANT_APPS tables.
+        return set(connection.introspection.table_names())
+
+    def related_objects(self, related_model, related_fields, objs):
+        if related_model._meta.db_table not in self._visible_tables:
+            # Empty queryset -- no DB hit, nothing to cascade for this model.
+            return related_model._base_manager.none()
+        return super().related_objects(related_model, related_fields, objs)
+
+
+class SchemaAwareCollector(SkipMissingSchemaTablesMixin, Collector):
+    """Collector used for the actual delete()."""
+
+
+class SchemaAwareNestedObjects(SkipMissingSchemaTablesMixin, NestedObjects):
+    """Collector used to build the admin delete-confirmation page."""
+
+
+def schema_aware_get_deleted_objects(objs, request, admin_site):
+    """Mirror of ``django.contrib.admin.utils.get_deleted_objects`` that uses
+    :class:`SchemaAwareNestedObjects`, so rendering the delete-confirmation page
+    doesn't query tables absent from the current schema (issue #691)."""
+    try:
+        obj = objs[0]
+    except IndexError:
+        return [], {}, set(), []
+    else:
+        using = router.db_for_write(obj._meta.model)
+    collector = SchemaAwareNestedObjects(using=using, origin=objs)
+    collector.collect(objs)
+    perms_needed = set()
+
+    def format_callback(obj):
+        model = obj.__class__
+        has_admin = model in admin_site._registry
+        opts = obj._meta
+
+        no_edit_link = "%s: %s" % (capfirst(opts.verbose_name), obj)
+
+        if has_admin:
+            if not admin_site._registry[model].has_delete_permission(request, obj):
+                perms_needed.add(opts.verbose_name)
+            try:
+                admin_url = reverse(
+                    "%s:%s_%s_change" % (admin_site.name, opts.app_label, opts.model_name),
+                    None,
+                    (quote(obj.pk),),
+                )
+            except NoReverseMatch:
+                return no_edit_link
+            return format_html(
+                '{}: <a href="{}">{}</a>', capfirst(opts.verbose_name), admin_url, obj
+            )
+        else:
+            return no_edit_link
+
+    to_delete = collector.nested(format_callback)
+    protected = [format_callback(obj) for obj in collector.protected]
+    model_count = {
+        model._meta.verbose_name_plural: len(objs)
+        for model, objs in collector.model_objs.items()
+    }
+
+    return to_delete, model_count, perms_needed, protected

--- a/src/tenant/tests/test_schema_aware_user_delete.py
+++ b/src/tenant/tests/test_schema_aware_user_delete.py
@@ -1,0 +1,88 @@
+"""Tests for schema-aware user deletion (issue #691).
+
+Deleting a user on the *public* schema used to fail because Django's deletion
+collector queried TENANT_APPS tables (e.g. quest_manager_questsubmission) that
+don't exist there.  The schema-aware collectors skip absent tables on the public
+schema, while remaining a no-op on tenant schemas (where every table exists and
+cascades must still work).
+"""
+from allauth.account.models import EmailAddress
+
+from django.contrib import admin as django_admin
+from django.contrib.auth import get_user_model
+from django.db import router
+from django.test import RequestFactory
+
+from django_tenants.test.cases import TenantTestCase
+from django_tenants.utils import get_public_schema_name, schema_context
+from model_bakery import baker
+
+from quest_manager.models import Quest, QuestSubmission
+from siteconfig.models import SiteConfig
+from tenant.deletion import (
+    SchemaAwareCollector,
+    SchemaAwareNestedObjects,
+    schema_aware_get_deleted_objects,
+)
+
+User = get_user_model()
+
+
+class SchemaAwareUserDeleteTest(TenantTestCase):
+
+    def test_public_schema_user_delete_succeeds(self):
+        """A user (with an allauth EmailAddress) can be deleted on the public
+        schema even though tenant-app tables are absent there (#691)."""
+        with schema_context(get_public_schema_name()):
+            user = User.objects.create_user("pub_del", "p@e.com", "pw")
+            EmailAddress.objects.create(user=user, email="p@e.com", verified=True, primary=True)
+            uid = user.pk
+
+            collector = SchemaAwareCollector(using=router.db_for_write(User))
+            collector.collect([user])   # would raise relation-does-not-exist without the fix
+            collector.delete()
+
+            self.assertFalse(User.objects.filter(pk=uid).exists())
+            self.assertFalse(EmailAddress.objects.filter(user_id=uid).exists())
+
+    def test_public_schema_nested_collect_does_not_raise(self):
+        """The admin delete-confirmation collector also skips absent tables."""
+        with schema_context(get_public_schema_name()):
+            user = User.objects.create_user("pub_nested", "n@e.com", "pw")
+            EmailAddress.objects.create(user=user, email="n@e.com", verified=True, primary=True)
+
+            collector = SchemaAwareNestedObjects(using=router.db_for_write(User))
+            collector.collect([user])  # would raise without the fix
+            self.assertIn(user, [o for objs in collector.model_objs.values() for o in objs])
+
+    def test_public_schema_get_deleted_objects(self):
+        """schema_aware_get_deleted_objects builds the confirmation data without
+        querying tenant tables."""
+        with schema_context(get_public_schema_name()):
+            superuser = User.objects.create_superuser("pub_su", "su@e.com", "pw")
+            user = User.objects.create_user("pub_gdo", "g@e.com", "pw")
+            EmailAddress.objects.create(user=user, email="g@e.com", verified=True, primary=True)
+
+            request = RequestFactory().get("/")
+            request.user = superuser
+            to_delete, model_count, perms_needed, protected = schema_aware_get_deleted_objects(
+                [user], request, django_admin.site,
+            )
+            self.assertIn("pub_gdo", str(to_delete))
+
+    def test_tenant_schema_user_delete_still_cascades(self):
+        """On a tenant schema every table exists, so the schema-aware collector
+        cascades exactly like the default (a regression guard for the fix)."""
+        user = baker.make(User)
+        quest = baker.make(Quest)
+        sub = baker.make(
+            QuestSubmission, user=user, quest=quest,
+            semester=SiteConfig.get().active_semester,
+        )
+
+        collector = SchemaAwareCollector(using=router.db_for_write(User))
+        collector.collect([user])
+        collector.delete()
+
+        self.assertFalse(User.objects.filter(pk=user.pk).exists())
+        self.assertFalse(QuestSubmission.objects.filter(pk=sub.pk).exists())

--- a/src/tenant/tests/test_schema_aware_user_delete.py
+++ b/src/tenant/tests/test_schema_aware_user_delete.py
@@ -16,8 +16,11 @@ mirrors ``tenant.tests.test_admin.PublicTenantTestAdminPublic``.
 from allauth.account.models import EmailAddress
 
 from django.conf import settings
+from django.contrib import admin as django_admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
+from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.test import RequestFactory
 from django.urls import reverse
 
 from django_tenants.test.cases import TenantTestCase
@@ -126,6 +129,38 @@ class SchemaAwareUserDeleteAdminPublicTest(TenantTestCase):
         self.assertEqual(perms_needed, set())
         self.assertEqual(protected, [])
 
+    def test_get_deleted_objects__reports_perms_needed_without_delete_permission(self):
+        """When the requesting user lacks delete permission on a collected
+        (admin-registered) model, its verbose name is reported in
+        ``perms_needed`` -- the ``has_delete_permission`` branch."""
+        with tenant_context(self.public_tenant):
+            staff = User.objects.create_user("staff_nodel", "s@e.com", "pw", is_staff=True)
+            request = RequestFactory().get("/")
+            request.user = staff  # staff, but no auth.delete_user permission
+
+            _, _, perms_needed, _ = schema_aware_get_deleted_objects(
+                [self.target], request, django_admin.site,
+            )
+        self.assertIn(User._meta.verbose_name, perms_needed)
+
+    def test_get_deleted_objects__unresolvable_change_url_falls_back_to_plain_label(self):
+        """When a collected object's admin change URL can't be reversed,
+        ``format_callback`` falls back to a plain (unlinked) label -- the
+        ``NoReverseMatch`` guard.  An ``AdminSite`` whose URLs aren't wired into
+        the URLconf makes ``reverse()`` fail for its registered models."""
+        with tenant_context(self.public_tenant):
+            unwired = AdminSite(name="unwired_site")
+            unwired.register(User)  # registered, but "unwired_site:..." isn't in urls
+            request = RequestFactory().get("/")
+            request.user = self.superuser
+
+            to_delete, _, _, _ = schema_aware_get_deleted_objects(
+                [self.target], request, unwired,
+            )
+        # Falls back to "User: target" with no <a href> link.
+        self.assertIn("target", str(to_delete))
+        self.assertNotIn("href", str(to_delete))
+
 
 class SchemaAwareUserDeleteAdminTenantTest(TenantTestCase):
     """Regression guard: on a tenant schema every table exists, so
@@ -151,6 +186,33 @@ class SchemaAwareUserDeleteAdminTenantTest(TenantTestCase):
         self.client.force_login(self.superuser)
         url = reverse("admin:auth_user_delete", args=(student.pk,))
         response = self.client.post(url, {"post": "yes"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(User.objects.filter(pk=student.pk).exists())
+        self.assertFalse(QuestSubmission.objects.filter(pk=sub.pk).exists())
+
+    def test_delete_queryset__tenant_schema_bulk_delete_still_cascades(self):
+        """The ``delete_selected`` bulk action on a tenant schema falls through
+        to Django's default ``delete_queryset`` and still cascades to the
+        selected users' QuestSubmission rows."""
+        student = baker.make(User)
+        quest = baker.make(Quest)
+        sub = baker.make(
+            QuestSubmission, user=student, quest=quest,
+            semester=SiteConfig.get().active_semester,
+        )
+
+        self.client.force_login(self.superuser)
+        changelist_url = reverse("admin:auth_user_changelist")
+        action_data = {
+            "action": "delete_selected",
+            ACTION_CHECKBOX_NAME: [str(student.pk)],
+        }
+        confirm = self.client.post(changelist_url, action_data)
+        self.assertEqual(confirm.status_code, 200)
+
+        action_data["post"] = "yes"
+        response = self.client.post(changelist_url, action_data)
 
         self.assertEqual(response.status_code, 302)
         self.assertFalse(User.objects.filter(pk=student.pk).exists())

--- a/src/tenant/tests/test_schema_aware_user_delete.py
+++ b/src/tenant/tests/test_schema_aware_user_delete.py
@@ -1,88 +1,157 @@
 """Tests for schema-aware user deletion (issue #691).
 
 Deleting a user on the *public* schema used to fail because Django's deletion
-collector queried TENANT_APPS tables (e.g. quest_manager_questsubmission) that
-don't exist there.  The schema-aware collectors skip absent tables on the public
-schema, while remaining a no-op on tenant schemas (where every table exists and
-cascades must still work).
+collector queried ``TENANT_APPS`` tables (e.g. ``quest_manager_questsubmission``)
+that don't exist there.  ``CustomUserAdmin`` routes deletion through the
+schema-aware collectors on the public schema, which skip absent tables, while
+remaining a no-op on tenant schemas (where every table exists and cascades must
+still work).
+
+These tests drive the *actual* admin endpoints with ``TenantClient`` -- the
+delete-confirmation page, single-object delete, and bulk ``delete_selected``
+action -- so they exercise the registered ``CustomUserAdmin`` overrides and would
+fail if it were unregistered or dispatched incorrectly.  The public-schema setup
+mirrors ``tenant.tests.test_admin.PublicTenantTestAdminPublic``.
 """
 from allauth.account.models import EmailAddress
 
-from django.contrib import admin as django_admin
+from django.conf import settings
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.auth import get_user_model
-from django.db import router
-from django.test import RequestFactory
+from django.urls import reverse
 
 from django_tenants.test.cases import TenantTestCase
-from django_tenants.utils import get_public_schema_name, schema_context
+from django_tenants.test.client import TenantClient
+from django_tenants.utils import tenant_context
 from model_bakery import baker
 
 from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
-from tenant.deletion import (
-    SchemaAwareCollector,
-    SchemaAwareNestedObjects,
-    schema_aware_get_deleted_objects,
-)
+from tenant.deletion import schema_aware_get_deleted_objects
+from tenant.models import Tenant
 
 User = get_user_model()
 
 
-class SchemaAwareUserDeleteTest(TenantTestCase):
+class SchemaAwareUserDeleteAdminPublicTest(TenantTestCase):
+    """Public-schema user deletion through the Django admin (issue #691).
 
-    def test_public_schema_user_delete_succeeds(self):
-        """A user (with an allauth EmailAddress) can be deleted on the public
-        schema even though tenant-app tables are absent there (#691)."""
-        with schema_context(get_public_schema_name()):
-            user = User.objects.create_user("pub_del", "p@e.com", "pw")
-            EmailAddress.objects.create(user=user, email="p@e.com", verified=True, primary=True)
-            uid = user.pk
+    On the public schema the ``TENANT_APPS`` tables are absent, so the default
+    admin delete cascade raises ``relation "..." does not exist``.  These tests
+    confirm ``CustomUserAdmin`` makes the confirmation page and the delete paths
+    succeed there.
+    """
 
-            collector = SchemaAwareCollector(using=router.db_for_write(User))
-            collector.collect([user])   # would raise relation-does-not-exist without the fix
-            collector.delete()
+    def setUp(self):
+        # Build the public tenant + a superuser to drive the admin, mirroring
+        # tenant.tests.test_admin.PublicTenantTestAdminPublic.
+        self.public_tenant = Tenant(schema_name="public", name="public")
+        with tenant_context(self.public_tenant):
+            self.superuser = User.objects.create_superuser(
+                username="admin",
+                password=settings.TENANT_DEFAULT_ADMIN_PASSWORD,
+            )
+            # Bulk-create to skip the tenant post_save/pre_save signals (fast).
+            Tenant.objects.bulk_create([self.public_tenant])
+            self.public_tenant.refresh_from_db()
+            self.public_tenant.domains.create(domain="localhost", is_primary=True)
 
+            # The user we'll delete, plus an allauth EmailAddress -- the original
+            # #691 failure surfaced first as a missing account_emailaddress table.
+            self.target = User.objects.create_user("target", "target@example.com", "pw")
+            EmailAddress.objects.create(
+                user=self.target, email="target@example.com", verified=True, primary=True,
+            )
+
+        self.client = TenantClient(self.public_tenant)
+
+    def test_get_deleted_objects__public_schema_confirmation_page_renders(self):
+        """The delete-confirmation page renders on the public schema (it would
+        raise ``relation ... does not exist`` without the schema-aware fix)."""
+        # Everything runs inside the public-schema context so force_login's
+        # last_login save (and the admin request) target the schema where the
+        # superuser and target actually live.
+        with tenant_context(self.public_tenant):
+            self.client.force_login(self.superuser)
+            url = reverse("admin:auth_user_delete", args=(self.target.pk,))
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "target")
+
+    def test_delete_model__public_schema_single_user_delete_succeeds(self):
+        """POSTing the delete-confirmation form deletes the user (and its
+        EmailAddress) on the public schema via ``delete_model``."""
+        with tenant_context(self.public_tenant):
+            self.client.force_login(self.superuser)
+            uid = self.target.pk
+            url = reverse("admin:auth_user_delete", args=(uid,))
+            response = self.client.post(url, {"post": "yes"})
+
+            self.assertEqual(response.status_code, 302)
             self.assertFalse(User.objects.filter(pk=uid).exists())
             self.assertFalse(EmailAddress.objects.filter(user_id=uid).exists())
 
-    def test_public_schema_nested_collect_does_not_raise(self):
-        """The admin delete-confirmation collector also skips absent tables."""
-        with schema_context(get_public_schema_name()):
-            user = User.objects.create_user("pub_nested", "n@e.com", "pw")
-            EmailAddress.objects.create(user=user, email="n@e.com", verified=True, primary=True)
+    def test_delete_queryset__public_schema_bulk_delete_succeeds(self):
+        """The ``delete_selected`` admin action deletes users on the public
+        schema via ``delete_queryset``."""
+        with tenant_context(self.public_tenant):
+            self.client.force_login(self.superuser)
+            uid = self.target.pk
+            changelist_url = reverse("admin:auth_user_changelist")
+            action_data = {
+                "action": "delete_selected",
+                ACTION_CHECKBOX_NAME: [str(uid)],
+            }
+            # First POST renders the "are you sure?" confirmation page.
+            confirm = self.client.post(changelist_url, action_data)
+            self.assertEqual(confirm.status_code, 200)
+            self.assertContains(confirm, "target")
 
-            collector = SchemaAwareNestedObjects(using=router.db_for_write(User))
-            collector.collect([user])  # would raise without the fix
-            self.assertIn(user, [o for objs in collector.model_objs.values() for o in objs])
+            # Second POST (with post=yes) actually performs the delete.
+            action_data["post"] = "yes"
+            response = self.client.post(changelist_url, action_data)
 
-    def test_public_schema_get_deleted_objects(self):
-        """schema_aware_get_deleted_objects builds the confirmation data without
-        querying tenant tables."""
-        with schema_context(get_public_schema_name()):
-            superuser = User.objects.create_superuser("pub_su", "su@e.com", "pw")
-            user = User.objects.create_user("pub_gdo", "g@e.com", "pw")
-            EmailAddress.objects.create(user=user, email="g@e.com", verified=True, primary=True)
+            self.assertEqual(response.status_code, 302)
+            self.assertFalse(User.objects.filter(pk=uid).exists())
 
-            request = RequestFactory().get("/")
-            request.user = superuser
+    def test_get_deleted_objects__empty_object_list_returns_empty(self):
+        """``schema_aware_get_deleted_objects`` handles an empty selection
+        (the ``IndexError`` guard) without touching the database."""
+        with tenant_context(self.public_tenant):
             to_delete, model_count, perms_needed, protected = schema_aware_get_deleted_objects(
-                [user], request, django_admin.site,
+                [], object(), None,
             )
-            self.assertIn("pub_gdo", str(to_delete))
+        self.assertEqual(to_delete, [])
+        self.assertEqual(model_count, {})
+        self.assertEqual(perms_needed, set())
+        self.assertEqual(protected, [])
 
-    def test_tenant_schema_user_delete_still_cascades(self):
-        """On a tenant schema every table exists, so the schema-aware collector
-        cascades exactly like the default (a regression guard for the fix)."""
-        user = baker.make(User)
+
+class SchemaAwareUserDeleteAdminTenantTest(TenantTestCase):
+    """Regression guard: on a tenant schema every table exists, so
+    ``CustomUserAdmin`` falls through to Django's default and the delete cascade
+    still removes related tenant rows (e.g. QuestSubmission)."""
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+        self.superuser = User.objects.create_superuser(
+            username="tenant_admin", email="ta@example.com", password="pw",
+        )
+
+    def test_delete_model__tenant_schema_still_cascades_to_submissions(self):
+        """Deleting a user through the admin on a tenant schema cascades to the
+        user's QuestSubmission rows exactly like the default admin."""
+        student = baker.make(User)
         quest = baker.make(Quest)
         sub = baker.make(
-            QuestSubmission, user=user, quest=quest,
+            QuestSubmission, user=student, quest=quest,
             semester=SiteConfig.get().active_semester,
         )
 
-        collector = SchemaAwareCollector(using=router.db_for_write(User))
-        collector.collect([user])
-        collector.delete()
+        self.client.force_login(self.superuser)
+        url = reverse("admin:auth_user_delete", args=(student.pk,))
+        response = self.client.post(url, {"post": "yes"})
 
-        self.assertFalse(User.objects.filter(pk=user.pk).exists())
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(User.objects.filter(pk=student.pk).exists())
         self.assertFalse(QuestSubmission.objects.filter(pk=sub.pk).exists())


### PR DESCRIPTION
### What?
Make it possible to delete a user on the **public** schema (e.g. a bytedeck admin/superuser) via Django admin, without the delete cascade crashing on tenant-only tables. Closes #691.

### Why?
Deleting a user on the public schema raised `relation "..." does not exist`. Django's deletion collector walks **every** reverse FK to `User` — including `TENANT_APPS` models like `QuestSubmission` — and queries their tables to gather the cascade. Those tables don't exist on the public schema, so `collector.collect()` throws.

The original report hit `account_emailaddress` (allauth was tenant-only at the time). allauth has since moved to `SHARED_APPS`, so that table now exists on public — but the delete then fails one step later on the next tenant-only table (`quest_manager_questsubmission`). I reproduced this on current `develop` while triaging #691. So the symptom ("can't delete public-schema users") was never actually resolved, just shifted downstream.

### How?
`src/tenant/deletion.py` — a `SkipMissingSchemaTablesMixin` for Django's deletion collectors that overrides `related_objects()` to return an empty queryset (no DB hit) for any related model whose table isn't visible in the current schema. Two concrete collectors use it:
* `SchemaAwareCollector` (for the actual `delete()`), and
* `SchemaAwareNestedObjects` (for the admin delete-confirmation page),

plus `schema_aware_get_deleted_objects()`, a mirror of Django's `get_deleted_objects()` that uses the nested variant.

`src/hackerspace_online/admin.py` — a `CustomUserAdmin` (subclass of Django's `UserAdmin`) that routes `get_deleted_objects`, `delete_model` and `delete_queryset` through the schema-aware collectors **only on the public schema**; on tenant schemas it defers to Django's default. Because the mixin only skips tables that genuinely aren't present, it's a no-op on tenant schemas — every table is there, so cascades are unchanged. (A public user has no tenant rows anyway: tenant FKs reference each tenant's own `auth_user`, not the public one.)

No model/migration changes.

### Testing?
`python src/manage.py test tenant hackerspace_online` locally (Postgres + Redis). New tests in `tenant/tests/test_schema_aware_user_delete.py`:
* public-schema user (with an allauth `EmailAddress`) deletes successfully — the exact #691 scenario;
* the confirmation-page collector (`SchemaAwareNestedObjects`) and `schema_aware_get_deleted_objects()` don't raise on the public schema;
* **tenant-schema** user delete still cascades to `QuestSubmission` (regression guard that the fix is a no-op there).

All pass. The only failure in the two suites is the pre-existing `PublicContactFormTest.test_valid_data`, which makes an external reCAPTCHA HTTPS call blocked by the sandbox network — unrelated to this change. `flake8 src` clean.

### Screenshots (if front end is affected)
N/A — admin/back-end behaviour only.

### Anything Else?
Found while working through the issue-tracker audit. The scope here is the `User` admin (the reported path); the same collector could be reused if other public-schema deletes hit the same wall.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user deletion from the admin interface on the public schema.
  * Prevented deletion confirmations and cascades from failing when tenant-only tables are unavailable.
  * Ensured related user records are removed correctly while preserving expected deletion behavior within tenant schemas.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->