### PR TITLE
Upgrade non-Django dependencies ahead of the Django 5.2 flip

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -27,9 +27,9 @@ tenant-schemas-celery>=4.0,<4.1
 
 # non django
 beautifulsoup4>=4.15,<4.16
-bleach[css]>=6,<7
+bleach[css]>=6.4,<7  # 6.4 includes the invisible-Unicode-character XSS fix
 celery>=5.6,<5.7
-cssutils>=2.15,<3.0
+cssutils>=2.15,<3.0  # 2.12+ split vendored encutils into its own package; upgrading an EXISTING venv clobbers it -- run: pip install --force-reinstall encutils
 dnspython>=2.6.1,<3.0
 html2text>=2025.4.15,<2026
 numpy>=1.26,<2.3  # 2.3+ requires Python >= 3.11; raise the ceiling with the Python upgrade

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -26,12 +26,12 @@ django-url-or-relative-url-field>=0.2.0,<0.3.0
 tenant-schemas-celery>=4.0,<4.1
 
 # non django
-beautifulsoup4>=4.12.3,<4.13
-bleach[css]>=5,<6
-celery>=5.3,<5.6
-cssutils==2.11.1
+beautifulsoup4>=4.15,<4.16
+bleach[css]>=6,<7
+celery>=5.6,<5.7
+cssutils>=2.15,<3.0
 dnspython>=2.6.1,<3.0
-html2text==2020.1.16
+html2text>=2025.4.15,<2026
 numpy==1.22
 pytz # required by django-redis which uses pickle, even though django-redis changelog says it doesn't us pickle anymore?
 
@@ -41,4 +41,4 @@ psycopg2-binary>=2.8.6,<2.10  # since our backend is PostgreSQL, Django and djan
 # server couldn't speak RESP3) is gone -- all environments now run redis:7 --
 # but the ceiling stays until celery/kombu declare redis-py 8 support.
 redis>=4.0.2,<8
-pillow>=10.3,<11.0  # used implicitly by django_resized (does not exist as an extra package either)
+pillow>=12.3,<13.0  # used implicitly by django_resized (does not exist as an extra package either)


### PR DESCRIPTION
### What?
Batch upgrade of the six remaining stale dependencies that do **not** depend on Django, so they can land before (and independently of) the Django 5.2 flip:

| Package | From | To (resolves) | Notes |
|---|---|---|---|
| pillow | `>=10.3,<11` | 12.3.0 | 12.x supports Python 3.10 |
| celery | `>=5.3,<5.6` | 5.6.3 | tenant-schemas-celery only requires `celery>=5` |
| beautifulsoup4 | `>=4.12.3,<4.13` | 4.15.0 | 4.13 was the big typing rewrite; API unchanged |
| bleach[css] | `>=5,<6` | 6.4.0 | comment/summernote sanitization paths covered by tests |
| html2text | `==2020.1.16` | 2025.4.15 | plain-text email rendering |
| cssutils | `==2.11.1` | 2.15.0 | see below — the exact pin finally explained |

numpy is deliberately **not** here — it moves in its own PR (#1995) so the 1.x→2.x jump has an isolated revert point.

### Why?
Part of the dependency modernization ahead of the Django 5.2 flip: everything Django-adjacent already moved in #1916; these six were the remaining old pins. Django-gated packages (django-crispy-forms 2.6, django-redis 7 — both require Django ≥5.2) stay ceilinged and will move with the flip itself.

### How?
Pin updates in `requirements-production.txt` only — no code changes needed. The only cssutils API the codebase uses (`from cssutils import CSSParser` in `siteconfig/forms.py`) is unchanged in 2.15.

**The cssutils `==2.11.1` mystery, solved:** cssutils ≥ 2.12 splits its previously-vendored `encutils` module into a separate PyPI package. On a **fresh** install (CI, Docker image builds) that's fine. But an **in-place** `pip install -r` upgrade breaks cssutils: pip installs the new `encutils` dist first, then uninstalls old cssutils — whose file manifest *owns* the `encutils/` directory — deleting the module the new package just installed. Anyone upgrading an existing local venv should run `pip install --force-reinstall encutils` once after upgrading. Deployment images are rebuilt fresh, so production is unaffected.

### Testing?
- **Full test suite against the upgraded set: 1076 tests, 0 failures** (Django still 4.2).
- Verified imports/versions in the built environment: pillow 12.3.0, celery 5.6.3, bs4 4.15.0, bleach 6.4.0, html2text 2025.4.15, cssutils 2.15.0.
- The suite covers the consumers directly: summernote CSS sanitizer + comment sanitization (bleach/cssutils), plain-text email generation (html2text), avatar/badge image handling (pillow via django-resized), and the task paths (celery, eager mode).

### Screenshots (if front end is affected)
N/A — dependency pins only.

### Anything Else?
- This closes out most of Dependabot's current suggestions; its remaining floor-bump PRs (django-tenants 3.10.2, django-import-export 4.4.1, etc.) are no-ops — those versions already install today under the existing ranges.
- `redis` stays `<8`: kombu 5.6.2 still declares support only for redis-py `<6.5`, so nothing upstream has blessed 8.x yet.
- Companion PR: #1995 (numpy 1.22 → 2.2).

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated production components to newer supported versions.
  - Refined version compatibility ranges to improve maintenance and support future updates.
  - No user-facing functionality or interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->