### PR TITLE
Make djcytoscape map-generation view tests deterministic

### DIFF
--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -31,7 +31,19 @@ class ViewTests(ViewTestUtilsMixin, TenantTestCase):
         Profile.objects.get_or_create(user=self.test_teacher)
         Profile.objects.get_or_create(user=self.test_student1)
 
-        self.map = baker.make('djcytoscape.CytoScape')
+        self.quest_ct = ContentType.objects.get(app_label='quest_manager', model='quest')
+        # Pin this map's initial object to a dedicated quest. baker.make would
+        # otherwise fill initial_content_type/initial_object_id with random
+        # values that could (rarely, depending on baker's RNG state across a
+        # multi-app run) collide with the object a POST test submits, which the
+        # CytoscapeGFKChoiceField then excludes as "already in use" -- making the
+        # form invalid only on unlucky orderings.
+        self.map_initial_quest = baker.make('quest_manager.Quest')
+        self.map = baker.make(
+            'djcytoscape.CytoScape',
+            initial_content_type=self.quest_ct,
+            initial_object_id=self.map_initial_quest.id,
+        )
 
     def test_all_page_status_codes_for_anonymous(self):
         ''' If not logged in then all views should redirect to home page  '''
@@ -99,9 +111,12 @@ class ViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         self.client.force_login(self.test_teacher)
 
-        # generate form data
-        content_type = ContentType.objects.filter(CytoScape.ALLOWED_INITIAL_CONTENT_TYPES).first()
-        object_ = content_type.model_class().objects.first()
+        # A dedicated, freshly-created quest as the initial object: it is not yet
+        # used by any map, so the CytoscapeGFKChoiceField won't exclude it. Using
+        # an unordered .objects.first() here made the test depend on which quest
+        # happened to be first and whether it was already a map's initial object.
+        content_type = self.quest_ct
+        object_ = baker.make('quest_manager.Quest')
 
         form_data = generate_form_data(model_form=GenerateQuestMapForm, name='New Name')
         form_data.update({'initial_content_object': f'{content_type.id}-{object_.id}'})
@@ -129,9 +144,10 @@ class ViewTests(ViewTestUtilsMixin, TenantTestCase):
 
         self.client.force_login(self.test_teacher)
 
-        # generate form data
-        content_type = ContentType.objects.filter(CytoScape.ALLOWED_INITIAL_CONTENT_TYPES).first()
-        object_ = content_type.model_class().objects.first()
+        # A dedicated quest (not used as any other map's initial object) so the
+        # CytoscapeGFKChoiceField accepts it; see test_ScapeGenerateMap__POST.
+        content_type = self.quest_ct
+        object_ = baker.make('quest_manager.Quest')
 
         form_data = generate_form_data(model_form=QuestMapForm, name='Updated Name')
         form_data.update({'initial_content_object': f'{content_type.id}-{object_.id}'})


### PR DESCRIPTION
### What?
Removes an order-dependent flake in `djcytoscape.tests.test_views.ViewTests.test_ScapeGenerateMap__POST` and `test_ScapeUpdateView__POST` by making their fixtures deterministic. Test-only change.

### Why?
`setUp` created the pre-existing map with `baker.make('djcytoscape.CytoScape')`, which fills `initial_content_type`/`initial_object_id` with **random** values (model_bakery ignores `limit_choices_to`). Each POST test then picked a target object via an **unordered** `ContentType.objects.filter(...).first()` / `.objects.first()`. When the map's random initial object happened to collide with the picked target, `CytoscapeGFKChoiceField` excluded that target as "already in use", the submitted form was invalid, and the view returned `200` instead of redirecting. Whether it collided depended on model_bakery's RNG state across a multi-app run and on unordered row order, so the tests were intermittently flaky.

### How?
- Pin the pre-existing map's initial object to a dedicated quest (`initial_content_type` = quest content type, `initial_object_id` = a freshly-created quest's id), so it can't randomly collide with a POST test's target.
- Have each POST test submit its own freshly-created quest as the target object instead of `.objects.first()`. A brand-new quest is guaranteed not to be any other map's initial object, so `CytoscapeGFKChoiceField` never excludes it.

No production code changes.

### Testing?
Ran `djcytoscape.tests.test_views` — all pass. The two POST tests no longer depend on RNG state or row ordering.

### Screenshots (if front end is affected)
N/A — test-only change.

### Anything Else?
Complements #1967, which fixes the shared root cause (`AllowedGFKChoiceField` caching an empty choice list at import time) behind the observed multi-app failures in these djcytoscape tests and in `quest_manager`'s `QuestPrereqsUpdate`. This PR is the smaller, test-only hardening for the separate random-collision issue specific to these two tests; the two PRs are independent and touch different files.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_