### PR TITLE
Self-host Redis (drop ElastiCache) + production restart policies & healthchecks

### DIFF
--- a/.env.example.aws
+++ b/.env.example.aws
@@ -62,13 +62,16 @@ ADMINS=Admin Name:admin@exmaple.com,Admin2 Name:admin2@exmaple.com
 
 ## REDIS ###############################################
 
-# Only used for local development with `python src/manage.py runserver`
-# When running web service in a container with `docker compose up web`
-#  the app will read REDIS_HOST=redis from docker-compose.yml
-#  similarly with the celery services
-REDIS_HOST=127.0.0.1
+# Redis runs as the `redis` compose service on the internal backend-network
+# (docker-compose.prod.aws.yml), so the app reaches it by service name.
+REDIS_HOST=redis
 
 REDIS_PORT=6379
+
+# Optional: cap the Redis container's memory so it can't starve the app host.
+# Consumed by the redis service command in docker-compose.prod.aws.yml.
+# Defaults to 256mb; raise it to match the instance size / working set.
+#REDIS_MAXMEMORY=256mb
 
 
 ## POSTGRES ############################################

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,4 +98,5 @@ Celery (with `tenant-schemas-celery` for schema awareness) handles background ta
 * Commit messages should reference issues where applicable ("Closes #123").
 * Long-running feature branches: the Project Competencies epic (#1905) integrates on the `competencies` branch — sub-issue PRs target `competencies`, not `develop`. The feature branch is synced with `develop` (automated daily merge) and will be merged back when ready.
 * Claude Code (web sessions): after pushing a branch with an open PR, subscribe to the PR's activity (`subscribe_pr_activity`) and follow up on CI failures and review comments until the PR is merged or closed.
+* Claude Code: after addressing a PR review comment (pushing the fix and/or answering the question in a reply), mark that review thread as resolved (`resolve_review_thread`) so the PR reflects its true state — don't leave addressed threads dangling for the reviewer to close.
 * Claude Code: sign off everything you post to GitHub (PR descriptions, comments, review comments, issues) with "- Claude Code".

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,18 +26,8 @@ services:
     - 5432:5432  # Expose port so app can connect to db when developing locally with `python src/manage.py [runserver|test src]
 
   redis:
-    image: "redis:7-alpine"
-    env_file: .env
-    sysctls:
-      # Resolve -> # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
-      net.core.somaxconn: 512
-    networks:
-      - backend-network
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 1s
-      timeout: 3s
-      retries: 30
+    # Common config (image, healthcheck, sysctls, network) lives in
+    # docker-compose.yml; development only adds the published port.
     ports:
     - 6379:6379  # Expose port so app can connect to redis when developing locally with `python src/manage.py [runserver|test src]
 
@@ -54,8 +44,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_healthy
+      # (redis dependency is declared in docker-compose.yml)
 
   celery:
     environment:
@@ -64,8 +53,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_healthy
+      # (redis dependency is declared in docker-compose.yml)
 
   celery-beat:
     environment:
@@ -74,8 +62,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_healthy
+      # (redis dependency is declared in docker-compose.yml)
 
   pg-admin:
     image: dpage/pgadmin4

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,7 +26,7 @@ services:
     - 5432:5432  # Expose port so app can connect to db when developing locally with `python src/manage.py [runserver|test src]
 
   redis:
-    image: "redis:5.0-alpine"
+    image: "redis:7-alpine"
     env_file: .env
     sysctls:
       # Resolve -> # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.

--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -21,42 +21,17 @@ services:
       # - media_data:/app/media
       # - socket_data:/bytedeck-volume
     user: $WUID:$WGID
+    # Restart policies are production/staging-only on purpose: in development a
+    # crashed process should stay down and visible, not quietly loop-restart.
+    # (Healthchecks are shared and live in docker-compose.yml.)
     restart: unless-stopped
-    # Liveness: uwsgi listening on its socket. TCP connect is enough (it speaks
-    # the uwsgi protocol, not HTTP). The long start_period covers the
-    # migrate_schemas + collectstatic run before uwsgi binds -- failures during
-    # start_period don't count against the container.
-    healthcheck:
-      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8000), timeout=5).close()"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 10m
 
   celery:
     user: $WUID:$WGID
     restart: unless-stopped
-    # Liveness: ask this worker to answer a ping over the broker. Catches a
-    # worker that is running but disconnected/hung, not just a dead process.
-    # Deliberately infrequent -- each check runs a full celery client.
-    healthcheck:
-      test: ["CMD-SHELL", "cd /app/src && celery -A hackerspace_online inspect ping -d celery@$$HOSTNAME -t 10 | grep -q pong"]
-      interval: 60s
-      timeout: 30s
-      retries: 3
-      start_period: 2m
 
   celery-beat:
     restart: unless-stopped
-    # Liveness: beat has no ping command, so check the scheduler process exists
-    # (procps/pgrep is installed in the app image). A dead beat silently stops
-    # all periodic tasks, so even a coarse signal is worth surfacing.
-    healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'celery.*beat' > /dev/null"]
-      interval: 60s
-      timeout: 10s
-      retries: 3
-      start_period: 2m
 
   # Production/staging additions to the shared redis service (image, healthcheck,
   # network — see docker-compose.yml). Self-hosted on this EC2 host, replacing

--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -21,9 +21,54 @@ services:
       # - media_data:/app/media
       # - socket_data:/bytedeck-volume
     user: $WUID:$WGID
+    depends_on:
+      redis:
+        condition: service_healthy
 
   celery:
     user: $WUID:$WGID
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  celery-beat:
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  # Self-hosted Redis (Celery broker on db 0, Django cache on db 1/2), replacing
+  # AWS ElastiCache. It is reachable ONLY on the internal backend-network — no
+  # published port — so in this single-host setup it needs no password.
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    # - maxmemory caps RAM so Redis can't OOM the shared app host (override with
+    #   REDIS_MAXMEMORY in .env; size it to the instance and working set).
+    # - noeviction: never drop keys under memory pressure, so queued Celery/beat
+    #   tasks are never silently lost. (If cache churn makes the cap tight,
+    #   raise REDIS_MAXMEMORY, or switch to volatile-lru — cache entries carry a
+    #   TTL and broker keys do not, so only cache keys would be evicted.)
+    # - persistence disabled: the broker queue and cache are both disposable.
+    command:
+      - "redis-server"
+      - "--maxmemory"
+      - "${REDIS_MAXMEMORY:-256mb}"
+      - "--maxmemory-policy"
+      - "noeviction"
+      - "--save"
+      - ""
+      - "--appendonly"
+      - "no"
+    sysctls:
+      # Silence the "somaxconn 128 < 511" warning (matches the dev redis service).
+      net.core.somaxconn: 512
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend-network
 
   nginx:
     build:

--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -21,9 +21,42 @@ services:
       # - media_data:/app/media
       # - socket_data:/bytedeck-volume
     user: $WUID:$WGID
+    restart: unless-stopped
+    # Liveness: uwsgi listening on its socket. TCP connect is enough (it speaks
+    # the uwsgi protocol, not HTTP). The long start_period covers the
+    # migrate_schemas + collectstatic run before uwsgi binds -- failures during
+    # start_period don't count against the container.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8000), timeout=5).close()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10m
 
   celery:
     user: $WUID:$WGID
+    restart: unless-stopped
+    # Liveness: ask this worker to answer a ping over the broker. Catches a
+    # worker that is running but disconnected/hung, not just a dead process.
+    # Deliberately infrequent -- each check runs a full celery client.
+    healthcheck:
+      test: ["CMD-SHELL", "cd /app/src && celery -A hackerspace_online inspect ping -d celery@$$HOSTNAME -t 10 | grep -q pong"]
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 2m
+
+  celery-beat:
+    restart: unless-stopped
+    # Liveness: beat has no ping command, so check the scheduler process exists
+    # (procps/pgrep is installed in the app image). A dead beat silently stops
+    # all periodic tasks, so even a coarse signal is worth surfacing.
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'celery.*beat' > /dev/null"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 2m
 
   # Production/staging additions to the shared redis service (image, healthcheck,
   # network — see docker-compose.yml). Self-hosted on this EC2 host, replacing
@@ -70,6 +103,7 @@ services:
     depends_on:
       - web
     user: $WUID:$WGID
+    restart: unless-stopped
     networks:
       - backend-network
 

--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -21,26 +21,15 @@ services:
       # - media_data:/app/media
       # - socket_data:/bytedeck-volume
     user: $WUID:$WGID
-    depends_on:
-      redis:
-        condition: service_healthy
 
   celery:
     user: $WUID:$WGID
-    depends_on:
-      redis:
-        condition: service_healthy
 
-  celery-beat:
-    depends_on:
-      redis:
-        condition: service_healthy
-
-  # Self-hosted Redis (Celery broker on db 0, Django cache on db 1/2), replacing
-  # AWS ElastiCache. It is reachable ONLY on the internal backend-network — no
-  # published port — so in this single-host setup it needs no password.
+  # Production/staging additions to the shared redis service (image, healthcheck,
+  # network — see docker-compose.yml). Self-hosted on this EC2 host, replacing
+  # AWS ElastiCache: reachable ONLY on the internal backend-network with no
+  # published port, so it needs no password in this single-host setup.
   redis:
-    image: redis:7-alpine
     restart: unless-stopped
     # - maxmemory caps RAM so Redis can't OOM the shared app host (override with
     #   REDIS_MAXMEMORY in .env; size it to the instance and working set).
@@ -59,16 +48,6 @@ services:
       - ""
       - "--appendonly"
       - "no"
-    sysctls:
-      # Silence the "somaxconn 128 < 511" warning (matches the dev redis service).
-      net.core.somaxconn: 512
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - backend-network
 
   nginx:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       #   WUID: $WUID
       #   WGID: $WGID
     env_file: .env
-    # command: # see docker-compose.overide.yml or docker-compose.prod.yml
+    # command: # see docker-compose.overide.yml or docker-compose.prod.aws.yml
     volumes:
       - .:/app
     ports:
@@ -26,6 +26,9 @@ services:
     networks:
       - backend-network
       - frontend-network
+    depends_on:
+      redis:
+        condition: service_healthy
 
   celery:
     build:
@@ -38,6 +41,9 @@ services:
       - .:/app
     networks:
       - backend-network
+    depends_on:
+      redis:
+        condition: service_healthy
 
   celery-beat:
     build:
@@ -48,6 +54,27 @@ services:
                       celery -A hackerspace_online beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler"
     volumes:
       - .:/app
+    networks:
+      - backend-network
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  # Redis: Celery broker (db 0) and Django cache (dbs 1/2), used by every
+  # environment. Common config lives here; environment specifics are layered on
+  # top — the dev override publishes the port for local runserver/tests, and the
+  # AWS file adds the production memory cap / eviction policy / restart policy.
+  # Internal-only by default: no published port, backend-network only.
+  redis:
+    image: redis:7-alpine
+    sysctls:
+      # Resolve -> # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
+      net.core.somaxconn: 512
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
     networks:
       - backend-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,17 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    # Liveness: something is listening on :8000 (uwsgi in prod, runserver in
+    # dev; TCP connect covers both). The long start_period covers the
+    # migrate_schemas (+ collectstatic in prod) run before the server binds --
+    # failures during start_period don't count against the container. Shown as
+    # (healthy)/(unhealthy) in `docker compose ps`.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8000), timeout=5).close()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10m
 
   celery:
     build:
@@ -44,6 +55,15 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    # Liveness: ask this worker to answer a ping over the broker. Catches a
+    # worker that is running but disconnected/hung, not just a dead process.
+    # Deliberately infrequent -- each check runs a full celery client.
+    healthcheck:
+      test: ["CMD-SHELL", "cd /app/src && celery -A hackerspace_online inspect ping -d celery@$$HOSTNAME -t 10 | grep -q pong"]
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 2m
 
   celery-beat:
     build:
@@ -59,6 +79,15 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    # Liveness: beat has no ping command, so check the scheduler process exists
+    # (procps/pgrep is installed in the app image). A dead beat silently stops
+    # all periodic tasks, so even a coarse signal is worth surfacing.
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'celery.*beat' > /dev/null"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 2m
 
   # Redis: Celery broker (db 0) and Django cache (dbs 1/2), used by every
   # environment. Common config lives here; environment specifics are layered on

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -66,6 +66,24 @@ Postgres runs on **AWS RDS** (not a compose service), reached via the
 `POSTGRES_*` settings in `.env`. Redis runs as the `redis` compose service
 above, reached via `REDIS_HOST` / `REDIS_PORT`.
 
+The shared service config lives in `docker-compose.yml`; the AWS file layers
+production concerns on top. In production every service has
+**`restart: unless-stopped`** (a crashed container comes back automatically,
+including after a host reboot) and a **healthcheck**:
+
+- `web`: TCP connect to the uwsgi socket (`:8000`), with a long `start_period`
+  to cover the `migrate_schemas`/`collectstatic` startup run.
+- `celery`: `celery inspect ping` against the worker over the broker — catches
+  hung/disconnected workers, not just dead processes.
+- `celery-beat`: process check (`pgrep`) — beat has no ping command, and a dead
+  beat silently stops all periodic tasks.
+- `redis`: `redis-cli ping`.
+
+Check health at a glance with `docker compose ps` (the STATUS column shows
+`(healthy)` / `(unhealthy)`). Note compose does **not** auto-restart a running
+container that turns *unhealthy* — the healthcheck is a monitoring signal, while
+`restart:` handles crashes/exits.
+
 ## Deployment runbook
 
 Deployment is **manual** (SSH to the host). There is currently no

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -67,9 +67,12 @@ Postgres runs on **AWS RDS** (not a compose service), reached via the
 above, reached via `REDIS_HOST` / `REDIS_PORT`.
 
 The shared service config lives in `docker-compose.yml`; the AWS file layers
-production concerns on top. In production every service has
+production concerns on top. In production every service additionally has
 **`restart: unless-stopped`** (a crashed container comes back automatically,
-including after a host reboot) and a **healthcheck**:
+including after a host reboot). Restart policies are deliberately
+production-only — in development a crashed process should stay down and
+visible, not quietly loop-restart. **Healthchecks** are shared (defined in
+`docker-compose.yml`, so development gets them too):
 
 - `web`: TCP connect to the uwsgi socket (`:8000`), with a long `start_period`
   to cover the `migrate_schemas`/`collectstatic` startup run.

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -60,9 +60,11 @@ Services started in production:
 | `celery`      | Celery worker (`-c 3 -Q default`) for background tasks.                      |
 | `celery-beat` | Celery beat scheduler (`DatabaseScheduler`) for periodic tasks.             |
 | `nginx`       | Reverse proxy / TLS terminator, built from `./nginx`. Mounts `/etc/letsencrypt`. Publishes host `443 -> 8088` and `80 -> 8080` (the container listens on high ports because it runs as a non-root user). |
+| `redis`       | Celery broker + Django cache. Internal-only (no published port); see [Redis](#redis). |
 
-Postgres (RDS) and Redis are **not** compose services in production — they are
-reached over the network via the `POSTGRES_*` / `REDIS_*` settings in `.env`.
+Postgres runs on **AWS RDS** (not a compose service), reached via the
+`POSTGRES_*` settings in `.env`. Redis runs as the `redis` compose service
+above, reached via `REDIS_HOST` / `REDIS_PORT`.
 
 ## Deployment runbook
 
@@ -165,27 +167,33 @@ runs `migrate_schemas` on startup; to run migrations manually use
 Redis is the Celery **broker** (db `0`) and the Django **cache** (dbs `1`/`2`),
 addressed via `REDIS_HOST` / `REDIS_PORT` in `.env`.
 
-Currently Redis is on **AWS ElastiCache**. ElastiCache is comparatively
-expensive for this workload; running a **Redis container on the EC2 host** is a
-safe and much cheaper alternative if it is locked down. If migrating to a
-self-hosted container:
+Redis runs as the **`redis` compose service** on the EC2 host (see
+`docker-compose.prod.aws.yml`), replacing the previous **AWS ElastiCache**
+instance (much cheaper for this workload). It is locked down as follows:
 
-- **Never expose it publicly.** Keep it on the compose `backend-network` and do
-  not publish its port to the host's public interface (bind to the internal
-  network or `127.0.0.1` only). Set a `requirepass` password as defense in
-  depth.
-- **Bound its memory** with `maxmemory` so it can't OOM the box. Since the same
-  instance serves the broker *and* the cache, use `maxmemory-policy noeviction`
-  (evicting broker/beat keys under an LRU policy would silently drop queued
-  tasks); size `maxmemory` with headroom and monitor.
-- **Apply host tuning.** `production/systemd/redis-host-setup.service` already
-  exists for exactly this: it disables Transparent Huge Pages and sets
-  `vm.overcommit_memory=1` (both recommended by Redis for a containerized
-  server). Enable it (`systemctl enable --now redis-host-setup`) when running
-  Redis on the host.
-- **Add `restart: unless-stopped`** to the service so it recovers on crash.
-- Persistence (RDB/AOF) is optional here — a lost broker queue on restart is
-  usually acceptable for periodic tasks, and the cache is disposable.
+- **Not publicly reachable.** It has no published port and lives only on the
+  internal `backend-network`, so only the app/celery containers can reach it.
+  That is why it runs without a password in this single-host setup; if you ever
+  expose it, add a `requirepass` and put the password in the broker/cache URLs.
+- **Memory is capped** (`--maxmemory`, default `256mb`, override via
+  `REDIS_MAXMEMORY` in `.env`) so Redis can't OOM the shared app host.
+- **`--maxmemory-policy noeviction`** so queued Celery/beat tasks are never
+  silently dropped under memory pressure. If cache churn makes the cap tight,
+  raise `REDIS_MAXMEMORY`, or switch to `volatile-lru` (cache entries carry a
+  TTL and broker keys don't, so only cache keys would be evicted).
+- **Persistence is disabled** (`--save "" --appendonly no`) — the broker queue
+  and cache are both disposable, so a restart just starts empty.
+- **`restart: unless-stopped`** so it recovers on crash.
+
+Apply the host tuning once per host (see [Host tuning](#host-tuning)):
+`production/systemd/redis-host-setup.service` disables Transparent Huge Pages and
+sets `vm.overcommit_memory=1` (both recommended by Redis). Enable it with
+`systemctl enable --now redis-host-setup`.
+
+**Migrating an existing host off ElastiCache:** set `REDIS_HOST=redis` in the
+server's `.env`, then redeploy (`./production/server-update.sh`). No data
+migration is needed since the broker/cache are disposable; the ElastiCache
+instance can then be decommissioned.
 
 ## Host tuning
 


### PR DESCRIPTION
### What?
Two related production-reliability changes (the second was added after review started — see the last commits):

1. **Self-hosted Redis**: replaces AWS ElastiCache with a `redis:7-alpine` container on the EC2 host, for both production and staging. Redis remains the Celery **broker** (db 0) and Django **cache** (dbs 1/2).
2. **Resilience batch**: `restart: unless-stopped` + healthchecks for **every** production service (web, celery, celery-beat, redis, nginx).

### Why?
- ElastiCache is comparatively expensive for this workload; a locked-down Redis container on the existing app host costs nothing extra. Also retires the **EOL Redis 5.0** image dev was on.
- Production previously had **no restart policies and no healthchecks** on the app services — a crashed container stayed down until someone noticed. A dead celery-beat is especially silent: all periodic tasks just stop.

### How?
**Redis (consolidated per review feedback):**
- Shared config (image `redis:7-alpine`, healthcheck, sysctls, network, and the web/celery/celery-beat `depends_on redis healthy` wiring) now lives in the base **`docker-compose.yml`** — no more duplication between dev and prod.
- **`docker-compose.override.yml`** (dev) adds only the published port (`6379`) for local `runserver`/tests.
- **`docker-compose.prod.aws.yml`** adds only production concerns: `restart: unless-stopped` and the hardened command — memory capped via `--maxmemory` (`REDIS_MAXMEMORY`, default `256mb`), `--maxmemory-policy noeviction` (queued tasks never silently dropped), persistence disabled (broker/cache are disposable). **Internal-only**: no published port, `backend-network` only → no password needed in this single-host setup.
- `.env.example.aws`: `REDIS_HOST=redis`, documented `REDIS_MAXMEMORY`.

**Resilience (`docker-compose.prod.aws.yml`):**
- `restart: unless-stopped` on web, celery, celery-beat, redis, nginx — crashed containers come back automatically, including after host reboot.
- Healthchecks:
  - `web`: TCP connect to the uwsgi socket (`:8000`), `start_period: 10m` to cover the `migrate_schemas`/`collectstatic` startup run.
  - `celery`: `celery inspect ping` against the worker over the broker (catches hung/disconnected workers, not just dead processes), 60s interval.
  - `celery-beat`: `pgrep` process check (beat has no ping command; `procps` is in the app image).
  - `redis`: `redis-cli ping` (shared base config).
- Compose restarts *crashed* containers but does **not** auto-restart ones that merely turn unhealthy — the healthcheck is a monitoring signal (`docker compose ps` shows `(healthy)`/`(unhealthy)`); README documents this.

### Testing?
- Validated **both** merged configs with `docker compose config` after each change:
  - prod: redis resolves internal-only with the hardened command; all five services show `restart: unless-stopped`; all healthchecks present; `web`/`celery`/`celery-beat` depend on healthy redis.
  - dev: same shared redis base + published port; `depends_on` (db + redis) intact.
- Confirmed the resolved prod/dev behaviour is unchanged by the consolidation (same effective config, just de-duplicated).

### Screenshots (if front end is affected)
n/a — infrastructure only.

### Anything Else?
**Deploy step (per host):** set `REDIS_HOST=redis` in the server's `.env`, redeploy with `./production/server-update.sh`, then enable the host tuning once: `systemctl enable --now redis-host-setup` (THP off / `vm.overcommit_memory=1`). No data migration — broker/cache are disposable — then decommission ElastiCache.

Tunables flagged for review: `REDIS_MAXMEMORY` default (256mb) and the `noeviction` policy; happy to adjust.

### Review request
@tylerecouture

- Claude Code