### PR TITLE
Fix AllowedGFKChoiceField caching an empty choice list (order-dependent test flake)

### DIFF
--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -159,26 +159,45 @@ class AllowedGFKChoiceField(GFKChoiceField):
     widget = GFKSelect2Widget
 
     def __init__(self, *args, **kwargs):
+        querysetsequence = self._build_querysetsequence()
+        super().__init__(querysetsequence, *args, **kwargs)
+        self._configure_widget_search_fields()
+
+    def _build_querysetsequence(self):
+        """Resolve the allowed-models QuerySetSequence from the *current* DB state.
+
+        The allowed models are looked up from the content-types table, so this
+        can only succeed once that table exists and is queryable in the active
+        schema. A field declared on a form class is constructed at *import time*
+        (Django evaluates ``prereq_object = PrereqGFKChoiceField()`` when the
+        form class body runs), which may happen before the database/tenant
+        schema is ready — e.g. while the test runner is importing test modules
+        to collect them. When that early lookup comes back empty the field would
+        otherwise cache an empty (all-invalid) choice list for the life of the
+        process, so every form instance copied from it rejects valid selections.
+
+        To avoid that, this is called again from ``__deepcopy__``: Django copies
+        the declared field into each form instance (``BaseForm.__init__`` does
+        ``self.fields = copy.deepcopy(self.base_fields)``), so rebuilding on copy
+        means every real form instance resolves its choices against the live
+        schema at request time, regardless of when the field was first imported.
+        """
         model_classes = []
         try:
             model_classes = self.get_allowed_model_classes()
-        except ContentType.DoesNotExist:
-            # table doesn't exist yet
-            pass
-        except ProgrammingError:
-            # django.db.utils.ProgrammingError: no such table:
-            # django_content_type (e.g. postgresql)
-            pass
-        except OperationalError:
-            # django.db.utils.OperationalError: no such table:
-            # django_content_type (e.g. sqlite)
+        except (ContentType.DoesNotExist, ProgrammingError, OperationalError):
+            # The content-types table isn't queryable yet (imported before
+            # migrations, or no such table on postgres/sqlite). Leave the choice
+            # list empty for now; the __deepcopy__ into a form instance rebuilds
+            # it once the schema is available.
             pass
 
-        querysetsequence = self.overridden_querysetsequence(
+        return self.overridden_querysetsequence(
             QuerySetSequence(*[x.objects.all() for x in model_classes])
         )
-        super().__init__(querysetsequence, *args, **kwargs)
 
+    def _configure_widget_search_fields(self):
+        """Populate the select2 widget's per-model search fields from the queryset."""
         search_fields = {}
         for qs in self.queryset.get_querysets():
             klass = qs.model
@@ -188,6 +207,18 @@ class AllowedGFKChoiceField(GFKChoiceField):
         self.widget.search_fields = search_fields
         self.widget.attrs['data-placeholder'] = 'Type to search'
         self.widget.attrs['data-theme'] = 'bootstrap'
+
+    def __deepcopy__(self, memo):
+        """Rebuild the allowed-models queryset when copied into a form instance.
+
+        See ``_build_querysetsequence`` for why the import-time snapshot can't be
+        trusted. ``ModelChoiceField.__deepcopy__`` copies the (possibly stale)
+        queryset and widget; we then re-resolve both against the current schema.
+        """
+        result = super().__deepcopy__(memo)
+        result.queryset = result._build_querysetsequence()
+        result._configure_widget_search_fields()
+        return result
 
     def get_allowed_model_classes(self):
         """Returns a list of allowed Model classes"""

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -88,3 +88,57 @@ class RestrictedFileFormFieldTest(TenantTestCase):
 
         # ensure content type is set correctly
         self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])
+
+
+class AllowedGFKChoiceFieldRebuildTest(TenantTestCase):
+    """Regression tests for AllowedGFKChoiceField rebuilding its choices on copy.
+
+    AllowedGFKChoiceField resolves its allowed models from the content-types
+    table when the field object is constructed. Form fields are constructed at
+    import time (when the form class body runs), which can happen before the
+    database/tenant schema is ready -- e.g. while the test runner imports test
+    modules to collect them -- leaving the field with an empty, all-invalid
+    choice list cached for the whole process. Django copies declared fields into
+    each form instance, so the field must rebuild its choices on deepcopy for
+    forms to accept valid selections regardless of import timing.
+    """
+
+    def test_deepcopy_rebuilds_empty_import_time_queryset(self):
+        """A field left empty at construction repopulates its choices when copied."""
+        import copy
+
+        from prerequisites.forms import PrereqGFKChoiceField
+        from prerequisites.models import IsAPrereqMixin
+
+        field = PrereqGFKChoiceField()
+        # Simulate the import-time failure mode: the allowed-models lookup came
+        # back empty (e.g. contenttypes not queryable when the field was built).
+        field.queryset = QuerySetSequence()
+        self.assertEqual(list(field.queryset.get_querysets()), [])
+
+        # Django copies declared fields into each form instance
+        # (BaseForm.__init__ deep-copies base_fields); the copy must rebuild
+        # its choices against the live schema.
+        copied = copy.deepcopy(field)
+        models = [qs.model for qs in copied.queryset.get_querysets()]
+
+        self.assertTrue(models, "deepcopy should have rebuilt a non-empty choice list")
+        self.assertEqual(models, IsAPrereqMixin.all_registered_model_classes())
+
+    def test_form_instance_has_valid_choices_even_if_declared_field_is_empty(self):
+        """A form using the field accepts a valid GFK selection through its copied field."""
+        import copy
+
+        from prerequisites.forms import PrereqFormInline, PrereqGFKChoiceField
+
+        # Force the declared (import-time) field to be empty, then confirm a form
+        # instance -- which deep-copies that field -- still resolves real choices.
+        empty_field = PrereqGFKChoiceField()
+        empty_field.queryset = QuerySetSequence()
+
+        form_field = copy.deepcopy(empty_field)
+        self.assertTrue([qs.model for qs in form_field.queryset.get_querysets()])
+
+        # And a real form built from the declared fields resolves choices too.
+        form = PrereqFormInline()
+        self.assertTrue([qs.model for qs in form.fields['prereq_object'].queryset.get_querysets()])


### PR DESCRIPTION
### What?
Fixes `AllowedGFKChoiceField` (the base of `PrereqGFKChoiceField` and `CytoscapeGFKChoiceField`) so it no longer caches an empty, all-invalid choice list when the field object is first constructed under conditions where the content-types table isn't queryable yet. This removes an order-dependent flake that could make `quest_manager.tests.test_views.QuestPrereqsUpdate.test_post_save_button__*` and `djcytoscape.tests.test_views.ViewTests.test_ScapeGenerateMap__POST` / `test_ScapeUpdateView__POST` fail in some multi-app test runs.

### Why?
`AllowedGFKChoiceField` resolves its allowed models from the content-types table in `__init__`. A form field is constructed when the form class body runs — at **import time** — which can happen before the database/tenant schema is ready, most notably while the test runner imports test modules to collect them. When that early lookup came back empty, the field cached an empty choice list. Because Django deep-copies declared fields into every form instance (`BaseForm.__init__` does `self.fields = copy.deepcopy(self.base_fields)`), that empty list was then reused for the whole process, so every form using the field rejected valid selections with "Select a valid choice" and returned `200` instead of redirecting. It only triggered on unlucky import orderings, which is why it appeared as an intermittent, order-dependent flake rather than a hard failure.

### How?
Rebuild the allowed-models queryset in `AllowedGFKChoiceField.__deepcopy__`, which Django calls when copying the declared field into each form instance. Every real form instance now resolves its choices against the live schema at request time, regardless of when the field was first imported. `__init__` is refactored to share the build and widget-configuration logic with `__deepcopy__`. A side benefit: `CytoscapeGFKChoiceField`'s "already in use" exclusion now reflects the current maps per request instead of a stale import-time snapshot.

No change to the public API of the field; the fix is internal to how the choice queryset is (re)built.

### Testing?
- Added regression tests in `utilities/tests/test_fields.py` that force an empty import-time queryset and assert a copied field, and a real form instance, repopulate their choices.
- Ran `utilities.tests.test_fields`, `prerequisites.tests.test_fields`, `djcytoscape.tests.test_fields`, and the previously-flaky `quest_manager.tests.test_views.QuestPrereqsUpdate` and `djcytoscape.tests.test_views.ViewTests` — all pass.
- Reproduced the original failure deterministically before the fix (field's allowed-models list resolved to `[]`, POST returned 200) and confirmed it resolves to the full model list and returns 302 after.

### Screenshots (if front end is affected)
N/A — no user-facing changes.

### Anything Else?
There is a separate, rarer latent flake specific to the two djcytoscape map-generation tests (a random-collision in their fixtures); that is addressed in a small follow-up test-only PR so this one stays a focused production fix.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_