### PR TITLE
CI: stop `docker compose run` from recreating the db container mid-migration

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,8 +18,15 @@ jobs:
         run: docker compose up -d
       - name: Check running containers
         run: docker ps -a
+      # The `docker compose run` steps below all use --no-deps: without it,
+      # `run` re-evaluates the service's depends_on and can RECREATE the db
+      # container while the web container (from `up -d` above) is still running
+      # its startup migrations -- killing web, so the later `docker compose
+      # exec web` fails with "service 'web' is not running". Everything these
+      # one-off containers need is already up, so never let `run` touch the
+      # rest of the stack. --rm stops them piling up as exited containers.
       - name: Check for potential django problems
-        run: docker compose run web python src/manage.py check
+        run: docker compose run --rm --no-deps web python src/manage.py check
       - name: Check production deployment security settings
         # Exercises the DEBUG=off (production/staging) config path so the
         # SECURE_*/cookie-security settings can't silently regress. Overrides
@@ -28,12 +35,12 @@ jobs:
         # setdefault semantics). --fail-level WARNING turns the deploy checks
         # into a hard gate.
         run: >
-          docker compose run --rm
+          docker compose run --rm --no-deps
           -e DEBUG=False
           -e SECRET_KEY=ci-deploy-check-only-not-a-real-secret-key-0123456789abcdef
           web python src/manage.py check --deploy --fail-level WARNING
       - name: Check for missing migrations
-        run: docker compose run web python src/manage.py makemigrations --check --dry-run
+        run: docker compose run --rm --no-deps web python src/manage.py makemigrations --check --dry-run
       - name: Run test suite
         run: |
           docker compose exec -T web coverage run --parallel-mode src/manage.py test src


### PR DESCRIPTION
### What?
Fix the intermittent "Build and Test" CI failure where the test step dies with `docker compose exec web` → **"service 'web' is not running"**. Adds `--no-deps --rm` to the three `docker compose run web ...` check steps in `build_and_test.yml`.

### Why?
The job starts the full stack with `docker compose up -d`; the web container then spends its first minutes running `migrate_schemas` before `runserver`. The subsequent bare `docker compose run web ...` steps (django check, deploy check, missing-migrations check) **re-evaluate web's `depends_on`** — and Compose can decide to **recreate the `db` container** while web is still mid-migration. That kills web's DB connection and the container with it, so the later `docker compose exec -T web coverage run ...` finds no running `web` service. Seen on PR #1963, whose run only went green on attempt 2.

### How?
`--no-deps` makes `docker compose run` create *only* the one-off container and never inspect, start, or recreate the service's dependencies — the race is eliminated by construction, not by timing. The one-off containers still join the compose networks, so they reach the already-running db/redis normally. `--rm` (previously only on the deploy-check step) stops the check containers accumulating as exited containers. A comment in the workflow explains why `--no-deps` is load-bearing so it doesn't get cleaned off later.

An alternative considered: `docker compose up -d --wait` to block until healthchecks pass. Not needed once `run` can't touch the stack at all, and `--no-deps` is the smaller, targeted change.

### Testing?
Workflow YAML validated; behavior change is CI-only (no application code). This PR's own "Build and Test" run exercises the modified steps end-to-end. The failure is a race, so a single green run doesn't prove absence — but with `--no-deps` the recreate code path is unreachable by construction.

### Screenshots (if front end is affected)
N/A — CI workflow only.

### Anything Else?
The dev experience is unaffected: `docker compose up` / local usage doesn't change; only the CI check steps pass extra flags.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated Django checks to run reliably without starting or recreating dependent services.
  * Enhanced production security validation while preserving required CI settings.
  * Added a check to detect missing database migrations before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->