### PR TITLE
Upgrade Django 4.2 → 5.2 LTS

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,12 +1,11 @@
-Django>=4.2.16,<4.3
+Django>=5.2,<5.3
 
-# All django-* packages below are pinned to ranges that support BOTH Django 4.2
-# and 5.2, so the framework can be flipped to 5.2 LTS without touching them.
+# The django-* packages below are pinned to ranges compatible with Django 5.2 LTS.
 django-allauth[socialaccount]>=65.18,<66  # the extra pulls pyjwt[crypto]/oauthlib/requests, needed by the Google provider
 django-bootstrap-datepicker-plus>=6.0.0,<7.0
 django-celery-beat>=2.8,<3.0
 django-colorful>=1.4,<2.0
-django-crispy-forms>=2.4,<2.6  # 2.6+ requires Django >= 5.2
+django-crispy-forms>=2.6,<3.0  # 2.6 requires Django >= 5.2 (now satisfied)
 crispy-bootstrap3>=2024.1,<2025  # bootstrap3 template pack, split out of django-crispy-forms in 2.x
 django-decorator-include>=3.3,<4.0
 django-embed-video>=1.4.10,<1.5
@@ -15,7 +14,7 @@ django-grappelli>=4.0.1,<5
 django-import-export>=4.3,<5.0
 django-querysetsequence>=0.18,<0.19
 django-recaptcha>=4.0,<4.2  # 4.0 renamed the package module from `captcha` to `django_recaptcha`
-django-redis>=6.0,<7.0  # 7.0+ requires Django >= 5.2
+django-redis>=7.0,<8.0  # 7.0 requires Django >= 5.2 (now satisfied)
 django-resized>=1.0.3,<1.1
 django-select2>=8.4,<8.5
 django-storages[boto3]>=1.14,<2

--- a/src/djcytoscape/forms.py
+++ b/src/djcytoscape/forms.py
@@ -50,11 +50,18 @@ class CytoscapeGFKChoiceField(AllowedGFKChoiceField):
 
 class GenerateQuestMapForm(FutureModelForm):
 
+    # initial_content_object is CytoScape's GenericForeignKey, declared below as a
+    # form field and persisted by FutureModelForm. It is intentionally NOT listed
+    # in Meta.fields: since Django 5.0, naming a non-editable model field (a GFK)
+    # in Meta.fields raises FieldError. field_order keeps the declared GFK in its
+    # original position (declared fields are otherwise appended after model fields);
+    # QuestMapForm inherits it and appends its extra fields after these three.
+    field_order = ['name', 'initial_content_object', 'parent_scape']
+
     class Meta:
         model = CytoScape
         fields = [
             'name',
-            'initial_content_object',
             'parent_scape',
         ]
 

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -149,7 +149,8 @@ class ByteDeckTenantTestCase(TenantTestCase):
         # cls) skips django-tenants' override (which would rebuild the schema).
         super(TenantTestCase, cls).setUpClass()
 
-    def _fixture_setup(self):
+    @classmethod
+    def _fixture_setup(cls):
         """Start the per-test savepoint, then clear the schema-keyed cache.
 
         Each test rolls back to a savepoint afterwards, but the process-global
@@ -160,6 +161,11 @@ class ByteDeckTenantTestCase(TenantTestCase):
         Clearing here — for every test, regardless of setUp overrides — guarantees
         each test reads cache-backed singletons fresh from its own pristine DB
         state. (Runs in addition to any cache.clear() a test's own setUp does.)
+
+        A ``classmethod`` since Django 5.1 made ``TestCase._fixture_setup`` one;
+        it is still invoked once per test method (it enters the per-test savepoint
+        that ``_fixture_teardown`` rolls back), so the cache is still cleared per
+        test — only the binding changed from instance to class.
         """
         super()._fixture_setup()
         cache.clear()

--- a/src/prerequisites/forms.py
+++ b/src/prerequisites/forms.py
@@ -29,10 +29,18 @@ class PrereqFormInline(FutureModelForm):
         # Kept with the form (rather than inline in the template) so it loads via {{ form.media.css }}.
         css = {'all': ('prerequisites/css/advanced_prereqs_form.css',)}
 
+    # prereq_object / or_prereq_object are the Prereq model's GenericForeignKeys,
+    # declared above as form fields and persisted by FutureModelForm (via the
+    # field's save_object_data()). They are intentionally NOT listed in
+    # Meta.fields: since Django 5.0, naming a non-editable model field (a GFK) in
+    # Meta.fields raises FieldError instead of silently ignoring it. Because
+    # declared fields not in Meta.fields are appended after the model fields,
+    # field_order restores the original interleaved column order for the formset.
+    field_order = ['prereq_object', 'prereq_count', 'prereq_invert', 'or_prereq_object', 'or_prereq_count', 'or_prereq_invert']
+
     class Meta:
         model = Prereq
-        # fields = ['prereq_content_type', 'prereq_object_id', 'prereq_count', 'prereq_invert']
-        fields = ['prereq_object', 'prereq_count', 'prereq_invert', 'or_prereq_object', 'or_prereq_count', 'or_prereq_invert']
+        fields = ['prereq_count', 'prereq_invert', 'or_prereq_count', 'or_prereq_invert']
         help_texts = {field: None for field in fields}
         labels = {
             'prereq_count': "Count",

--- a/src/quest_manager/migrations/0049_inprogress_submission_unique_constraint.py
+++ b/src/quest_manager/migrations/0049_inprogress_submission_unique_constraint.py
@@ -38,6 +38,13 @@ def remove_duplicate_in_progress_submissions(apps, schema_editor):
         .filter(is_completed=False, first_time_completed__isnull=True)
         .order_by("pk")
         .values_list("pk", "user_id", "quest_id", "semester_id")
+        # Clear any prefetch the active manager may have added (QuestSubmission's
+        # default manager prefetches quest__tags): this scan only reads scalar
+        # tuples, and since Django 5.1 iterator() raises if the queryset carries
+        # a prefetch_related() without an explicit chunk_size. A real migration
+        # uses the historical (plain) manager and has nothing to clear; this keeps
+        # the scan correct if the concrete manager is ever used instead.
+        .prefetch_related(None)
     )
     for pk, user_id, quest_id, semester_id in in_progress.iterator():
         if semester_id is None:


### PR DESCRIPTION
### What?
The final phase of the Django 4.2 → 5.2 LTS upgrade: flip the framework pin to `Django>=5.2,<5.3` and drop the two dependency ceilings that were held back only for 4.2 compatibility, plus the handful of code adaptations for APIs Django changed between 4.2 and 5.2.

`requirements-production.txt`:

| Package | From | To | Note |
|---|---|---|---|
| Django | `>=4.2.16,<4.3` | `>=5.2,<5.3` | resolves to 5.2.16 |
| django-crispy-forms | `>=2.4,<2.6` | `>=2.6,<3.0` | 2.6 requires Django ≥ 5.2 |
| django-redis | `>=6.0,<7.0` | `>=7.0,<8.0` | 7.0 requires Django ≥ 5.2 |

### Why?
Django 4.2's extended support has lapsed — the app has been on an EOL framework version. This is the last step of the staged plan: #1897 (Phase 0, removed-API sweep on 4.2), #1916 (Phase 1, every third-party dep moved to a dual-4.2/5.2 version), then #1995 (numpy) and #1996 (the non-Django batch). Because Phase 1 already moved every Django-adjacent package to a 5.2-compatible pin, the framework move itself is small.

### How?
Only these five code changes are needed for Django 5.0/5.1 behavioural changes; everything else already declared 5.2 support.

- **`prerequisites/forms.py`, `djcytoscape/forms.py`** — the GenericForeignKey selectors (`prereq_object`/`or_prereq_object`, `initial_content_object`) are declared `FutureModelForm` fields, persisted via the field's `save_object_data()`. Since **Django 5.0**, naming a non-editable model field (a GFK) in `Meta.fields` raises `FieldError` instead of silently ignoring it, so they're dropped from `Meta.fields`; `field_order` keeps the original field/column layout (declared fields are otherwise appended after the model fields).
- **`hackerspace_online/tests/utils.py`** — `ByteDeckTenantTestCase._fixture_setup` is now a `classmethod`, matching **Django 5.1** (`TestCase._fixture_setup` became one). It still runs once per test method (it enters the per-test savepoint), so the per-test `cache.clear()` is unchanged — only the binding moved from instance to class. (This one mismatch produced ~990 errors before the fix.)
- **`quest_manager/migrations/0049_…`** — clear the default manager's prefetch (`.prefetch_related(None)`) before `.iterator()`: since **Django 5.1**, `.iterator()` raises on a prefetched queryset without an explicit `chunk_size`, and this dedup scan only reads scalar tuples anyway. A real migration uses the historical (plain) manager and has nothing to clear; this keeps the scan correct if the concrete manager is ever active.

Verified upstream compatibility for the packages Phase 1 flagged as flip-time risks: `django-summernote` 0.8.20, `django-grappelli` 4.0.4 (upstream: "Compatible with Django 5.x"), and `django-embed-video` 1.4.10 all import and their consumers pass on 5.2.

### Testing?
On Django **5.2.16** (crispy-forms 2.6, django-redis 7.0, numpy 2.2.6):
- `python src/manage.py check` — no issues
- `python src/manage.py makemigrations --check --dry-run` — no changes detected
- `ruff check src` — all checks passed
- **Full suite: 1089 tests, OK** (0 failures / 0 errors)

### Screenshots (if front end is affected)
N/A — no user-visible change; the prereq/quest-map forms render identically (`field_order` preserves the original layout).

### Anything Else?
- **Follow-up (Step 4, separate PR):** bump the runtime from Python 3.10 → 3.12 (`Dockerfile` + CI). Python 3.10's EOL (Oct 2026) is the binding ceiling on a few pins — once on ≥3.11, `numpy` can lift its `<2.3` cap.
- `django-grappelli` stays `<5` (5.0.0 targets Django 6.x; 4.0.4 is the Django 5.x line). No CHANGELOG entry, matching the other pre-flip dependency PRs (#1995/#1996) — this can fold into the release notes.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_