### PR TITLE
Hotfix develop: comments test_models NameError from #1997/#2006 merge collision

### DIFF
--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -73,7 +73,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
             Comment.objects.create_comment(user=user, text="hi", path="/" + "x" * 400)
 
 
-class CommentModelValidationTest(TenantTestCase):
+class CommentModelValidationTest(ByteDeckTenantTestCase):
     """flag()/unflag() validate the comment before saving (issue #1630)."""
 
     def setUp(self):


### PR DESCRIPTION
### What?

One-line fix: `CommentModelValidationTest(TenantTestCase)` → `CommentModelValidationTest(ByteDeckTenantTestCase)` in `comments/tests/test_models.py`.

### Why?

`develop`'s Build and Test is currently red ([run 29595823619](https://github.com/bytedeck/bytedeck/actions/runs/29595823619)):

```
ERROR: comments.tests.test_models (unittest.loader._FailedTest)
ImportError: ... class CommentModelValidationTest(TenantTestCase):
NameError: name 'TenantTestCase' is not defined
```

This is a merge collision between two PRs that were each fine on their own:

- **#1997** (test-suite reuse) converted this file to `ByteDeckTenantTestCase` and removed the now-unused `from django_tenants.test.cases import TenantTestCase` import.
- **#2006** concurrently added `CommentModelValidationTest(TenantTestCase)` to the same file.

Merging both left `CommentModelValidationTest` referencing `TenantTestCase` with no import, so the whole `comments.tests.test_models` module fails to import and the job errors. GitHub's mergeability check doesn't catch this (no textual conflict), and neither PR's own CI saw it.

### How?

`CommentModelValidationTest` is a plain-ORM validation test (`flag()`/`unflag()` raising `ValidationError`), so it's safe on the reused schema. `ByteDeckTenantTestCase` is already imported in the file, so the fix is just the base class — consistent with the file's other tenant tests. I also grepped the tree to confirm no other test file has a bare, unimported `TenantTestCase` base class.

### Testing?

- `python src/manage.py test comments`: **30 tests, OK**.
- `ruff check src/comments/tests/test_models.py`: clean.
- Full-suite verification in progress; will confirm on this PR.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Branched fresh off `develop` (since #1997 already merged). This is the follow-up hotfix for that merge interaction.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_