### PR TITLE
Improve djcytoscape test coverage (TempCampaign, managers, tasks, transition nodes, views)

### DIFF
--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -188,6 +188,91 @@ class TempCampaignTest(ByteDeckTenantTestCase):
     def test_object_creation(self):
         self.assertIsInstance(self.temp_campaign, TempCampaign)
 
+    def test_str__no_children(self):
+        """A campaign with no nodes reports that it has no children."""
+        self.assertIn("No children", str(TempCampaign(parent_node_id=1)))
+
+    def test_str__with_children(self):
+        """A campaign's string lists its parent id and each child node."""
+        tc = TempCampaign(parent_node_id=1)
+        tc.add_node(node_id=10, prereq_node_id=None)
+        tc.add_node(node_id=11, prereq_node_id=None)
+        rendered = str(tc)
+        self.assertIn("Parent: 1", rendered)
+        self.assertIn("Child:10", rendered)
+        self.assertIn("Child:11", rendered)
+
+    def test_add_node__existing_id_appends_prereq(self):
+        """Re-adding an existing node id appends the new prereq instead of duplicating the node."""
+        tc = TempCampaign(parent_node_id=1)
+        tc.add_node(node_id=10, prereq_node_id=100)
+        tc.add_node(node_id=10, prereq_node_id=101)
+        self.assertEqual(len(tc.nodes), 1)
+        self.assertEqual(tc.get_node(10).prereq_node_ids, [100, 101])
+
+    def test_add_campaign_reliant(self):
+        """Nodes directly reliant on the campaign are tracked in campaign_reliant_node_ids."""
+        tc = TempCampaign(parent_node_id=1)
+        tc.add_campaign_reliant(reliant_node_id=42)
+        self.assertEqual(tc.campaign_reliant_node_ids, [42])
+
+    def test_has_internal_reliant(self):
+        """has_internal_reliant is True only when an internal node is a reliant of the given node."""
+        tc = TempCampaign(parent_node_id=1)
+        tc.add_node(node_id=10, prereq_node_id=None)
+        tc.add_node(node_id=11, prereq_node_id=None)
+        # node 11 (internal) relies on node 10 -> internal reliant
+        tc.add_reliant(node_id=10, reliant_node_id=11)
+        self.assertTrue(tc.has_internal_reliant(tc.get_node(10)))
+        # node 11's reliant is an external id -> not internal
+        tc.add_reliant(node_id=11, reliant_node_id=999)
+        self.assertFalse(tc.has_internal_reliant(tc.get_node(11)))
+
+    def test_is_non_sequential(self):
+        """is_non_sequential runs over a campaign whose nodes share a common prereq.
+
+        Note: the method body compares a *list* with ``is True`` (``get_common_prereq_node_ids()
+        is True``), so it currently always returns False regardless of the campaign's shape.
+        This test pins that current behavior; it should be revisited if the comparison is fixed.
+        """
+        tc = TempCampaign(parent_node_id=1)
+        tc.add_node(node_id=10, prereq_node_id=100)
+        tc.add_node(node_id=11, prereq_node_id=100)
+        # Both nodes share prereq 100, so get_common_prereq_node_ids() is non-empty...
+        self.assertEqual(tc.get_common_prereq_node_ids(), [100])
+        # ...but `[...] is True` is False, so is_non_sequential() returns False today.
+        self.assertFalse(tc.is_non_sequential())
+
+
+class CytoManagerTests(ByteDeckTenantTestCase):
+    """Tests for the CytoElement/CytoScape manager helpers (random-node pickers and lookups)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.map = generate_real_primary_map()
+
+    def test_get_random_node__returns_node_in_scape(self):
+        """get_random_node returns a NODE element belonging to the given scape."""
+        node = CytoElement.objects.get_random_node(self.map)
+        self.assertEqual(node.scape_id, self.map.id)
+        self.assertEqual(node.group, CytoElement.NODES)
+
+    def test_get_random_node_triangular_distribution__returns_node_in_scape(self):
+        """The triangular-distribution picker also returns a node from the scape."""
+        node = CytoElement.objects.get_random_node_triangular_distribution(self.map)
+        self.assertEqual(node.scape_id, self.map.id)
+        self.assertEqual(node.group, CytoElement.NODES)
+
+    def test_get_map_for_init__missing_then_found(self):
+        """get_map_for_init returns None when no map initiates the object, else that map."""
+        quest = baker.make('quest_manager.Quest')
+        self.assertIsNone(CytoScape.objects.get_map_for_init(quest))
+
+        scape = CytoScape.generate_map(quest, "Quest Map")
+        found = CytoScape.objects.get_map_for_init(quest)
+        self.assertEqual(found, scape)
+        self.assertEqual(found.initial_object_id, quest.id)
+
 
 class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
     @classmethod
@@ -222,6 +307,30 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         quest = baker.make('quest_manager.Quest')
         CytoScape.generate_map(quest, "test")
         self.assertEqual(CytoScape.objects.count(), 2)
+
+    def test_generate_map__transition_node_for_tilde_quest(self):
+        """A reliant quest whose label starts with '~' is turned into a transition
+        (child-map link) node: is_transition_node() detects it and
+        convert_to_transition_node() flags the node and restyles it."""
+        start = baker.make('quest_manager.Quest', name="Start Quest")
+        # A '~'-prefixed name marks a map break -> transition node (autobreak on by default).
+        transition = baker.make('quest_manager.Quest', name="~Continue in the next map")
+        transition.add_simple_prereqs([start])  # transition relies on start
+
+        scape = CytoScape.generate_map(start, "Transition Map")
+
+        node = CytoElement.objects.get(
+            scape=scape, selector_id=CytoElement.generate_selector_id(transition),
+        )
+        self.assertTrue(node.is_transition)
+        self.assertIn("child-map", node.classes)
+
+    def test_is_transition_node__autobreak_off_returns_false(self):
+        """With autobreak disabled, no node is treated as a transition node."""
+        scape = self.map
+        scape.autobreak = False
+        any_node = scape.cytoelement_set.filter(group=CytoElement.NODES).first()
+        self.assertFalse(scape.is_transition_node(any_node))
 
     def test_generate_map__long_name_xp(self):
         """

--- a/src/djcytoscape/tests/test_tasks.py
+++ b/src/djcytoscape/tests/test_tasks.py
@@ -1,8 +1,14 @@
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+
 from model_bakery import baker
 
 from djcytoscape.models import CytoScape
-from djcytoscape.tasks import regenerate_map
+from djcytoscape.tasks import regenerate_all_maps, regenerate_map
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from notifications.models import Notification
+
+User = get_user_model()
 
 
 class CytoScapeTaskTests(ByteDeckTenantTestCase):
@@ -10,6 +16,38 @@ class CytoScapeTaskTests(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
         cls.quest = baker.make('quest_manager.Quest')
+
+    def _bad_map(self):
+        """A map whose initial object no longer exists (initial_object_id points at nothing)."""
+        quest_ct = ContentType.objects.get(app_label='quest_manager', model='quest')
+        return CytoScape.objects.create(
+            name="Bad Map", initial_content_type=quest_ct, initial_object_id=999999,
+        )
+
+    def test_regenerate_all_maps(self):
+        """regenerate_all_maps regenerates valid maps, deletes maps whose initial
+        object is gone, and notifies the requesting user of the failure and of the
+        overall completion."""
+        requesting_user = baker.make(User, is_staff=True)
+        good_map = CytoScape.generate_map(self.quest, "Good Map")
+        bad_map = self._bad_map()
+
+        notes_before = Notification.objects.all_for_user(requesting_user).count()
+        regenerate_all_maps.apply(args=[requesting_user.id], queue='default').get()
+
+        # the valid map survives; the broken one is removed
+        self.assertTrue(CytoScape.objects.filter(id=good_map.id).exists())
+        self.assertFalse(CytoScape.objects.filter(id=bad_map.id).exists())
+
+        # one "failed to regenerate" notice for the bad map + one "completed" notice
+        notes_after = Notification.objects.all_for_user(requesting_user).count()
+        self.assertEqual(notes_after - notes_before, 2)
+
+    def test_regenerate_map__deleted_initial_object_is_swallowed(self):
+        """regenerate_map silently drops a map whose initial object no longer exists (no raise)."""
+        bad_map = self._bad_map()
+        regenerate_map.apply(args=[[bad_map.id]], queue='default').get()
+        self.assertFalse(CytoScape.objects.filter(id=bad_map.id).exists())
 
     def test_regenerate_map(self):
         """ tests if regenerate map task runs successfully """

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -234,3 +234,24 @@ class RegenerateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             response=self.client.get(reverse('djcytoscape:regenerate_all')),
             expected_url=reverse('djcytoscape:primary'),
         )
+
+    def test_regenerate_all__many_maps_processed_in_background(self):
+        """With more than 5 maps, regeneration is offloaded to a background task
+        and the user is warned it is being processed in the background."""
+        for i in range(6):
+            CytoScape.generate_map(baker.make('quest_manager.Quest'), f"Extra Map {i}")
+        self.assertGreater(CytoScape.objects.count(), 5)
+
+        response = self.client.get(reverse('djcytoscape:regenerate_all'), follow=True)
+        self.assertTrue(
+            any("background" in str(m) for m in response.context['messages']),
+            "expected a 'processed in the background' warning message",
+        )
+
+    def test_quest_map_interlink__existing_map_renders(self):
+        """Interlinking to an object that already initiates a map renders that map."""
+        response = self.client.get(reverse(
+            'djcytoscape:quest_map_interlink',
+            args=[self.map.initial_content_type_id, self.map.initial_object_id, self.map.id],
+        ))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### What?

Adds tests for previously-untested **live** code in `djcytoscape` (the worst-covered app at ~83%). Test-only change — no production code touched.

### Why?

A full-suite coverage pass flagged `djcytoscape` as the biggest gap (126 missing lines; `models.py` alone 102). Digging in, a large chunk of that "gap" turned out to be **dead code** (see "Anything Else?"); the rest was genuinely-untested behavior worth locking down — map transition nodes, the regenerate tasks, and several manager/`TempCampaign` helpers.

### How?

New/expanded tests:

- **`TempCampaign` pure-logic methods** — `__str__` (with/without children), `add_node` (existing-id appends a prereq), `add_campaign_reliant`, `has_internal_reliant`, and `is_non_sequential`.
- **Managers** — `get_random_node`, `get_random_node_triangular_distribution`, `get_map_for_init` (missing + found).
- **`tasks.py` → 100%** — `regenerate_all_maps` (regenerates valid maps, deletes maps whose initial object is gone, notifies the requesting user of the failure and of completion) and `regenerate_map`'s deleted-object branch.
- **Map generation** — a `~`-prefixed reliant quest becomes a transition/child-map node (covers `is_transition_node` + `convert_to_transition_node`), plus the autobreak-off path.
- **Views** — `regenerate_all`'s ">5 maps → background task" branch, and `quest_map_interlink` rendering an existing map.

Two latent issues surfaced (flagged, not changed here):
- `TempCampaign.is_non_sequential()` does `get_common_prereq_node_ids() is True` — comparing a **list** with `is True`, so it always returns `False`. The test pins current behavior with a note.

### Testing?

- `python src/manage.py test djcytoscape`: **66 tests, OK**.
- `ruff check src/djcytoscape/tests`: clean.
- `tasks.py` coverage 57.7% → **100%**; net new coverage across `models.py`/`views.py`.

### Screenshots (if front end is affected)

N/A — tests only.

### Anything Else?

**Dead code found (recommend a follow-up removal, ~90 lines):**
- `CytoScapeManager.generate_random_tree_scape` and `generate_random_scape` — **zero callers**, and they pass `layout_name`/`layout_options` kwargs for fields that were **dropped from the model**, so calling them would raise `TypeError`. Broken + unused.
- `CytoScape.create_child_map_node` — zero callers.
- `CytoElementManager.get_random_node` / `get_random_node_triangular_distribution` are only reachable via the dead `generate_random_scape`.

Removing these would delete ~43 of the remaining uncovered `models.py` lines outright (plus the two `get_random_node*` helpers) and clean up broken code — a bigger coverage win than any test. Left out of this PR since it deletes production code; happy to do it as a focused follow-up.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_