### PR TITLE
Enable DB connection health checks alongside CONN_MAX_AGE

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -422,6 +422,13 @@ DATABASES = {
         'HOST': POSTGRES_HOST,
         'PORT': POSTGRES_PORT,
         'CONN_MAX_AGE': CONN_MAX_AGE,
+        # Companion to CONN_MAX_AGE: verify a persistent connection is still
+        # alive at the start of each request and transparently reconnect if it
+        # died while idle (RDS failover, network blip, server-side timeout).
+        # Without this, a dead pooled connection surfaces as an intermittent
+        # InterfaceError/OperationalError on whatever request draws it.
+        # https://docs.djangoproject.com/en/4.2/ref/settings/#conn-health-checks
+        'CONN_HEALTH_CHECKS': True,
     }
 }
 

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -52,3 +52,15 @@ class DeploymentSettingsGuardTest(SimpleTestCase):
         """DEBUG=False with a unique SECRET_KEY on a real domain passes the guard."""
         # Should not raise.
         _validate_deployment_settings("bytedeck.com", False, "a-real-random-secret-key")
+
+
+class DatabaseConnectionSettingsTest(SimpleTestCase):
+    """Persistent DB connections (CONN_MAX_AGE) must be paired with connection
+    health checks, otherwise a pooled connection that died while idle (RDS
+    failover, network blip, server-side timeout) surfaces as an intermittent
+    error on whatever request draws it."""
+
+    def test_conn_health_checks_enabled(self):
+        """CONN_HEALTH_CHECKS must be True so dead persistent connections are
+        detected and transparently re-established at the start of a request."""
+        self.assertTrue(settings.DATABASES["default"]["CONN_HEALTH_CHECKS"])


### PR DESCRIPTION
### What?
Adds `'CONN_HEALTH_CHECKS': True` to the `DATABASES` config — the companion setting that #1965's `CONN_MAX_AGE=60` was missing.

### Why?
With persistent connections but no health checks, a pooled connection that dies while idle (RDS failover, network blip, server-side idle timeout) isn't detected until a request draws it — which then fails with an intermittent `InterfaceError`/`OperationalError`. With `CONN_HEALTH_CHECKS=True`, Django verifies the connection at the start of each request and transparently reconnects instead. ([Django docs](https://docs.djangoproject.com/en/4.2/ref/settings/#conn-health-checks))

### How?
One line in `DATABASES['default']` with an explanatory comment, directly under the existing `CONN_MAX_AGE` entry.

### Testing?
Added `DatabaseConnectionSettingsTest.test_conn_health_checks_enabled` in `src/hackerspace_online/tests/test_settings.py` asserting the flag is set, matching the existing settings-test style.

### Screenshots (if front end is affected)
n/a — settings only.

### Anything Else?
The health check is skipped entirely when `CONN_MAX_AGE=0` (Django only checks pooled connections), so pinning `CONN_MAX_AGE=0` in an env for pgbouncer-style setups keeps working unchanged.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_