### PR TITLE
Ops reliability: celery failure alerts, session cleanup, bounded select2 cache

### DIFF
--- a/src/hackerspace_online/celery.py
+++ b/src/hackerspace_online/celery.py
@@ -72,6 +72,17 @@ def email_admins_on_task_failure(sender=None, task_id=None, exception=None, einf
     task+exception type per hour, so a failing per-schema fan-out can't send
     hundreds of emails. Never raises: error reporting must not be able to
     take down the worker.
+
+    Arguments (all supplied by celery's task_failure signal):
+        sender: the task object that failed (its `name` attribute is used;
+            falls back to repr() if absent).
+        task_id (str): id of the failed task instance.
+        exception (Exception): the exception the task raised.
+        einfo: billiard ExceptionInfo whose str() is the traceback.
+        **kwargs: remaining signal arguments (args, kwargs, traceback);
+            accepted and ignored, as the signal contract requires.
+
+    Returns None.
     """
     from django.core.cache import cache
     from django.core.mail import mail_admins

--- a/src/hackerspace_online/celery.py
+++ b/src/hackerspace_online/celery.py
@@ -4,6 +4,7 @@ from django.conf import settings
 
 from tenant_schemas_celery.app import CeleryApp
 from celery.schedules import crontab
+from celery.signals import task_failure
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hackerspace_online.settings')
@@ -50,7 +51,53 @@ app.conf.beat_schedule = {
             "queue": "default",
         }
     },
+    "Clear expired sessions in all schemas daily task": {
+        "task": "tenant.tasks.clear_expired_sessions_in_all_schemas",
+        "schedule": crontab(minute=0, hour=2),
+        "options": {
+            "queue": "default",
+        }
+    },
 }
+
+
+@task_failure.connect
+def email_admins_on_task_failure(sender=None, task_id=None, exception=None, einfo=None, **kwargs):
+    """Email ADMINS when any celery task raises during execution.
+
+    Without this, task exceptions vanish into the worker log: no task in the
+    project configures retries, there is no result backend, and
+    CELERY_TASK_IGNORE_RESULT is on -- so a broken periodic task could fail
+    silently for weeks. Throttled via the cache to one email per
+    task+exception type per hour, so a failing per-schema fan-out can't send
+    hundreds of emails. Never raises: error reporting must not be able to
+    take down the worker.
+    """
+    from django.core.cache import cache
+    from django.core.mail import mail_admins
+
+    try:
+        task_name = getattr(sender, 'name', None) or repr(sender)
+        throttle_key = f'task-failure-emailed:{task_name}:{type(exception).__name__}'
+        # cache.add is atomic: returns False if the key already exists.
+        if not cache.add(throttle_key, True, timeout=60 * 60):
+            return
+        mail_admins(
+            subject=f'Celery task failed: {task_name}',
+            message=(
+                f'Task: {task_name}\n'
+                f'Task id: {task_id}\n'
+                f'Exception: {exception!r}\n\n'
+                f'{einfo}\n\n'
+                'Further failures of this task with the same exception type are '
+                'suppressed for 1 hour.'
+            ),
+            fail_silently=True,
+        )
+    except Exception:
+        # e.g. the cache itself is down -- swallow it; the original task
+        # failure is already in the worker log.
+        pass
 
 
 # @app.task(bind=True)

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -374,7 +374,14 @@ CACHES = {
         },
         'KEY_FUNCTION': 'django_tenants.cache.make_key',
         'REVERSE_KEY_FUNCTION': 'django_tenants.cache.reverse_key',
-        'TIMEOUT': None,
+        # Was TIMEOUT: None (never expire). django-select2 pickles a queryset
+        # per rendered widget into this cache, so with no TTL the entries
+        # accumulate forever -- and with the production Redis capped by
+        # maxmemory + noeviction, an ever-growing cache eventually makes Redis
+        # refuse ALL writes (breaking the shared Celery broker too). 24h covers
+        # any realistic open-form lifetime (an ajax lookup after expiry just
+        # means reopening the form) while keeping the cache bounded.
+        'TIMEOUT': env.int('SELECT2_CACHE_TIMEOUT', default=60 * 60 * 24),
     }
 }
 

--- a/src/hackerspace_online/tests/test_celery.py
+++ b/src/hackerspace_online/tests/test_celery.py
@@ -11,6 +11,12 @@ class FakeTask:
     """Stand-in for the celery task object passed as `sender` to task_failure."""
 
     def __init__(self, name):
+        """Store the dotted task name the handler reads off the sender.
+
+        Args:
+            name (str): value for the `name` attribute, mirroring a real
+                celery task's registered name.
+        """
         self.name = name
 
 
@@ -25,7 +31,15 @@ class EmailAdminsOnTaskFailureTest(SimpleTestCase):
         cache.clear()
 
     def _fire(self, task_name="app.tasks.some_task", exception=None):
-        """Invoke the handler the way celery's task_failure signal would."""
+        """Invoke the handler the way celery's task_failure signal would.
+
+        Args:
+            task_name (str): name given to the FakeTask sender.
+            exception (Exception | None): exception to report; defaults to a
+                ValueError.
+
+        Returns None; assertions inspect mail.outbox afterwards.
+        """
         email_admins_on_task_failure(
             sender=FakeTask(task_name),
             task_id="abc-123",

--- a/src/hackerspace_online/tests/test_celery.py
+++ b/src/hackerspace_online/tests/test_celery.py
@@ -1,0 +1,78 @@
+from unittest.mock import patch
+
+from django.core import mail
+from django.core.cache import cache
+from django.test import SimpleTestCase
+
+from hackerspace_online.celery import app, email_admins_on_task_failure
+
+
+class FakeTask:
+    """Stand-in for the celery task object passed as `sender` to task_failure."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class EmailAdminsOnTaskFailureTest(SimpleTestCase):
+    """The task_failure handler is the only visibility we have into celery task
+    exceptions (no retries, no result backend, results ignored), so it must
+    email ADMINS -- throttled so a failing fan-out can't send hundreds of
+    emails, and without ever raising itself."""
+
+    def setUp(self):
+        """Each test starts with an empty throttle cache."""
+        cache.clear()
+
+    def _fire(self, task_name="app.tasks.some_task", exception=None):
+        """Invoke the handler the way celery's task_failure signal would."""
+        email_admins_on_task_failure(
+            sender=FakeTask(task_name),
+            task_id="abc-123",
+            exception=exception or ValueError("boom"),
+            einfo="traceback goes here",
+        )
+
+    def test_task_failure__emails_admins(self):
+        """A task failure sends one email naming the task and exception."""
+        self._fire()
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("app.tasks.some_task", mail.outbox[0].subject)
+        self.assertIn("ValueError", mail.outbox[0].body)
+
+    def test_task_failure__throttles_repeat_failures(self):
+        """A second identical failure within the throttle window sends nothing."""
+        self._fire()
+        self._fire()
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_task_failure__different_exception_type_not_throttled(self):
+        """A different exception type for the same task is a distinct alert."""
+        self._fire(exception=ValueError("boom"))
+        self._fire(exception=KeyError("boom"))
+        self.assertEqual(len(mail.outbox), 2)
+
+    def test_task_failure__sender_without_name(self):
+        """A sender with no usable name falls back to repr() instead of crashing."""
+        email_admins_on_task_failure(
+            sender=None, task_id="abc", exception=ValueError("x"), einfo=""
+        )
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_task_failure__never_raises_when_cache_is_down(self):
+        """If the throttle cache itself errors, the handler swallows it -- error
+        reporting must not be able to take down the worker."""
+        with patch("django.core.cache.cache.add", side_effect=RuntimeError("redis down")):
+            self._fire()  # must not raise
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class BeatScheduleTest(SimpleTestCase):
+    """The session-cleanup task must actually be scheduled: DatabaseScheduler
+    installs app.conf.beat_schedule entries as PeriodicTask rows on startup, so
+    presence in the dict is what gets it running in production."""
+
+    def test_clear_expired_sessions_scheduled(self):
+        """The beat schedule includes the daily clearsessions fan-out task."""
+        entry = app.conf.beat_schedule["Clear expired sessions in all schemas daily task"]
+        self.assertEqual(entry["task"], "tenant.tasks.clear_expired_sessions_in_all_schemas")

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -119,3 +119,14 @@ class CelerySettingsTest(SimpleTestCase):
         """The worker must retry the broker connection at startup instead of
         dying if redis is momentarily slower to come up."""
         self.assertTrue(settings.CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP)
+
+
+class Select2CacheTest(SimpleTestCase):
+    """The select2 cache pickles a queryset per rendered widget; with no TTL
+    those entries accumulate forever, and with production Redis capped by
+    maxmemory+noeviction an unbounded cache eventually makes Redis refuse all
+    writes (breaking the shared celery broker too)."""
+
+    def test_select2_cache_has_finite_ttl(self):
+        """The select2 cache must have a finite TTL (default 24h), never None."""
+        self.assertEqual(settings.CACHES["select2"]["TIMEOUT"], 60 * 60 * 24)

--- a/src/tenant/tasks.py
+++ b/src/tenant/tasks.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from django.core.management import call_command
 from django.template.loader import get_template
+
+from django_tenants.utils import get_tenant_model, schema_context
 
 from hackerspace_online.celery import app
 from utilities.html import textify
@@ -24,3 +27,22 @@ def send_email_message(subject, message, recipient_list, **kwargs):
     )
     email.attach_alternative(msg, "text/html")
     email.send()
+
+
+@app.task(name="tenant.tasks.clear_expired_sessions_in_all_schemas")
+def clear_expired_sessions_in_all_schemas():
+    """Run Django's `clearsessions` in the public schema and every tenant schema.
+
+    Sessions are database-backed and `django.contrib.sessions` is in both
+    SHARED_APPS and TENANT_APPS, so a django_session table exists per schema and
+    each one accumulates expired rows (8-week SESSION_COOKIE_AGE) until purged.
+    Nothing else cleans them up, so this runs daily via celery beat. The purge
+    is a single DELETE per schema, so looping inline is fine even with many
+    tenants.
+    """
+    schema_names = ['public'] + list(
+        get_tenant_model().objects.exclude(schema_name='public').values_list('schema_name', flat=True)
+    )
+    for schema_name in schema_names:
+        with schema_context(schema_name):
+            call_command('clearsessions')

--- a/src/tenant/tasks.py
+++ b/src/tenant/tasks.py
@@ -39,6 +39,9 @@ def clear_expired_sessions_in_all_schemas():
     Nothing else cleans them up, so this runs daily via celery beat. The purge
     is a single DELETE per schema, so looping inline is fine even with many
     tenants.
+
+    Takes no arguments and returns None; it is invoked by celery beat, which
+    ignores the return value.
     """
     schema_names = ['public'] + list(
         get_tenant_model().objects.exclude(schema_name='public').values_list('schema_name', flat=True)

--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -38,7 +38,16 @@ class ClearExpiredSessionsTaskTest(TenantTestCase):
     session tables grow forever."""
 
     def _make_session(self, key, expired):
-        """Create a session row in the current schema, expired or not."""
+        """Create a session row in the current schema, expired or not.
+
+        Args:
+            key (str): session_key for the new row (must be unique per schema).
+            expired (bool): True dates the session one day in the past
+                (eligible for clearsessions), False one day in the future.
+
+        Returns:
+            Session: the created django.contrib.sessions row.
+        """
         from datetime import timedelta
 
         from django.contrib.sessions.models import Session

--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -29,3 +29,44 @@ class TenantTasksTests(TenantTestCase):
         self.assertEqual(mail.outbox[0].subject, "O hi, World!")
         # john doe was first in a list of recipients (BCC)
         self.assertIn("john@doe.com", mail.outbox[0].bcc)
+
+
+class ClearExpiredSessionsTaskTest(TenantTestCase):
+    """clear_expired_sessions_in_all_schemas purges expired django_session rows
+    in every schema. Sessions are db-backed with an 8-week cookie age and
+    nothing else runs clearsessions, so without this task the per-schema
+    session tables grow forever."""
+
+    def _make_session(self, key, expired):
+        """Create a session row in the current schema, expired or not."""
+        from datetime import timedelta
+
+        from django.contrib.sessions.models import Session
+        from django.utils import timezone
+
+        delta = timedelta(days=-1) if expired else timedelta(days=1)
+        return Session.objects.create(
+            session_key=key, session_data="x", expire_date=timezone.now() + delta
+        )
+
+    def test_clear_expired_sessions_in_all_schemas__purges_only_expired(self):
+        """Expired sessions are deleted in both the tenant and public schemas;
+        unexpired sessions survive."""
+        from django.contrib.sessions.models import Session
+
+        from django_tenants.utils import schema_context
+
+        self._make_session("tenant-expired", expired=True)
+        self._make_session("tenant-valid", expired=False)
+        with schema_context("public"):
+            self._make_session("public-expired", expired=True)
+            self._make_session("public-valid", expired=False)
+
+        task_result = tasks.clear_expired_sessions_in_all_schemas.apply()
+        self.assertTrue(task_result.successful())
+
+        self.assertFalse(Session.objects.filter(session_key="tenant-expired").exists())
+        self.assertTrue(Session.objects.filter(session_key="tenant-valid").exists())
+        with schema_context("public"):
+            self.assertFalse(Session.objects.filter(session_key="public-expired").exists())
+            self.assertTrue(Session.objects.filter(session_key="public-valid").exists())


### PR DESCRIPTION
### What?
Three fixes from the round-2 infrastructure review (items #2/#3/#4):

1. **Celery task failures now email `ADMINS`.** A `task_failure` signal handler in `celery.py` — previously task exceptions **vanished into the worker log** (no task configures retries, there's no result backend, and results are ignored), so a broken daily task could fail silently for weeks. Throttled via atomic `cache.add` to one email per task+exception-type per hour (a failing per-schema fan-out can't send hundreds), and wrapped so error reporting can never take down the worker.
2. **Daily session cleanup.** New `tenant.tasks.clear_expired_sessions_in_all_schemas` + beat entry (02:00): sessions are db-backed with an 8-week cookie age, a `django_session` table exists in **every** schema, and nothing ever ran `clearsessions` — unbounded growth in every deck. The task loops public + all tenant schemas (a single DELETE each, so the inline loop is fine).
3. **select2 cache bounded.** `TIMEOUT: None` → 24 h (env-tunable via `SELECT2_CACHE_TIMEOUT`). django-select2 pickles a queryset per rendered widget into Redis db 2; with no TTL those accumulate forever, and with the production Redis capped by `maxmemory` + `noeviction`, an unbounded cache eventually makes Redis **refuse all writes** — which would break the shared Celery broker too. A lookup on a form left open >24 h just requires reopening the form.

### Why?
See above — these are respectively: the highest-impact reliability gap (invisible failures), a slow unbounded-growth bug in every tenant schema, and a latent Redis-outage trigger created by the interaction of the old no-TTL cache with the new memory cap.

### How?
Smallest-possible surface: one signal handler, one task + one beat-schedule entry (DatabaseScheduler installs `beat_schedule` entries as `PeriodicTask` rows on startup, so the dict entry is sufficient to get it running), one settings value.

### Testing?
All logical branches covered by new tests:
- `EmailAdminsOnTaskFailureTest` — sends, throttles repeats, distinct exception types alert separately, sender-without-name fallback, and never-raises-when-cache-is-down.
- `ClearExpiredSessionsTaskTest` (TenantTestCase) — expired rows purged in both tenant and public schemas, unexpired rows survive.
- `BeatScheduleTest` + `Select2CacheTest` — schedule entry and TTL locked in.

### Screenshots (if front end is affected)
n/a.

### Anything Else?
Plain `ADMINS` email was chosen over Sentry for now per discussion — a separate issue covers what Sentry's free tier would add. Requires `ADMINS`/`SERVER_EMAIL` + SMTP env vars to be set in production for the alerts to actually deliver (they already are, per the env reference in SERVER-README).

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added daily cleanup of expired sessions across all tenant environments.
  - Administrators now receive email alerts when background tasks fail, with duplicate alerts limited for a short period.
  - Added configurable expiration for Select2 cache entries, defaulting to 24 hours.

- **Bug Fixes**
  - Prevented expired session data and indefinitely retained Select2 cache entries from accumulating.

- **Tests**
  - Added coverage for task failure alerts, session cleanup, scheduling, and cache expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->