### PR TITLE
Keep campaign quests vertically stacked on the quest map — Closes #1787

### DIFF
--- a/src/djcytoscape/static/djcytoscape/js/maps.js
+++ b/src/djcytoscape/static/djcytoscape/js/maps.js
@@ -121,6 +121,41 @@ cy.style()
  *
 /**************************************/
 
+// #1787: Keep a campaign's quests vertically stacked even when one of them is also a
+// prerequisite for a quest OUTSIDE the campaign.
+//
+// dagre positions each node horizontally (Brandes-Köpf) by aligning it under the
+// *median* of its neighbours, and it ignores edge weight when doing so. So a quest that
+// is a prereq for both its in-campaign successor and an out-of-campaign quest gets
+// centred between the two, dragging the in-campaign successor sideways instead of
+// keeping it directly below.
+//
+// dagre counts each parallel edge as a separate neighbour (its graph is a multigraph),
+// so temporarily adding a hidden duplicate of every intra-campaign edge — one whose
+// source and target share the same compound/campaign parent — pulls the median back
+// onto the in-campaign successor. The chain stacks vertically and the out-of-campaign
+// branch is pushed off to the side. When a quest branches to two quests that are BOTH
+// in the campaign, both edges are duplicated equally, so they still spread apart as
+// before (matching the issue's "unless both subsequent quests are within the same
+// campaign"). The duplicates only bias the layout; they're removed right after
+// positioning (dagre runs synchronously here since animation is off), so they never
+// render or affect interaction.
+var campaignLayoutEdges = [];
+cy.edges().forEach(function (edge) {
+    var sourceParent = edge.source().parent();
+    // nonempty() guards the top-level case: two parent-less nodes both have an empty
+    // parent collection, and empty.same(empty) is true, which would wrongly match
+    // every edge between quests that aren't in any campaign.
+    if (sourceParent.nonempty() && sourceParent.same(edge.target().parent())) {
+        campaignLayoutEdges.push({
+            group: 'edges',
+            data: { source: edge.source().id(), target: edge.target().id() },
+            classes: 'hidden',
+        });
+    }
+});
+var addedCampaignLayoutEdges = cy.add(campaignLayoutEdges);
+
 var layout = cy.layout({
 
     // name: 'breadthfirst',
@@ -137,6 +172,9 @@ var layout = cy.layout({
     "rankSep": 15,  // vertical seperation of nodes // try 24 for taxi?
 });
 layout.run()
+
+// Remove the layout-only helper edges now that every node has its position.
+addedCampaignLayoutEdges.remove();
 
 /***************************************
  *


### PR DESCRIPTION
### What?
On the quest map, quests in a campaign now stay vertically stacked even when one of them is also a prerequisite for a quest **outside** the campaign. Previously the in-campaign successor drifted sideways (e.g. "Blender Basics 3" no longer sat directly below "Blender Basics 2").

### Why?
Reported in #1787. In a campaign chain `BB1 → BB2 → BB3 → BB4`, if `BB2` is also a prereq for some out-of-campaign quest, `BB2`'s in-campaign successor got shoved off the campaign's vertical line.

Root cause is in the **dagre layout, not the data**. dagre assigns horizontal positions with the Brandes-Köpf algorithm, aligning each node under the *median* of its neighbours, and it **ignores edge weight** when doing so (I confirmed this empirically — even `edgeWeight: 1000` left x-positions byte-identical). A quest that branches to an in-campaign successor and an out-of-campaign quest therefore gets centred between the two, dragging the successor sideways.

### How?
dagre's graph is a **multigraph** and counts each parallel edge as a separate neighbour. So, just before running the layout, `maps.js` now adds a **hidden duplicate of every intra-campaign edge** (both endpoints sharing the same compound/campaign parent node). That pulls the median back onto the in-campaign successor:

- the campaign chain stacks vertically, and the out-of-campaign branch is pushed to the side;
- when a quest branches to two quests that are **both** in the campaign, both edges are duplicated equally, so they still spread apart — matching the issue's "unless both subsequent quests are within the same campaign";
- the duplicates only bias the layout and are removed immediately after positioning (dagre runs synchronously here since animation is off), so they never render or affect interaction.

No stored data or map regeneration is needed — the fix runs at render time, so it applies to every existing map on every deck.

Levers I tried and rejected before landing on this: per-edge `edgeWeight` (no effect on x — dagre BK ignores weight); `minlen` on the out-of-campaign edge (made it worse — shifted the prereq and dropped the branch a rank); edge input order (no effect).

### Testing?
This is a client-side dagre layout change with no server-side logic and no JS test harness in the repo, so I verified it by driving the **real** map assets (`cytoscape.min.js` + `dagre.min.js` + `cytoscape-dagre.js` + the actual `maps.js`) in headless Chromium and reading node positions:

- **Reported scenario:** chain x-offset from prereq went from **20px (drifting) → 0px (perfectly stacked)**; the branch quest stays on its own rank off to the side; the 6 original edges remain (helper duplicates removed).
- **Both-successors-in-campaign scenario:** positions **unchanged** before/after the fix (the legitimate spread is preserved).

### Screenshots (if front end is affected)
Before/after, rendered with the real map assets:

**BEFORE** — Blender Basics 3 & 4 drift left of Blender Basics 2.
**AFTER** — the four Blender Basics quests stack in a straight vertical line; "Other Quest" branches off to the right.

_(Rendered locally during review; the layout positions above quantify the same result.)_

### Anything Else?
- The change is confined to `src/djcytoscape/static/djcytoscape/js/maps.js` (the dagre layout config). No models, migrations, or cached `elements_json` change.
- This composes cleanly with the deterministic ordering from #1977 and the campaign `map_order` from #2016 — those control emission order (which campaign is left vs right); this controls vertical alignment *within* a campaign.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph layout positioning so related nodes within the same campaign are stacked more accurately.
  * Temporary layout adjustments are removed after positioning, ensuring no extra connections appear or affect interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->