### PR TITLE
Return 404 (not 500) for missing quest in archive/unarchive flow — Closes #1856

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3912,3 +3912,46 @@ class QuestArchiveViewTest(ByteDeckTenantTestCase):
 
         # Confirm redirect to archived quests page
         self.assertRedirects(response, reverse('quests:archived'))
+
+    def test_get__already_archived_quest_returns_404(self):
+        """The archive confirmation page 404s for an already-archived quest (#1856).
+
+        QuestArchive is a DetailView whose default queryset excludes archived quests,
+        so there is nothing left to confirm-archive once a quest is archived.
+        """
+        archived_quest = baker.make(Quest, name="Already Archived", archived=True)
+        url = reverse('quests:quest_archive', args=[archived_quest.id])
+        self.assertEqual(self.client.get(url).status_code, 404)
+
+    def test_post__already_archived_quest_returns_404(self):
+        """Posting to archive an already-archived quest 404s instead of re-running the
+        archive logic (#1856).
+
+        Archiving is effectively a no-op once a quest is archived; because the view's
+        default queryset excludes archived quests, the object lookup 404s and the
+        submission-deletion/XP-invalidation side effects never run a second time.
+        """
+        archived_quest = baker.make(Quest, name="Already Archived", archived=True)
+        url = reverse('quests:quest_archive', args=[archived_quest.id])
+        self.assertEqual(self.client.post(url).status_code, 404)
+
+    def test_post__nonexistent_quest_returns_404(self):
+        """Posting to archive a quest id that does not exist 404s cleanly rather than
+        raising an unhandled exception (#1856).
+        """
+        nonexistent_id = 9999999
+        self.assertFalse(Quest.objects.all_including_archived().filter(id=nonexistent_id).exists())
+        url = reverse('quests:quest_archive', args=[nonexistent_id])
+        self.assertEqual(self.client.post(url).status_code, 404)
+
+    def test_unarchive__nonexistent_quest_returns_404(self):
+        """Unarchiving a quest id that does not exist 404s cleanly (#1856).
+
+        The view previously looked the quest up with ``QuerySet.get()``, which raised
+        ``Quest.DoesNotExist`` for a bad id and surfaced as an unhandled 500; it now
+        uses ``get_object_or_404``.
+        """
+        nonexistent_id = 9999999
+        self.assertFalse(Quest.objects.all_including_archived().filter(id=nonexistent_id).exists())
+        url = reverse('quests:unarchive', args=[nonexistent_id])
+        self.assertEqual(self.client.post(url).status_code, 404)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1558,7 +1558,11 @@ def unarchive(request, quest_id):
     Returns:
         HttpResponseRedirect: Redirects to the Drafts tab with a success message.
     """
-    quest = Quest.objects.all_including_archived().get(id=quest_id)
+    # Use get_object_or_404 (not QuerySet.get) so a manually entered/stale quest id
+    # returns a clean 404 instead of raising Quest.DoesNotExist as an unhandled 500
+    # (issue #1856). all_including_archived() is required because the default manager
+    # excludes archived quests -- the only ones this view acts on.
+    quest = get_object_or_404(Quest.objects.all_including_archived(), id=quest_id)
 
     # Make the link that leads to the quests detail page to include in the message
     link = f'<a href="{quest.get_absolute_url()}">{quest.name}</a>'


### PR DESCRIPTION
### What?
Adds error handling and test coverage for the archive-flow edge cases deferred from #1846: archiving/unarchiving a quest that is **already archived** or **does not exist**.

### Why?
Reported in #1856. Two edge cases were unhandled or insufficiently covered:
- archiving an already-archived quest, and
- archiving/unarchiving a quest id that doesn't exist (which could raise an unhandled exception).

The maintainer's guidance on the issue: it's fine not to render friendly error pages for manually entered URLs, **as long as nothing bad can happen**. This PR makes sure of that and locks the behaviour in with tests.

### How?
Findings after tracing both flows:
- **Archive (`QuestArchive`, class-based `DetailView`)** already fails safe. Its default queryset excludes archived quests, so both an already-archived id and a non-existent id resolve to a clean **404** — the submission-deletion / XP-invalidation side effects never run a second time. No code change needed here; just added tests to guard it.
- **Unarchive (`unarchive`, function view)** was the real gap: it looked the quest up with `QuerySet.get()`, so a manually entered / stale id raised `Quest.DoesNotExist` and surfaced as an unhandled **500**. Switched it to `get_object_or_404(Quest.objects.all_including_archived(), id=quest_id)` — a missing id now returns a clean **404**. It still uses `all_including_archived()` because the default manager hides archived quests (the only ones this view acts on).

Nothing destructive can happen from a manually entered URL in these flows: the missing / already-archived cases 404 before any state change.

### Testing?
Added 4 tests to `QuestArchiveViewTest` (test-driven — the unarchive test failed with a 500 before the fix, passes after):
- `test_get__already_archived_quest_returns_404`
- `test_post__already_archived_quest_returns_404`
- `test_post__nonexistent_quest_returns_404`
- `test_unarchive__nonexistent_quest_returns_404`

`python manage.py test quest_manager.tests.test_views.QuestArchiveViewTest` → 7 passing; the unarchive happy-path (`test_teacher_can_unarchive_quest`) and `QuestBulkEditViewTests` still pass; `ruff check` clean.

### Screenshots (if front end is affected)
N/A — backend/error-handling change only.

### Anything Else?
- Scope is intentionally narrow: `unarchive` gets the `get_object_or_404` guard; the archive view is already safe and only gains regression tests.
- Not changed (noting for awareness): calling `unarchive` on a quest that isn't actually archived is a staff-only, reversible no-op that also unpublishes it — out of scope here and gated behind staff access, per the maintainer's "manual URLs are OK as long as nothing bad happens".

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or stale quest links now return a clear 404 page instead of an unhandled server error.
  - Archive and unarchive actions consistently return 404 responses when the quest does not exist or is already archived.

- **Tests**
  - Added regression coverage for invalid quest archive and unarchive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->