### PR TITLE
Don't treat a no-op prereq save as a change

### DIFF
--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -365,6 +365,33 @@ class BadgeViewTests(ViewTestUtilsMixin, TenantTestCase):
         messages = [str(m) for m in response.wsgi_request._messages]
         self.assertFalse(any(grant_url in m for m in messages))
 
+    def test_badge_prereqs_update__no_change_is_noop(self):
+        """Saving a badge's prereqs form without adding or changing anything (only the
+        empty extra form, untouched) must not report an update or show the grant-check
+        prompt (issue #1980). test_badge is published, so a broken guard would show both.
+        """
+        self.client.force_login(self.test_teacher)
+        form_prefix = "prerequisites-prereq-parent_content_type-parent_object_id"
+        # the single extra form as the browser renders it untouched: no prereq_object, and
+        # the count fields at their rendered defaults -> the form is unchanged/empty
+        formset_data = {
+            f"{form_prefix}-TOTAL_FORMS": "1",
+            f"{form_prefix}-INITIAL_FORMS": "0",
+            f"{form_prefix}-MIN_NUM_FORMS": "0",
+            f"{form_prefix}-MAX_NUM_FORMS": "1000",
+            f"{form_prefix}-0-prereq_count": "1",
+            f"{form_prefix}-0-or_prereq_count": "1",
+        }
+        response = self.client.post(
+            reverse('badges:badge_prereqs_update', args=[self.test_badge.id]), data=formset_data
+        )
+
+        self.assertRedirects(response, self.test_badge.get_absolute_url())
+        messages = [str(m) for m in response.wsgi_request._messages]
+        grant_url = reverse('badges:grant_qualifying', args=[self.test_badge.id])
+        self.assertFalse(any("Prerequisites have been updated" in m for m in messages))
+        self.assertFalse(any(grant_url in m for m in messages))
+
     def test_scape_update_message_on_update_delete(self):
         """ Checks if delete and update function gives a success message when a badge is related to map """
         # setup

--- a/src/badges/views.py
+++ b/src/badges/views.py
@@ -75,8 +75,12 @@ class BadgePrereqsUpdate(ObjectPrereqsFormView):
         ready — issue #1157). The prompt links to badge_grant_qualifying, which confirms
         the count before granting. Only published badges can be auto-granted.
         """
+        # Only prompt when the prereqs actually changed — a no-op save shouldn't nag the
+        # teacher to run a grant-check (issue #1980); the base view already skips its own
+        # save/messages in that case.
+        changed = form.has_changed()
         response = super().form_valid(form)
-        if self.object.published:
+        if changed and self.object.published:
             badge_name = SiteConfig.get().custom_name_for_badge.lower()
             grant_url = reverse('badges:grant_qualifying', args=[self.object.id])
             # Messages render with |safe (messages-snippet.html), matching how the rest of the

--- a/src/prerequisites/views.py
+++ b/src/prerequisites/views.py
@@ -44,6 +44,13 @@ class ObjectPrereqsFormView(NonPublicOnlyViewMixin, SingleObjectMixin, FormView)
         return self.ObjectPrereqFormset(**self.get_form_kwargs(), instance=self.object)
 
     def form_valid(self, form):
+        # `form` is the prereq formset. If nothing actually changed (e.g. the teacher
+        # hit Save without editing anything, or removed the always-present empty "extra"
+        # form), skip the save so we don't claim the prerequisites were updated or trigger
+        # a needless map regeneration. Issue #1980.
+        if not form.has_changed():
+            return HttpResponseRedirect(self.get_success_url())
+
         form.save()
 
         messages.success(


### PR DESCRIPTION
### What?
Makes saving the prerequisites form a no-op when nothing actually changed.

Closes #1980

### Why?
`ObjectPrereqsFormView.form_valid` (the shared view behind both the quest and badge "Edit Prerequisites" forms) always:
- re-saved the formset,
- flashed **"Prerequisites have been updated for …"**, and
- (when `map_auto_update` is on) kicked off a **map regeneration**,

…even when the teacher just hit **Save** without editing anything, or removed the always-present empty *extra* form. My #1157 work made this worse on badges by *also* prompting a grant-check on every such save.

### How?
- **`prerequisites/views.py`** — guard the save/messages/map-regeneration on `form.has_changed()`. If nothing changed, `form_valid` just redirects back to the detail page.
- **`badges/views.py`** — `BadgePrereqsUpdate.form_valid` checks `has_changed()` before showing the grant-check prompt, so a no-op save no longer nags the teacher.

### Testing?
- New `test_badge_prereqs_update__no_change_is_noop`: an untouched save on a published badge shows **neither** the "updated" message **nor** the grant prompt.
- The existing changed-path tests still assert the update message / grant prompt appear when prereqs actually change.
- Ran the full `prerequisites` suite (65) plus the badge and quest prereq view classes — all pass. flake8 clean.

*Note:* the quest-side no-op is exercised through the same shared `form_valid`; I tested it via the badge form because the `QuestPrereqsUpdate` test class is sensitive to the known `AllowedGFKChoiceField` choice-ordering flake and adding cases there destabilized it.

### Screenshots (if front end is affected)
N/A — behavioural fix (no more spurious "updated" message / map recalc / grant prompt on an unchanged save).

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_