### PR TITLE
CI: run the test suite once per PR commit, cancel stale runs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,25 @@
 name: Build and Tests
 
-on: [push, pull_request]
+# Run on pushes to the long-lived branches only, plus every pull request.
+# Without the branch filter, a push to a PR branch triggered BOTH a push run
+# and a pull_request run -- the whole ~30 min suite twice per commit.
+# `competencies` is included because it's a long-running integration branch
+# that sub-issue PRs target (see CLAUDE.md). master/staging must stay here:
+# the auto-deploy workflow (deploy.yml) fires via workflow_run when this
+# workflow succeeds on those branches.
+on:
+  push:
+    branches: [develop, staging, master, competencies]
+  pull_request:
+
+# A force-push or rapid follow-up commit cancels the now-stale in-progress
+# run instead of letting both finish. Each PR and each branch gets its own
+# group (github.ref), so unrelated runs never cancel each other. Cancelling
+# a stale master/staging run is safe for auto-deploy: the cancelled run
+# never reaches "success", so deploy.yml simply fires for the newest SHA.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,15 @@
 name: Ruff
 
-on: [push, pull_request]
+# Same trigger/concurrency scheme as build_and_test.yml: long-lived branches
+# on push, every PR, and stale in-progress runs cancelled on new pushes.
+on:
+  push:
+    branches: [develop, staging, master, competencies]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
### What?
Stops the CI suite from running twice for every commit on a PR branch, and cancels stale in-progress runs when a branch is pushed again.

Both `build_and_test.yml` and `lint.yml` changed the same way:
- `on: [push, pull_request]` → `push` restricted to the long-lived branches (`develop`, `staging`, `master`, `competencies`); `pull_request` kept for all PRs.
- Added a `concurrency` group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`.

### Why?
With `on: [push, pull_request]`, every commit to a branch with an open PR triggered **both** a `push` run and a `pull_request` run — the full ~30-minute suite twice, doubling Actions minutes and queue time for zero extra signal. Separately, a force-push or quick follow-up commit left the now-obsolete previous run burning a runner to completion.

### How?
- The `push` branch filter keeps CI on direct pushes to the branches that matter: `develop` (default), `staging`/`master` (auto-deploy fires via `deploy.yml`'s `workflow_run` on **Build and Tests** success there — they must stay in the push list), and `competencies` (the long-running integration branch that sub-issue PRs target).
- Every other branch still gets full CI through its pull request, which is the path that gates merges.
- The concurrency group is per-workflow-per-ref, so unrelated branches/PRs never cancel each other. Cancelling a stale `master`/`staging` run is safe for auto-deploy: a cancelled run never reaches `success`, so `workflow_run` simply fires for the newest SHA only — which is what you want anyway.
- `deploy.yml` already has its own (non-cancelling) concurrency group and is untouched; `codeql-analysis.yml` was already branch-restricted.

### Testing?
YAML validated with a parser. Behavior is exercised by this PR itself: it should get exactly one **Build and Tests** and one **Ruff** run (from `pull_request` only — `claude/ci-dedupe` is not in the push list). Note the *old* workflow definitions still run one last time on the push event for this branch (workflows-on-push come from the pushed ref), so this PR's own commit will still show a duplicate pair; dedupe takes effect for pushes made after this lands anywhere the new definition exists.

### Screenshots (if front end is affected)
n/a

### Anything Else?
One trade-off to be aware of: pushing a branch **without** opening a PR now runs no CI. If anyone relies on push-CI for PR-less scratch branches, they can open a draft PR to get the same coverage.

- Claude Code

### Review request
@tylerecouture

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, test, and lint checks to run on selected branches and all pull requests.
  * Added automatic cancellation of outdated in-progress checks when newer changes are submitted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->