### PR TITLE
Upgrade the runtime from Python 3.10 to 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install ruff
       run: pip install ruff
     - name: Lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ByteDeck is a multi-tenant Django LMS (gamified with "quests" and "badges") originating from Timberline Secondary School's Digital Hackerspace. Each tenant (a "deck") is a separate Postgres schema served from its own subdomain via [django-tenants](https://django-tenants.readthedocs.io/en/latest/). The stack is Django + PostgreSQL + Redis + Celery, run with Docker Compose. Python 3.10 is required. The main branch is `develop`.
+ByteDeck is a multi-tenant Django LMS (gamified with "quests" and "badges") originating from Timberline Secondary School's Digital Hackerspace. Each tenant (a "deck") is a separate Postgres schema served from its own subdomain via [django-tenants](https://django-tenants.readthedocs.io/en/latest/). The stack is Django + PostgreSQL + Redis + Celery, run with Docker Compose. Python 3.12 is required. The main branch is `develop`.
 
 ## Development Commands
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 #### For development within the container in VS Code ##
 # https://code.visualstudio.com/docs/remote/containers

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ As a sanity check, make sure docker compose works too:
 If you can't run docker without sudo, you can try adding yourself to the docker group (is this still needed? I don't think so)
 `sudo usermod -aG docker $USER`
 
-#### Make sure you have Python3.10
+#### Make sure you have Python3.12
 
 Using a different version of Python will probably give you errors when installing the dependencies due to slight changes between versions:
-`sudo apt install python3.10`
+`sudo apt install python3.12`
 
 ### Getting the Code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # the whole codebase and is a separate decision.
 line-length = 150
 extend-exclude = ["migrations"]
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.lint]
 # E/W = pycodestyle, F = pyflakes (the flake8 core); B = flake8-bugbear

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -31,7 +31,7 @@ celery>=5.6,<5.7
 cssutils>=2.15,<3.0  # 2.12+ split vendored encutils into its own package; upgrading an EXISTING venv clobbers it -- run: pip install --force-reinstall encutils
 dnspython>=2.6.1,<3.0
 html2text>=2025.4.15,<2026
-numpy>=1.26,<2.3  # 2.3+ requires Python >= 3.11; raise the ceiling with the Python upgrade
+numpy>=1.26,<2.6  # ceiling lifted with the Python 3.12 upgrade (2.3+ needs Python >= 3.11, 2.5+ needs >= 3.12 -- both now satisfied)
 pytz # required by django-redis which uses pickle, even though django-redis changelog says it doesn't us pickle anymore?
 
 # subdependencies


### PR DESCRIPTION
### What?
Bump the runtime from **Python 3.10 → 3.12**, and lift the `numpy` ceiling that existed only because of Python 3.10.

| Change | From | To |
|---|---|---|
| `Dockerfile` base image | `python:3.10-slim` | `python:3.12-slim` |
| `lint.yml` CI Python | `3.10` | `3.12` |
| `pyproject.toml` ruff `target-version` | `py310` | `py312` |
| `numpy` (`requirements-production.txt`) | `>=1.26,<2.3` | `>=1.26,<2.6` |
| `README.md`, `CLAUDE.md` | "Python 3.10" | "Python 3.12" |

### Why?
Python 3.10 reaches end-of-life in October 2026, and it was the binding ceiling on the dependency set — `numpy` was explicitly capped at `<2.3` with the note "raise the ceiling with the Python upgrade" (2.3+ needs Python ≥ 3.11, 2.5+ needs ≥ 3.12). This is the runtime half of the modernization arc whose framework half landed in #2015 (Django 5.2): #1897 → #1916 → #1995/#1996 → #2015 → **this**. The app now runs the current Django LTS on a current, supported Python.

### How?
- **Runtime:** `python:3.12-slim` in the `Dockerfile` (the image every `web`/`celery`/`celery-beat` service builds from), and the `setup-python` step in the ruff lint workflow.
- **Lint target:** ruff `target-version = "py312"`. No lint-output change — the rule set is `E/W/F/B/C4` with no `UP` (pyupgrade) rules, so `target-version` only updates the declared floor. (The separate pre-commit `pyupgrade` hook is deliberately kept at `--py38-plus` and is left untouched.)
- **numpy:** ceiling `<2.3` → `<2.6` (resolves to 2.5.1 on 3.12). The codebase's only numpy usage is stable public API — `busday_count`/`is_busday`/`busday_offset`, `clip`/`arange`/`histogram`/`add`, `array`/`sort`/`mean`/`median` — all cleared in the numpy-2.0 removed-API sweep in #1995; nothing 2.3–2.5 removes touches it.
- **Removed-API sweep:** grepped `src/` for everything Python 3.11/3.12 dropped or deprecated — `distutils`, `imp`, `asyncore`/`asynchat`/`smtpd`, the removed `unittest` aliases (`failUnless`/`assertEquals`/…), `typing.io`/`typing.re`, `configparser.SafeConfigParser`, `datetime.utcnow`/`utcfromtimestamp`, `inspect.getargspec`. **All clean — no code changes needed.**

### Testing?
On **Python 3.12.13** with **numpy 2.5.1** (Django 5.2.16, psycopg2-binary 2.9.12, crispy-forms 2.6, django-redis 7.0):
- `pip install -r requirements.txt` — clean; every dependency resolves to a 3.12 wheel (no source-build failures).
- `python src/manage.py check` — no issues
- `python src/manage.py makemigrations --check --dry-run` — no changes detected
- `ruff check src` — all checks passed
- **Full suite: 1089 tests, OK** (0 failures / 0 errors)

### Screenshots (if front end is affected)
N/A — no user-visible change.

### Anything Else?
- `uwsgi==2.0.31` (installed in the `Dockerfile`, production server only — not in `requirements.txt`, not used by tests) builds on Python 3.12; CI's image build exercises that path.
- `python:3.12-slim` is Debian bookworm, the same apt package set the Dockerfile already installs.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_