### PR TITLE
Show a spinner while bootstrap-tables load, no unstyled flash (#1981)

### DIFF
--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -1108,3 +1108,37 @@ div.btn-group.action-btn-group {
 
 
 
+
+/* === #1981: prevent the bootstrap-table "flash of unstyled table" ================= */
+/* Data tables (data-toggle="table") are server-rendered as a plain <table>, so the
+   browser paints the raw, unstyled table first and then — a second or two later on large
+   tables — bootstrap-table tears it down and rebuilds it (pagination, search, fixed layout).
+   That rebuild is the visible "jump". This file is loaded in the render-blocking <head>, so
+   hiding the raw table here stops it from ever being painted; custom.js drops a spinner into
+   its place and the rules below reveal the finished table. */
+table[data-toggle="table"] {
+    /* take the raw table out of flow while hidden so a big table doesn't reserve a tall
+       blank gap under the spinner */
+    position: absolute;
+    visibility: hidden;
+}
+
+/* Once bootstrap-table wraps the table in .bootstrap-table it is fully formatted — put it
+   back in flow and show it. Version-independent and JS-free, so the table always appears. */
+.bootstrap-table table[data-toggle="table"],
+table[data-toggle="table"].bt-reveal {
+    position: static;
+    visibility: visible;
+}
+
+/* Spinner shown in the table's place while it formats (inserted by custom.js). */
+.bt-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    color: #999;
+}
+.bt-loading .fa {
+    opacity: 0.6;
+}

--- a/src/static/js/custom.js
+++ b/src/static/js/custom.js
@@ -36,4 +36,40 @@ $(document).ready(function() {
        window.location.href = $(this).attr("href");
      });
 
+    // #1981: bootstrap-table reformats server-rendered tables on load, briefly showing the raw
+    // table before it "jumps" into the styled/paginated version. The head CSS (custom_common.css)
+    // hides those tables until they're formatted; here we show a spinner in the gap and make sure
+    // the table is revealed even if bootstrap-table's script never runs.
+    $('table[data-toggle="table"]').each(function() {
+        var $table = $(this);
+
+        // If bootstrap-table already initialized this table (its script ran before this one),
+        // it is wrapped and the CSS has already revealed it — nothing to do.
+        if ($table.closest('.bootstrap-table').length) {
+            return;
+        }
+
+        var $spinner = $(
+            '<div class="bt-loading" role="status" aria-label="Loading table">' +
+            '<i class="fa fa-spinner fa-spin fa-2x" aria-hidden="true"></i></div>'
+        );
+        $table.before($spinner);
+
+        // Poll for bootstrap-table to wrap the table (robust to script load order and to the
+        // different bootstrap-table versions loaded across the site). Drop the spinner once
+        // wrapped — or after a timeout, so a failed/late bootstrap-table can never leave the
+        // data hidden (the fallback class reveals the raw table).
+        var start = Date.now();
+        var poll = setInterval(function() {
+            var wrapped = $table.closest('.bootstrap-table').length;
+            if (wrapped || Date.now() - start > 6000) {
+                clearInterval(poll);
+                $spinner.remove();
+                if (!wrapped) {
+                    $table.addClass('bt-reveal');
+                }
+            }
+        }, 50);
+    });
+
 });


### PR DESCRIPTION
### What?
Stops data tables from flashing their raw, unstyled HTML and then "jumping" into the formatted bootstrap-table a second or two later. Instead the table area shows a **loading spinner** until bootstrap-table has finished, then the finished table appears in place.

Closes #1981

### Why?
Every data table is server-rendered as a plain `<table data-toggle="table">`, and bootstrap-table reformats it (pagination / search / fixed layout) on load. On large tables the browser paints the raw table first and reflows into the styled one after — the visible jump in the issue. It affects ~15 table pages (quests, approvals, submissions, badges, portfolios, campaigns, tags, profiles, library…).

### How?
Two small changes to already-global assets, so every table is covered uniformly (bootstrap-table itself is loaded per-section at a few different versions):

- **`custom_common.css`** (loaded render-blocking in `<head>`): hides `table[data-toggle="table"]` from first paint so the raw table is never shown, and takes it out of flow while hidden so a large table doesn't reserve a tall blank gap. Once bootstrap-table wraps the table in `.bootstrap-table` it's revealed again — a version-independent, JS-free reveal. Also styles the spinner.
- **`custom.js`** (loaded site-wide): drops a spinner into the table's place while it formats and removes it once the table is wrapped. It **polls** for the wrapper, so it works regardless of script load order or bootstrap-table version, and has a timeout fallback that reveals the raw table if bootstrap-table never runs (e.g. a CDN hiccup) — a script failure can't hide the data permanently.

### Testing?
No server-side code changed, so there's no Django test to add here. I verified the behavior in **headless Chromium** against the bundled bootstrap-table assets, simulating a delayed init:

- **During load:** the raw table is not painted (no unstyled flash), the content below it doesn't get pushed down (hidden table is out of flow), and the spinner shows in the gap.
- **After init:** the table is revealed and fully functional — search box, sortable columns, "Showing 1 to 10 of 180 rows", page-size selector, and pagination all render.
- **Fallback:** with bootstrap-table never loading, after the timeout the raw table is revealed (all rows visible, spinner removed) — so the data is never stuck hidden.

### Screenshots (if front end is affected)
Front end is affected. Behavior change is temporal (no single-frame diff): the raw-table flash/jump is replaced by a centered spinner that swaps to the finished table. **Worth a quick eyeball on a real deck** with a large table (e.g. the student list) to confirm it reads well with the site's Bootstrap 3 + Font Awesome styling loaded.

### Anything Else?
This is the lightweight spinner/fade approach. If you ever want the fancier Facebook-style skeleton rows, that'd be a follow-up (per-table row/column shapes).

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an unstyled table from briefly appearing while enhanced tables load.
  * Added a loading indicator for tables awaiting initialization.
  * Ensured tables remain visible if enhanced formatting is delayed or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->