### PR TITLE
Hotfix develop: tenant test_tasks NameError from #1997/#2003 merge collision

### DIFF
--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -31,7 +31,7 @@ class TenantTasksTests(ByteDeckTenantTestCase):
         self.assertIn("john@doe.com", mail.outbox[0].bcc)
 
 
-class ClearExpiredSessionsTaskTest(TenantTestCase):
+class ClearExpiredSessionsTaskTest(ByteDeckTenantTestCase):
     """clear_expired_sessions_in_all_schemas purges expired django_session rows
     in every schema. Sessions are db-backed with an 8-week cookie age and
     nothing else runs clearsessions, so without this task the per-schema


### PR DESCRIPTION
### What?

One-line fix: `ClearExpiredSessionsTaskTest(TenantTestCase)` → `ClearExpiredSessionsTaskTest(ByteDeckTenantTestCase)` in `tenant/tests/test_tasks.py`.

### Why?

`develop`'s Build and Test is red again ([run 3659](https://github.com/bytedeck/bytedeck/actions/runs/29628793075)):

```
ERROR: tenant.tests.test_tasks (unittest.loader._FailedTest)
ImportError: ... class ClearExpiredSessionsTaskTest(TenantTestCase):
NameError: name 'TenantTestCase' is not defined
```

Same cross-PR collision class as #2009 — two PRs each green alone:

- **#1997** (test-suite reuse) converted this file to `ByteDeckTenantTestCase` and removed the now-unused `from django_tenants.test.cases import TenantTestCase` import.
- **#2003** ("Ops reliability", branched off pre-#1997 develop) added `ClearExpiredSessionsTaskTest(TenantTestCase)` to the same file.

Merged together, the class references `TenantTestCase` with no import → the whole `tenant.tests.test_tasks` module fails to import → job errors. GitHub's mergeability check doesn't flag it (no textual conflict), and #2003's own CI (pre-#1997 base) didn't see it.

### How?

`ClearExpiredSessionsTaskTest` asserts per-`session_key` purge results inside the test transaction, so it's safe on the reused schema. `ByteDeckTenantTestCase` is already imported, so it's just the base class — matching the file's other class (`TenantTasksTests`). I also scanned the whole tree to confirm no other file has a bare, unimported `TenantTestCase` base class (only this one).

### Testing?

- `python src/manage.py test tenant.tests.test_tasks`: **2 tests, OK**.
- `ruff check src/tenant/tests/test_tasks.py`: clean.
- Full-suite verification in progress; will confirm on this PR.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

This is the second collision surfaced by #1997's import cleanup meeting a concurrently-merged PR. Both are one-line base-class fixes; the underlying cause is in-flight PRs branched before #1997 adding `TenantTestCase` classes to files whose import #1997 removed. Nothing structural to change here, but worth being aware of while other pre-#1997 branches land.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated session cleanup task test coverage to use the standard tenant test configuration.
  * Existing session creation, expiration, and purge behavior checks remain covered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->