### PR TITLE
Enable persistent DB connections (CONN_MAX_AGE)

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -407,6 +407,12 @@ POSTGRES_DB_NAME = env('POSTGRES_DB_NAME')
 POSTGRES_USER = env('POSTGRES_USER')
 POSTGRES_PASSWORD = env('POSTGRES_PASSWORD', default=None)
 
+# Persist database connections across requests instead of opening a new one each time
+# (Django's default of 0 closes the connection at the end of every request).
+# Env-configurable so it can be tuned per deployment or pinned to 0 where a connection
+# pooler (e.g. pgbouncer in transaction mode) makes persistent connections undesirable.
+CONN_MAX_AGE = env.int('CONN_MAX_AGE', default=60)
+
 DATABASES = {
     'default': {
         'ENGINE': 'django_tenants.postgresql_backend',
@@ -414,7 +420,8 @@ DATABASES = {
         'USER': POSTGRES_USER,
         'PASSWORD': POSTGRES_PASSWORD,
         'HOST': POSTGRES_HOST,
-        'PORT': POSTGRES_PORT
+        'PORT': POSTGRES_PORT,
+        'CONN_MAX_AGE': CONN_MAX_AGE,
     }
 }
 


### PR DESCRIPTION
### What?
Sets `CONN_MAX_AGE` on the default database so connections persist across requests instead of being opened and closed on every request.

Closes #908

### Why?
Django's default `CONN_MAX_AGE` is `0`, which opens a fresh database connection at the start of each request and closes it at the end. Reusing connections across requests removes that per-request connect/teardown overhead — this is the specific item on Django's [deployment checklist](https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/#conn-max-age) that #908 asks for.

### How?
```python
CONN_MAX_AGE = env.int('CONN_MAX_AGE', default=60)

DATABASES = {
    'default': {
        ...
        'CONN_MAX_AGE': CONN_MAX_AGE,
    }
}
```
- **Env-configurable** so it can be tuned per deployment, or pinned to `0` where a connection pooler (e.g. pgbouncer in transaction-pooling mode) makes long-lived persistent connections undesirable. Default is a conservative `60` seconds.
- **Tenant-safe:** django-tenants resets the connection's `search_path` on each tenant activation, so a reused connection is re-scoped to the correct schema on every request — persistent connections and multi-tenancy coexist safely.

### Testing?
- `manage.py check` passes; the setting resolves to `60` by default.
- Smoke-ran `siteconfig.tests.test_views` (8 tests) with the setting active to confirm the request/tenant cycle is unaffected — all pass. flake8 clean.

No unit test is added: this is a settings/config default (a value assertion would be tautological and settings aren't exercised by the test DB's connection lifecycle). Happy to add a regression guard if you'd prefer one.

### Screenshots (if front end is affected)
N/A — settings-only change.

### Anything Else?
Worth a quick sanity check against production's Postgres `max_connections` vs. the number of web/celery workers, since persistent connections hold a slot per worker for up to `CONN_MAX_AGE` seconds. If that's ever tight, set `CONN_MAX_AGE=0` in that environment's config to opt back out.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_