### PR TITLE
Fix develop: F821 undefined TenantTestCase in tenant test_tasks

### DIFF
--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -31,7 +31,7 @@ class TenantTasksTests(ByteDeckTenantTestCase):
         self.assertIn("john@doe.com", mail.outbox[0].bcc)
 
 
-class ClearExpiredSessionsTaskTest(TenantTestCase):
+class ClearExpiredSessionsTaskTest(ByteDeckTenantTestCase):
     """clear_expired_sessions_in_all_schemas purges expired django_session rows
     in every schema. Sessions are db-backed with an 8-week cookie age and
     nothing else runs clearsessions, so without this task the per-schema


### PR DESCRIPTION
### What?
Fixes a lint failure on `develop`: `ruff check src` reports

```
src/tenant/tests/test_tasks.py:34:36: F821 Undefined name `TenantTestCase`
```

which currently makes the **Lint with ruff** check red on `develop` and on every open PR branched from it (e.g. #2012).

### Why?
`tenant/tests/test_tasks.py` declares `class ClearExpiredSessionsTaskTest(TenantTestCase)`, but the module only imports `ByteDeckTenantTestCase` (the sibling `TenantTasksTests` uses it). `TenantTestCase` is undefined at that line.

It's a cross-PR merge collision: #1997 converted the suite's stock `TenantTestCase` classes to `ByteDeckTenantTestCase` and dropped that import, while #2003 concurrently added this new class still referencing `TenantTestCase`. Neither PR's own CI saw the combination; it only broke once both landed on `develop` (same failure mode as the earlier #2009 fix).

### How?
Point the class at `ByteDeckTenantTestCase`, matching the sibling class and the name the module already imports. That's also the correct base — the test drives tenant and public schema contexts via `schema_context`.

### Testing?
- `ruff check src` → All checks passed.
- `python src/manage.py test src/tenant/tests/test_tasks` → 2 passed (including the previously-broken `ClearExpiredSessionsTaskTest`).

### Screenshots (if front end is affected)
N/A — test-only change.

### Anything Else?
One-line hotfix to unblock Lint across all open PRs. No production code touched.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_