### PR TITLE
Hotfix: nginx [emerg] unknown directive + svc.sh pager freezing deploys

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,10 +14,14 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Long uwsgi_param names (e.g. HTTP_X_FORWARDED_PROTO) overflow the default
-    # 64-byte hash bucket, making nginx warn "could not build optimal
-    # uwsgi_params_hash" on every start; a bigger bucket silences it.
-    uwsgi_params_hash_bucket_size 128;
+    # NOTE: nginx warns "could not build optimal uwsgi_params_hash, you should
+    # increase either uwsgi_params_hash_max_size: 512 or
+    # uwsgi_params_hash_bucket_size: 64" at startup (our long uwsgi_param names
+    # like HTTP_X_FORWARDED_PROTO overflow the bucket). That advice is generated
+    # by nginx's generic hash code, but NO such directives exist in the uwsgi
+    # module -- its params-hash sizes are hardcoded -- so following the advice
+    # produces [emerg] unknown directive and nginx refuses to start. The warning
+    # is benign and unavoidable; live with it.
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';

--- a/production/setup-runner.sh
+++ b/production/setup-runner.sh
@@ -29,9 +29,17 @@ RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
 MARKER="$RUNNER_DIR/.bytedeck-runner-setup-version"
 REPO_URL="https://github.com/bytedeck/bytedeck"
 
+svc() {
+    # Always run svc.sh with the systemd pager disabled: svc.sh shells out to
+    # `systemctl status`, which on a TTY opens an interactive pager (less) and
+    # freezes the deploy until 'q' is pressed. An empty SYSTEMD_PAGER is
+    # equivalent to systemctl --no-pager.
+    (cd "$RUNNER_DIR" && sudo env SYSTEMD_PAGER= SYSTEMD_LESS= ./svc.sh "$@")
+}
+
 service_running() {
     # svc.sh proxies systemctl status: exit 0 = active.
-    (cd "$RUNNER_DIR" && sudo ./svc.sh status >/dev/null 2>&1)
+    svc status >/dev/null 2>&1
 }
 
 # --- Fast path: already set up and current ----------------------------------
@@ -41,14 +49,14 @@ if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$SETUP_VERSION" ]; then
         exit 0
     fi
     echo "Deploy runner: configured but service not running -- starting it."
-    (cd "$RUNNER_DIR" && sudo ./svc.sh start)
+    svc start
     exit 0
 fi
 
 # --- Adopt a runner that was configured manually -----------------------------
 if [ -f "$RUNNER_DIR/.runner" ]; then
     echo "Deploy runner: existing configuration found in $RUNNER_DIR -- adopting it."
-    service_running || (cd "$RUNNER_DIR" && sudo ./svc.sh start)
+    service_running || svc start
     echo "$SETUP_VERSION" > "$MARKER"
     exit 0
 fi
@@ -112,8 +120,8 @@ tar xzf runner.tar.gz && rm runner.tar.gz
     --work _work
 
 # Install as a systemd service running as this user, so it survives reboots.
-sudo ./svc.sh install "$(whoami)"
-sudo ./svc.sh start
+svc install "$(whoami)"
+svc start
 
 echo "$SETUP_VERSION" > "$MARKER"
 echo ""


### PR DESCRIPTION
### What?
Fixes two deploy-breaking bugs currently biting staging:

1. **nginx crash-loop** — removes `uwsgi_params_hash_bucket_size 128;` from `nginx/nginx.conf`. I added it in #1982 following nginx's *own* startup-warning advice ("you should increase … uwsgi_params_hash_bucket_size"), but that advice is generated by nginx's generic hash code and **no such directive exists** — the uwsgi module's params-hash sizes are hardcoded. nginx fails with `[emerg] unknown directive` and never starts.
2. **`setup-runner.sh` freeze** — the runner's `svc.sh` shells out to `systemctl status`, which opens an interactive **pager** on a TTY and blocks until `q`; Ctrl+C there kills the rest of `server-update.sh`, skipping the app restart. All `svc.sh` calls now go through a helper that sets `SYSTEMD_PAGER=` (equivalent to `--no-pager`).

### Why?
Staging's nginx container is crash-looping right now on the `[emerg]`, and the runner setup froze mid-deploy. My fault on both — I followed nginx's misleading advice without validating it against a real binary, and didn't account for systemctl's pager in the interactive path.

### How? / Testing?
- **nginx**: verified the fixed `nginx.conf` differs from the pre-#1982 config (which ran in production for years) by **comments only** — the replacement comment documents that the startup warning is benign and *not* tunable, so this trap isn't re-walked.
- **runner script**: `sh -n` clean; regression-tested the adopt/start paths with a mock `svc.sh` that hard-fails whenever `SYSTEMD_PAGER` isn't disabled — all paths pass.

### Screenshots (if front end is affected)
n/a.

### Anything Else?
- **Recovery on staging after merge:** `git pull && ./production/server-update.sh` (or let the runner auto-deploy the merge if it's live). Since the frozen run was Ctrl+C'd before the app-restart step, this run also completes the interrupted deploy.
- Both bugs also exist on `develop` (via #1982 / #1962) — they'll come back on the next staging→develop back-merge, same as the allauth hotfix.
- The original "could not build optimal uwsgi_params_hash" startup **warning returns and stays** — it is unavoidable with our long `uwsgi_param` names and harmless.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_