### PR TITLE
Fix broken checkbox layout on the prereq form

### DIFF
--- a/src/prerequisites/forms.py
+++ b/src/prerequisites/forms.py
@@ -24,6 +24,11 @@ class PrereqFormInline(FutureModelForm):
 
     or_prereq_object = PrereqGFKChoiceField(required=False)
 
+    class Media:
+        # Fixes the crispy-bootstrap3 checkbox layout on the advanced prereqs form (issue #1978).
+        # Kept with the form (rather than inline in the template) so it loads via {{ form.media.css }}.
+        css = {'all': ('prerequisites/css/advanced_prereqs_form.css',)}
+
     class Meta:
         model = Prereq
         # fields = ['prereq_content_type', 'prereq_object_id', 'prereq_count', 'prereq_invert']

--- a/src/prerequisites/static/prerequisites/css/advanced_prereqs_form.css
+++ b/src/prerequisites/static/prerequisites/css/advanced_prereqs_form.css
@@ -1,0 +1,18 @@
+/* crispy-bootstrap3 renders each formset checkbox in a <td class="checkbox">.
+   Bootstrap 3's .checkbox rules assume a block wrapper with a <label>: they set the
+   cell to display:block and absolutely-position the input with a negative margin, which
+   drags the NOT/Delete checkboxes out of their table cells. Restore normal table-cell
+   layout for the prereq formset. Issue #1978.
+
+   Loaded via PrereqFormInline.Media so it arrives with the form's own {{ form.media.css }}.
+   The #id_prereq_formset id is set on the <form> by PrereqFormsetHelper.form_id. */
+#id_prereq_formset td.checkbox {
+  display: table-cell;
+  text-align: center;
+  vertical-align: middle;
+}
+
+#id_prereq_formset td.checkbox input[type="checkbox"] {
+  position: static;
+  margin: 0;
+}

--- a/src/prerequisites/templates/prerequisites/advanced_prereqs_form.html
+++ b/src/prerequisites/templates/prerequisites/advanced_prereqs_form.html
@@ -5,22 +5,6 @@
 {% block head %}
   {{ form.media.css }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
-  <style>
-    /* crispy-bootstrap3 renders each formset checkbox in a <td class="checkbox">.
-       Bootstrap 3's .checkbox rules assume a block wrapper with a <label>: they set the
-       cell to display:block and absolutely-position the input with a negative margin, which
-       drags the NOT/Delete checkboxes out of their table cells. Restore normal table-cell
-       layout for the prereq formset. Issue #1978. */
-    #id_prereq_formset td.checkbox {
-      display: table-cell;
-      text-align: center;
-      vertical-align: middle;
-    }
-    #id_prereq_formset td.checkbox input[type="checkbox"] {
-      position: static;
-      margin: 0;
-    }
-  </style>
 {% endblock %}
 
 {% block heading_inner %}Advanced Prerequisites Form{% endblock %}

--- a/src/prerequisites/templates/prerequisites/advanced_prereqs_form.html
+++ b/src/prerequisites/templates/prerequisites/advanced_prereqs_form.html
@@ -5,6 +5,22 @@
 {% block head %}
   {{ form.media.css }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+  <style>
+    /* crispy-bootstrap3 renders each formset checkbox in a <td class="checkbox">.
+       Bootstrap 3's .checkbox rules assume a block wrapper with a <label>: they set the
+       cell to display:block and absolutely-position the input with a negative margin, which
+       drags the NOT/Delete checkboxes out of their table cells. Restore normal table-cell
+       layout for the prereq formset. Issue #1978. */
+    #id_prereq_formset td.checkbox {
+      display: table-cell;
+      text-align: center;
+      vertical-align: middle;
+    }
+    #id_prereq_formset td.checkbox input[type="checkbox"] {
+      position: static;
+      margin: 0;
+    }
+  </style>
 {% endblock %}
 
 {% block heading_inner %}Advanced Prerequisites Form{% endblock %}

--- a/src/prerequisites/tests/test_forms.py
+++ b/src/prerequisites/tests/test_forms.py
@@ -1,0 +1,41 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from django_tenants.test.client import TenantClient
+from model_bakery import baker
+
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from prerequisites.forms import PrereqFormInline
+
+User = get_user_model()
+
+
+class PrereqFormInlineMediaTest(ByteDeckTenantTestCase):
+    """The checkbox-layout fix (issue #1978) is shipped as a static CSS file loaded through the
+    form's own Media, so it arrives with {{ form.media.css }} rather than an inline <style>.
+    """
+
+    CSS = 'prerequisites/css/advanced_prereqs_form.css'
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
+        self.teacher = baker.make(User, is_staff=True)
+
+    def test_form_media_includes_prereq_css(self):
+        """PrereqFormInline declares the layout-fix stylesheet in its Media."""
+        self.assertIn(self.CSS, str(PrereqFormInline().media))
+
+    def test_prereq_form_page_loads_the_css(self):
+        """The stylesheet is actually emitted on the advanced prereqs form page — for both the
+        quest and badge prereq forms, which share advanced_prereqs_form.html.
+        """
+        self.client.force_login(self.teacher)
+        quest = baker.make('quest_manager.Quest')
+        badge = baker.make('badges.Badge')
+
+        for url in (reverse('quests:quest_prereqs_update', args=[quest.pk]),
+                    reverse('badges:badge_prereqs_update', args=[badge.pk])):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, self.CSS)


### PR DESCRIPTION
### What?
Fixes the mangled checkbox layout on the Advanced Prerequisites form (the NOT / Delete checkboxes).

Closes #1978

### Why?
django-crispy-forms 2.x + crispy-bootstrap3 renders each formset checkbox as `<td class="checkbox">`. Bootstrap 3's `.checkbox` rules are written for a block wrapper that contains a `<label>`: they set `display: block` and absolutely-position `input[type=checkbox]` with a negative left margin. Applied to a **table cell**, that makes the cell stop behaving as a table cell and yanks the checkbox out of its column — the "checkboxes are all messed up" reported on both the badge and quest prereq forms (both render `advanced_prereqs_form.html`).

### How?
A small CSS reset scoped to the prereq formset (`#id_prereq_formset`) in that template's `<head>`:
```css
#id_prereq_formset td.checkbox { display: table-cell; text-align: center; vertical-align: middle; }
#id_prereq_formset td.checkbox input[type="checkbox"] { position: static; margin: 0; }
```
No markup or logic changes — the checkbox cells just render as normal centered table cells again.

### Testing?
Pure styling fix. Confirmed both prereq forms still render (200) with the reset present; the checkbox markup is unchanged. **Worth a quick eyeball in the browser** to confirm the columns line up.

### Screenshots (if front end is affected)
Before: NOT/Delete checkboxes fall out of their table columns (see #1978). After: they sit centered in their cells.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox alignment in the advanced prerequisites form.
  * Ensured NOT and Delete checkboxes remain correctly positioned within their table cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->