### PR TITLE
Fix badge action-button row and status button target

### DIFF
--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -24,26 +24,27 @@
 
         {% if request.user.is_staff %}
         <div class="col-xs-12 col-sm-4 text-right">
-          <div class="pull-right">
+          {# btn-group keeps the actions on a single row (fa-fw gives them a uniform width) #}
+          <div class="btn-group pull-right" role="group">
             <a class="btn btn-warning" title="Edit" href="{% url 'badges:badge_update' badge.id %}">
-              <i class="fa fa-edit"></i>
+              <i class="fa fa-fw fa-edit"></i>
             </a>
             <a class="btn btn-primary" title="Copy" href="{% url 'badges:badge_copy' badge.id %}">
-              <i class="fa fa-copy"></i>
+              <i class="fa fa-fw fa-copy"></i>
             </a>
             <a class="btn btn-danger" title="Delete" href="{% url 'badges:badge_delete' badge.id %}">
-              <i class="fa fa-trash-o"></i>
+              <i class="fa fa-fw fa-trash-o"></i>
             </a>
             <a class="btn btn-success" title="Grant to a student" href="{% url 'badges:grant' badge.id 0 %}">
-              <i class="fa fa-user"></i>
+              <i class="fa fa-fw fa-user"></i>
             </a>
-            <a class="btn btn-success" title="Bulk grant to multiple student" href="{% url 'badges:bulk_grant_badge' badge.id %}">
-              <i class="fa fa-users"></i>
+            <a class="btn btn-success" title="Bulk grant to multiple students" href="{% url 'badges:bulk_grant_badge' badge.id %}">
+              <i class="fa fa-fw fa-users"></i>
             </a>
             {% if badge.published %}
             <a class="btn btn-success" title="Grant to all students who meet this {{ config.custom_name_for_badge|lower }}'s prerequisites"
                href="{% url 'badges:grant_qualifying' badge.id %}">
-              <i class="fa fa-fw fa-users"></i>
+              <i class="fa fa-fw fa-user-plus"></i>
             </a>
             {% endif %}
           </div>

--- a/src/quest_manager/templates/quest_manager/submission_buttons_other.html
+++ b/src/quest_manager/templates/quest_manager/submission_buttons_other.html
@@ -11,7 +11,7 @@
         target="_blank" href="{% url 'quests:approved_for_quest' s.quest.id %}">
         <i class="fa fa-fw fa-folder-o"></i></a>
     <a title="View status of all students for this quest" class="btn btn-default" role="button"
-        target="_blank" href="{% url 'quests:quest_user_status' s.quest.id %}">
+        href="{% url 'quests:quest_user_status' s.quest.id %}">
         <i class="fa fa-fw fa-users"></i></a>
     <a title="View summary data for this quest" class="btn btn-default" role="button"
         target="_blank" href="{% url 'quests:summary' s.quest.id %}">


### PR DESCRIPTION
### What?
Two small frontend follow-ups to recently merged work.

Closes #1979
Partially addresses #1973 (item 7)

### Why / How?
**#1979 — badge "grant to qualifying students" button** (`badges/detail.html`)
The button added in #1925 reused the bulk-grant icon (`fa-users`) and pushed the staff action row onto a second line:
- Gave it a **distinct icon**, `fa-user-plus` (grant single = `fa-user`, bulk = `fa-users`, qualifying = `fa-user-plus`).
- Wrapped the staff action buttons in a `btn-group` so they stay on **one row**.
- Added `fa-fw` to every icon in the row so the buttons are a **uniform width**.

**#1973 item 7 — completion-status button** (`submission_buttons_other.html`)
Dropped `target="_blank"` on the "student completion status" button (added in #1935) so it opens in the same tab, per item 7 of #1973. (The other items on #1973 are separate enhancements to the status page and are left for that issue.)

### Testing?
Template-only change. Rendering is exercised by the existing badge-detail view test (`test_all_badge_page_status_codes_for_teachers`), which passes. The button layout is a visual change — worth a quick eyeball in the browser to confirm the row and icon look right.

### Screenshots (if front end is affected)
Visual change to the badge detail action-button row (distinct icon + single row) and the submission status button now opens in-tab.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment and consistency of staff action buttons on badge detail pages.
  * Standardized action icons for a more uniform appearance.
  * Clarified the bulk grant button label to indicate it applies to multiple students.
  * Preserved existing actions, links, and visibility conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->