### PR TITLE
Silence nginx/uwsgi startup warnings (dead OCSP stapling, params hash, ini nits)

### DIFF
--- a/nginx/bytedeck.conf.template
+++ b/nginx/bytedeck.conf.template
@@ -22,9 +22,6 @@ server {
 
     server_name ${DOMAIN} *.${DOMAIN};
 
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
-    resolver_timeout 5s;
-
     ## Deny illegal Host headers
     if ($host !~* ^(${DOMAIN}|.+\.${DOMAIN})$ ) {
         return 444;
@@ -104,12 +101,12 @@ server {
     # HSTS (ngx_http_headers_module is required) (63072000 seconds)
     add_header Strict-Transport-Security "max-age=63072000" always;
 
-    # OCSP stapling
-    ssl_stapling on;
-    ssl_stapling_verify on;
-
-    # verify chain of trust of OCSP response using Root CA and Intermediate certs
-    ssl_trusted_certificate /etc/letsencrypt/live/${DOMAIN}/chain.pem;
+    # OCSP stapling intentionally NOT configured: Let's Encrypt shut down its
+    # OCSP responders in 2025 (in favour of CRLs), so its certificates carry no
+    # OCSP URL and "ssl_stapling on" only produced a startup warning
+    # ('"ssl_stapling" ignored, no OCSP responder URL in the certificate').
+    # The `resolver` directive that existed solely for OCSP fetching was
+    # removed along with it.
 
     # GZIP SETTINGS: https://www.nginx.com/blog/help-the-world-by-healing-your-nginx-configuration/#Enabling-Gzip-Compression-for-HTML-CSS-and-JavaScript-Files
     gzip on;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,11 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+
+    # Long uwsgi_param names (e.g. HTTP_X_FORWARDED_PROTO) overflow the default
+    # 64-byte hash bucket, making nginx warn "could not build optimal
+    # uwsgi_params_hash" on every start; a bigger bucket silences it.
+    uwsgi_params_hash_bucket_size 128;
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';

--- a/src/uwsgi.aws.ini
+++ b/src/uwsgi.aws.ini
@@ -39,7 +39,9 @@ threads         = 2
 # the maximum `processes`, keep a small floor of workers and spawn more only
 # under load, then retire them when idle. This cuts idle memory dramatically
 # while preserving peak capacity. https://uwsgi-docs.readthedocs.io/en/latest/Cheaper.html
-cheaper-algo    = spare         ; always-available algo (no extra plugin needed)
+# NOTE: cheaper-algo is intentionally not set. "spare" is already the built-in
+# default, and naming it explicitly made this pip-built uwsgi log "unable to
+# find requested cheaper algorithm, falling back to spare" on every start.
 cheaper         = 2             ; minimum workers to keep running
 cheaper-initial = 2             ; workers to spawn at startup
 cheaper-step    = 2             ; spawn this many extra workers at a time under load
@@ -52,9 +54,12 @@ cheaper-overload = 30           ; observation window (s) the cheaper logic uses 
 # 500 errors. Bump it. https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html
 buffer-size     = 16384
 
-socket          = 0.0.0.0:8000  ; TCP socket to nginx. A unix socket needs a volume shared
-                                ; with the nginx container (see socket_data in the compose file);
-                                ; the perf gain over TCP on a docker network is negligible, so we use TCP.
+# TCP socket to nginx. A unix socket would need a volume shared with the nginx
+# container (see socket_data in the compose file); the perf gain over TCP on a
+# docker network is negligible, so we use TCP. Keep the comment on its own
+# lines: uwsgi does NOT strip inline `;` comments from values, so an inline
+# comment here leaks into the socket string (visible in the startup log).
+socket          = 0.0.0.0:8000
 
 vacuum          = true          ; on exit, clean up any temporary files or UNIX sockets it created
 
@@ -67,6 +72,12 @@ worker-reload-mercy = 60        ; How long to wait before forcefully killing wor
 
 harakiri        = 60            ; Forcefully kill workers stuck for >60s on a single request
 harakiri-verbose = true         ; Log a backtrace when harakiri fires, so slow requests are diagnosable
+
+# Buffer request bodies larger than this (bytes) to a temp file before the
+# request hits a worker, so a slow upload can't burn a worker's harakiri
+# window (silences uwsgi's "harakiri without post buffering" startup warning).
+# Low risk either way: nginx already buffers client bodies before proxying.
+post-buffering  = 8192
 
 # This setting is causing errors: https://github.com/unbit/uwsgi/issues/1978
 # https://stackoverflow.com/questions/62250160/uwsgi-runtimeerror-cannot-release-un-acquired-lock


### PR DESCRIPTION
### What?
Cleans up every warning observed in the staging startup logs that's actually worth acting on:

| Log message | Verdict | Fix |
|---|---|---|
| `"ssl_stapling" ignored, no OCSP responder URL in the certificate` | **Dead config — remove** | Removed `ssl_stapling`/`ssl_stapling_verify`/`ssl_trusted_certificate` + the `resolver` that existed only for OCSP fetching |
| `could not build optimal uwsgi_params_hash…` | Cosmetic — silence | `uwsgi_params_hash_bucket_size 128;` in `nginx.conf` |
| `unable to find requested cheaper algorithm, falling back to spare` | Cosmetic — silence | Dropped explicit `cheaper-algo = spare` (spare **is** the built-in default; the fallback was the requested algo, so behaviour is unchanged) |
| `WARNING: you have enabled harakiri without post buffering` | Minor real risk — fix | `post-buffering = 8192` so a slow upload can't burn a worker's harakiri window |
| `uwsgi socket 0 bound to TCP address 0.0.0.0:8000  ; TCP socket to nginx…` | Comment leaking into the value — fix | uwsgi doesn't strip inline `;` comments from values; moved the comment onto its own lines |
| `connect() failed (113: No route to host) while connecting to upstream` | **Not a config problem — no action** | These were symptoms of the web container crash-loop fixed by #1971 (nginx trying to reach a dead/recreated container). Gone since the hotfix deployed. |
| `your server socket listen backlog is limited to 100 connections` | Informational — no action | Fine at current scale; raising it needs a container `somaxconn` sysctl too, not worth the moving parts now |

### Why?
The OCSP one deserves the headline: **Let's Encrypt shut down its OCSP responders in 2025** (moving revocation to CRLs), so LE certificates no longer carry an OCSP URL and `ssl_stapling` can never engage again — it's permanently dead config that warns on every start. The rest is noise reduction so real problems stand out in `docker compose logs`.

### How?
- `nginx/bytedeck.conf.template`: OCSP block + resolver removed, with a comment explaining why stapling is intentionally absent.
- `nginx/nginx.conf`: one-line hash bucket bump (our long `HTTP_X_FORWARDED_PROTO` uwsgi_param overflows the 64-byte default).
- `src/uwsgi.aws.ini`: `cheaper-algo` removed (default is identical), `post-buffering = 8192` added, socket comment moved off the value line.

### Testing?
- Rendered the template with `envsubst` semantics and verified: no active `ssl_stapling`/`resolver` directives remain, `${DOMAIN}` substitution intact, cert paths correct.
- Verified `uwsgi.aws.ini` has no `cheaper-algo` directive, a clean `socket = 0.0.0.0:8000` value, and `post-buffering` set.
- No TLS behaviour change: modern browsers stopped relying on OCSP stapling (Chrome never soft-failed on it; Firefox disabled OCSP checks by default in 2025) — revocation is handled client-side via CRLite/CRLSets.

### Screenshots (if front end is affected)
n/a — server config only.

### Anything Else?
Targets `develop` per the normal flow; cherry-pick/merge to `staging` if you want the warnings gone there before the next develop→staging sync. After deploy, an nginx start should log no warnings at all.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web server startup reliability by preventing configuration warnings related to request parameter handling.
  * Removed unsupported TLS certificate status stapling configuration to avoid unnecessary OCSP resolver behavior.
  * Improved handling of larger request bodies by buffering them more reliably during processing.

* **Documentation**
  * Clarified server configuration behavior and startup fallbacks through updated inline guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->