### PR TITLE
Relax Referrer-Policy so YouTube (and other) embeds load — Closes #1896

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -978,6 +978,19 @@ if DEBUG and not TESTING:
     # }
 
 
+# Referrer-Policy value applied in production (see the security block below).
+# Named at module scope so it stays importable/testable even though the block
+# that applies it is skipped under TESTING. We deliberately deviate from
+# Django's "same-origin" default: under "same-origin" the browser sends *no*
+# Referer on cross-origin requests, which breaks third-party embeds that gate
+# on the referrer -- most visibly YouTube, whose iframe player refuses to load
+# and shows an error (issue #1896). "strict-origin-when-cross-origin" is the
+# modern browser default and web.dev's recommended value: it sends only the
+# origin (scheme + host, never the path) cross-origin, and the full URL
+# same-origin, so embeds work again while paths are still never leaked off-site.
+# Any non-None value keeps `check --deploy` (security.W022) green.
+PRODUCTION_SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
 # PRODUCTION / STAGING SECURITY SETTINGS ###############################
 # Hardening applied whenever DEBUG is off -- i.e. production AND staging
 # (staging mirrors prod). These are intentionally NOT applied in local
@@ -1031,10 +1044,11 @@ if not DEBUG and not TESTING:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = env("SECURE_HSTS_PRELOAD", default=False)
 
-    # Misc hardening flagged by `check --deploy`. NOSNIFF and the "same-origin"
-    # referrer policy match Django's own defaults; X_FRAME_OPTIONS "DENY" is
-    # already the effective default via XFrameOptionsMiddleware -- set here so
-    # the intent is explicit and the deploy check stays green.
+    # Misc hardening flagged by `check --deploy`. NOSNIFF and X_FRAME_OPTIONS
+    # "DENY" match the effective defaults (the latter via XFrameOptionsMiddleware)
+    # -- set here so the intent is explicit and the deploy check stays green.
     SECURE_CONTENT_TYPE_NOSNIFF = True
-    SECURE_REFERRER_POLICY = "same-origin"
     X_FRAME_OPTIONS = "DENY"
+    # Sends the origin (not the path) cross-origin so YouTube and other embeds
+    # load again; see PRODUCTION_SECURE_REFERRER_POLICY above and issue #1896.
+    SECURE_REFERRER_POLICY = PRODUCTION_SECURE_REFERRER_POLICY

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -1051,4 +1051,6 @@ if not DEBUG and not TESTING:
     X_FRAME_OPTIONS = "DENY"
     # Sends the origin (not the path) cross-origin so YouTube and other embeds
     # load again; see PRODUCTION_SECURE_REFERRER_POLICY above and issue #1896.
-    SECURE_REFERRER_POLICY = PRODUCTION_SECURE_REFERRER_POLICY
+    # Excluded from coverage because this block only runs outside the test
+    # harness; the policy value itself is covered directly by ReferrerPolicyTest.
+    SECURE_REFERRER_POLICY = PRODUCTION_SECURE_REFERRER_POLICY  # pragma: no cover

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -1,8 +1,13 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.test import RequestFactory, SimpleTestCase
+from django.http import HttpResponse
+from django.middleware.security import SecurityMiddleware
+from django.test import RequestFactory, SimpleTestCase, override_settings
 
-from hackerspace_online.settings import _validate_deployment_settings
+from hackerspace_online.settings import (
+    PRODUCTION_SECURE_REFERRER_POLICY,
+    _validate_deployment_settings,
+)
 
 
 class SecureProxySSLHeaderTest(SimpleTestCase):
@@ -52,6 +57,31 @@ class DeploymentSettingsGuardTest(SimpleTestCase):
         """DEBUG=False with a unique SECRET_KEY on a real domain passes the guard."""
         # Should not raise.
         _validate_deployment_settings("bytedeck.com", False, "a-real-random-secret-key")
+
+
+class ReferrerPolicyTest(SimpleTestCase):
+    """The production Referrer-Policy must not be "same-origin". Under
+    "same-origin" the browser strips the Referer from every cross-origin request,
+    so YouTube's iframe player (and other referrer-gated embeds) refuse to load
+    and show an error -- issue #1896. The production block that applies the policy
+    is skipped under TESTING, so the value is exercised via its module-level
+    constant and Django's SecurityMiddleware rather than settings.SECURE_*."""
+
+    def test_production_referrer_policy__is_not_same_origin(self):
+        """The policy must be "strict-origin-when-cross-origin" (browser default,
+        web.dev recommended), never "same-origin", so cross-origin embeds still
+        receive the origin as referrer and load correctly."""
+        self.assertEqual(PRODUCTION_SECURE_REFERRER_POLICY, "strict-origin-when-cross-origin")
+        self.assertNotEqual(PRODUCTION_SECURE_REFERRER_POLICY, "same-origin")
+
+    def test_security_middleware__emits_the_referrer_policy_header(self):
+        """SecurityMiddleware must turn the production policy into a
+        Referrer-Policy response header, proving the chosen value is what
+        browsers (and thus the YouTube embed request) actually see."""
+        with override_settings(SECURE_REFERRER_POLICY=PRODUCTION_SECURE_REFERRER_POLICY):
+            middleware = SecurityMiddleware(lambda request: HttpResponse())
+            response = middleware(RequestFactory().get("/"))
+        self.assertEqual(response.headers["Referrer-Policy"], "strict-origin-when-cross-origin")
 
 
 class DatabaseConnectionSettingsTest(SimpleTestCase):


### PR DESCRIPTION
### What?
Changes the production `Referrer-Policy` from `same-origin` to `strict-origin-when-cross-origin` so that embedded YouTube videos (and any other referrer-gated third-party embed) load correctly.

### Why?
Embedded YouTube videos fail to play in production, showing an error instead of the player (#1896).

Root cause: `django.middleware.security.SecurityMiddleware` ships `Referrer-Policy: same-origin` on every response — this is `SECURE_REFERRER_POLICY`, and `same-origin` is Django's built-in default (it was also set explicitly in the July production-hardening commit). Under `same-origin`, the browser sends **no `Referer` header on any cross-origin request**. YouTube's iframe player gates on the referrer, so with no referrer it refuses to load.

This only reproduces in production/staging — the security block is skipped when `DEBUG` or `TESTING` — which is why it never showed up in local development.

`strict-origin-when-cross-origin` is the modern browser default and the value [web.dev recommends](https://web.dev/articles/referrer-best-practices) (the same source cited in the issue). It sends only the **origin** (scheme + host, never the path) on cross-origin requests, and the full URL same-origin — so referrer-gated embeds work again while request paths are still never leaked off-site.

Compared to the temporary per-deck JS workaround posted on the issue, this one-line policy change fixes **every** embed — existing and new — on **every** deck, with no per-deck Custom JS, no iframe reload/flicker, and no content migration.

### How?
- `src/hackerspace_online/settings.py`: set the production `SECURE_REFERRER_POLICY` to `strict-origin-when-cross-origin`. The value is pulled out into an importable module-level `PRODUCTION_SECURE_REFERRER_POLICY` constant, because the security block that applies it is skipped under `TESTING` (so `settings.SECURE_REFERRER_POLICY` doesn't exist during tests) — same testability pattern the file already uses for `_validate_deployment_settings`.
- Any non-`None` value keeps `manage.py check --deploy` (security.W022) green, so the CI deploy-check gate stays passing.

### Testing?
- New `ReferrerPolicyTest` in `src/hackerspace_online/tests/test_settings.py`:
  - asserts the policy is `strict-origin-when-cross-origin` and explicitly **not** `same-origin` (the regression);
  - drives `SecurityMiddleware` with that value and asserts the emitted `Referrer-Policy` response header matches — proving what the browser (and thus the YouTube embed request) actually sees.
- Verified the tests genuinely fail on the old `same-origin` value and pass on the fix.
- `python manage.py test hackerspace_online.tests.test_settings` → 18 passing; `ruff check` clean.

### Screenshots (if front end is affected)
N/A — no visual/markup change; this is an HTTP response-header policy change.

### Anything Else?
- This keeps `same-origin`-level privacy for same-origin navigation and only relaxes the **cross-origin** case to send the origin (not the full path). For this multi-tenant LMS that means an external destination can see the deck's origin (e.g. `https://yourschool.bytedeck.com`) but never the path — the standard, widely-used default.
- The Embed Video tool was left unchanged: since the fix is at the policy layer, new embeds need no per-iframe `referrerpolicy` attribute. If a stricter global policy is ever reintroduced, a per-iframe attribute in `summernote-video-attributes.js` would be the follow-up.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_