### PR TITLE
Pin dependency floors to current versions; cap ceilings at next major

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -36,7 +36,6 @@ cssutils>=2.15.0,<3.0  # 2.12+ split vendored encutils into its own package; upg
 dnspython>=2.8.0,<3.0
 html2text>=2025.4.15,<2026
 numpy>=2.5.1,<3.0
-pytz>=2026.2,<2027  # required by django-redis which uses pickle, even though django-redis changelog says it doesn't us pickle anymore?
 
 # subdependencies
 psycopg2-binary>=2.9.12,<3.0  # since our backend is PostgreSQL, Django and django-tenants use this to interact with the db

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,43 +1,47 @@
-Django>=5.2,<5.3
+Django>=5.2.16,<5.3
 
-# The django-* packages below are pinned to ranges compatible with Django 5.2 LTS.
-django-allauth[socialaccount]>=65.18,<66  # the extra pulls pyjwt[crypto]/oauthlib/requests, needed by the Google provider
+# Version policy: floors are the versions currently in use; ceilings block the
+# next MAJOR (allowing backwards-compatible minor/patch updates), except where a
+# tighter cap is required for compatibility (noted inline). 0.x packages are
+# capped at the next 0.minor, since for 0.x that is the breaking-change unit.
+# The django-* packages below are all compatible with Django 5.2 LTS.
+django-allauth[socialaccount]>=65.18.0,<66  # the extra pulls pyjwt[crypto]/oauthlib/requests, needed by the Google provider
 django-bootstrap-datepicker-plus>=6.0.0,<7.0
-django-celery-beat>=2.8,<3.0
-django-colorful>=1.4,<2.0
-django-crispy-forms>=2.6,<3.0  # 2.6 requires Django >= 5.2 (now satisfied)
+django-celery-beat>=2.9.0,<3.0
+django-colorful>=1.4.0,<2.0
+django-crispy-forms>=2.6,<3.0  # 2.6 requires Django >= 5.2
 crispy-bootstrap3>=2024.1,<2025  # bootstrap3 template pack, split out of django-crispy-forms in 2.x
-django-decorator-include>=3.3,<4.0
-django-embed-video>=1.4.10,<1.5
-django-environ>=0.12,<0.15
-django-grappelli>=4.0.1,<5
-django-import-export>=4.3,<5.0
+django-decorator-include>=3.5,<4.0
+django-embed-video>=1.4.10,<2.0
+django-environ>=0.14.0,<0.15
+django-grappelli>=4.0.4,<5  # compat cap: 4.0.x targets Django 5.x, 5.0.0 requires Django 6.x
+django-import-export>=4.4.1,<5.0
 django-querysetsequence>=0.18,<0.19
-django-recaptcha>=4.0,<4.2  # 4.0 renamed the package module from `captcha` to `django_recaptcha`
-django-redis>=7.0,<8.0  # 7.0 requires Django >= 5.2 (now satisfied)
-django-resized>=1.0.3,<1.1
-django-select2>=8.4,<8.5
-django-storages[boto3]>=1.14,<2
-django-summernote>=0.8,<0.9
-django-taggit>=6.1,<7.0
-django-tenants>=3.10,<3.11
+django-recaptcha>=4.1.0,<4.2  # 4.0 renamed the package module from `captcha` to `django_recaptcha`
+django-redis>=7.0.0,<8.0  # 7.0 requires Django >= 5.2
+django-resized>=1.0.3,<2.0
+django-select2>=8.4.8,<9.0
+django-storages[boto3]>=1.14.6,<2
+django-summernote>=0.8.20.0,<0.9
+django-taggit>=6.1.0,<7.0
+django-tenants>=3.10.2,<3.11  # compat cap: multitenancy core, tracks Django closely -- hold at the tested minor
 django-url-or-relative-url-field>=0.2.0,<0.3.0
-tenant-schemas-celery>=4.0,<4.1
+tenant-schemas-celery>=4.0.3,<5.0
 
 # non django
-beautifulsoup4>=4.15,<4.16
-bleach[css]>=6.4,<7  # 6.4 includes the invisible-Unicode-character XSS fix
-celery>=5.6,<5.7
-cssutils>=2.15,<3.0  # 2.12+ split vendored encutils into its own package; upgrading an EXISTING venv clobbers it -- run: pip install --force-reinstall encutils
-dnspython>=2.6.1,<3.0
+beautifulsoup4>=4.15.0,<5.0
+bleach[css]>=6.4.0,<7  # 6.4 includes the invisible-Unicode-character XSS fix
+celery>=5.6.3,<6.0
+cssutils>=2.15.0,<3.0  # 2.12+ split vendored encutils into its own package; upgrading an EXISTING venv clobbers it -- run: pip install --force-reinstall encutils
+dnspython>=2.8.0,<3.0
 html2text>=2025.4.15,<2026
-numpy>=1.26,<2.6  # ceiling lifted with the Python 3.12 upgrade (2.3+ needs Python >= 3.11, 2.5+ needs >= 3.12 -- both now satisfied)
-pytz # required by django-redis which uses pickle, even though django-redis changelog says it doesn't us pickle anymore?
+numpy>=2.5.1,<3.0
+pytz>=2026.2,<2027  # required by django-redis which uses pickle, even though django-redis changelog says it doesn't us pickle anymore?
 
 # subdependencies
-psycopg2-binary>=2.8.6,<2.10  # since our backend is PostgreSQL, Django and django-tenants use this to interact with the db
+psycopg2-binary>=2.9.12,<3.0  # since our backend is PostgreSQL, Django and django-tenants use this to interact with the db
 # pulled in via django-redis/celery. The old reason for <8 (the redis 5.0
 # server couldn't speak RESP3) is gone -- all environments now run redis:7 --
 # but the ceiling stays until celery/kombu declare redis-py 8 support.
-redis>=4.0.2,<8
-pillow>=12.3,<13.0  # used implicitly by django_resized (does not exist as an extra package either)
+redis>=7.4.1,<8
+pillow>=12.3.0,<13.0  # used implicitly by django_resized (does not exist as an extra package either)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 -r requirements-production.txt
-django-debug-toolbar>=2.1
-django-debug-toolbar-template-timings>=0.9
+django-debug-toolbar>=7.0.0,<8.0
+django-debug-toolbar-template-timings>=0.9,<0.10
 
 # CLI
-coveralls  # includes coverage
-ruff
-pipdeptree>=3.1.1
-pre-commit
+coveralls>=4.1.0,<5.0  # includes coverage
+ruff>=0.15.22,<0.16  # 0.x lint tool: pin tightly so CI lint results stay reproducible
+pipdeptree>=3.1.1,<4.0
+pre-commit>=4.6.0,<5.0
 
 # code debugging/tests
-freezegun>=0.3.12
-mock>=2.0,<6.0
-model_bakery>=1.1,<2.0
-names
+freezegun>=1.5.5,<2.0
+mock>=5.2.0,<6.0
+model_bakery>=1.24.0,<2.0
+names>=0.3.0,<0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 -r requirements-production.txt
 django-debug-toolbar>=7.0.0,<8.0
-django-debug-toolbar-template-timings>=0.9,<0.10
 
 # CLI
 coveralls>=4.1.0,<5.0  # includes coverage
-ruff>=0.15.22,<0.16  # 0.x lint tool: pin tightly so CI lint results stay reproducible
+ruff>=0.15.22,<0.16  # 0.x lint tool: cap at the next 0.minor so a new rule set can't land unpinned
 pipdeptree>=3.1.1,<4.0
 pre-commit>=4.6.0,<5.0
 

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -950,7 +950,6 @@ if DEBUG and not TESTING:
     MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware', ]
     INSTALLED_APPS += (
         'debug_toolbar',
-        'template_timings_panel',
         # http://django-cachalot.readthedocs.io
         # 'cachalot',
     )
@@ -963,7 +962,6 @@ if DEBUG and not TESTING:
         'debug_toolbar.panels.sql.SQLPanel',
         'debug_toolbar.panels.staticfiles.StaticFilesPanel',
         'debug_toolbar.panels.templates.TemplatesPanel',
-        'template_timings_panel.panels.TemplateTimings.TemplateTimings',
         # 'cachalot.panels.CachalotPanel',
         'debug_toolbar.panels.cache.CachePanel',
         'debug_toolbar.panels.signals.SignalsPanel',


### PR DESCRIPTION
### What?
Tighten the dependency version ranges in `requirements-production.txt` and `requirements.txt`, and drop two dead dependencies surfaced during review:

- **Floors → the exact versions we run today** (e.g. `Django>=5.2.16`, `celery>=5.6.3`, `numpy>=2.5.1`, `psycopg2-binary>=2.9.12`, `django-import-export>=4.4.1`).
- **Ceilings → the next major** (`<X+1`), so backwards-compatible minor/patch updates ("bugfixes and tweaks") are allowed but a breaking major is not. A handful of caps stay tighter for documented compatibility reasons (below). `0.x` packages are capped at the next `0.minor`, since for `0.x` that is the breaking-change unit.
- **Added ceilings to deps that had none** (`coveralls`, `ruff`, `pre-commit`, `names`, `django-debug-toolbar`).
- **Removed two dead dependencies** (see below).

### Why?
The floors had drifted well below what we actually run and test — a fresh environment could resolve to an old, untested version (or, for the unpinned dev tools, a future breaking one). Raising each floor to the in-use version makes installs reproducible and documents the tested set; the next-major ceilings keep routine updates flowing without risking a breaking major.

### How?
`requirements-production.txt` / `requirements.txt`, plus a small `settings.py` cleanup for the removed panel — no runtime code changes.

**Dead dependencies removed:**
- **`pytz`** — nothing in the repo imports it and no installed package depends on it (`pipdeptree --reverse pytz` is empty); Django 5.2 and celery 5.6 both use `zoneinfo`.
- **`django-debug-toolbar-template-timings`** — a dev-only debug-toolbar panel whose module reads `DEFAULT_EXCEPTION_REPORTER_FILTER`, a Django setting removed in 3.1, so it crashes when the toolbar loads it on Django 5.2. Removed the dep and its two hooks in `settings.py`'s DEBUG block. (Tests run with `DEBUG=False`, so the suite never exercised it.)

**Compat caps kept tighter than next-major (intentional):**
- `Django <5.3` — minor releases remove deprecated APIs.
- `django-tenants <3.11` — the multitenancy core; tracks Django closely.
- `django-grappelli <5` — 4.0.x targets Django 5.x; 5.0.0 requires Django 6.x.
- `django-recaptcha <4.2` — held at the tested minor.
- `redis <8` — kombu hasn't declared redis-py 8 support (existing, documented).

### Testing?
A **clean** `pip install -r requirements.txt` from `python:3.12-slim` under the new ranges resolves to the version set we already validated (nothing newer than the tested versions exists above the old caps yet). Against that resolution, **with `pytz` and `template-timings` removed**:
- `python src/manage.py check` — no issues
- `python src/manage.py makemigrations --check --dry-run` — no changes detected
- `ruff check src` — all checks passed
- **Full suite: 1156 tests, OK** (0 failures / 0 errors)

### Screenshots (if front end is affected)
N/A — dependency pins + a dev-only settings cleanup.

### Anything Else?
Follows the Django 5.2 (#2015) + Python 3.12 (#2017) modernization; this locks the ranges to what those landed on and removes two now-dead deps. Dependabot will still propose in-range minor/patch bumps and the occasional major (which stays a deliberate, reviewed change).

### Review request
@tylerecouture

- Claude Code