### PR TITLE
Self-heal missing allauth account tables before account.0003 (develop twin of #1971)

### DIFF
--- a/src/tenant/migrations/0015_ensure_allauth_account_tables.py
+++ b/src/tenant/migrations/0015_ensure_allauth_account_tables.py
@@ -1,0 +1,59 @@
+# Self-healing repair for schemas whose django-allauth `account` tables are
+# missing even though the migration history records them as applied.
+#
+# Background: on long-lived databases (production/staging public schema, some
+# development environments) the early `account` migrations were recorded as
+# applied without the tables ever being created (faked history from when
+# allauth was first added). Nothing touched those tables for years, so the
+# inconsistency was invisible — until the django-allauth upgrade (>=65, from
+# the Django 5.2 dep-modernization) shipped account.0003, whose ALTER against
+# account_emailaddress crashes with 'relation "account_emailaddress" does not
+# exist' and blocks `migrate_schemas` (and therefore every deploy).
+#
+# This migration runs BEFORE account.0003 (run_before) and creates any missing
+# account tables using the historical model state as of account.0002, so 0003+
+# can then apply normally. On healthy schemas — including fresh databases,
+# where account.0001/0002 really run first thanks to the dependency below —
+# every table already exists and this is a no-op.
+
+from django.db import migrations
+
+
+def ensure_allauth_account_tables(apps, schema_editor):
+    """Create any missing django-allauth `account` tables in the schema
+    currently being migrated.
+
+    Uses the historical model state (as of account.0002, per this migration's
+    dependencies), so the created tables match what the recorded-but-never-run
+    migrations should have produced; later account migrations then apply
+    cleanly on top. Table existence is checked through the connection's
+    introspection, which respects the active schema's search_path under
+    django-tenants, so each schema is repaired (or skipped) independently.
+    """
+    connection = schema_editor.connection
+    existing_tables = set(connection.introspection.table_names())
+    # EmailAddress first: EmailConfirmation has a foreign key to it.
+    for model_name in ("EmailAddress", "EmailConfirmation"):
+        model = apps.get_model("account", model_name)
+        if model._meta.db_table not in existing_tables:
+            schema_editor.create_model(model)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tenant", "0014_auto_20231116_0308"),
+        # Pin the historical model state the tables are created from.
+        ("account", "0002_email_max_length"),
+    ]
+
+    # Guarantee this repair runs before the first allauth migration that
+    # executes SQL against account_emailaddress on upgraded installs.
+    run_before = [
+        ("account", "0003_alter_emailaddress_create_unique_verified_email"),
+    ]
+
+    operations = [
+        # Reverse is a no-op: we never want to drop the tables on rollback.
+        migrations.RunPython(ensure_allauth_account_tables, migrations.RunPython.noop),
+    ]

--- a/src/tenant/tests/test_migrations.py
+++ b/src/tenant/tests/test_migrations.py
@@ -1,0 +1,52 @@
+import importlib
+
+from django.apps import apps as django_apps
+from django.db import connection
+
+from django_tenants.test.cases import TenantTestCase
+
+# Migration modules start with a digit, so import via importlib.
+ensure_allauth_account_tables = importlib.import_module(
+    "tenant.migrations.0015_ensure_allauth_account_tables"
+).ensure_allauth_account_tables
+
+
+class EnsureAllauthAccountTablesTest(TenantTestCase):
+    """The 0015_ensure_allauth_account_tables data migration repairs schemas
+    whose migration history records django-allauth's `account` migrations as
+    applied even though the tables were never created (e.g. the production and
+    staging public schemas), which made the allauth >=65 upgrade migration
+    account.0003 crash with 'relation "account_emailaddress" does not exist'
+    and block every deploy."""
+
+    ACCOUNT_TABLES = ("account_emailaddress", "account_emailconfirmation")
+
+    def _existing_account_tables(self):
+        """Return the subset of allauth account tables present in the current schema."""
+        return {t for t in connection.introspection.table_names() if t in self.ACCOUNT_TABLES}
+
+    def _run_migration_function(self):
+        """Invoke the migration's RunPython callable the way the executor would."""
+        with connection.schema_editor() as schema_editor:
+            ensure_allauth_account_tables(django_apps, schema_editor)
+
+    def test_ensure_allauth_account_tables__recreates_missing_tables(self):
+        """When the account tables are missing (phantom migration history), the
+        migration recreates them so later allauth migrations can apply."""
+        with connection.cursor() as cursor:
+            # Confirmation first (it has a FK to emailaddress); CASCADE for safety.
+            cursor.execute("DROP TABLE IF EXISTS account_emailconfirmation CASCADE")
+            cursor.execute("DROP TABLE IF EXISTS account_emailaddress CASCADE")
+        self.assertEqual(self._existing_account_tables(), set())
+
+        self._run_migration_function()
+
+        self.assertEqual(self._existing_account_tables(), set(self.ACCOUNT_TABLES))
+
+    def test_ensure_allauth_account_tables__noop_when_tables_exist(self):
+        """On healthy schemas the migration changes nothing and raises nothing."""
+        self.assertEqual(self._existing_account_tables(), set(self.ACCOUNT_TABLES))
+
+        self._run_migration_function()  # must not raise (e.g. no duplicate-table error)
+
+        self.assertEqual(self._existing_account_tables(), set(self.ACCOUNT_TABLES))


### PR DESCRIPTION
### What?
Identical cherry-pick of the staging hotfix **#1971**: adds `tenant.0015_ensure_allauth_account_tables`, a self-healing data migration that recreates django-allauth `account` tables in schemas whose migration history records them as applied but where they were never created, guaranteed (`run_before`) to run before allauth's `account.0003`.

### Why?
The allauth `>=65` upgrade (#1916) crash-loops any long-lived database with the phantom-history state — staging's public schema is broken right now (see #1971), and older development databases will hit the same wall. Landing the same migration in `develop` self-heals dev environments and keeps `develop`/`staging` consistent (the file is byte-identical, so future `develop → staging` merges are clean).

### How? / Testing?
See #1971 — same commit, same migration, same `TenantTestCase` tests covering the repair path (tables dropped → recreated) and the no-op path (healthy schema untouched).

### Screenshots (if front end is affected)
n/a.

### Anything Else?
Merge whichever of this and #1971 first; the other stays clean since the content is identical.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_