### PR TITLE
Stop the profile email change from 500ing on DNS resolver errors

### DIFF
--- a/src/profile_manager/forms.py
+++ b/src/profile_manager/forms.py
@@ -1,3 +1,4 @@
+import dns.exception
 import dns.resolver
 
 from django import forms
@@ -73,11 +74,16 @@ class ProfileForm(forms.ModelForm):
             try:
                 dns.resolver.resolve(domain, 'MX')
                 # If it doesn't throw an exception, the domain has MX records
-            except dns.resolver.NoAnswer:
-                # Some domains don't answer, such as sd72.bc.ca!
-                pass
             except dns.resolver.NXDOMAIN:
                 raise forms.ValidationError(f"{domain} doesn't appear to exist. Enter a valid email address or leave it blank.")
+            except dns.exception.DNSException:
+                # Any other DNS failure — NoAnswer (some domains don't answer, such as sd72.bc.ca!),
+                # NoNameservers, timeouts, resolver misconfiguration, etc. — means we couldn't verify
+                # the domain, not that it's invalid. This is best-effort validation, and the real gate
+                # is the verification email sent afterward, so fail open rather than blocking (or 500ing)
+                # the email change. Previously only NoAnswer/NXDOMAIN were caught, so a resolver error on
+                # a server with restricted/slow outbound DNS crashed the profile form with a 500 (issue #1976).
+                pass
 
         if email and email_address_exists(email, exclude_user=self.instance.user):
             raise forms.ValidationError("A user is already registered with this email address.")

--- a/src/profile_manager/tests/test_forms.py
+++ b/src/profile_manager/tests/test_forms.py
@@ -6,6 +6,7 @@ from profile_manager.forms import ProfileForm
 from siteconfig.models import SiteConfig
 
 from unittest.mock import patch, MagicMock
+import dns.exception
 import dns.resolver
 
 
@@ -81,6 +82,20 @@ class ProfileFormTest(ByteDeckTenantTestCase):
             form.is_valid()
             cleaned_email = form.cleaned_data['email']
             self.assertEqual(cleaned_email, 'example@domainwithnoanswer.com')
+
+    def test_clean_email__dns_lookup_error_fails_open(self):
+        """A DNS lookup failure that isn't NXDOMAIN (NoNameservers, a timeout, resolver
+        misconfiguration, etc.) means we simply couldn't verify the domain — not that it's
+        invalid. clean_email should fail open and accept the email rather than let the
+        exception propagate and 500 the whole profile form (issue #1976). Without the broad
+        dns.exception.DNSException handler these would crash instead of validating.
+        """
+        for exc in (dns.resolver.NoNameservers, dns.resolver.LifetimeTimeout, dns.exception.Timeout):
+            with self.subTest(exception=exc.__name__):
+                form = ProfileForm(instance=self.user.profile, data={'email': 'example@gmail.com'})
+                with patch('dns.resolver.resolve', side_effect=exc):
+                    self.assertTrue(form.is_valid())
+                    self.assertEqual(form.cleaned_data['email'], 'example@gmail.com')
 
     def test_profile_with_custom_profile_field(self):
         """ tests if user can create a profile with `custom_profile_field` when SiteConfig.custom_profile_field


### PR DESCRIPTION
### What?
Fixes the **500 Server Error** a deck owner hit when changing their email address on their profile (`/profiles/1/edit/`).

Closes #1976

### Why?
`ProfileForm.clean_email` verifies the email's domain with a DNS `MX` lookup, but only caught two dnspython exceptions:

```python
except dns.resolver.NoAnswer:   # pass
except dns.resolver.NXDOMAIN:   # graceful "domain doesn't exist" error
```

Any **other** dnspython error — `NoNameservers`, `LifetimeTimeout`, `dns.exception.Timeout`, resolver misconfiguration, etc. — propagated straight out of the form and crashed the whole page with a 500. These are exactly the errors a server with restricted or slow outbound DNS raises, which is what happened on staging. I reproduced it: patching `dns.resolver.resolve` to raise `NoNameservers` makes the real `profiles:profile_update` view return **500**.

It looked owner-specific (per the issue), but it isn't — the owner was simply the first person to change an email on a freshly-created deck. The owner-email-change flow itself already works fine once the DNS check doesn't crash.

### How?
Catch the broad `dns.exception.DNSException` (the base class of all dnspython errors) and **fail open** — a lookup that fails for any reason other than `NXDOMAIN` means we *couldn't verify* the domain, not that it's invalid. Domain verification here is best-effort; the verification email sent right afterward is the real gate, so a resolver error should never block (or crash) a legitimate email change. `NXDOMAIN` still raises the existing "doesn't appear to exist" message.

I chose fail-open over showing a "couldn't verify domain" error because the domain the owner entered was valid — the failure was environmental, so surfacing an error would be a confusing false-negative. Happy to switch to a graceful `ValidationError` instead if you'd prefer that UX.

### Testing?
- New test `test_clean_email__dns_lookup_error_fails_open` covers `NoNameservers`, `LifetimeTimeout`, and `Timeout`; it errors on the old code (exceptions propagate) and passes with the fix.
- Full `profile_manager` suite (67 tests) passes; `ruff check` clean.

### Screenshots (if front end is affected)
No UI change. The reported failure was the 500 error page at `/profiles/1/edit/`.

### Anything Else?
This also answers the question in the issue — *"How do owners change their email? Is there a way without switching users?"*: **owners change their email exactly like any other user.** Editing the profile sets `User.email`, creates an unverified `EmailAddress`, and emails a verification link; clicking it promotes the new address to primary and cleans up the old one (`email_confirmed_handler`). No user switch or ownership transfer is required — the 500 was just masking that already-working flow.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_