### PR TITLE
Upgrade numpy 1.22 → 2.2 (ceiling <2.3 while on Python 3.10)

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -32,7 +32,7 @@ celery>=5.3,<5.6
 cssutils==2.11.1
 dnspython>=2.6.1,<3.0
 html2text==2020.1.16
-numpy==1.22
+numpy>=1.26,<2.3  # 2.3+ requires Python >= 3.11; raise the ceiling with the Python upgrade
 pytz # required by django-redis which uses pickle, even though django-redis changelog says it doesn't us pickle anymore?
 
 # subdependencies


### PR DESCRIPTION
### What?
Bump `numpy==1.22` → `numpy>=1.26,<2.3` (resolves to **2.2.6** on Python 3.10). One-line requirements change; no code changes needed.

### Why?
numpy 1.22 is from December 2021 — four years old and long out of support. This is part of the pre-Django-5.2 dependency modernization (numpy doesn't depend on Django, so it can move independently). It's split from the batch-upgrade PR because a 1.x→2.x major jump deserves its own revert point.

The `<2.3` ceiling is deliberate: **numpy 2.3+ requires Python ≥ 3.11** and the app runs 3.10 (`python:3.10-slim`). The ceiling comment says to raise it together with the Python upgrade.

### How?
Swept the whole of `src/` for numpy-2.0 removed APIs (`np.float_`, `np.NaN`, `np.unicode_`, `np.core.*`, `ptp()`, etc.) — **nothing found**. The only numpy usage is stable public API:
- `courses/models.py` — `busday_count` / `is_busday` / `busday_offset` (semester date math)
- `courses/views.py` — `clip` / `arange` / `histogram` / `add` (mark distribution)
- `quest_manager/views.py` — `array` / `sort` / `mean` / `median` / `histogram` (submission-time stats)

None of these were touched by the 2.0 breaking changes, so the pin bump is the entire diff.

### Testing?
Full `courses` + `quest_manager` app suites (the only numpy consumers) against numpy 2.2.6: **378 tests, 0 failures** — this includes the semester business-day calculations and the mark-calculations histogram views. CI runs the complete suite on top.

### Screenshots (if front end is affected)
N/A — no user-visible change.

### Anything Else?
Companion to the non-Django batch-upgrade PR (pillow/celery/bs4/bleach/html2text/cssutils). Dependabot has been proposing numpy 2.5.x (#1960 etc.) — that needs Python ≥3.12, hence this capped range instead.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported NumPy version range to allow newer compatible releases while maintaining compatibility with the current Python version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->