### PR TITLE
Deck request: confirmation page explaining next steps (Closes #1946)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ pre-commit install
 
 The bare `python` / `pre-commit` commands above assume the local venv; with docker-only setups wrap them instead (e.g. `docker compose run web bash -c "python src/manage.py initdb"`).
 
-The site only works via `http://localhost:8000` (not `0.0.0.0`) because the multi-tenant architecture requires a domain name. `localhost:8000` is the public tenant; each deck is served from its own subdomain (e.g. `http://hackerspace.localhost:8000`). Admin login is `admin` / `password` (from `.env`). Create tenants at `http://localhost:8000/decks/new/`. Full stack: `docker compose up` (web, db, redis, celery, celery-beat).
+The site only works via `http://localhost:8000` (not `0.0.0.0`) because the multi-tenant architecture requires a domain name. `localhost:8000` is the public tenant; each deck is served from its own subdomain (e.g. `http://hackerspace.localhost:8000`). Admin login is `admin` / `password` (from `.env`). Create tenants at `http://localhost:8000/decks/request/new/`. Full stack: `docker compose up` (web, db, redis, celery, celery-beat).
 
 ### Tests and Linting
 

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -19,7 +19,7 @@ class SecureProxySSLHeaderTest(SimpleTestCase):
         so build_absolute_uri produces https:// links instead of http://."""
         request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="https")
         self.assertTrue(request.is_secure())
-        self.assertTrue(request.build_absolute_uri("/decks/new/").startswith("https://"))
+        self.assertTrue(request.build_absolute_uri("/decks/request/new/").startswith("https://"))
 
     def test_forwarded_http_request_is_not_secure(self):
         """Without the https forwarded scheme, the request stays plain HTTP so the

--- a/src/tenant/templates/tenant/request_new_deck_submitted.html
+++ b/src/tenant/templates/tenant/request_new_deck_submitted.html
@@ -1,0 +1,45 @@
+{% extends "public/base.html" %}
+
+{% block content %}
+<div class="container my-5" style="max-width: 720px;">
+    <h1 class="mb-3">Thanks &mdash; check your email to continue</h1>
+    <p class="lead">
+        We've sent a verification link to the email address you entered. Follow the
+        steps below to finish setting up your new deck.
+    </p>
+
+    <h2 class="h4 mt-4">What happens next</h2>
+    <ol class="mb-4">
+        <li class="mb-2">
+            <strong>Verify your email.</strong> Click the verification link in the
+            email we just sent you.
+            <span class="text-muted">(No email? Check your spam or junk folder.)</span>
+        </li>
+        <li class="mb-2">
+            <strong>Name &amp; create your deck.</strong> The link opens a short form
+            where you choose a name and create your deck.
+        </li>
+        <li class="mb-2">
+            <strong>Sign in.</strong> Once your deck is created, you'll get a
+            <strong>welcome email</strong> with your initial login credentials, and
+            you can sign in at your deck's own web address.
+        </li>
+    </ol>
+
+    <div class="alert alert-info" role="alert">
+        <h2 class="h5 alert-heading">Good to know</h2>
+        <ul class="mb-0">
+            <li>
+                The verification link is valid for <strong>{{ verification_validity }}</strong>
+                and can be used to create <strong>one deck</strong>.
+            </li>
+            <li>
+                Didn't get the email? You can request another after about
+                <strong>{{ resend_cooldown }}</strong> (one email per address in that window).
+            </li>
+        </ul>
+    </div>
+
+    <a class="btn btn-outline-primary mt-2" href="{% url 'decks:request_new_deck' %}">Back to the request form</a>
+</div>
+{% endblock %}

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -132,7 +132,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
 
     @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
     @patch.object(DeckRequestService, "send_verification_email")
-    def test_successful_deck_request_sends_email_and_redirects_to_confirmation(self, mock_send_email, mock_captcha):
+    def test_RequestNewDeck_form_valid__sends_email_and_redirects_to_confirmation(self, mock_send_email, mock_captcha):
         """A valid deck request sends the verification email and redirects to the
         dedicated confirmation page (not back to the form with a flash message)."""
         form_data = {
@@ -169,7 +169,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
 
     @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
     @patch.object(DeckRequestService, "send_verification_email")
-    def test_deck_request_redirect_identical_whether_or_not_email_sent(self, mock_send_email, mock_captcha):
+    def test_RequestNewDeck_form_valid__redirect_identical_whether_or_not_email_sent(self, mock_send_email, mock_captcha):
         """The response must not reveal whether an email was actually sent: both a
         first (email-sending) request and a throttled second request for the same
         address redirect to the same confirmation page."""
@@ -190,7 +190,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertEqual(first.url, confirmation_url)
         self.assertEqual(second.url, confirmation_url)
 
-    def test_confirmation_page_renders_workflow_and_timeouts(self):
+    def test_RequestNewDeckSubmitted_get__renders_workflow_and_timeouts(self):
         """The confirmation page renders through the public base template and lays
         out the 3-step onboarding workflow plus the validity window, single-use
         constraint, spam reminder, and resend cooldown."""
@@ -211,7 +211,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
         self.assertContains(response, "one deck")
         self.assertContains(response, "5 minutes")
 
-    def test_confirmation_page_timeouts_track_configured_values(self):
+    def test_RequestNewDeckSubmitted_get_context_data__timeouts_track_configured_values(self):
         """The timeout copy is derived from DeckRequestService's settings, not
         hard-coded: changing the configured values changes the rendered page."""
         with patch.object(DeckRequestService, "TOKEN_MAX_AGE", 7200), \

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -17,7 +17,9 @@ from django_tenants.utils import get_public_schema_name
 from django_tenants.utils import tenant_context
 
 from hackerspace_online.tests.utils import ViewTestUtilsMixin
-from tenant.views import non_public_only_view, public_only_view, TenantCreate, TenantForm, EmailVerificationRequiredMixin
+from tenant.views import (
+    non_public_only_view, public_only_view, TenantCreate, TenantForm, EmailVerificationRequiredMixin, _humanize_seconds,
+)
 from tenant.models import Tenant
 from tenant.utils import DeckRequestService
 from siteconfig.models import SiteConfig
@@ -130,11 +132,9 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
 
     @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
     @patch.object(DeckRequestService, "send_verification_email")
-    def test_successful_deck_request_sends_email_and_shows_message(self, mock_send_email, mock_captcha):
-        """
-        Ensure that submitting a valid deck request triggers the verification
-        email to be sent and returns a redirect response.
-        """
+    def test_successful_deck_request_sends_email_and_redirects_to_confirmation(self, mock_send_email, mock_captcha):
+        """A valid deck request sends the verification email and redirects to the
+        dedicated confirmation page (not back to the form with a flash message)."""
         form_data = {
             "first_name": "John",
             "last_name": "Doe",
@@ -144,7 +144,11 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
         response = self.client.post(reverse("decks:request_new_deck"), data=form_data)
         mock_send_email.assert_called_once()
         mock_captcha.assert_called()
-        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(
+            response,
+            reverse("decks:request_new_deck_submitted"),
+            fetch_redirect_response=False,
+        )
 
     @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
     @patch.object(DeckRequestService, "send_verification_email")
@@ -162,6 +166,62 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
 
         # only the first submission actually sent an email
         mock_send_email.assert_called_once()
+
+    @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
+    @patch.object(DeckRequestService, "send_verification_email")
+    def test_deck_request_redirect_identical_whether_or_not_email_sent(self, mock_send_email, mock_captcha):
+        """The response must not reveal whether an email was actually sent: both a
+        first (email-sending) request and a throttled second request for the same
+        address redirect to the same confirmation page."""
+        form_data = {
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "same@example.com",
+            "captcha": "dummy",
+        }
+        first = self.client.post(reverse("decks:request_new_deck"), data=form_data)
+        second = self.client.post(reverse("decks:request_new_deck"), data=form_data)
+
+        # the second was throttled (no second email), yet the outcome is identical
+        mock_send_email.assert_called_once()
+        confirmation_url = reverse("decks:request_new_deck_submitted")
+        self.assertEqual(first.status_code, 302)
+        self.assertEqual(second.status_code, 302)
+        self.assertEqual(first.url, confirmation_url)
+        self.assertEqual(second.url, confirmation_url)
+
+    def test_confirmation_page_renders_workflow_and_timeouts(self):
+        """The confirmation page renders through the public base template and lays
+        out the 3-step onboarding workflow plus the validity window, single-use
+        constraint, spam reminder, and resend cooldown."""
+        response = self.client.get(reverse("decks:request_new_deck_submitted"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "tenant/request_new_deck_submitted.html")
+        self.assertTemplateUsed(response, "public/base.html")
+
+        # the 3-step workflow
+        self.assertContains(response, "Verify your email")
+        self.assertContains(response, "create your deck")
+        self.assertContains(response, "welcome email")
+        # spam reminder
+        self.assertContains(response, "spam")
+        # validity window (TOKEN_MAX_AGE = 3600) + single-use, and resend cooldown
+        # (REQUEST_COOLDOWN = 300), surfaced as friendly durations
+        self.assertContains(response, "1 hour")
+        self.assertContains(response, "one deck")
+        self.assertContains(response, "5 minutes")
+
+    def test_confirmation_page_timeouts_track_configured_values(self):
+        """The timeout copy is derived from DeckRequestService's settings, not
+        hard-coded: changing the configured values changes the rendered page."""
+        with patch.object(DeckRequestService, "TOKEN_MAX_AGE", 7200), \
+                patch.object(DeckRequestService, "REQUEST_COOLDOWN", 600):
+            response = self.client.get(reverse("decks:request_new_deck_submitted"))
+        self.assertContains(response, "2 hours")
+        self.assertContains(response, "10 minutes")
+        # the old (default) copy must be gone, proving it wasn't hard-coded
+        self.assertNotContains(response, "1 hour")
+        self.assertNotContains(response, "5 minutes")
 
     @patch("tenant.models.Tenant.full_clean")
     def test_form_save_persists_tenant_without_touching_owner(self, mock_full_clean):
@@ -297,6 +357,27 @@ class TenantCreateViewTest(ViewTestUtilsMixin, TenantTestCase):
         with tenant_context(self.public_tenant):
             response = view.form_valid(form)
         self.assertEqual(response.status_code, 302)
+
+
+class HumanizeSecondsTest(TestCase):
+    """Tests for the `_humanize_seconds` helper used to surface deck-request
+    timeouts on the confirmation page as friendly, non-drifting copy."""
+
+    def test_humanize_seconds__picks_largest_whole_unit_with_correct_plural(self):
+        """A whole number of seconds is rendered in the largest exact unit
+        (hours, then minutes, then seconds), singular or plural as appropriate."""
+        cases = {
+            3600: "1 hour",     # TOKEN_MAX_AGE default
+            7200: "2 hours",
+            300: "5 minutes",   # REQUEST_COOLDOWN default
+            60: "1 minute",
+            90: "90 seconds",   # not a whole minute -> falls back to seconds
+            1: "1 second",
+            0: "0 seconds",
+        }
+        for seconds, expected in cases.items():
+            with self.subTest(seconds=seconds):
+                self.assertEqual(_humanize_seconds(seconds), expected)
 
     def test_verify_deck_request_valid_token_populates_session(self):
         """A valid nonce stores the verified request (including the nonce) in the

--- a/src/tenant/urls.py
+++ b/src/tenant/urls.py
@@ -7,5 +7,6 @@ app_name = 'tenant'
 urlpatterns = [
     path('new/', views.TenantCreate.as_view(), name='new'),
     path("request-new-deck/", views.RequestNewDeck.as_view(), name="request_new_deck"),
+    path("request-new-deck/submitted/", views.RequestNewDeckSubmitted.as_view(), name="request_new_deck_submitted"),
     path("request-new-deck/verify/<path:nonce>/", views.verify_deck_request, name="verify_deck_request"),
 ]

--- a/src/tenant/urls.py
+++ b/src/tenant/urls.py
@@ -5,8 +5,10 @@ from . import views
 app_name = 'tenant'
 
 urlpatterns = [
-    path('new/', views.TenantCreate.as_view(), name='new'),
-    path("request-new-deck/", views.RequestNewDeck.as_view(), name="request_new_deck"),
-    path("request-new-deck/submitted/", views.RequestNewDeckSubmitted.as_view(), name="request_new_deck_submitted"),
-    path("request-new-deck/verify/<path:nonce>/", views.verify_deck_request, name="verify_deck_request"),
+    # The whole deck-request flow lives under /decks/request/, in flow order:
+    # request form -> "check your email" page -> emailed verify link -> new-deck info form
+    path("request/", views.RequestNewDeck.as_view(), name="request_new_deck"),
+    path("request/email-verification/", views.RequestNewDeckSubmitted.as_view(), name="request_new_deck_submitted"),
+    path("request/verify/<path:nonce>/", views.verify_deck_request, name="verify_deck_request"),
+    path("request/new/", views.TenantCreate.as_view(), name="new"),
 ]

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -367,6 +367,14 @@ class RequestNewDeckSubmitted(PublicOnlyViewMixin, TemplateView):
         """Surface the deck-request timeouts as friendly strings, derived from
         ``DeckRequestService``'s settings so the on-page copy can't drift from
         the values actually enforced.
+
+        Args:
+            **kwargs: Keyword arguments from the URLconf, passed through to the
+                base ``TemplateView`` implementation.
+
+        Returns:
+            dict: The template context, with ``verification_validity`` and
+            ``resend_cooldown`` duration strings added to the base context.
         """
         context = super().get_context_data(**kwargs)
         context["verification_validity"] = _humanize_seconds(DeckRequestService.TOKEN_MAX_AGE)

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -11,7 +11,7 @@ from django.utils.decorators import method_decorator
 from django.utils.text import slugify
 from django.utils import timezone
 from django.views.generic.edit import CreateView
-from django.views.generic import FormView
+from django.views.generic import FormView, TemplateView
 from django.urls import reverse_lazy
 
 from django_tenants.utils import get_public_schema_name
@@ -240,7 +240,9 @@ class RequestNewDeck(PublicOnlyViewMixin, FormView):
 
     form_class = DeckRequestForm
     template_name = "tenant/request_new_deck.html"
-    success_url = reverse_lazy("decks:request_new_deck")
+    # Redirect to a dedicated confirmation page that explains the next steps,
+    # instead of dropping the user back on the form with a thin flash banner.
+    success_url = reverse_lazy("decks:request_new_deck_submitted")
 
     def form_valid(self, form):
         """
@@ -248,23 +250,24 @@ class RequestNewDeck(PublicOnlyViewMixin, FormView):
 
         Extracts the user's first name, last name, and email from the form.
         Generates a signed verification token and sends an email containing
-        the verification link. A success message is displayed prompting the
-        user to check their inbox.
+        the verification link, then redirects to a confirmation page that
+        explains the next steps.
 
         Args:
             form (DeckRequestForm): The validated form instance containing
                 the user's information.
 
         Returns:
-            HttpResponse: Redirect to the success URL as defined by FormView.
+            HttpResponse: Redirect to the confirmation page (``success_url``).
         """
         first_name = form.cleaned_data["first_name"]
         last_name = form.cleaned_data["last_name"]
         email = form.cleaned_data["email"]
 
         # Throttle verification emails per address so this public endpoint can't
-        # be used to flood someone's inbox. Always show the same success message
-        # regardless, so the response never reveals whether an email was sent.
+        # be used to flood someone's inbox. We always redirect to the same
+        # confirmation page regardless of whether an email was actually sent, so
+        # the response never reveals whether the address was already in cooldown.
         # The email is hashed into the key so raw addresses aren't exposed in
         # cache tooling, and cache.add() reserves the key atomically so two
         # concurrent requests can't both slip past the check and send twice.
@@ -274,7 +277,6 @@ class RequestNewDeck(PublicOnlyViewMixin, FormView):
             nonce = DeckRequestService.create_request(first_name, last_name, email)
             DeckRequestService.send_verification_email(first_name, email, nonce, request=self.request)
 
-        messages.success(self.request, "Check your email to verify your request!")
         return super().form_valid(form)
 
 
@@ -322,3 +324,51 @@ def verify_deck_request(request, nonce):
 
     # redirect to deck creation form
     return redirect("decks:new")
+
+
+def _humanize_seconds(seconds):
+    """Render a whole number of seconds as a friendly duration string.
+
+    Used to surface the deck-request timeouts (``TOKEN_MAX_AGE`` /
+    ``REQUEST_COOLDOWN``) on the confirmation page from their actual configured
+    values, so the on-page copy can't drift. Examples: ``3600 -> "1 hour"``,
+    ``300 -> "5 minutes"``, ``90 -> "90 seconds"``.
+
+    Args:
+        seconds (int): A non-negative number of seconds.
+
+    Returns:
+        str: The duration in the largest whole unit (hours, then minutes, then
+        seconds) with correct singular/plural wording.
+    """
+    for unit_seconds, unit_name in ((3600, "hour"), (60, "minute"), (1, "second")):
+        if seconds >= unit_seconds and seconds % unit_seconds == 0:
+            value = seconds // unit_seconds
+            return f"{value} {unit_name}{'s' if value != 1 else ''}"
+    return f"{seconds} seconds"
+
+
+class RequestNewDeckSubmitted(PublicOnlyViewMixin, TemplateView):
+    """Confirmation page shown after a deck request is submitted.
+
+    Replaces the old "check your email" flash message with a full page that
+    walks the requester through the onboarding workflow (verify email -> name
+    and create the deck -> welcome email with credentials) and states the
+    verification-link validity window and resend cooldown.
+
+    The page is static informational content rendered for every valid
+    submission, so — like the flash message it replaces — it never reveals
+    whether an email was actually sent (see ``RequestNewDeck.form_valid``).
+    """
+
+    template_name = "tenant/request_new_deck_submitted.html"
+
+    def get_context_data(self, **kwargs):
+        """Surface the deck-request timeouts as friendly strings, derived from
+        ``DeckRequestService``'s settings so the on-page copy can't drift from
+        the values actually enforced.
+        """
+        context = super().get_context_data(**kwargs)
+        context["verification_validity"] = _humanize_seconds(DeckRequestService.TOKEN_MAX_AGE)
+        context["resend_cooldown"] = _humanize_seconds(DeckRequestService.REQUEST_COOLDOWN)
+        return context


### PR DESCRIPTION
### What?
After submitting the **Request a New Deck** form, the requester now lands on a dedicated **confirmation page** that explains the onboarding workflow and the relevant timeouts — instead of the old green flash message ("Check your email to verify your request!") shown at the top of the same form.

Per review, the whole deck-request flow also moved under **`/decks/request/`**:

| Path | Page |
|---|---|
| `/decks/request/` | the request form |
| `/decks/request/email-verification/` | post-submit "check your email" page (new) |
| `/decks/request/verify/<nonce>/` | emailed verification link |
| `/decks/request/new/` | the new-deck info form (was `/decks/new/`) |

### Why?
The flash message was easy to miss and gave no guidance about what happens next, how long the verification link lasts, or what the multi-step flow looks like. The sibling **Request a New Deck** page already reads as a real page; this makes the post-submit step match (#1946).

### How?
- **New view** `RequestNewDeckSubmitted` — a public-only `TemplateView` at `decks/request/email-verification/`, extending `public/base.html`.
- **`RequestNewDeck.success_url`** now points at it, and the `messages.success(...)` flash is dropped.
- **Template** `tenant/request_new_deck_submitted.html` lays out the 3-step workflow (verify email → name & create your deck → welcome email with credentials), plus a "Good to know" box covering the verification-link validity window, the single-use/one-deck constraint, a spam-folder reminder, and the resend cooldown.
- **Timeouts aren't hard-coded.** A small `_humanize_seconds()` helper renders `DeckRequestService.TOKEN_MAX_AGE` (→ "1 hour") and `REQUEST_COOLDOWN` (→ "5 minutes") into friendly copy, surfaced via the view's context, so the page can't drift from the values actually enforced.
- **Non-disclosure preserved.** The redirect is unconditional, so — like the flash it replaces — the response never reveals whether an email was actually sent (a throttled repeat request lands on the same confirmation page).
- **URL restructure** (review request): all four routes now live under `request/` in `tenant/urls.py`. URL names are unchanged and every reference is name-based (`reverse` / `{% url %}`), so only two literal strings needed updating (the https settings test and the CLAUDE.md docs pointer).

### Testing?
New/updated tests in `tenant/tests/test_views.py`:
- Valid request redirects to the confirmation page (not back to the form).
- The confirmation page renders through `public/base.html` and contains the 3-step workflow + validity window + single-use + spam reminder + resend cooldown.
- The timeout copy tracks the configured values (patched `TOKEN_MAX_AGE`/`REQUEST_COOLDOWN` → "2 hours"/"10 minutes"), proving it isn't hard-coded.
- First (email-sending) and throttled second request redirect identically (non-disclosure).
- `_humanize_seconds` unit coverage (hours/minutes/seconds, singular/plural, zero).

All tenant view + settings tests pass (33 tests, 0 failures against the post-#1916 dependency set on `develop`); `flake8` clean.

### Screenshots (if front end is affected)
New static confirmation page; no screenshot attached. It reuses the public base chrome (navbar/footer/branding) like the Request-a-New-Deck page.

### Anything Else?
- Verification emails sent before this deploys contain the old `/decks/request-new-deck/verify/...` link, which will 404 afterwards. The nonces only live an hour, so the window is small, and re-requesting works.
- Companion to #1947 (the Create New Deck form now extends the same public base, PR #1955).

Closes #1946.

### Review request
@tylerecouture

- Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a confirmation page after submitting a new deck request.
  - Added clear email verification instructions and information about verification and resend time limits.
  - Reorganized deck request and verification URLs under a consistent `/decks/request/` path.

- **Documentation**
  - Updated setup guidance with the new deck request URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->