### PR TITLE
Fix F821 lint error in comments test (ByteDeckTenantTestCase)

### DIFF
--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -73,7 +73,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
             Comment.objects.create_comment(user=user, text="hi", path="/" + "x" * 400)
 
 
-class CommentModelValidationTest(TenantTestCase):
+class CommentModelValidationTest(ByteDeckTenantTestCase):
     """flag()/unflag() validate the comment before saving (issue #1630)."""
 
     def setUp(self):


### PR DESCRIPTION
### What?
Hotfix: `develop` currently fails `ruff check src` (so **CI is red on every open PR**).

### Why?
`comments/tests/test_models.py:76` — `CommentModelValidationTest` (added in #2006) still subclasses `TenantTestCase`, but a later refactor changed this module to import `ByteDeckTenantTestCase` and removed the `TenantTestCase` import. The leftover reference is now an undefined name:

```
src/comments/tests/test_models.py:76:34: F821 Undefined name `TenantTestCase`
```

Two PRs landed close together (my #2006 and the `ByteDeckTenantTestCase` test-infra refactor) and the collision wasn't caught.

### How?
Change that one class to subclass `ByteDeckTenantTestCase`, matching the two sibling tenant test classes already in the same file.

### Testing?
`ruff check src` → **All checks passed**. `CommentModelValidationTest` + `CommentManagerTest` (8 tests) pass under the corrected base.

### Screenshots (if front end is affected)
N/A.

### Review request
@tylerecouture — worth merging promptly since it unblocks CI for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_