### PR TITLE
Automated deploys via self-hosted runners (gated on green CI)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy
+
+# Automated deploys via self-hosted runners, gated on green CI.
+#
+# This triggers AFTER the "Build and Tests" workflow finishes, and only deploys
+# when that run succeeded, was a push (not a PR), and was on master or staging.
+# The branch model is develop -> staging -> master: merging to staging deploys
+# the staging host, merging to master deploys production.
+#
+# INERT until a self-hosted runner is registered on each host with the matching
+# label (see production/SERVER-README.md -> "Automated deploys"):
+#   - production host: labels [self-hosted, production]
+#   - staging host:    labels [self-hosted, staging]
+
+on:
+  workflow_run:
+    workflows: ["Build and Tests"]
+    types: [completed]
+    branches: [master, staging]
+
+# The deploy only reads the repo (checkout happens on the host, not here).
+permissions:
+  contents: read
+
+# Serialize deploys per environment; never interrupt an in-flight deploy.
+concurrency:
+  group: deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-production:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: [self-hosted, production]
+    environment: production
+    timeout-minutes: 30
+    steps:
+      - name: Deploy the tested commit to production
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          # Override with a BYTEDECK_APP_DIR repo variable if the checkout lives elsewhere.
+          APP_DIR: ${{ vars.BYTEDECK_APP_DIR || '/home/ubuntu/bytedeck' }}
+        run: |
+          set -euo pipefail
+          echo "Deploying $SHA ($BRANCH) in $APP_DIR"
+          cd "$APP_DIR"
+          git fetch --prune origin "$BRANCH"
+          git checkout -B "$BRANCH" "$SHA"
+          ./production/server-update.sh
+
+  deploy-staging:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'staging'
+    runs-on: [self-hosted, staging]
+    environment: staging
+    timeout-minutes: 30
+    steps:
+      - name: Deploy the tested commit to staging
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          APP_DIR: ${{ vars.BYTEDECK_APP_DIR || '/home/ubuntu/bytedeck' }}
+        run: |
+          set -euo pipefail
+          echo "Deploying $SHA ($BRANCH) in $APP_DIR"
+          cd "$APP_DIR"
+          git fetch --prune origin "$BRANCH"
+          git checkout -B "$BRANCH" "$SHA"
+          ./production/server-update.sh

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -66,9 +66,11 @@ reached over the network via the `POSTGRES_*` / `REDIS_*` settings in `.env`.
 
 ## Deployment runbook
 
-Deployment is **manual** (SSH to the host). There is currently no
-auto-deploy on push — see [Automating deploys](#automating-deploys-future) for
-how we could add it.
+Deploys are **automated**: merging to `staging` (staging host) or `master`
+(production host) runs CI and then, on success, a self-hosted GitHub Actions
+runner on that host runs `production/server-update.sh` — see
+[Automated deploys](#automated-deploys). You can still deploy **manually** (for a
+hotfix, or if a runner is down) by SSHing to the host:
 
 ```bash
 # On the EC2 host, as the ubuntu user:
@@ -86,7 +88,8 @@ git pull                      # master (prod) or staging (staging host)
    (which runs `docker compose ... up -d`).
 5. `nginx -s reload` inside the nginx container (works around nginx sometimes
    not reconnecting to uwsgi after a restart).
-6. Tail the compose logs.
+6. Tail the compose logs when run interactively; print a recent snapshot and
+   exit when run non-interactively (e.g. from the deploy runner).
 
 The app is managed by the **`bytedeck.com.service`** systemd unit
 (`Type=oneshot`, `RemainAfterExit=yes`) so it comes back up automatically on
@@ -250,19 +253,53 @@ request, so it redirects every request forever).
 - **Logs:** `docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml logs -f`
 - **Redis warnings about THP / overcommit:** enable `redis-host-setup.service`.
 
-## Automating deploys (future)
+## Automated deploys
 
-There is currently no automation on push to `master`/`staging`; deploys are
-manual. Options to automate, roughly in order of preference:
+Deploys run automatically via a **self-hosted GitHub Actions runner on each
+host**, gated on green CI. The flow follows the branch model
+(`develop → staging → master`): merging to `staging` deploys the staging host,
+merging to `master` deploys production. No inbound SSH is exposed — the runner
+pulls jobs from GitHub.
 
-1. **Self-hosted GitHub Actions runner on each EC2 host** — a workflow triggered
-   on push to `master` (prod runner) / `staging` (staging runner) runs
-   `git pull && ./production/server-update.sh`. No inbound SSH exposure; the
-   runner pulls jobs from GitHub.
-2. **GitHub Actions + SSH deploy** — a workflow SSHes into the host (dedicated
-   deploy key stored as a repo/environment secret) and runs the deploy script.
-   Simpler, but exposes an SSH path and needs the host key pinned.
+**How it works** (`.github/workflows/deploy.yml`):
 
-Either should gate on CI passing first, and staging should auto-deploy before
-production. Ask in an issue before implementing so we can decide on secrets and
-runner placement.
+- It triggers via `workflow_run` **after** the *Build and Tests* workflow
+  finishes, and only runs when that run **succeeded**, was a **push** (not a PR),
+  and was on `master` or `staging`. So nothing deploys unless CI is green.
+- `master` runs the `deploy-production` job on the runner labelled
+  `[self-hosted, production]`; `staging` runs `deploy-staging` on
+  `[self-hosted, staging]`.
+- On the host, the job checks the app dir out to the exact tested commit and runs
+  the deploy script:
+  ```bash
+  cd "$APP_DIR"                        # default /home/ubuntu/bytedeck; override with
+                                       # the BYTEDECK_APP_DIR repo variable
+  git fetch --prune origin "$BRANCH"
+  git checkout -B "$BRANCH" "$SHA"     # $SHA = the commit that passed CI
+  ./production/server-update.sh
+  ```
+- A `concurrency` group serializes deploys per environment; each job has a
+  30-minute timeout.
+
+**One-time host setup** (per host):
+
+1. **Register the runner.** Repo *Settings → Actions → Runners → New self-hosted
+   runner*; follow the on-host steps and give it the right label — `production`
+   on the prod host, `staging` on the staging host. Run it as the `ubuntu` user
+   that owns `/home/ubuntu/bytedeck` (so `git` and `docker` work), and install it
+   as a service so it survives reboots (`sudo ./svc.sh install ubuntu && sudo ./svc.sh start`).
+2. **Passwordless sudo.** `server-update.sh` uses `sudo` for the systemd steps,
+   so the runner user needs passwordless sudo for them (a sudoers drop-in
+   allowing `systemctl`, `cp`, `mkdir`). Without it the deploy fails.
+3. **`.env` + Docker** are already set up on the host from the manual-deploy
+   days; nothing extra is needed.
+
+**Optional — require approval for production.** The jobs use GitHub
+*Environments* (`production` / `staging`). Add a *required reviewers* rule to the
+`production` environment (repo *Settings → Environments*) if you want prod
+deploys to wait for a manual click.
+
+**Safety notes:** `git checkout -B` resets tracked files to the tested commit —
+untracked files like `.env` and media are preserved, but don't keep local edits
+to tracked files on a host. Until the runners are registered the workflow is
+inert (the deploy jobs simply have nowhere to run).

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -296,10 +296,16 @@ pulls jobs from GitHub.
 3. **`.env` + Docker** are already set up on the host from the manual-deploy
    days; nothing extra is needed.
 
-**Optional — require approval for production.** The jobs use GitHub
-*Environments* (`production` / `staging`). Add a *required reviewers* rule to the
-`production` environment (repo *Settings → Environments*) if you want prod
-deploys to wait for a manual click.
+**Production deploys require manual approval.** The jobs use GitHub
+*Environments* (`production` / `staging`), and the `production` environment has
+a *required reviewers* rule — so a `master` push still runs CI automatically,
+but the deploy job then pauses with "Waiting for review" until a reviewer
+approves it in the Actions UI (*Review deployments → production → Approve and
+deploy*). Staging has no such rule and deploys fully automatically.
+
+One-time settings for this rule (repo *Settings → Environments → production*):
+enable **Required reviewers** (add the maintainer), and restrict **Deployment
+branches** to `master` so no other branch can use the production environment.
 
 **Safety notes:** `git checkout -B` resets tracked files to the tested commit —
 untracked files like `.env` and media are preserved, but don't keep local edits

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -285,14 +285,23 @@ pulls jobs from GitHub.
 
 **One-time host setup** (per host):
 
-1. **Register the runner.** Repo *Settings → Actions → Runners → New self-hosted
-   runner*; follow the on-host steps and give it the right label — `production`
-   on the prod host, `staging` on the staging host. Run it as the `ubuntu` user
-   that owns `/home/ubuntu/bytedeck` (so `git` and `docker` work), and install it
-   as a service so it survives reboots (`sudo ./svc.sh install ubuntu && sudo ./svc.sh start`).
+1. **Register the runner — automated.** Run `./production/server-update.sh`
+   interactively (or `./production/setup-runner.sh` directly) as the `ubuntu`
+   user. If no runner is set up, it offers to install one: it derives the label
+   from `ROOT_DOMAIN` in `.env` (`bytedeck.com` → `production`, otherwise
+   `staging`), prompts for a short-lived registration token (repo *Settings →
+   Actions → Runners → New self-hosted runner* — copy the `--token` value),
+   installs the latest runner into `~/actions-runner`, and registers it as a
+   systemd service so it survives reboots. On every later run it detects the
+   existing install (a `SETUP_VERSION` marker file plus a service-status check)
+   and skips in one line; a manually-configured runner is adopted as-is. The
+   runner binary itself self-updates after installation. When run
+   non-interactively (e.g. by the deploy runner) it never prompts and never
+   fails the deploy — it just reports if setup is missing.
 2. **Passwordless sudo.** `server-update.sh` uses `sudo` for the systemd steps,
-   so the runner user needs passwordless sudo for them (a sudoers drop-in
-   allowing `systemctl`, `cp`, `mkdir`). Without it the deploy fails.
+   so the runner user needs passwordless sudo for them (stock EC2 Ubuntu already
+   grants the `ubuntu` user this via cloud-init — verify with `sudo -n true`).
+   Without it the deploy fails.
 3. **`.env` + Docker** are already set up on the host from the manual-deploy
    days; nothing extra is needed.
 

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -83,9 +83,11 @@ git pull                      # master (prod) or staging (staging host)
 
 1. `docker compose ... build` the images.
 2. Copy `production/systemd/bytedeck.com.service` into `/etc/systemd/system/`.
-3. Install the certbot-renew override (see [TLS](#tls--certificates)).
-4. `systemctl daemon-reload`, then enable and **restart** `bytedeck.com.service`
-   (which runs `docker compose ... up -d`).
+3. Install the certbot-renew override (see [TLS](#tls--certificates)) and the
+   `redis-host-setup.service` host tuning (disables THP, sets
+   `vm.overcommit_memory=1` — the settings the dockerized Redis warns about).
+4. `systemctl daemon-reload`, enable + run `redis-host-setup`, then enable and
+   **restart** `bytedeck.com.service` (which runs `docker compose ... up -d`).
 5. `nginx -s reload` inside the nginx container (works around nginx sometimes
    not reconnecting to uwsgi after a restart).
 6. Tail the compose logs when run interactively; print a recent snapshot and

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -19,10 +19,16 @@ sudo cp production/systemd/bytedeck.com.service /etc/systemd/system/bytedeck.com
 sudo mkdir -p /etc/systemd/system/snap.certbot.renew.service.d
 sudo cp production/systemd/snap.certbot.renew.service.override.conf /etc/systemd/system/snap.certbot.renew.service.d/snap.certbot.renew.service.override.conf
 
+# Install the Redis host tuning (disable THP, vm.overcommit_memory=1 -- the
+# settings the dockerized Redis warns about at startup). Runs now and on boot.
+sudo cp production/systemd/redis-host-setup.service /etc/systemd/system/redis-host-setup.service
+
 # Load the new systemd modules
 sudo systemctl daemon-reload
 
-# Ensure the service is enabled then restart it
+# Ensure the services are enabled, apply the Redis host tuning, then restart the app
+sudo systemctl enable redis-host-setup.service
+sudo systemctl restart redis-host-setup.service
 sudo systemctl enable bytedeck.com.service
 sudo systemctl restart bytedeck.com
 

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -23,6 +23,11 @@ sudo cp production/systemd/snap.certbot.renew.service.override.conf /etc/systemd
 # settings the dockerized Redis warns about at startup). Runs now and on boot.
 sudo cp production/systemd/redis-host-setup.service /etc/systemd/system/redis-host-setup.service
 
+# Ensure the GitHub Actions deploy runner is set up (idempotent: skips fast
+# when already installed and running; offers interactive setup when missing
+# and a human is at the terminal). Never fails the deploy.
+./production/setup-runner.sh || echo "WARN: deploy-runner setup check failed; continuing."
+
 # Load the new systemd modules
 sudo systemctl daemon-reload
 

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -1,25 +1,40 @@
 #!/bin/sh
+# Build the images and (re)start the app via its systemd unit.
+#
+# Run from anywhere, either manually on the host or automatically by the Deploy
+# workflow (.github/workflows/deploy.yml) on a self-hosted runner.
+set -e
 
-docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml build
+# Always operate from the repo root, regardless of the caller's CWD.
+cd "$(dirname "$0")/.."
 
-# Update the web apps systemd unit file
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
+
+$COMPOSE build
+
+# Update the web app's systemd unit file
 sudo cp production/systemd/bytedeck.com.service /etc/systemd/system/bytedeck.com.service
 
-# Install override to force nginx server to relaod its configuration after certbot renews the SSL certificate
+# Install override to force nginx to reload its configuration after certbot renews the SSL certificate
 sudo mkdir -p /etc/systemd/system/snap.certbot.renew.service.d
 sudo cp production/systemd/snap.certbot.renew.service.override.conf /etc/systemd/system/snap.certbot.renew.service.d/snap.certbot.renew.service.override.conf
 
-# load the new systemd modules
+# Load the new systemd modules
 sudo systemctl daemon-reload
 
-# ensure the service is enabled then restart it
+# Ensure the service is enabled then restart it
 sudo systemctl enable bytedeck.com.service
 sudo systemctl restart bytedeck.com
 
-# Restart the nginx server
-# sometime nginx doens't reconnect to uwsgi, this help when run manually
-# hoping this fixes the problem
-docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml exec nginx nginx -s reload
+# Restart the nginx server: sometimes nginx doesn't reconnect to uwsgi after a
+# restart, and this helps when run manually. Best-effort: -T avoids needing a
+# TTY (so it works on the runner), and a failed reload shouldn't fail the deploy.
+$COMPOSE exec -T nginx nginx -s reload || echo "WARN: nginx reload failed; continuing."
 
-
-docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml logs -f
+# Show logs. Follow them when run interactively; in an automated deploy (no TTY,
+# e.g. the CI runner) print a recent snapshot and exit so the job can finish.
+if [ -t 1 ]; then
+  $COMPOSE logs -f
+else
+  $COMPOSE logs --tail=100 --no-color
+fi

--- a/production/setup-runner.sh
+++ b/production/setup-runner.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Idempotent setup of the GitHub Actions self-hosted deploy runner on this host.
+#
+# Called from server-update.sh on every deploy, and safe to run directly:
+#   - If the runner is already configured and its service is running (and the
+#     SETUP_VERSION marker matches), it prints one line and exits.
+#   - If a runner was configured manually, it is adopted as-is (service checked,
+#     marker stamped) rather than reinstalled.
+#   - If no runner exists and the shell is interactive, it offers to set one up,
+#     prompting for the short-lived registration token from GitHub.
+#   - If no runner exists and the shell is NOT interactive (e.g. running under
+#     the deploy runner itself), it prints a hint and exits 0 -- deploys must
+#     never fail on this.
+#
+# The runner LABEL is derived from ROOT_DOMAIN in .env: bytedeck.com ->
+# "production", anything else -> "staging" (matching deploy.yml's runs-on).
+# The runner binary self-updates after installation, so SETUP_VERSION tracks
+# only *our* setup shape (labels, service user, install dir); bump it when
+# those requirements change to force a re-run on the hosts.
+set -e
+
+SETUP_VERSION="1"
+
+# Operate from the repo root regardless of caller CWD (matches server-update.sh).
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
+MARKER="$RUNNER_DIR/.bytedeck-runner-setup-version"
+REPO_URL="https://github.com/bytedeck/bytedeck"
+
+service_running() {
+    # svc.sh proxies systemctl status: exit 0 = active.
+    (cd "$RUNNER_DIR" && sudo ./svc.sh status >/dev/null 2>&1)
+}
+
+# --- Fast path: already set up and current ----------------------------------
+if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$SETUP_VERSION" ]; then
+    if service_running; then
+        echo "Deploy runner: already set up (v$SETUP_VERSION) and running -- skipping."
+        exit 0
+    fi
+    echo "Deploy runner: configured but service not running -- starting it."
+    (cd "$RUNNER_DIR" && sudo ./svc.sh start)
+    exit 0
+fi
+
+# --- Adopt a runner that was configured manually -----------------------------
+if [ -f "$RUNNER_DIR/.runner" ]; then
+    echo "Deploy runner: existing configuration found in $RUNNER_DIR -- adopting it."
+    service_running || (cd "$RUNNER_DIR" && sudo ./svc.sh start)
+    echo "$SETUP_VERSION" > "$MARKER"
+    exit 0
+fi
+
+# --- Not set up: only proceed if a human is at the terminal ------------------
+if [ ! -t 0 ]; then
+    echo "Deploy runner: NOT set up on this host. Run ./production/setup-runner.sh"
+    echo "interactively (or follow SERVER-README.md -> 'Automated deploys') to enable"
+    echo "automated deploys. Continuing without it."
+    exit 0
+fi
+
+# Derive the label from this host's .env so prod/staging need no prompt.
+ROOT_DOMAIN="$(sed -n 's/^ROOT_DOMAIN=//p' "$REPO_ROOT/.env" 2>/dev/null | tail -1)"
+if [ "$ROOT_DOMAIN" = "bytedeck.com" ]; then
+    LABEL="production"
+else
+    LABEL="staging"
+fi
+
+echo ""
+echo "GitHub Actions deploy runner is not set up on this host."
+echo "  install dir : $RUNNER_DIR"
+echo "  repo        : $REPO_URL"
+echo "  label       : $LABEL   (derived from ROOT_DOMAIN=${ROOT_DOMAIN:-<unset>})"
+echo "  service user: $(whoami)"
+printf "Set it up now? [y/N] "
+read -r REPLY
+case "$REPLY" in
+    y|Y|yes|YES) ;;
+    *) echo "Skipping runner setup."; exit 0 ;;
+esac
+
+echo ""
+echo "Get a registration token (expires after ~1 hour):"
+echo "  $REPO_URL/settings/actions/runners/new -> copy the value after --token"
+printf "Registration token: "
+read -r TOKEN
+[ -n "$TOKEN" ] || { echo "No token given; aborting runner setup." >&2; exit 1; }
+
+# Latest runner release (it self-updates afterwards, so 'latest at install
+# time' is the right choice; no version to maintain here).
+echo "Resolving latest runner version..."
+VER="$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest \
+        | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"
+[ -n "$VER" ] || { echo "Could not resolve the runner version from the GitHub API; set it up manually (see SERVER-README.md)." >&2; exit 1; }
+
+echo "Installing actions-runner v$VER into $RUNNER_DIR..."
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+curl -fsSL -o runner.tar.gz \
+    "https://github.com/actions/runner/releases/download/v${VER}/actions-runner-linux-x64-${VER}.tar.gz"
+tar xzf runner.tar.gz && rm runner.tar.gz
+
+# --unattended: no further prompts; --replace: take over a same-named runner.
+./config.sh --unattended --replace \
+    --url "$REPO_URL" \
+    --token "$TOKEN" \
+    --name "bytedeck-$LABEL" \
+    --labels "$LABEL" \
+    --work _work
+
+# Install as a systemd service running as this user, so it survives reboots.
+sudo ./svc.sh install "$(whoami)"
+sudo ./svc.sh start
+
+echo "$SETUP_VERSION" > "$MARKER"
+echo ""
+echo "Deploy runner installed and running (label: $LABEL)."
+echo "Verify it shows as 'Idle' at: $REPO_URL/settings/actions/runners"


### PR DESCRIPTION
### What?
Adds automated deployment for staging and production. Each host runs a self-hosted GitHub Actions runner, and a deploy runs automatically **after CI passes** — merging to `staging` deploys the staging host, merging to `master` deploys production. Manual `server-update.sh` remains as a fallback. Later commits also add: the **redis-host-setup** systemd install (THP / `vm.overcommit_memory` tuning the dockerized Redis warns about), the **production approval gate** docs, and an **idempotent runner-setup script** so even the one-time host setup is automated.

### Why?
Deploys were fully manual (SSH in, `git pull`, run the script). This automates the `develop → staging → master` flow while keeping a hard "only deploy if green" gate, with no inbound SSH exposure (the runner pulls jobs from GitHub).

### How?
- **`.github/workflows/deploy.yml`**
  - Triggers via `workflow_run` **after** the *Build and Tests* workflow finishes, and only runs when it **succeeded**, was a **push** (not a PR), and was on `master`/`staging` → nothing deploys unless CI is green.
  - `master` → `deploy-production` on the `[self-hosted, production]` runner; `staging` → `deploy-staging` on `[self-hosted, staging]`.
  - Each job, on the host, checks the app dir out to the **exact tested commit** (`git checkout -B $BRANCH $SHA`) and runs `./production/server-update.sh`.
  - Uses GitHub *Environments*: **production has a required-reviewers rule** (CI runs automatically; the prod deploy pauses for a one-click approval), staging deploys hands-free. Per-environment `concurrency` group, 30-min timeout, `permissions: contents: read`.
- **`production/server-update.sh`** — made runner-safe (`set -e`, repo-root `cd`, non-fatal `-T` nginx reload, TTY-aware logs so a CI job can't hang on `logs -f`), installs + runs **`redis-host-setup.service`** on every deploy, and calls the runner-setup check below.
- **`production/setup-runner.sh`** *(new)* — idempotent one-time runner registration, same pattern as the systemd installs:
  - Fast skip when set up (a `SETUP_VERSION` marker + service-status check; the marker tracks *our* setup shape — the runner binary self-updates, so no version chasing).
  - Adopts a manually-configured runner as-is.
  - When missing + interactive: derives the label from `ROOT_DOMAIN` in `.env` (`bytedeck.com` → `production`, else `staging`), prompts for the short-lived registration token, installs the latest runner into `~/actions-runner`, registers it (`--unattended --replace`) and installs it as a systemd service.
  - When missing + non-interactive (e.g. under the deploy runner itself): prints a hint, exits 0 — deploys never fail on this.
- **`production/SERVER-README.md`** — documents the design, the (now mostly automated) one-time host setup, and the production approval gate.

### Testing?
- `deploy.yml` validated as YAML; `workflow_run` keys off the exact workflow name `"Build and Tests"`.
- `server-update.sh` / `setup-runner.sh` pass `sh -n`; exercised setup-runner's four detection paths (missing+non-interactive → hint/exit 0; manual install → adopt + stamp marker; marker current → one-line skip; service down → restart) with a mocked `svc.sh`.
- Confirmed the README anchors match the new headings.

### Screenshots (if front end is affected)
n/a — CI/infra only.

### Anything Else?
**One-time setup per host** (now mostly automated):
1. Run `./production/server-update.sh` (or `./production/setup-runner.sh`) interactively as `ubuntu` — it offers runner setup and prompts only for the registration token from repo *Settings → Actions → Runners → New self-hosted runner*.
2. Verify passwordless sudo (`sudo -n true`) — stock EC2 Ubuntu already has it.
3. Repo *Settings → Environments → production*: **Required reviewers** + restrict **Deployment branches** to `master`.

Notes:
- `workflow_run` workflows run from the **default branch**, so this takes effect once merged to `develop` and then applies to `master`/`staging` pushes.
- Until runners are registered the workflow is **inert** — safe to merge ahead of host setup.

### Review request
@tylerecouture

- Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated deployments after successful builds to staging and production environments.
  - Deployments now run against the exact committed version and are serialized to prevent overlapping releases.
  - Added automated setup and management for deployment runners on application hosts.
  - Improved deployment handling for system services, Redis host tuning, nginx reloads, and application logs.

- **Documentation**
  - Updated server deployment instructions with automated deployment workflows, approval requirements, setup guidance, and manual hotfix procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->