### PR TITLE
Fix develop: test_tasks NameError from a cross-PR merge collision

### DIFF
--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -31,7 +31,12 @@ class TenantTasksTests(ByteDeckTenantTestCase):
         self.assertIn("john@doe.com", mail.outbox[0].bcc)
 
 
-class ClearExpiredSessionsTaskTest(TenantTestCase):
+class ClearExpiredSessionsTaskTest(ByteDeckTenantTestCase):
+    # The task enumerates every schema and this test also writes to the public
+    # schema, so use an isolated per-class schema rather than the shared reused
+    # one (see ByteDeckTenantTestCase's schema-machinery caveat).
+    reuse_schema = False
+
     """clear_expired_sessions_in_all_schemas purges expired django_session rows
     in every schema. Sessions are db-backed with an 8-week cookie age and
     nothing else runs clearsessions, so without this task the per-schema


### PR DESCRIPTION
### What?
One-line fix: `ClearExpiredSessionsTaskTest(TenantTestCase)` → `ClearExpiredSessionsTaskTest(ByteDeckTenantTestCase)` (with `reuse_schema = False`) in `tenant/tests/test_tasks.py`.

### Why?
`develop`'s Build and Test is currently red — `tenant/tests/test_tasks.py` imports **only** `ByteDeckTenantTestCase`, but `ClearExpiredSessionsTaskTest` (added in #2003) subclasses the unimported `TenantTestCase`, so the whole module fails to import and errors the run:

```
ERROR: tenant.tests.test_tasks (unittest.loader._FailedTest)
NameError: name 'TenantTestCase' is not defined
```

This is the same cross-PR collision as #2009 (`comments/test_models`): #1997 renamed the tenant test base to `ByteDeckTenantTestCase`, while #2003 concurrently added a class using the old name. There's no textual merge conflict, so neither PR's own CI caught it.

### How?
`ClearExpiredSessionsTaskTest` enumerates **every** schema and also writes to the **public** schema, so it takes an isolated per-class schema (`reuse_schema = False`) rather than the shared reused one — matching the stock `TenantTestCase` behaviour the author intended, and consistent with `MigrationDedupTest` in `quest_manager` (which opts out for the same schema-machinery reason). The sibling `TenantTasksTests` in the same file already uses `ByteDeckTenantTestCase`.

### Testing?
- `python src/manage.py test tenant.tests.test_tasks` → **OK** (both `TenantTasksTests` and `ClearExpiredSessionsTaskTest`). It errored at import before.
- `ruff check src/tenant/tests/test_tasks.py` → clean.

### Screenshots (if front end is affected)
N/A — test-only.

### Anything Else?
Branched fresh off `develop`. Worth merging promptly since it unblocks CI for every open PR.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for expired-session cleanup scenarios.
  * Existing session and task execution coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->