### PR TITLE
Bring the whole test suite up to the naming + docstring conventions (empty the guard denylist)

### DIFF
--- a/src/announcements/tests/test_models.py
+++ b/src/announcements/tests/test_models.py
@@ -7,13 +7,15 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 class AnnouncementTestModel(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create an announcement shared across the test methods."""
         cls.announcement = baker.make(Announcement)
 
-    def test_creation(self):
+    def test_creation__str_returns_title(self):
+        """An announcement is created and its string representation is its title."""
         self.assertIsInstance(self.announcement, Announcement)
         self.assertEqual(str(self.announcement), self.announcement.title)
 
-    def test_get_comments(self):
+    def test_get_comments__returns_only_connected_comments(self):
         """Test that an announcement returns comments connected to it"""
         comment1 = baker.make("comments.Comment", target_object=self.announcement)
         comment2 = baker.make("comments.Comment", target_object=self.announcement)

--- a/src/announcements/tests/test_signals.py
+++ b/src/announcements/tests/test_signals.py
@@ -16,10 +16,11 @@ class AnnouncementsSignalsTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and student shared across the test methods."""
         cls.teacher = baker.make(User, username='teacher', is_staff=True)
         cls.student = baker.make(User, username='student', is_staff=False)
 
-    def test_save_announcement_signal(self):
+    def test_save_announcement_signal__creates_and_deletes_publish_task(self):
         """
         Test that after a model is saved that a celery-beat tasks exists to publish it if conditions are correct.
         The task should also exists in the public schema.

--- a/src/announcements/tests/test_tasks.py
+++ b/src/announcements/tests/test_tasks.py
@@ -24,6 +24,7 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create an announcement, teacher, students, and AI user shared across the test methods."""
         cls.announcement = baker.make(Announcement)
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -38,7 +39,7 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
             },
         )
 
-    def test_get_users_to_email(self):
+    def test_get_users_to_email__returns_only_verified_opted_in_users(self):
         """Should return correct list of users to email"""
 
         course = baker.make(Course)
@@ -96,8 +97,8 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
 
         self.assertEqual(len(emails), 12 if settings.TENANT_DEFAULT_OWNER_EMAIL else 11)  # 11 + deck owner = 12
 
-    def test_send_announcement_emails(self):
-
+    def test_send_announcement_emails__task_succeeds(self):
+        """The send_announcement_emails task runs to completion successfully."""
         task_result = tasks.send_announcement_emails.apply(
             kwargs={
                 "content": "",
@@ -107,7 +108,8 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
         )
         self.assertTrue(task_result.successful())
 
-    def test_publish_announcement(self):
+    def test_publish_announcement__clears_draft_and_removes_task(self):
+        """Publishing marks the announcement non-draft, disables auto_publish, and removes its periodic task."""
         self.assertTrue(self.announcement.draft)
         task_result = tasks.publish_announcement.apply(
             kwargs={
@@ -132,7 +134,8 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
             with schema_context(get_public_schema_name()):
                 PeriodicTask.objects.get(name=task_name)
 
-    def test_publish_announcement_past_date(self):
+    def test_publish_announcement__past_release_date(self):
+        """An announcement with a past release date is still published (draft cleared)."""
         past_announcement = baker.make(Announcement,
                                        datetime_released=timezone.now() - timedelta(days=90))
         self.assertTrue(past_announcement.draft)
@@ -150,8 +153,8 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
         past_announcement.refresh_from_db()
         self.assertFalse(past_announcement.draft)
 
-    def test_send_notifications(self):
-
+    def test_send_notifications__task_succeeds(self):
+        """The send_notifications task runs to completion successfully, directly and via apply()."""
         tasks.send_notifications(self.ai_user.id, self.announcement.id)
 
         # run method as synchronous task

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -21,6 +21,7 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, students, and a published announcement shared across the test methods."""
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
@@ -30,9 +31,10 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.ann_pk = cls.test_announcement.pk
 
     def setUp(self):
+        """Set up a tenant test client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_announcement_page_status_codes_for_anonymous(self):
+    def test_all_announcement_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to login page '''
 
         self.assertRedirectsLogin('announcements:list')
@@ -46,13 +48,10 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('announcements:copy', args=[1])
         self.assertRedirectsLogin('announcements:publish', args=[1])
 
-    def test_all_announcement_page_status_codes_for_students(self):
+    def test_all_announcement_page_status_codes__students(self):
+        """Students can view lists/comments but get 403 on staff-only announcement views."""
         # log in a student
         self.client.force_login(self.test_student1)
-
-        # all_fields = self.test_announcement._meta.get_fields()
-        # for field in all_fields:
-        #     print(field, getattr(self.test_announcement, field.name))
 
         # students should have access to these:
         self.assert200('announcements:list')
@@ -78,7 +77,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403('announcements:publish', args=[1])
         self.assert403('announcements:archived')
 
-    def test_all_announcement_page_status_codes_for_teachers(self):
+    def test_all_announcement_page_status_codes__teachers(self):
+        """Teachers can access the list, archive, comment, and all staff-only announcement views."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -109,15 +109,18 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             expected_url=reverse('announcements:list', args=[self.ann_pk]),
         )
 
-    def test_teachers_have_archive_button(self):
+    def test_archive_button__visible_to_teachers(self):
+        """Teachers see the 'Archived' button on the announcements list."""
         self.client.force_login(self.test_teacher)
         self.assertContains(self.client.get(reverse('announcements:list')), "Archived")
 
-    def test_students_do_not_see_archive_button(self):
+    def test_archive_button__hidden_from_students(self):
+        """Students do not see the 'Archived' button on the announcements list."""
         self.client.force_login(self.test_student1)
         self.assertNotContains(self.client.get(reverse('announcements:list')), "Archived")
 
-    def test_draft_announcement(self):
+    def test_draft_announcement__hidden_from_students_until_published(self):
+        """Students only see an announcement in the list once it is no longer a draft."""
         draft_announcement = baker.make(Announcement)  # default is draft
         self.assertTrue(draft_announcement.draft)
 
@@ -135,7 +138,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(self.client.get(reverse('announcements:list')), draft_announcement.title)
 
     # @patch('announcements.views.publish_announcement.apply_async')
-    def test_publish_announcement(self):
+    def test_publish_announcement__removes_publish_link(self):
+        """Posting to the publish view redirects to the announcement and the publish link disappears once published."""
         draft_announcement = baker.make(Announcement)
 
         # log in a teacher
@@ -159,7 +163,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # publish link for this announcement should no longer appear in the list:
         self.assertNotContains(self.client.get(reverse('announcements:list')), publish_link)
 
-    def test_create_announcement_from_past_date_auto_publish(self):
+    def test_create_announcement__past_date_auto_publish_invalid(self):
+        """The form rejects an auto-published announcement with a past release date."""
         draft_announcement = baker.make(
             Announcement,
             datetime_released=timezone.now() - timedelta(days=3),
@@ -169,7 +174,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors['datetime_released'], ['An Announcement that is auto published cannot have a past release date.'])
 
-    def test_create_announcement_auto_publish_and_archive(self):
+    def test_create_announcement__auto_publish_and_archived_invalid(self):
+        """The form rejects an announcement that is both archived and auto-published."""
         draft_announcement = baker.make(
             Announcement,
             datetime_released=timezone.now() - timedelta(days=3),
@@ -184,7 +190,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(form.errors['auto_publish'], ['An Announcement that is archived cannot be auto published.'])
         # self.add_error("auto_publish", forms.ValidationError('An Announcement that is archived cannot be auto published.'))
 
-    def test_comment_on_announcement_by_student(self):
+    def test_comment_on_announcement__by_student(self):
+        """A student's comment post requires the comment_button, returning 404 without it."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -231,7 +238,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotIn('<img', comment.text)
         self.assertIn('&lt;script&gt;', comment.text)
 
-    def test_copy_announcement(self):
+    def test_copy_announcement__creates_new_announcement(self):
+        """Copying an announcement via POST creates a new announcement and redirects to it."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -334,14 +342,16 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, student, and a published announcement shared across the test methods."""
         cls.test_teacher = baker.make(User, is_staff=True)
         cls.test_student = baker.make(User)
         cls.test_announcement = baker.make(Announcement, draft=False)
 
     def setUp(self):
+        """Set up a tenant test client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_archived_announcement(self):
+    def test_archived_announcement__hidden_from_list(self):
         """ Archived announcements should not appear in announcements list"""
         archived_announcement = baker.make(Announcement, archived=True)
         self.assertTrue(archived_announcement.archived)
@@ -358,12 +368,13 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Users can now see it
         self.assertContains(self.client.get(reverse('announcements:list')), archived_announcement.title)
 
-    def test_archived_announcements_visible_on_archived_page(self):
+    def test_archived_announcements__visible_on_archived_page(self):
+        """Archived announcements appear on the dedicated archived page."""
         self.client.force_login(self.test_teacher)
         archived_announcement = baker.make(Announcement, archived=True)
         self.assertContains(self.client.get(reverse('announcements:archived')), archived_announcement.title)
 
-    def test_archived_announcements_are_paginated(self):
+    def test_archived_announcements__are_paginated(self):
         """2nd page after 20 announcements, and view forwards to announcements on 2nd page
         """
         # create enough announcements to create a second page, oldest should be on second page
@@ -376,7 +387,7 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, "/announcements/archived/?page=2")
         self.assertNotContains(response, "/announcements/archived/?page=3")
 
-    def test_get_absolute_url_for_archived(self):
+    def test_get_absolute_url__for_archived(self):
         """get_absolute_url should redirect/load the proper page with the archived announcement"""
         # create enough announcements to create a second page
         oldest_announcement = baker.make(Announcement, archived=True, draft=False)
@@ -401,7 +412,7 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, oldest_announcement.title)
 
-    def test_announcement_draft_not_archived_after_semester_close(self):
+    def test_announcement_draft__not_archived_after_semester_close(self):
         """ Draft announcements should not be archived when a semester is closed """
         draft_ann = baker.make(Announcement, archived=False, draft=True)
 

--- a/src/badges/tests/test_forms.py
+++ b/src/badges/tests/test_forms.py
@@ -10,7 +10,7 @@ User = get_user_model()
 
 class BadgeAssertionFormTest(ByteDeckTenantTestCase):
 
-    def test_badge_assertion_form(self):
+    def test_badge_assertion_form__valid_with_badge_and_user(self):
         """ Form with a badge and user is valid. """
         form_data = {
             'badge': baker.make('badges.Badge').pk,
@@ -19,7 +19,7 @@ class BadgeAssertionFormTest(ByteDeckTenantTestCase):
         form = BadgeAssertionForm(data=form_data)
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_badge_assertion_form_no_xp(self):
+    def test_badge_assertion_form__valid_with_do_not_grant_xp(self):
         """ Form is still valid when the do_not_grant_xp option is checked. """
         form_data = {
             'badge': baker.make('badges.Badge').pk,
@@ -29,7 +29,7 @@ class BadgeAssertionFormTest(ByteDeckTenantTestCase):
         form = BadgeAssertionForm(data=form_data)
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_bulk_badge_assertion_form(self):
+    def test_bulk_badge_assertion_form__valid_with_badge_and_students(self):
         """ Form with a badge and a list of student profiles is valid. """
         form_data = {
             'badge': baker.make('badges.Badge').pk,

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -18,18 +18,20 @@ User = get_user_model()
 class BadgeRarityModelTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create rarities at known percentiles (clearing the defaults first)."""
         # clear default mark range variables
         BadgeRarity.objects.all().delete()
         cls.common = baker.make(BadgeRarity, percentile=90.0)
         cls.rare = baker.make(BadgeRarity, percentile=80.0)
         cls.ultrarare = baker.make(BadgeRarity, percentile=70.0)
 
-    def test_badge_rarity_creation(self):
+    def test_badge_rarity__creation(self):
+        """A BadgeRarity is created and its str is its name."""
         self.assertIsInstance(self.common, BadgeRarity)
         self.assertEqual(str(self.common), self.common.name)
 
-    def test_get_rarity(self):
-
+    def test_get_rarity__returns_matching_rarity_for_percentile(self):
+        """get_rarity() maps a percentile to its rarity, capping values above 100."""
         self.assertEqual(BadgeRarity.objects.get_rarity(69.0), self.ultrarare)
         self.assertEqual(BadgeRarity.objects.get_rarity(79.0), self.rare)
         self.assertEqual(BadgeRarity.objects.get_rarity(80.0), self.rare)
@@ -45,13 +47,15 @@ class BadgeRarityModelTest(ByteDeckTenantTestCase):
 class BadgeTypeModelTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a BadgeType for the class tests."""
         cls.badge_type = baker.make(BadgeType)
 
-    def test_badge_type_creation(self):
+    def test_badge_type__creation(self):
+        """A BadgeType is created and its str is its name."""
         self.assertIsInstance(self.badge_type, BadgeType)
         self.assertEqual(str(self.badge_type), self.badge_type.name)
 
-    def test_model_protection(self):
+    def test_model_protection__badge_type_with_badges(self):
         """ Badge types shouldn't be deleted if they have any assigned badges """
 
         # make sure initial variables are in place
@@ -66,9 +70,11 @@ class BadgeTypeModelTest(ByteDeckTenantTestCase):
 class BadgeSeriesTestModel(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a BadgeSeries for the class tests."""
         cls.badge_series = baker.make(BadgeSeries)
 
-    def test_badge_series_creation(self):
+    def test_badge_series__creation(self):
+        """A BadgeSeries is created and its str is its name."""
         self.assertIsInstance(self.badge_series, BadgeSeries)
         self.assertEqual(str(self.badge_series), self.badge_series.name)
 
@@ -77,16 +83,19 @@ class BadgeTestModel(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a Badge for the class tests."""
         cls.badge = baker.make(Badge)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_badge_creation(self):
+    def test_badge__creation(self):
+        """A Badge is created and its str is its name."""
         self.assertIsInstance(self.badge, Badge)
         self.assertEqual(str(self.badge), self.badge.name)
 
-    def test_get_icon_url(self):
+    def test_get_icon_url__default_and_custom(self):
         """If the badge has an icon, return its url, otherwise return default icon url from SiteConfig"""
 
         # doesn't have an icon, should return default
@@ -98,11 +107,13 @@ class BadgeTestModel(ByteDeckTenantTestCase):
         self.badge.save()
         self.assertEqual(self.badge.get_icon_url(), self.badge.icon.url)
 
-    def test_badge_url(self):
+    def test_badge_url__absolute_url_returns_200(self):
+        """The badge's absolute url is reachable and returns 200."""
         self.assertEqual(self.client.get(self.badge.get_absolute_url(), follow=True).status_code, 200)
 
     @mock.patch('badges.models.BadgeRarity.objects.get_rarity')
     def test_get_rarity_icon__without_rarity(self, mock_get_rarity):
+        """get_rarity_icon() returns an empty string when the badge has no rarity."""
         mock_get_rarity.return_value = None
 
         result = self.badge.get_rarity_icon()
@@ -113,6 +124,7 @@ class BadgeTestModel(ByteDeckTenantTestCase):
     @mock.patch('badges.models.BadgeRarity.objects.get_rarity')
     @mock.patch('badges.models.Badge.percent_of_active_users_granted_this')
     def test_get_rarity_icon__with_rarity(self, mock_percentile, mock_get_rarity):
+        """get_rarity_icon() returns the rarity's icon html when the badge has a rarity."""
         mock_percentile.return_value = 80  # Set the desired percentile value
         mock_badge_rarity = mock.Mock()
         mock_badge_rarity.get_icon_html.return_value = '<span class="badge-icon">Icon</span>'
@@ -130,19 +142,17 @@ class BadgeAssertionManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and student for the manager tests."""
         cls.sem = SiteConfig.get().active_semester
 
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
-        # cls.assertion = baker.make(BadgeAssertion, semester=cls.sem)
-        # cls.badge = Recipe(Badge, xp=20).make()
-
-        # cls.badge_assertion_recipe = Recipe(BadgeAssertion, user=cls.student, badge=cls.badge, semester=cls.sem)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_user_badge_assertion_count(self):
+    def test_user_badge_assertion_count__annotates_count_per_user(self):
         """Test that BadgeAssertion.objects.user_assertion_count_of_badge() returns a User queryset with
         the correct number of assertions for each user as an "assertion_count" annotation on the queryset"""
 
@@ -160,7 +170,7 @@ class BadgeAssertionManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(qs.get(id=user2.id).assertion_count, 1)
         self.assertNotIn(user3, qs)
 
-    def test_all_for_user_distinct(self):
+    def test_all_for_user_distinct__distinct_by_badge_and_sorted(self):
         """
         BadgeAssertion.objects.all_for_user_distinct() returns a queryset of BadgeAssertions assigned to a user
         that are distinct by badge, and sorted by badge.badge_type.sort_order, badge.sort_order
@@ -217,6 +227,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, student, badge and reusable assertion recipe."""
         cls.sem = SiteConfig.get().active_semester
 
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
@@ -227,16 +238,20 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         cls.badge_assertion_recipe = Recipe(BadgeAssertion, user=cls.student, badge=cls.badge, semester=cls.sem)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_badge_assertion_creation(self):
+    def test_badge_assertion__creation(self):
+        """A BadgeAssertion is created and its str is its badge's name."""
         self.assertIsInstance(self.assertion, BadgeAssertion)
         self.assertEqual(str(self.assertion), self.assertion.badge.name)
 
-    def test_badge_assertion_url(self):
+    def test_badge_assertion_url__absolute_url_returns_200(self):
+        """The assertion's absolute url is reachable and returns 200."""
         self.assertEqual(self.client.get(self.assertion.get_absolute_url(), follow=True).status_code, 200)
 
-    def test_badge_assertion_count(self):
+    def test_badge_assertion__count(self):
+        """count() returns the number of times the badge has been granted to the user."""
         num = 5
         for _ in range(num):
             badge_assertion = BadgeAssertion.objects.create_assertion(
@@ -251,7 +266,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         # print(num, count)
         self.assertEqual(num, count)
 
-    def test_badge_assertion_count_bootstrap_badge(self):
+    def test_count_bootstrap_badge__empty_when_below_two(self):
         """Returns empty string if count < 2, else returns proper count"""
         badge_assertion = baker.make(BadgeAssertion, semester=self.sem)
         self.assertEqual(badge_assertion.count_bootstrap_badge(), "")
@@ -269,7 +284,8 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         # print(num, count)
         self.assertEqual(num, count)
 
-    def test_badge_assertion_get_duplicate_assertions(self):
+    def test_get_duplicate_assertions__returns_all_duplicates(self):
+        """get_duplicate_assertions() returns every assertion of the same badge for the user."""
         num = 5
         values = []
         for _ in range(num):
@@ -279,7 +295,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         qs = badge_assertion.get_duplicate_assertions()
         self.assertQuerySetEqual(list(qs), values, )
 
-    def test_badge_assertions_dict_items_prefetches_duplicates(self):
+    def test_badge_assertions_dict_items__prefetches_duplicates(self):
         """badge_assertions_dict_items pre-populates each distinct badge's
         duplicate assertions, so get_duplicate_assertions() serves them from
         memory with no query per badge (the profile page renders one popover
@@ -300,8 +316,8 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         self.assertEqual(duplicate_counts[badge_a.id], 2)
         self.assertEqual(duplicate_counts[badge_b.id], 3)
 
-    def test_badge_assertion_manager_create_assertion(self):
-
+    def test_create_assertion__without_semester_or_teacher(self):
+        """create_assertion() builds a BadgeAssertion whether or not a teacher is passed."""
         # no semester
         new_assertion = BadgeAssertion.objects.create_assertion(
             self.student,
@@ -317,7 +333,8 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         )
         self.assertIsInstance(new_assertion, BadgeAssertion)
 
-    def test_badge_assertion_manager_xp_to_date(self):
+    def test_calculate_xp_to_date__sums_granted_badge_xp(self):
+        """calculate_xp_to_date() totals the XP of the badges granted to the user by a date."""
         xp = BadgeAssertion.objects.calculate_xp_to_date(self.student, timezone.now())
         self.assertEqual(xp, 0)
 
@@ -330,7 +347,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         xp = BadgeAssertion.objects.calculate_xp_to_date(self.student, timezone.now())
         self.assertEqual(xp, self.badge.xp)
 
-    def test_badge_assertion_manager_get_by_type_for_user(self):
+    def test_get_by_type_for_user__one_entry_per_badge_type(self):
         """ get_by_type_for_user should return one entry per BadgeType, where the entry for the
         granted badge's type contains the user's assertion and all other entries are empty. """
         assertion = self.badge_assertion_recipe.make()
@@ -342,7 +359,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
             else:
                 self.assertQuerySetEqual(entry['list'], [])
 
-    def test_badge_assertion_manager_check_for_new_assertions(self):
+    def test_check_for_new_assertions__grants_unlocked_badges_recursively(self):
         """ check_for_new_assertions should grant badges whose prerequisites the user meets,
         including badges unlocked by a badge granted in the same call (recursion). """
         # chain: self.badge -> badge_a -> badge_b
@@ -361,7 +378,8 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         self.assertTrue(BadgeAssertion.objects.all_for_user_badge(self.student, badge_a, False).exists())
         self.assertTrue(BadgeAssertion.objects.all_for_user_badge(self.student, badge_b, False).exists())
 
-    def test_fraction_of_active_users_granted_this(self):
+    def test_fraction_of_active_users_granted_this__matches_ratio(self):
+        """fraction/percent_of_active_users_granted_this() reflect the share of active users with the badge."""
         num_students_with_badge = 3
 
         students_with_badge = baker.make(User, _quantity=num_students_with_badge)
@@ -434,34 +452,34 @@ class BadgeRarityCacheInvalidationTest(ByteDeckTenantTestCase):
         """Populate the rarity cache so the test's write can be shown to invalidate it."""
         BadgeRarity.objects.get_rarities_cached()
 
-    def test_save_invalidates_cache(self):
+    def test_save__invalidates_cache(self):
         """Creating a BadgeRarity (via save) must invalidate the cache (post_save signal)."""
         self.warm_cache()
         rarity = baker.make(BadgeRarity, name='Test Rarity', percentile=0.123)
         self.assertEqual(BadgeRarity.objects.get_rarity(0.1).pk, rarity.pk)
         self.assert_cache_matches_db()
 
-    def test_queryset_delete_invalidates_cache(self):
+    def test_queryset_delete__invalidates_cache(self):
         """Queryset .delete() must invalidate the cache (receivers disable fast-delete, so post_delete fires)."""
         rarity = baker.make(BadgeRarity, name='Test Rarity', percentile=0.123)
         self.warm_cache()
         BadgeRarity.objects.filter(pk=rarity.pk).delete()
         self.assert_cache_matches_db()
 
-    def test_queryset_update_invalidates_cache(self):
+    def test_queryset_update__invalidates_cache(self):
         """Queryset .update() fires no signals; the BadgeRarityQuerySet.update override must invalidate the cache."""
         rarity = baker.make(BadgeRarity, name='Test Rarity', percentile=0.123)
         self.warm_cache()
         BadgeRarity.objects.filter(pk=rarity.pk).update(percentile=0.456)
         self.assert_cache_matches_db()
 
-    def test_bulk_create_invalidates_cache(self):
+    def test_bulk_create__invalidates_cache(self):
         """bulk_create() fires no signals; the BadgeRarityQuerySet.bulk_create override must invalidate the cache."""
         self.warm_cache()
         BadgeRarity.objects.bulk_create([BadgeRarity(name='Bulk Rarity', percentile=0.123)])
         self.assert_cache_matches_db()
 
-    def test_bulk_update_invalidates_cache(self):
+    def test_bulk_update__invalidates_cache(self):
         """bulk_update() fires no signals; the BadgeRarityQuerySet.bulk_update override must invalidate the cache."""
         rarity = baker.make(BadgeRarity, name='Test Rarity', percentile=0.123)
         self.warm_cache()

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -27,6 +27,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create teacher, students, a badge, badge type and assertion for the badge view tests."""
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
@@ -41,9 +42,10 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_assertion = baker.make(BadgeAssertion)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_badge_page_status_codes_for_anonymous(self):
+    def test_all_badge_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to home  '''
         b_pk = self.test_badge.pk
         a_pk = self.test_assertion.pk
@@ -62,8 +64,8 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('badges:revoke', args=[a_pk])
         self.assertRedirectsLogin('badges:grant_qualifying', args=[b_pk])
 
-    def test_all_badge_page_status_codes_for_students(self):
-
+    def test_all_badge_page_status_codes__students(self):
+        """Students may view the list/detail pages but get 403 on all staff-only badge views."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -88,7 +90,8 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(self.client.get(reverse('badges:badge_prereqs_update', args=[b_pk])).status_code, 403)
 
-    def test_all_badge_page_status_codes_for_teachers(self):
+    def test_all_badge_page_status_codes__teachers(self):
+        """Teachers get 200 on every badge view, including create/update/grant/revoke."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -111,7 +114,8 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('badges:badge_prereqs_update', args=[b_pk])
         self.assert200('badges:grant_qualifying', args=[b_pk])
 
-    def test_badge_create(self):
+    def test_badge_create__creates_badge(self):
+        """Posting valid data to the create view creates a new badge and redirects to the list."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -147,6 +151,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(list(form_data['tags'].values_list('name', flat=True)), ['tag'])
 
     def test_badge_copy__POST(self):
+        """Posting to the copy view creates a new badge from the submitted data."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -169,7 +174,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         new_badge = Badge.objects.latest('datetime_created')
         self.assertEqual(new_badge.name, "badge copy test")
 
-    def test_assertion_create_and_delete(self):
+    def test_assertion__create_and_delete(self):
         """ Ensure that the create and delete views properly add and remove the badges from the users profile
         and adds/subtracts XP."""
         # log in a teacher
@@ -211,7 +216,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.test_student1.profile.refresh_from_db()
         self.assertEqual(self.test_student1.profile.xp_cached, xp_initial)
 
-    def test_assertion_create_no_xp(self):
+    def test_assertion_create__no_xp(self):
         """Don't grant XP for this badge assertion"""
         self.client.force_login(self.test_teacher)
 
@@ -231,7 +236,8 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         new_assertion = BadgeAssertion.objects.latest('timestamp')
         self.assertEqual(new_assertion.do_not_grant_xp, True)
 
-    def test_bulk_assertion_create(self):
+    def test_bulk_assertion_create__grants_to_all_selected(self):
+        """Bulk granting a badge to multiple students creates one assertion per student."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -385,7 +391,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(any("Prerequisites have been updated" in m for m in messages))
         self.assertFalse(any(grant_url in m for m in messages))
 
-    def test_scape_update_message_on_update_delete(self):
+    def test_scape_update_message__on_update_and_delete(self):
         """ Checks if delete and update function gives a success message when a badge is related to map """
         # setup
         badge = baker.make(Badge)
@@ -481,6 +487,7 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student and a badge type for the badge type view tests."""
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
@@ -488,16 +495,17 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.badge_type = baker.make(BadgeType)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_page_status_codes_for_anonymous(self):
+    def test_all_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to login page '''
         self.assertRedirectsLogin('badges:badge_types')
         self.assertRedirectsLogin('badges:badge_type_create')
         self.assertRedirectsLogin('badges:badge_type_update', args=[self.badge_type.pk])
         self.assertRedirectsLogin('badges:badge_type_delete', args=[self.badge_type.pk])
 
-    def test_all_page_status_codes_for_students(self):
+    def test_all_page_status_codes__students_forbidden(self):
         ''' If not logged in then all views should redirect to 403 '''
         self.client.force_login(self.test_student1)
 
@@ -507,13 +515,13 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403('badges:badge_type_update', args=[self.badge_type.pk])
         self.assert403('badges:badge_type_delete', args=[self.badge_type.pk])
 
-    def test_BadgeTypeList_view(self):
+    def test_BadgeTypeList_view__staff_can_view(self):
         """ Admin should be able to view badge type list """
         self.client.force_login(self.test_teacher)
         response = self.client.get(reverse('badges:badge_types'))
         self.assertEqual(response.status_code, 200)
 
-    def test_BadgeTypeCreate_view(self):
+    def test_BadgeTypeCreate_view__staff_can_create(self):
         """ Admin should be able to create a course """
         self.client.force_login(self.test_teacher)
         data = {
@@ -526,7 +534,7 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         test_badgetype = BadgeType.objects.get(name=data['name'])
         self.assertEqual(test_badgetype.name, data['name'])
 
-    def test_BadgeTypeUpdate_view(self):
+    def test_BadgeTypeUpdate_view__staff_can_update(self):
         """ Admin should be able to update a badge type """
         self.client.force_login(self.test_teacher)
         # set name and icon to something they wouldn't normally be
@@ -619,6 +627,7 @@ class BadgeAjaxTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student with several badge assertions (and their notifications) for the popup tests."""
         cls.student = baker.make(User)
 
         # create multiple assertions of the same badge
@@ -634,9 +643,10 @@ class BadgeAjaxTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.create_assertion_notification(cls.badge_single)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_status_codes(self):
+    def test_status_codes__badge_popup_endpoints(self):
         ''' tests correct status codes for `on_show_badge_popup` and `on_close_badge_popup`
         403 - because not ajax
         302 - because of not logged in (LoginRequiredMixin)
@@ -667,7 +677,7 @@ class BadgeAjaxTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('badges:ajax_on_close_badge_popup'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 200)
 
-    def test_on_show_badge_popup(self):
+    def test_on_show_badge_popup__context_values(self):
         """ Checks if badge popup shows correct the correct context values and if
         the badges in "new_badges" have the correct "duplicates" variable
         """
@@ -708,7 +718,7 @@ class BadgeAjaxTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(json_data['show'])
         self.assertFalse(json_data['html'])
 
-    def test_on_close_badge_popup(self):
+    def test_on_close_badge_popup__marks_notifications_read(self):
         """ Check if 'badges:ajax_on_close_badge_popup' closes all unread badge notifications
         """
         # check for initial notifications

--- a/src/bytedeck_summernote/tests/test_admin.py
+++ b/src/bytedeck_summernote/tests/test_admin.py
@@ -10,7 +10,7 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 class ByteDeckSummernoteModelAdminMixinTestCase(TestCase):
 
-    def test_get_summernote_widget_class(self):
+    def test_get_summernote_widget_class__not_implemented_then_overridden(self):
         """
         Test two things:
         1. that the get_summernote_widget_class method raises a NotImplementedError when called directly,
@@ -42,6 +42,7 @@ class TestByteDeckSummernoteSafeModelAdmin(ByteDeckTenantTestCase):
     """ByteDeck's Summernote implementation, so called 'Safe' variant"""
 
     def setUp(self):
+        """Set up admin site and refreshed django_summernote config."""
         self.username = "lqez"
         self.password = "ohmygoddess"
         self.site = AdminSite()
@@ -50,7 +51,7 @@ class TestByteDeckSummernoteSafeModelAdmin(ByteDeckTenantTestCase):
         self.app_config.update_config()
         self.summernote_config = self.app_config.config
 
-    def test_admin_model(self):
+    def test_admin_model__safe_widget_injected(self):
         """Safe widget (iframe variant) injected into customized admin class"""
         from bytedeck_summernote.admin import (
             ByteDeckSummernoteSafeModelAdmin,
@@ -67,7 +68,7 @@ class TestByteDeckSummernoteSafeModelAdmin(ByteDeckTenantTestCase):
             ByteDeckSummernoteSafeWidget,
         )
 
-    def test_admin_model_inplace(self):
+    def test_admin_model_inplace__safe_inplace_widget_injected(self):
         """Safe widget (non-iframe variant aka inplace) injected into customized admin class"""
         from bytedeck_summernote.admin import ByteDeckSummernoteSafeModelAdmin
         from bytedeck_summernote.widgets import ByteDeckSummernoteSafeInplaceWidget
@@ -83,7 +84,8 @@ class TestByteDeckSummernoteSafeModelAdmin(ByteDeckTenantTestCase):
 
         self.summernote_config["iframe"] = True
 
-    def test_admin_summernote_fields(self):
+    def test_admin_summernote_fields__safe_widget_only_for_listed_fields(self):
+        """Safe widget is injected only when the field is in summernote_fields."""
         from bytedeck_summernote.admin import ByteDeckSummernoteSafeModelAdmin
         from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
 
@@ -112,6 +114,7 @@ class TestByteDeckSummernoteAdvancedModelAdmin(ByteDeckTenantTestCase):
     """ByteDeck's Summernote implementation, so called 'Advanced' variant"""
 
     def setUp(self):
+        """Set up admin site and refreshed django_summernote config."""
         self.username = "lqez"
         self.password = "ohmygoddess"
         self.site = AdminSite()
@@ -120,7 +123,7 @@ class TestByteDeckSummernoteAdvancedModelAdmin(ByteDeckTenantTestCase):
         self.app_config.update_config()
         self.summernote_config = self.app_config.config
 
-    def test_admin_model(self):
+    def test_admin_model__advanced_widget_injected(self):
         """Advanced widget (iframe variant) injected into customized admin class"""
         from bytedeck_summernote.admin import (
             ByteDeckSummernoteAdvancedModelAdmin,
@@ -137,7 +140,7 @@ class TestByteDeckSummernoteAdvancedModelAdmin(ByteDeckTenantTestCase):
             ByteDeckSummernoteAdvancedWidget,
         )
 
-    def test_admin_model_inplace(self):
+    def test_admin_model_inplace__advanced_inplace_widget_injected(self):
         """Advanced widget (non-iframe variant aka inplace) injected into customized admin class"""
         from bytedeck_summernote.admin import ByteDeckSummernoteAdvancedModelAdmin
         from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedInplaceWidget
@@ -153,7 +156,8 @@ class TestByteDeckSummernoteAdvancedModelAdmin(ByteDeckTenantTestCase):
 
         self.summernote_config["iframe"] = True
 
-    def test_admin_summernote_fields(self):
+    def test_admin_summernote_fields__advanced_widget_only_for_listed_fields(self):
+        """Advanced widget is injected only when the field is in summernote_fields."""
         from bytedeck_summernote.admin import ByteDeckSummernoteAdvancedModelAdmin
         from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedWidget
 

--- a/src/bytedeck_summernote/tests/test_css_sanitizier.py
+++ b/src/bytedeck_summernote/tests/test_css_sanitizier.py
@@ -6,7 +6,7 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 class TestCSSSanitizer(ByteDeckTenantTestCase):
     """ByteDeck's CSSSanitizer implementation, fixes various issues"""
 
-    def test_sanitize_css(self):
+    def test_sanitize_css__preserves_escaped_values(self):
         """The sanitizer should not strip/remove escaped CSS values."""
         from bytedeck_summernote.css_sanitizer import CSSSanitizer
         from bytedeck_summernote.settings import STYLES

--- a/src/bytedeck_summernote/tests/test_views.py
+++ b/src/bytedeck_summernote/tests/test_views.py
@@ -7,9 +7,10 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 class TestByteDeckSummernoteView(ByteDeckTenantTestCase):
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_url(self):
+    def test_url__editor_view_responds(self):
         """Customized view class is configured and respond"""
         url = reverse("bytedeck_summernote-editor", kwargs={"id": "foobar"})
         response = self.client.get(url)

--- a/src/bytedeck_summernote/tests/test_widgets.py
+++ b/src/bytedeck_summernote/tests/test_widgets.py
@@ -6,7 +6,7 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 class TestByteDeckSummernoteSafeWidget(ByteDeckTenantTestCase):
     """ByteDeck's Summernote implementation, so called 'Safe' variant"""
 
-    def test_widget(self):
+    def test_widget__safe_cleans_xss(self):
         """Safe widget (iframe variant) input is "cleaned" to prevent XSS scripts from executing"""
         from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
 
@@ -22,7 +22,7 @@ class TestByteDeckSummernoteSafeWidget(ByteDeckTenantTestCase):
 
         self.assertEqual(value, '&lt;script&gt;alert("Hello")&lt;/script&gt;')
 
-    def test_widget_inplace(self):
+    def test_widget_inplace__safe_cleans_xss(self):
         """Safe widget (non-iframe aka inplace variant) input is "cleaned" to prevent XSS scripts from executing"""
         from bytedeck_summernote.widgets import ByteDeckSummernoteSafeInplaceWidget
 
@@ -37,7 +37,7 @@ class TestByteDeckSummernoteSafeWidget(ByteDeckTenantTestCase):
 
         self.assertEqual(value, '&lt;script&gt;alert("Hello")&lt;/script&gt;')
 
-    def test_config_codeview_filter(self):
+    def test_config_codeview_filter__safe_enabled(self):
         """Safe widget (iframe variant) configured to prevent XSS scripts from executing"""
         from bytedeck_summernote.widgets import ByteDeckSummernoteSafeWidget
 
@@ -50,7 +50,7 @@ class TestByteDeckSummernoteSafeWidget(ByteDeckTenantTestCase):
 class TestByteDeckSummernoteAdvancedWidget(ByteDeckTenantTestCase):
     """ByteDeck's Summernote implementation, so called 'Advanced' variant"""
 
-    def test_widget(self):
+    def test_widget__advanced_preserves_input(self):
         """Advanced widget (iframe variant) input is preserved "as-is", no sanitization is done"""
         from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedWidget
 
@@ -66,7 +66,7 @@ class TestByteDeckSummernoteAdvancedWidget(ByteDeckTenantTestCase):
 
         self.assertEqual(value, '<script>alert("Hello")</script>')
 
-    def test_widget_inplace(self):
+    def test_widget_inplace__advanced_preserves_input(self):
         """Advanced widget (non-iframe aka inplace variant) input is preserved "as-is", no sanitization is done"""
         from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedInplaceWidget
 
@@ -81,7 +81,7 @@ class TestByteDeckSummernoteAdvancedWidget(ByteDeckTenantTestCase):
 
         self.assertEqual(value, '<script>alert("Hello")</script>')
 
-    def test_config_codeview_filter(self):
+    def test_config_codeview_filter__advanced_disabled(self):
         """Advanced widget (iframe variant) configured to disable XSS protection"""
         from bytedeck_summernote.widgets import ByteDeckSummernoteAdvancedWidget
 

--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -15,6 +15,7 @@ User = get_user_model()
 class CommentManagerTest(ByteDeckTenantTestCase):
 
     def test_create_comment__with_required_parameters(self):
+        """create_comment() with only user, text, and path leaves the target and parent unset."""
         user = baker.make(User)
         path = "/some/path/"
         text = "This is a comment."
@@ -28,6 +29,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
         self.assertIsNone(comment.parent)
 
     def test_create_comment__without_path(self):
+        """create_comment() raises ValueError when no path is provided."""
         user = baker.make(User)
         text = "This is a comment."
         with self.assertRaises(ValueError) as cm:
@@ -35,6 +37,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(str(cm.exception), "Must include a path when adding a comment")
 
     def test_create_comment__without_user(self):
+        """create_comment() raises ValueError when no user is provided."""
         path = "/some/path/"
         text = "This is a comment."
         with self.assertRaises(ValueError) as cm:
@@ -42,6 +45,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(str(cm.exception), "Must include a user when adding a comment")
 
     def test_create_comment__with_all_parameters(self):
+        """create_comment() stores the target content type/object id and parent when supplied."""
         user = User.objects.create(username="testuser")
         path = "/some/path/"
         text = "This is a comment."
@@ -77,6 +81,7 @@ class CommentModelValidationTest(ByteDeckTenantTestCase):
     """flag()/unflag() validate the comment before saving (issue #1630)."""
 
     def setUp(self):
+        """Create a valid comment used by each validation test."""
         self.comment = Comment.objects.create_comment(user=baker.make(User), text="hi", path="/some/path/")
 
     def test_flag__runs_full_clean(self):
@@ -94,25 +99,28 @@ class CommentModelValidationTest(ByteDeckTenantTestCase):
 
 
 class CleanHTMLTests(TestCase):
-    def test_format_unformatted_links(self):
+    def test_clean_html__formats_unformatted_links(self):
+        """Bare URLs in text are wrapped in anchor tags opening in a new tab."""
         text = '<p>Visit my website: example.com</p>'
         expected_output = '<p>Visit my website: <a href="http://example.com" target="_blank">example.com</a></p>'
         cleaned_text = clean_html(text)
         self.assertEqual(cleaned_text, expected_output)
 
-    def test_skip_formatted_links(self):
+    def test_clean_html__skips_already_formatted_links(self):
+        """Existing anchor tags are left unchanged."""
         text = '<p>Visit my website: <a href="http://example.com" target="_blank">example.com</a></p>'
         expected_output = '<p>Visit my website: <a href="http://example.com" target="_blank">example.com</a></p>'
         cleaned_text = clean_html(text)
         self.assertEqual(cleaned_text, expected_output)
 
-    def test_set_links_target_blank(self):
+    def test_clean_html__sets_links_target_blank(self):
+        """Anchor tags without a target get target="_blank" added."""
         text = '<a href="http://example.com">Link</a>'
         expected_output = '<a href="http://example.com" target="_blank">Link</a>'
         cleaned_text = clean_html(text)
         self.assertEqual(cleaned_text, expected_output)
 
-    def test_fix_missing_closing_ul_tag(self):
+    def test_clean_html__fixes_missing_closing_ul_tag(self):
         """ TODO: Test passes but the function isn't very good.
         Closes the list in the wrong place.  Need to fix the function."""
         text = '<ul><li>Item 1</li><p>Paragraph</p>'
@@ -120,7 +128,8 @@ class CleanHTMLTests(TestCase):
         cleaned_text = clean_html(text)
         self.assertEqual(cleaned_text, expected_output)
 
-    def test_remove_script_tags(self):
+    def test_clean_html__removes_script_tags(self):
+        """Script tags and their contents are stripped from the html."""
         text = '<p>Some text<script>alert("Hello");</script></p>'
         expected_output = '<p>Some text</p>'
         cleaned_text = clean_html(text)
@@ -131,21 +140,25 @@ class CommentModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and student shared across the test methods."""
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
 
-    def test_comment_creation(self):
+    def test_comment_creation__str_returns_text(self):
+        """A comment is created and its string representation is its text."""
         comment = baker.make(Comment)
         self.assertIsInstance(comment, Comment)
         self.assertEqual(str(comment), comment.text)
 
-    def test_get_absolute_url(self):
+    def test_get_absolute_url__returns_url(self):
+        """A comment exposes a non-null absolute url."""
         comment = baker.make(Comment)
         self.assertIsInstance(comment, Comment)
         self.assertEqual(str(comment), comment.text)
         self.assertIsNotNone(comment.get_absolute_url())
 
-    def test_orphaned_li_tags(self):
+    def test_orphaned_li_tags__wrapped_in_ul(self):
+        """Orphaned <li> tags in comment text are wrapped in a <ul> on save."""
         bad_comment_texts = [
             "<li>1</li><li>2</li>",
             "<div><li>1</li><li>2</li>",
@@ -163,7 +176,8 @@ class CommentModelTest(ByteDeckTenantTestCase):
             self.assertIn("<ul>", comment.text)
             self.assertIn("</ul>", comment.text)
 
-    def test_script_removal(self):
+    def test_script_removal__strips_script_tags(self):
+        """Script tags in comment text are removed on save."""
         bad_text = "<p>stuff</p><script>do bad stuff</script>"
 
         comment = Comment.objects.create_comment(
@@ -174,7 +188,8 @@ class CommentModelTest(ByteDeckTenantTestCase):
 
         self.assertNotIn("<script>", comment.text)
 
-    def test_comment_text_unchanged(self):
+    def test_comment_text__unchanged_for_valid_html(self):
+        """Valid html in comment text is preserved unchanged."""
         text = "<p>This is some good html snippet that shouldn't be changed</p>"
 
         comment = Comment.objects.create_comment(
@@ -187,29 +202,33 @@ class CommentModelTest(ByteDeckTenantTestCase):
 
         self.assertHTMLEqual(comment.text, text)
 
-    def test_flag(self):
+    def test_flag__sets_flagged_true(self):
+        """flag() marks an unflagged comment as flagged."""
         comment = baker.make(Comment)
         self.assertFalse(comment.flagged)
         comment.flag()
         self.assertTrue(comment.flagged)
 
-    def test_unflag(self):
+    def test_unflag__sets_flagged_false(self):
+        """unflag() clears the flagged state of a flagged comment."""
         comment = baker.make(Comment, flagged=True)
         self.assertTrue(comment.flagged)
         comment.unflag()
         self.assertFalse(comment.flagged)
 
-    def test_get_origin(self):
+    def test_get_origin__returns_path(self):
+        """get_origin() returns the comment's path."""
         comment = baker.make(Comment)
         self.assertEqual(comment.get_origin(), comment.path)
 
-    def test_is_child(self):
+    def test_is_child__true_only_for_child(self):
+        """is_child() is true for a comment with a parent and false otherwise."""
         parent = baker.make(Comment)
         child = baker.make(Comment, parent=parent)
         self.assertTrue(child.is_child())
         self.assertFalse(parent.is_child())
 
-    def test_get_children(self):
+    def test_get_children__returns_all_children(self):
         "Test that method returns a queryset including all children"
         parent = baker.make(Comment)
 

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -16,6 +16,7 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create users, an announcement, and comments shared across the test methods."""
         cls.student = baker.make(User)
         cls.teacher = baker.make(User, is_staff=True)
         cls.announcement = baker.make('announcements.Announcement')
@@ -31,10 +32,11 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.comment_decoy = baker.make('comments.Comment', target_content_type=None)
 
     def setUp(self):
+        """Set up a tenant test client for each test."""
         self.client = TenantClient(self.tenant)
 
     @patch('comments.models.Comment.unflag')
-    def test_unflag(self, mock_unflag):
+    def test_unflag__staff_only_calls_unflag(self, mock_unflag):
         """Test that unflag view is only accessible to staff users,
         and that it calls the unflag method on the comment and redirects to the comment's path
         """
@@ -55,7 +57,7 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         mock_unflag.assert_called_once()
 
     @patch('comments.models.Comment.flag')
-    def test_flag(self, mock_flag):
+    def test_flag__staff_only_calls_flag(self, mock_flag):
         """Test that unflag view is only accessible to staff users,
         and that it calls the flag method on the comment and redirects to the comment's path
         """
@@ -76,7 +78,7 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         mock_flag.assert_called_once()
 
     @patch('comments.models.Comment.flag')
-    def test_delete(self, mock_flag):
+    def test_delete__staff_only_removes_comment(self, mock_flag):
         """Test that delete view is only accessible to staff users,
         and that deletes the comment and redirects tot he comments (former) path
         """
@@ -106,7 +108,7 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, path)
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
 
-    def test_delete_comment_path(self):
+    def test_delete_comment__cancel_button_path(self):
         ''' Test if the 'Cancel' button in src/comments/templates/comments/confirm_delete.html
         correctly contains the `comment.path` as its href attribute.
         '''

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -20,12 +20,15 @@ class MarkRangeModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a MarkRange with a 50% minimum for the class tests."""
         cls.mr_50 = baker.make(MarkRange, minimum_mark=50.0)
 
-    def test_mark_range_creation(self):
+    def test_mark_range__creation(self):
+        """A MarkRange is created as the expected model instance."""
         self.assertIsInstance(self.mr_50, MarkRange)
 
     def test_mark_range__str__(self):
+        """str(MarkRange) is the name followed by its minimum mark percentage."""
         expected_str = f"{self.mr_50.name} ({self.mr_50.minimum_mark}%)"
         self.assertEqual(str(self.mr_50), expected_str)
 
@@ -33,13 +36,15 @@ class MarkRangeModelTest(ByteDeckTenantTestCase):
 class MarkRangeManagerTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Clear the default mark ranges and create ranges at 50% and 75% minimums."""
         # clear default mark range variables (every test in this class expects the defaults gone)
         MarkRange.objects.all().delete()
 
         cls.mr_50 = baker.make(MarkRange, minimum_mark=50.0)
         cls.mr_75 = baker.make(MarkRange, minimum_mark=75.0)
 
-    def test_get_range(self):
+    def test_get_range__by_mark(self):
+        """get_range() returns the highest range whose minimum the mark meets."""
         mr_100 = baker.make(MarkRange, minimum_mark=100.0)
 
         self.assertEqual(MarkRange.objects.get_range(25.0), None)
@@ -48,7 +53,8 @@ class MarkRangeManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(MarkRange.objects.get_range(75.0), self.mr_75)
         self.assertEqual(MarkRange.objects.get_range(101.0), mr_100)
 
-    def test_get_range_with_course(self):
+    def test_get_range__with_course(self):
+        """get_range() honours course-specific ranges when courses are passed."""
         c1 = baker.make(Course)
         c2 = baker.make(Course)
         mr_50_c1 = baker.make(MarkRange, minimum_mark=50.0, courses=[c1])
@@ -65,7 +71,7 @@ class MarkRangeManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(MarkRange.objects.get_range(101.0, [c2]), self.mr_75)
         self.assertEqual(MarkRange.objects.get_range(101.0, [c1, c2]), mr_100_c1)
 
-    def test_get_range_for_user(self):
+    def test_get_range_for_user__by_cached_mark(self):
         """ Test that `get_mark_range_for_user` returns the correct mark range for a given user.
         """
         user = baker.make(User)
@@ -88,7 +94,7 @@ class MarkRangeManagerTest(ByteDeckTenantTestCase):
 
 class BlockModelManagerTest(ByteDeckTenantTestCase):
 
-    def test_grouped_teachers_blocks_equals_one(self):
+    def test_grouped_teachers_blocks__single_teacher(self):
         """
             Should only return 1 group of teachers if regardless of the number of Blocks
         """
@@ -102,7 +108,7 @@ class BlockModelManagerTest(ByteDeckTenantTestCase):
 
         self.assertEqual(len(group.keys()), 1)
 
-    def test_grouped_teachers_blocks_more_than_one(self):
+    def test_grouped_teachers_blocks__multiple_teachers(self):
         """ Should return 3 group of teachers teaching Default, [AB] and [CD] blocks"""
 
         teacher_owner = User.objects.get(username='owner')
@@ -131,15 +137,16 @@ class BlockModelManagerTest(ByteDeckTenantTestCase):
 class SemesterModelManagerTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a September 2019 semester for the manager tests."""
         cls.semester_start = date(2019, 9, 1)  # Sep 1st 2019
         cls.semester_end = date(2019, 9, 30)  # Sep 30th, 2019
         cls.semester1 = baker.make(Semester, first_day=cls.semester_start, last_day=cls.semester_end)
 
-    def test_get_current(self):
+    def test_get_current__returns_active_semester(self):
         """ Get's the current semester as defined by SiteConfig """
         self.assertEqual(Semester.objects.get_current(), SiteConfig.get().active_semester)
 
-    def test_get_current_as_queryset(self):
+    def test_get_current__as_queryset(self):
         """ Get's the current semester object in a quesryset  """
         self.assertQuerySetEqual(Semester.objects.get_current(as_queryset=True), [SiteConfig.get().active_semester])
 
@@ -148,6 +155,7 @@ class SemesterModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a September 2019 semester used across the semester model tests."""
         cls.semester_start = date(2019, 9, 1)  # Sep 1st 2019
         cls.semester_end = date(2019, 9, 30)  # Sep 30th, 2019
         cls.today_fake = date(2019, 9, 15)  # Sep 15 2019, some date in the semester
@@ -156,7 +164,8 @@ class SemesterModelTest(ByteDeckTenantTestCase):
                                   last_day=cls.semester_end
                                   )
 
-    def test_semester_creation(self):
+    def test_semester__creation(self):
+        """A Semester is created as the expected model instance."""
         self.assertIsInstance(self.semester, Semester)
 
     def test_str__name_set(self):
@@ -185,7 +194,8 @@ class SemesterModelTest(ByteDeckTenantTestCase):
         self.assertEqual(semester.num_days(), 0)
         self.assertEqual(semester.num_days(upto_today=True), 0)
 
-    def test_is_open(self):
+    def test_is_open__within_and_outside_dates(self):
+        """is_open() is True on and between the first and last day, and False outside them."""
         # before semester starts: False
         before_start = self.semester_start - timedelta(days=1)
         with freeze_time(before_start, tz_offset=0):
@@ -210,7 +220,7 @@ class SemesterModelTest(ByteDeckTenantTestCase):
 
         # Timezone problems?
 
-    def test_num_days(self):
+    def test_num_days__excludes_weekends_and_excluded_dates(self):
         """The number of classes in the semester, from start to end date excluding weekends and excluded dates
         """
         # no excluded dates yet, so 21 weekdays in Sep 2019 (see setup)
@@ -227,7 +237,7 @@ class SemesterModelTest(ByteDeckTenantTestCase):
 
         self.assertIsInstance(self.semester.num_days(), int)
 
-    def test_num_days_upto_today(self):
+    def test_num_days__upto_today(self):
         """The number of classes in the semester SO FAR up to today
         """
         with freeze_time(date(2019, 9, 15), tz_offset=0):
@@ -237,7 +247,7 @@ class SemesterModelTest(ByteDeckTenantTestCase):
         with freeze_time(date(2019, 10, 15), tz_offset=0):
             self.assertEqual(self.semester.num_days(upto_today=True), 21)
 
-    def test_excluded_days(self):
+    def test_excluded_days__returns_excluded_dates(self):
         """ returns a list of dates excluded for this semester (holidays and other non-instructional days) """
         # add some excluded dates
         baker.make(ExcludedDate, semester=self.semester, date=date(2019, 9, 1))  # Sun, shouldn't count
@@ -246,43 +256,48 @@ class SemesterModelTest(ByteDeckTenantTestCase):
         dates = self.semester.excluded_days()
         self.assertListEqual(list(dates), [date(2019, 9, 1), date(2019, 9, 2)])
 
-    def test_days_so_far(self):
+    def test_days_so_far__equals_num_days_upto_today(self):
+        """days_so_far() equals num_days(upto_today=True)."""
         self.assertEqual(self.semester.days_so_far(), self.semester.num_days(upto_today=True))
 
-    def test_fraction_complete(self):
+    def test_fraction_complete__partway_through(self):
         """ how far through the semester as a fraction """
         with freeze_time(date(2019, 9, 15), tz_offset=0):
             # 10 days so far (excluding weekends) / 21 days total
             fraction_complete = self.semester.fraction_complete()
             self.assertAlmostEqual(fraction_complete, 10 / 21)
 
-    def test_percent_complete(self):
+    def test_percent_complete__partway_through(self):
         """ how far through the semester as a percent """
         with freeze_time(date(2019, 9, 15), tz_offset=0):
             # 10 days so far (excluding weekends) / 21 days total * 100
             percent_complete = self.semester.percent_complete()
             self.assertAlmostEqual(percent_complete, 10 / 21 * 100)
 
-    def test_get_interim1_date(self):
+    def test_get_interim1_date__quarter_point(self):
+        """get_interim1_date() is the date a quarter of the way through the semester."""
         self.assertEqual(self.semester.get_interim1_date(), self.semester.get_date(0.25))
 
-    def test_get_term_date(self):
+    def test_get_term_date__midpoint(self):
+        """get_term_date() is the date halfway through the semester."""
         self.assertEqual(self.semester.get_term_date(), self.semester.get_date(0.5))
 
-    def test_get_interim2_date(self):
+    def test_get_interim2_date__three_quarter_point(self):
+        """get_interim2_date() is the date three quarters of the way through the semester."""
         self.assertEqual(self.semester.get_interim2_date(), self.semester.get_date(0.75))
 
-    def test_get_final_date(self):
+    def test_get_final_date__last_day(self):
+        """get_final_date() is the semester's last day."""
         self.assertEqual(self.semester.get_final_date(), self.semester.last_day)
 
-    def test_get_date(self):
+    def test_get_date__rolls_back_off_weekends(self):
         """ Gets the closest date, rolling back if it falls on a weekend or excluded
         after a fraction of the semester is over """
         self.assertEqual(self.semester.get_date(0.25), date(2019, 9, 6))
         self.assertEqual(self.semester.get_date(0.5), date(2019, 9, 13))  # lands on a weekend so roll back to the friday
         self.assertEqual(self.semester.get_date(1.0), self.semester.last_day)
 
-    def test_get_datetime_by_days_since_start(self):
+    def test_get_datetime_by_days_since_start__skips_weekends(self):
         """ 5 days since start of semester should fall on 6 Sep 2019,
         6 days should push through weekend and land on 9 Sep 2019 """
         dt = self.semester.get_datetime_by_days_since_start(5)
@@ -293,7 +308,7 @@ class SemesterModelTest(ByteDeckTenantTestCase):
         expected = timezone.make_aware(datetime(2019, 9, 9, 23, 59, 59, 999999), timezone.get_default_timezone())
         self.assertEqual(dt, expected)
 
-    def test_reset_students_xp_cached(self):
+    def test_reset_students_xp_cached__zeroes_xp(self):
         """Students' xp_cached should be set to 0."""
         student = baker.make(User)
         course = baker.make(Course)
@@ -312,17 +327,19 @@ class CourseModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a Course for the class tests."""
         cls.course = baker.make(Course)
 
-    def test_course_creation(self):
+    def test_course__creation(self):
+        """A Course is created and its str is its title."""
         self.assertIsInstance(self.course, Course)
         self.assertEqual(str(self.course), self.course.title)
 
-    def test_get_absolute_url(self):
+    def test_get_absolute_url__returns_course_list(self):
         """All courses return the course list"""
         self.assertEqual(self.course.get_absolute_url(), reverse('courses:course_list'))
 
-    def test_condition_met_as_prerequisite(self):
+    def test_condition_met_as_prerequisite__currently_registered(self):
         """ If the user is CURRENTLY registered in this course, then condition is met """
         student = baker.make(User)
         baker.make(CourseStudent, user=student, course=self.course)
@@ -331,7 +348,7 @@ class CourseModelTest(ByteDeckTenantTestCase):
         baker.make(CourseStudent, user=student, course=self.course, semester=SiteConfig.get().active_semester)
         self.assertTrue(self.course.condition_met_as_prerequisite(student, 1))
 
-    def test_model_protection(self):
+    def test_model_protection__course_with_students(self):
         """
             Quick test to see if Course model deletion is prevented when trying to delete Course model programmatically
 
@@ -351,18 +368,19 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student registered in a course in the active semester."""
         cls.student = baker.make(User, username='test_student')
         cls.course = baker.make(Course)
         cls.course_student = baker.make(CourseStudent, user=cls.student, course=cls.course, semester=SiteConfig.get().active_semester)
 
-    def test_current_course(self):
+    def test_current_course__returns_active_semester_course(self):
         """ Currently returns the first course in the active semester, if there are more than one"""
         # Add a second course to the student during active semester (+ SetUp)
         sc2 = baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=SiteConfig.get().active_semester)
         # order doesn't matter here, as long as it's one fo the courses the student is currently registered in
         self.assertIn(CourseStudent.objects.current_course(self.student), [sc2, self.course_student])
 
-    def test_all_for_user_semester(self):
+    def test_all_for_user_semester__filters_by_user_and_semester(self):
         """ Test that method returns all CourseStudent objects for a given user and semester """
         semester_to_check = baker.make(Semester)
 
@@ -383,7 +401,7 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         self.assertQuerySetEqual(course_students, [sc1, sc2], ordered=False)
 
     @patch('profile_manager.models.Profile.xp_per_course')
-    def test_calc_semester_grades(self, xp_per_course):
+    def test_calc_semester_grades__deactivates_and_sets_final_xp(self, xp_per_course):
         """Test that method loops through all students, deactivates the student course, and sets a final_xp value"""
 
         # second student in same course as setup
@@ -417,8 +435,8 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         self.assertRaises(ValueError, CourseStudent.objects.calc_semester_grades,
                           Semester.objects.get_current())
 
-    def test_all_users_for_active_semester(self):
-
+    def test_all_users_for_active_semester__excludes_inactive(self):
+        """all_users_for_active_semester() counts active-semester students, excluding inactive users."""
         # There should be 1 student in the active semester
         self.assertEqual(CourseStudent.objects.all_users_for_active_semester().count(), 1)
 
@@ -433,19 +451,18 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student registered in a course in the active semester."""
         cls.student = baker.make(User)
         cls.course = baker.make(Course)
         cls.course_student = baker.make(CourseStudent, user=cls.student, course=cls.course, semester=SiteConfig.get().active_semester)
 
-    def test_course_student_creation(self):
+    def test_course_student__creation(self):
+        """A CourseStudent is created as the expected model instance."""
         self.assertIsInstance(self.course_student, CourseStudent)
-        # self.assertEqual(str(self.course), self.course.title)
-
-    # def test_course_student_get_absolute_url(self):
-    #     self.assertEqual(self.course_student.get_absolute_url(), reverse('courses:list'))
 
     @patch('courses.models.Semester.fraction_complete')
-    def test_calc_mark(self, fraction_complete):
+    def test_calc_mark__scales_with_fraction_complete(self, fraction_complete):
+        """calc_mark() scales a student's XP into a mark based on how far the semester has progressed."""
         fraction_complete.return_value = 0.5
         course = baker.make(Course, xp_for_100_percent=100)
         course_student = baker.make(CourseStudent, user=self.student, course=course, semester=SiteConfig.get().active_semester)
@@ -474,8 +491,8 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         course_student.calc_mark(50)
 
     @patch('courses.models.Semester.days_so_far')
-    def test_xp_per_day_ave(self, days_so_far):
-
+    def test_xp_per_day_ave__divides_xp_by_days(self, days_so_far):
+        """xp_per_day_ave() is the student's cached XP divided by days so far, or 0 when no days."""
         self.student.profile.xp_cached = 120
         self.student.profile.save()
         days_so_far.return_value = 10
@@ -491,10 +508,11 @@ class BlockModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student and a Block for the class tests."""
         cls.student = baker.make(User)
         cls.block = baker.make(Block)
 
-    def test_model_protection(self):
+    def test_model_protection__block_with_students(self):
         """
             Quick test to see if Block model deletion is prevented when trying to delete Block model programmatically
             Block deletion is only prevented when there are CourseStudent models linked via foreign key to the Block model
@@ -508,7 +526,7 @@ class BlockModelTest(ByteDeckTenantTestCase):
         # see if models.PROTECT is in place
         self.assertRaises(ProtectedError, self.block.delete)
 
-    def test_condition_met_as_prerequisite(self):
+    def test_condition_met_as_prerequisite__registered_in_block_active_semester(self):
         """ If the user is registered in a course in this block during the active semester, then condition is met
         Tests check condition on self.block for self.student """
 
@@ -530,7 +548,7 @@ class BlockModelTest(ByteDeckTenantTestCase):
 
 class RankManagerTest(ByteDeckTenantTestCase):
 
-    def test_get_rank(self):
+    def test_get_rank__returns_rank_for_xp(self):
         """ Test that the correct rank is returned for a given XP value"""
 
         # default ranks are create from 0-1000XP, so test above that range.
@@ -556,7 +574,7 @@ class RankManagerTest(ByteDeckTenantTestCase):
         rank_0 = Rank.objects.get_rank(-100)
         self.assertIsNotNone(rank_0)
 
-    def test_get_next_rank(self):
+    def test_get_next_rank__returns_next_rank_for_xp(self):
         """ Test that the correct rank is returned for a given XP value"""
 
         # default ranks are create from 0-1000XP, so test above that range.
@@ -578,19 +596,21 @@ class RankModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Clear the default ranks and create a single TestRank at 0 XP."""
         # every test in this class expects the default ranks gone, with only TestRank remaining
         Rank.objects.all().delete()
         cls.rank = baker.make(Rank, name="TestRank", xp=0)
 
-    def test_rank_creation(self):
+    def test_rank__creation(self):
+        """A Rank is created and its str is its name."""
         self.assertIsInstance(self.rank, Rank)
         self.assertEqual(str(self.rank), self.rank.name)
 
-    def test_get_absolute_url(self):
+    def test_get_absolute_url__returns_ranks_list(self):
         """Absolute url for all ranks is the ranks list page"""
         self.assertEqual(self.rank.get_absolute_url(), reverse('courses:ranks'))
 
-    def test_get_icon_url(self):
+    def test_get_icon_url__default_and_custom(self):
         """Returns the icon url for the rank, if no url then returns the default icon from SiteConfig"""
         self.assertEqual(self.rank.get_icon_url(), SiteConfig.get().get_default_icon_url())
         self.rank.icon = 'test.png'
@@ -621,14 +641,14 @@ class RankCacheInvalidationTest(ByteDeckTenantTestCase):
         """Populate the rank cache so the test's write can be shown to invalidate it."""
         Rank.objects.get_ranks_cached()
 
-    def test_cached_rank_lookups_hit_no_queries(self):
+    def test_cached_rank_lookups__hit_no_queries(self):
         """With a warm cache, get_rank() and get_next_rank() must not query the database."""
         self.warm_cache()
         with self.assertNumQueries(0):
             Rank.objects.get_rank(100)
             Rank.objects.get_next_rank(100)
 
-    def test_save_invalidates_cache(self):
+    def test_save__invalidates_cache(self):
         """Creating a Rank (via save) and re-saving it must invalidate the cache (post_save signal)."""
         self.warm_cache()
         rank = baker.make(Rank, xp=123456)
@@ -639,21 +659,21 @@ class RankCacheInvalidationTest(ByteDeckTenantTestCase):
         rank.save()
         self.assert_cache_matches_db()
 
-    def test_instance_delete_invalidates_cache(self):
+    def test_instance_delete__invalidates_cache(self):
         """Deleting a Rank instance must invalidate the cache (post_delete signal)."""
         rank = baker.make(Rank, xp=123456)
         self.warm_cache()
         rank.delete()
         self.assert_cache_matches_db()
 
-    def test_queryset_delete_invalidates_cache(self):
+    def test_queryset_delete__invalidates_cache(self):
         """Queryset .delete() must invalidate the cache (receivers disable fast-delete, so post_delete fires)."""
         rank = baker.make(Rank, xp=123456)
         self.warm_cache()
         Rank.objects.filter(pk=rank.pk).delete()
         self.assert_cache_matches_db()
 
-    def test_queryset_update_invalidates_cache(self):
+    def test_queryset_update__invalidates_cache(self):
         """Queryset .update() fires no signals; the RankQuerySet.update override must invalidate the cache."""
         rank = baker.make(Rank, xp=123456)
         self.warm_cache()
@@ -661,13 +681,13 @@ class RankCacheInvalidationTest(ByteDeckTenantTestCase):
         self.assertEqual(Rank.objects.get_rank(654321).pk, rank.pk)
         self.assert_cache_matches_db()
 
-    def test_bulk_create_invalidates_cache(self):
+    def test_bulk_create__invalidates_cache(self):
         """bulk_create() fires no signals; the RankQuerySet.bulk_create override must invalidate the cache."""
         self.warm_cache()
         Rank.objects.bulk_create([Rank(name='Bulk Rank', xp=123456)])
         self.assert_cache_matches_db()
 
-    def test_bulk_update_invalidates_cache(self):
+    def test_bulk_update__invalidates_cache(self):
         """bulk_update() fires no signals; the RankQuerySet.bulk_update override must invalidate the cache."""
         rank = baker.make(Rank, xp=123456)
         self.warm_cache()

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -96,7 +96,7 @@ class BlockModelManagerTest(ByteDeckTenantTestCase):
 
     def test_grouped_teachers_blocks__single_teacher(self):
         """
-            Should only return 1 group of teachers if regardless of the number of Blocks
+            Should only return 1 group of teachers regardless of the number of Blocks
         """
 
         teacher_owner = User.objects.get(username='owner')
@@ -143,11 +143,11 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
         cls.semester1 = baker.make(Semester, first_day=cls.semester_start, last_day=cls.semester_end)
 
     def test_get_current__returns_active_semester(self):
-        """ Get's the current semester as defined by SiteConfig """
+        """ Gets the current semester as defined by SiteConfig """
         self.assertEqual(Semester.objects.get_current(), SiteConfig.get().active_semester)
 
     def test_get_current__as_queryset(self):
-        """ Get's the current semester object in a quesryset  """
+        """ Gets the current semester object in a queryset  """
         self.assertQuerySetEqual(Semester.objects.get_current(as_queryset=True), [SiteConfig.get().active_semester])
 
 
@@ -377,7 +377,7 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         """ Currently returns the first course in the active semester, if there are more than one"""
         # Add a second course to the student during active semester (+ SetUp)
         sc2 = baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=SiteConfig.get().active_semester)
-        # order doesn't matter here, as long as it's one fo the courses the student is currently registered in
+        # order doesn't matter here, as long as it's one of the courses the student is currently registered in
         self.assertIn(CourseStudent.objects.current_course(self.student), [sc2, self.course_student])
 
     def test_all_for_user_semester__filters_by_user_and_semester(self):

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -29,6 +29,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and a student for the rank view tests."""
         # need a teacher and a student so tests can log in as each with force_login()
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -36,9 +37,10 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_student1 = User.objects.create_user('test_student')
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_rank_page_status_codes_for_anonymous(self):
+    def test_all_rank_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to login page '''
 
         self.assertRedirectsLogin('courses:ranks')
@@ -46,7 +48,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('courses:rank_update', args=[1])
         self.assertRedirectsLogin('courses:rank_delete', args=[1])
 
-    def test_all_rank_page_status_codes_for_students(self):
+    def test_all_rank_page_status_codes__students(self):
         ''' If logged in as student then all views except ranks list view should redirect to login page '''
         self.client.force_login(self.test_student1)
         self.assert200('courses:ranks')
@@ -56,7 +58,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403('courses:rank_update', args=[1])
         self.assert403('courses:rank_delete', args=[1])
 
-    def test_all_rank_page_status_codes_for_staff(self):
+    def test_all_rank_page_status_codes__staff(self):
         ''' If logged in as staff then all views should return code 200 for successful retrieval of page '''
         self.client.force_login(self.test_teacher)
 
@@ -65,7 +67,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('courses:rank_update', args=[1])
         self.assert200('courses:rank_delete', args=[1])
 
-    def test_RanksList_view(self):
+    def test_RanksList_view__accessible_when_logged_in(self):
         """ Admin and students should be able to view ranks. Anonymous users should be asked to login if they attempt to view ranks. """
 
         # Anonymous user
@@ -84,7 +86,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Should contain 13 default ranks e.g. Digital Novice, Digital Ameteur II, etc
         self.assertEqual(response.context['object_list'].count(), 13)
 
-    def test_RankCreate_view(self):
+    def test_RankCreate_view__staff_can_create(self):
         """ Admin should be able to create a rank """
         self.client.force_login(self.test_teacher)
         data = {
@@ -98,7 +100,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         rank = Rank.objects.get(name=data['name'])
         self.assertEqual(rank.name, data['name'])
 
-    def test_RankUpdate_view(self):
+    def test_RankUpdate_view__staff_can_update(self):
         """ Admin should be able to update a rank """
         self.client.force_login(self.test_teacher)
         data = {
@@ -112,7 +114,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(rank.name, data['name'])
         self.assertEqual(rank.xp, data['xp'])
 
-    def test_RankDelete_view(self):
+    def test_RankDelete_view__staff_can_delete(self):
         """ Admin should be able to delete a rank """
         self.client.force_login(self.test_teacher)
 
@@ -122,7 +124,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('courses:ranks'))
         self.assertEqual(before_delete_count - 1, after_delete_count)
 
-    def test_scape_update_message_on_update_delete(self):
+    def test_scape_update_message__on_update_and_delete(self):
         """ Checks if delete and update function gives a success message when a rank is related to map """
         # setup
         rank = baker.make(Rank, name='rank')
@@ -154,6 +156,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, student, block, course and grade plus valid registration form data."""
         # need a teacher and a student so tests can log in as each with force_login()
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -172,9 +175,10 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         }
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_page_status_codes_for_anonymous(self):
+    def test_all_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to home page '''
         self.assertRedirectsLogin('courses:create')
         self.assertRedirectsLogin('courses:join', args=[1])
@@ -207,7 +211,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # Refer to rank specific tests for Rank CRUD views
 
-    def test_all_page_status_codes_for_students(self):
+    def test_all_page_status_codes__students(self):
         ''' Test student access to views '''
         self.client.force_login(self.test_student1)
         self.assert200('courses:create')
@@ -244,7 +248,8 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # Refer to rank specific tests for Rank CRUD views
 
-    def test_all_page_status_codes_for_staff(self):
+    def test_all_page_status_codes__staff(self):
+        """Staff get 200 on all course management views."""
         self.client.force_login(self.test_teacher)
 
         # Staff access only
@@ -272,7 +277,8 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('courses:course_update', args=[1])
         self.assert200('courses:course_delete', args=[1])
 
-    def test_course_student_update_status_codes(self):
+    def test_course_student_update__status_codes(self):
+        """The CourseStudent update view is login-required, staff-only (403 for students, 200 for staff)."""
         course_student = baker.make(CourseStudent)
         # anon
         self.client.logout()
@@ -300,7 +306,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         active_sem.refresh_from_db()
         self.assertTrue(active_sem.closed)
 
-    def test_SemesterActivate(self):
+    def test_SemesterActivate__changes_active_semester(self):
         """When this view is accessed, the siteconfig's active semester should be changed
         and the view should redirect tot he semester_list """
         self.client.force_login(self.test_teacher)
@@ -309,7 +315,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('courses:semester_list'))
         self.assertEqual(SiteConfig.get().active_semester, Semester.objects.get(pk=new_semester.pk))
 
-    def test_CourseList_view(self):
+    def test_CourseList_view__staff_can_view(self):
         """ Admin should be able to view course list """
         self.client.force_login(self.test_teacher)
         response = self.client.get(reverse('courses:course_list'))
@@ -318,7 +324,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Should contain Default and another one via bake
         self.assertEqual(response.context['object_list'].count(), 2)
 
-    def test_CourseCreate_view(self):
+    def test_CourseCreate_view__staff_can_create(self):
         """ Admin should be able to create a course """
         self.client.force_login(self.test_teacher)
         data = {
@@ -331,7 +337,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         course = Course.objects.get(title=data['title'])
         self.assertEqual(course.title, data['title'])
 
-    def test_CourseUpdate_view(self):
+    def test_CourseUpdate_view__staff_can_update(self):
         """ Admin should be able to update a course """
         self.client.force_login(self.test_teacher)
         data = {
@@ -384,6 +390,7 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, student, block, course and grade plus valid registration form data."""
         # need a teacher and a student so tests can log in as each with force_login()
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -402,9 +409,10 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         }
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_CourseStudentUpdate_view(self):
+    def test_CourseStudentUpdate_view__staff_can_update(self):
         """ Staff can update a student's course """
 
         course_student = baker.make(
@@ -426,7 +434,7 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         course_student.refresh_from_db()
         self.assertEqual(course_student.course.pk, new_course.pk)
 
-    def test_CourseAddStudent_view(self):
+    def test_CourseAddStudent_view__staff_can_add(self):
         '''Staff can add a student to a course'''
 
         # Almost similar to `test_CourseStudentCreate_view` but just uses courses:join
@@ -471,7 +479,7 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('profiles:profile_detail', args=[self.test_student1.id]))
         self.assertEqual(self.test_student1.coursestudent_set.count(), 2)
 
-    def test_CourseStudentDelete_view(self):
+    def test_CourseStudentDelete_view__teacher_can_delete(self):
         """ Teacher should be able to delete a student from a course (StudentCourse object)
         and should redirect to the student's profile when complete. """
         self.client.force_login(self.test_teacher)
@@ -487,7 +495,7 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('profiles:profile_detail', args=[self.test_student1.profile.id]))
         self.assertEqual(before_delete_count - 1, after_delete_count)
 
-    def test_CourseStudentCreate_view(self):
+    def test_CourseStudentCreate_view__student_self_registers(self):
         '''Students can register themselves in a course. Illegally accessing the registration view after registering will give an error 403'''
         self.client.force_login(self.test_student1)
 
@@ -595,6 +603,7 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and reusable MarkRange form data for create/update posts."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
         # set form data in setUpTestData to be used for posting to create/update forms
@@ -609,9 +618,10 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         }
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_MarkRangeList_view(self):
+    def test_MarkRangeList_view__lists_all(self):
         """The MarkRange list view's object list should contain all MarkRange objects"""
 
         # login a teacher
@@ -621,7 +631,7 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('courses:markranges'))
         self.assertQuerySetEqual(response.context['object_list'], MarkRange.objects.all())
 
-    def test_MarkRangeCreate_view(self):
+    def test_MarkRangeCreate_view__staff_can_create(self):
         """Staff users can create new MarkRange objects through the create view form"""
 
         # login a teacher
@@ -634,7 +644,7 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('courses:markranges'))
         self.assertTrue(MarkRange.objects.filter(name="TestMarkRange").exists())
 
-    def test_MarkRangeUpdate_view(self):
+    def test_MarkRangeUpdate_view__staff_can_update(self):
         """Staff users can edit existing MarkRange objects through the update view form"""
 
         # login a teacher
@@ -647,7 +657,7 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('courses:markranges'))
         self.assertEqual(MarkRange.objects.get(id=1).name, "TestMarkRange")
 
-    def test_MarkRangeDelete_view(self):
+    def test_MarkRangeDelete_view__staff_can_delete(self):
         """Staff users can delete MarkRange objects through the delete view"""
 
         # login a teacher
@@ -688,12 +698,15 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher for the class tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_SemesterList_view(self):
+    def test_SemesterList_view__lists_semesters(self):
+        """The semester list view renders each semester with its day counts and excluded-date counts."""
         self.client.force_login(self.test_teacher)
 
         response = self.client.get(reverse('courses:semester_list'))
@@ -717,6 +730,7 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, str(semester))
 
     def test_SemesterCreate__without_ExcludedDates__view(self):
+        """Creating a semester with no excluded dates saves it and redirects to the list."""
         self.client.force_login(self.test_teacher)
 
         post_data = {
@@ -770,7 +784,8 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertFalse(response.context['formset'].is_valid())
 
-    def test_SemesterUpdate_view(self):
+    def test_SemesterUpdate_view__updates_dates(self):
+        """Posting new dates to the update view saves them to the semester."""
         self.client.force_login(self.test_teacher)
 
         post_data = {
@@ -895,7 +910,7 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         message = self.get_message_list(response)[0]
         self.assertIn('There are some students with negative XP', str(message))
 
-    def test_SemesterDelete_view(self):
+    def test_SemesterDelete_view__deletes_semester(self):
         """ Admin should be able to delete a semester, as long as:
             - it is not the active semester
             - it has no coursesstudent objects (students registered in a course in the semester)
@@ -914,12 +929,14 @@ class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher for the class tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_BlockList_view(self):
+    def test_BlockList_view__staff_can_view(self):
         """ Admin should be able to view block list """
         self.client.force_login(self.test_teacher)
         response = self.client.get(reverse('courses:block_list'))
@@ -928,7 +945,7 @@ class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Should contain one block
         self.assertEqual(response.context['object_list'].count(), 1)
 
-    def test_BlockCreate_view(self):
+    def test_BlockCreate_view__staff_can_create(self):
         """ Admin should be able to create a block """
         self.client.force_login(self.test_teacher)
         data = {
@@ -941,7 +958,7 @@ class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         block = Block.objects.get(name=data['name'])
         self.assertEqual(block.name, data['name'])
 
-    def test_BlockUpdate_view(self):
+    def test_BlockUpdate_view__staff_can_update(self):
         """ Admin should be able to update a block """
         self.client.force_login(self.test_teacher)
         data = {
@@ -990,7 +1007,7 @@ class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, dt_atag_link)
         self.assertContains(response, dt_well_ptag)
 
-    def test_BlockForm_initial_values(self):
+    def test_BlockForm__initial_values(self):
         """
             Test if the form passed through context has correct initial values
         """
@@ -1005,6 +1022,7 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase)
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, block, course and active/inactive semesters for the chart tests."""
         cls.teacher = baker.make(User, is_staff=True)
 
         cls.block = baker.make(Block)
@@ -1013,6 +1031,7 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase)
         cls.inactive_semester = baker.make(Semester)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
     def create_student_course(self, xp):
@@ -1053,28 +1072,32 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase)
         # without select_related('profile') each extra student adds a query
         self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
 
-    def test_non_ajax_status_code(self):
+    def test_non_ajax_status_code__forbidden(self):
+        """A non-ajax request to the mark distribution chart is forbidden (403)."""
         self.assert403('courses:mark_distribution_chart', args=[self.teacher.pk])
 
-    def test_ajax_status_code_for_anonymous(self):
+    def test_ajax_status_code__anonymous_redirected(self):
+        """An anonymous ajax request to the mark distribution chart is redirected (302)."""
         # checks redirect with ajax style request "HTTP_X_REQUESTED_WITH='XMLHttpRequest'"
         response = self.client.get(reverse('courses:mark_distribution_chart', args=[self.teacher.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 302)
 
-    def test_ajax_status_code_for_students(self):
+    def test_ajax_status_code__students(self):
+        """A logged-in student's ajax request to the mark distribution chart succeeds (200)."""
         user = baker.make(User)
         self.client.force_login(user)
 
         response = self.client.get(reverse('courses:mark_distribution_chart', args=[self.teacher.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 200)
 
-    def test_ajax_status_code_for_teachers(self):
+    def test_ajax_status_code__teachers(self):
+        """A logged-in teacher's ajax request to the mark distribution chart succeeds (200)."""
         self.client.force_login(self.teacher)
 
         response = self.client.get(reverse('courses:mark_distribution_chart', args=[self.teacher.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 200)
 
-    def test_no_users_outside_active_semester_in_histogram_values(self):
+    def test_histogram_values__exclude_users_outside_active_semester(self):
         """ histogram values should only belong to users who belong in the active semester"""
         # create inactive semester students
         inactive_sem_students = [self.create_student_course(100) for i in range(5)]
@@ -1099,7 +1122,7 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase)
         self.assertNotEqual(total_students, len(inactive_sem_students))
         self.assertEqual(total_students, len(active_sem_students))
 
-    def test_no_test_users_in_histogram_values(self):
+    def test_histogram_values__exclude_test_users(self):
         """ test users should not show up in histogram values """
         # create test users students
         test_account_students = [self.create_student_course(100) for i in range(5)]
@@ -1129,6 +1152,7 @@ class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student registered in a course with a fixed-date active semester for the progress chart tests."""
         cls.student = baker.make(User)
         cls.block = baker.make(Block)
         cls.course = baker.make(Course)
@@ -1154,6 +1178,7 @@ class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.base_xp = 1
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
     def create_quest_and_submissions(self, xp, quest_submission_date, quest_submission_quantity=1):
@@ -1183,11 +1208,11 @@ class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         return quest, quest_submissions
 
-    def test_non_ajax_status_code(self):
+    def test_non_ajax_status_code__forbidden(self):
         """ 403 unless verified ajax POST request """
         self.assert403('courses:ajax_progress_chart', args=[self.student.pk])
 
-    def test_ajax_status_code_for_anonymous(self):
+    def test_ajax_status_code__anonymous_redirected(self):
         """ checks redirect with ajax style request "HTTP_X_REQUESTED_WITH='XMLHttpRequest'"
         redirects because of LoginRequiredMixin
         """
@@ -1198,7 +1223,8 @@ class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('courses:ajax_progress_chart', args=[self.student.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 302)
 
-    def test_ajax_status_code_for_student(self):
+    def test_ajax_status_code__student(self):
+        """A student's ajax POST to the progress chart succeeds (200) while a GET returns 404."""
         self.client.force_login(self.student)
 
         # post
@@ -1344,6 +1370,7 @@ class MarkCalculationsViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student registered in a course worth 1000 XP for 100% for the mark calculation tests."""
         cls.student = baker.make(User)
 
         cls.block = baker.make(Block)
@@ -1358,6 +1385,7 @@ class MarkCalculationsViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
         # to show mark calculation page without 404 you need to turn this on
@@ -1428,12 +1456,14 @@ class AjaxRankPopupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student for the rank popup tests."""
         cls.student = baker.make(User)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_status_codes(self):
+    def test_status_codes__ranked_popup_endpoints(self):
         ''' tests correct status codes for `on_show_ranked_popup` and `on_close_ranked_popup`
         403 - because not ajax
         302 - because of not logged in (LoginRequiredMixin)
@@ -1464,7 +1494,7 @@ class AjaxRankPopupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('courses:ajax_on_close_ranked_popup'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEqual(response.status_code, 200)
 
-    def test_on_show_ranked_popup(self):
+    def test_on_show_ranked_popup__correct_ranks(self):
         """ Checks if earned_rank and next_rank are correct when requesting json from ranked popups
         """
         # make sure theres enough initial ranks for test
@@ -1551,7 +1581,7 @@ class AjaxRankPopupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotEqual(context['earned_rank'], previous_rank)
         self.assertEqual(context['next_rank'], next_rank)
 
-    def test_on_close_ranked_popup(self):
+    def test_on_close_ranked_popup__marks_latest_read(self):
         """ Check if 'courses:ajax_on_show_ranked_popup' closes only the latest ranked notification
         """
         # create 2 rank up notifications

--- a/src/djcytoscape/tests/test_fields.py
+++ b/src/djcytoscape/tests/test_fields.py
@@ -8,8 +8,8 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 class CytoscapeGFKChoiceFieldTest(ByteDeckTenantTestCase):
 
-    def test_queryset(self):
-        """ Quick test to see if the hardcoded model list is equal to CytoScape.ALLOWED_INITIAL_CONTENT_TYPES """
+    def test_queryset__matches_allowed_initial_content_types(self):
+        """The field's queryset models match CytoScape.ALLOWED_INITIAL_CONTENT_TYPES."""
         from djcytoscape.forms import CytoscapeGFKChoiceField
 
         dynamically_loaded_models = [
@@ -19,8 +19,8 @@ class CytoscapeGFKChoiceFieldTest(ByteDeckTenantTestCase):
 
         self.assertEqual(dynamically_loaded_models, [qs.model for qs in f.queryset.get_querysets()])
 
-    def test_overridden_querysetsequence(self):
-        """ Quick test to see if the overridden_querysetsence method does custom filtering or not """
+    def test_overridden_querysetsequence__excludes_in_use_initial_objects(self):
+        """overridden_querysetsequence excludes objects already used as a map's initial object."""
         from djcytoscape.forms import CytoscapeGFKChoiceField
 
         dynamically_loaded_models = [

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -63,22 +63,28 @@ class JSONTestCaseMixin:
 class CleanJSONTest(JSONTestCaseMixin, SimpleTestCase):
     """ All tests for the method: def clean_JSON(dirty_json_str): """
 
-    def test_clean_json_no_braces(self):
+    def test_clean_JSON__no_braces(self):
+        """A brace-less key/value string is cleaned into valid JSON."""
         self.assertValidJSON(clean_JSON('"key": true'))
 
-    def test_clean_json_trailing_comma_no_braces(self):
+    def test_clean_JSON__trailing_comma_no_braces(self):
+        """A brace-less string with a trailing comma is cleaned into valid JSON."""
         self.assertValidJSON(clean_JSON('"key": true,'))
 
-    def test_clean_json_trailing_comma_with_braces(self):
+    def test_clean_JSON__trailing_comma_with_braces(self):
+        """A braced object with a trailing comma is cleaned into valid JSON."""
         self.assertValidJSON(clean_JSON('{"key": true,}'))
 
-    def test_clean_json_unquoted_key(self):
+    def test_clean_JSON__unquoted_key(self):
+        """An unquoted key is quoted so the result is valid JSON."""
         self.assertValidJSON(clean_JSON('key: true'))
 
-    def test_clean_json_single_quoted_key(self):
+    def test_clean_JSON__single_quoted_key(self):
+        """A single-quoted key is normalised to double quotes for valid JSON."""
         self.assertValidJSON(clean_JSON('\'key\': true'))
 
-    def test_clean_old_defaults_INIT_OPTIONS(self):
+    def test_clean_JSON__old_defaults_init_options(self):
+        """The legacy INIT_OPTIONS defaults block is cleaned into valid JSON."""
         json_str = """minZoom: 0.5,
             maxZoom: 1.5,
             wheelSensitivity: 0.1,
@@ -89,7 +95,8 @@ class CleanJSONTest(JSONTestCaseMixin, SimpleTestCase):
             """
         self.assertValidJSON(clean_JSON(json_str))
 
-    def test_clean_old_defaults_NODE_STYLES(self):
+    def test_clean_JSON__old_defaults_node_styles(self):
+        """The legacy NODE_STYLES defaults block is cleaned into valid JSON."""
         json_str = """label: 'data(label)',
             'text-valign':   'center', 'text-halign': 'right',
             'text-margin-x': '-155',
@@ -108,7 +115,8 @@ class CleanJSONTest(JSONTestCaseMixin, SimpleTestCase):
             """
         self.assertValidJSON(clean_JSON(json_str))
 
-    def test_clean_old_defaults_EDGE_STYLES(self):
+    def test_clean_JSON__old_defaults_edge_styles(self):
+        """The legacy EDGE_STYLES defaults block is cleaned into valid JSON."""
         json_str = """'width': 1,
             'curve-style':   'bezier',
             'line-color':    'black',
@@ -124,18 +132,21 @@ class CleanJSONTest(JSONTestCaseMixin, SimpleTestCase):
 class CytoElementModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Generate the real primary map to populate CytoElement rows for the tests."""
         cls.map = generate_real_primary_map()
 
-    def test_object_creation(self):
+    def test_object_creation__is_cytoelement_instance(self):
+        """A baked object is a CytoElement instance."""
         self.element = baker.make(CytoElement)
         self.assertIsInstance(self.element, CytoElement)
 
-    def test_json(self):
-        """ Should be valid json string, check by deserializing """
+    def test_json__is_valid_json_string(self):
+        """Each element's json() returns a deserializable JSON string."""
         for element in CytoElement.objects.all():
             self.assertValidJSON(element.json())
 
-    def test_json_dict(self):
+    def test_json_dict__is_valid_dict_with_data(self):
+        """Each element's json_dict() is a serializable dict with a 'data' key (and 'classes' for nodes)."""
         for element in CytoElement.objects.all():
             json_dict = element.json_dict()
             self.assertIsInstance(json_dict, dict)
@@ -144,8 +155,8 @@ class CytoElementModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
             if element.is_node():  # Quests, Campaigns and Badges should have a class
                 self.assertIn('classes', json_dict)
 
-    def test_valid_urls(self):
-        """ tests if valid urls wont throw ValidationErrors """
+    def test_full_clean__valid_urls(self):
+        """Valid href URLs pass full_clean without raising ValidationError."""
         element = baker.make(CytoElement)
         valid_urls = [
             '/',
@@ -168,8 +179,8 @@ class CytoElementModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
             except ValidationError:
                 self.fail(f"{url} is not a valid URL")
 
-    def test_invalid_urls(self):
-        """ tests if invalid urls throw ValidationErrors """
+    def test_full_clean__invalid_urls(self):
+        """Invalid href URLs raise ValidationError during full_clean."""
         element = baker.make(CytoElement)
         invalid_urls = [
             ' ',  # space
@@ -186,9 +197,11 @@ class CytoElementModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
 class TempCampaignNodeTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Build a TempCampaignNode instance for the tests."""
         cls.temp_campaign_node = TempCampaignNode(id_=1)
 
-    def test_object_creation(self):
+    def test_object_creation__is_instance_and_str_is_id(self):
+        """A TempCampaignNode is created and its string form is its id."""
         self.assertIsInstance(self.temp_campaign_node, TempCampaignNode)
         # this doesn't matter, can be changed
         self.assertEqual(str(self.temp_campaign_node), str(self.temp_campaign_node.id))
@@ -197,9 +210,11 @@ class TempCampaignNodeTest(ByteDeckTenantTestCase):
 class TempCampaignTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Build a TempCampaign instance for the tests."""
         cls.temp_campaign = TempCampaign(parent_node_id=1)
 
-    def test_object_creation(self):
+    def test_object_creation__is_instance(self):
+        """A baked TempCampaign is a TempCampaign instance."""
         self.assertIsInstance(self.temp_campaign, TempCampaign)
 
     def test_str__no_children(self):
@@ -224,13 +239,13 @@ class TempCampaignTest(ByteDeckTenantTestCase):
         self.assertEqual(len(tc.nodes), 1)
         self.assertEqual(tc.get_node(10).prereq_node_ids, [100, 101])
 
-    def test_add_campaign_reliant(self):
+    def test_add_campaign_reliant__tracks_node_id(self):
         """Nodes directly reliant on the campaign are tracked in campaign_reliant_node_ids."""
         tc = TempCampaign(parent_node_id=1)
         tc.add_campaign_reliant(reliant_node_id=42)
         self.assertEqual(tc.campaign_reliant_node_ids, [42])
 
-    def test_has_internal_reliant(self):
+    def test_has_internal_reliant__true_only_for_internal_reliant(self):
         """has_internal_reliant is True only when an internal node is a reliant of the given node."""
         tc = TempCampaign(parent_node_id=1)
         tc.add_node(node_id=10, prereq_node_id=None)
@@ -242,7 +257,7 @@ class TempCampaignTest(ByteDeckTenantTestCase):
         tc.add_reliant(node_id=11, reliant_node_id=999)
         self.assertFalse(tc.has_internal_reliant(tc.get_node(11)))
 
-    def test_is_non_sequential(self):
+    def test_is_non_sequential__always_false_due_to_is_true_comparison(self):
         """is_non_sequential runs over a campaign whose nodes share a common prereq.
 
         Note: the method body compares a *list* with ``is True`` (``get_common_prereq_node_ids()
@@ -263,6 +278,7 @@ class CytoManagerTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Generate the real primary map to give the manager helpers nodes to work with."""
         cls.map = generate_real_primary_map()
 
     def test_get_random_node__returns_node_in_scape(self):
@@ -291,15 +307,17 @@ class CytoManagerTests(ByteDeckTenantTestCase):
 class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Generate the real primary map as a shared fixture for the scape tests."""
         # tests that regenerate/mutate the map only touch the DB, which is rolled
         # back per test, and self.map is a per-test deep copy — safe class-level fixture
         cls.map = generate_real_primary_map()
 
-    def test_object_creation(self):
+    def test_object_creation__is_instance_and_str_is_name(self):
+        """A generated map is a CytoScape whose string form is its name."""
         self.assertIsInstance(self.map, CytoScape)
         self.assertEqual(str(self.map), self.map.name)
 
-    def test_object_alphabetical_order(self):
+    def test_object_alphabetical_order__maps_ordered_by_name(self):
         """
         Map objects are ordered alphabetically at the model level to ensure
         proper sorting consistently sitewide.
@@ -317,7 +335,8 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         # A queryset created from all objects is ordered correctly by default
         self.assertQuerySetEqual(all_maps, all_maps.order_by('name'))
 
-    def test_generate_map(self):
+    def test_generate_map__creates_new_scape(self):
+        """generate_map creates a new CytoScape for the given initial object."""
         quest = baker.make('quest_manager.Quest')
         CytoScape.generate_map(quest, "test")
         self.assertEqual(CytoScape.objects.count(), 2)
@@ -380,17 +399,20 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         self.map.refresh_from_db()
         self.assertFalse(self.map.is_the_primary_scape)
 
-    def test_elements_dict(self):
+    def test_elements_dict__has_nodes_and_edges(self):
+        """elements_dict returns a serializable dict containing 'nodes' and 'edges'."""
         eles_dict = self.map.elements_dict()
         self.assertIsInstance(eles_dict, dict)
         self.assertValidJSONDict(eles_dict)
         self.assertIn('nodes', eles_dict)
         self.assertIn('edges', eles_dict)
 
-    def test_generate_elements_json(self):
+    def test_generate_elements_json__is_valid_json(self):
+        """generate_elements_json returns a valid JSON string."""
         self.assertValidJSON(self.map.generate_elements_json())
 
-    def test_class_styles_list(self):
+    def test_class_styles_list__returns_selector_style_dicts(self):
+        """class_styles_list returns dicts each carrying a 'selector' and 'style'."""
         styles_list = self.map.class_styles_list()
         self.assertIsInstance(styles_list, list)
         style1 = styles_list[0]
@@ -399,11 +421,11 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         self.assertIn('selector', style1)
         self.assertIn('style', style1)
 
-    def test_regenerate(self):
+    def test_regenerate__no_error_on_good_map(self):
         """Can regenerate without error on a known good map object"""
         self.map.regenerate()
 
-    def test_cytoelement_ordering_is_a_total_order(self):
+    def test_cytoelement_ordering__is_a_total_order(self):
         """CytoElement.Meta.ordering must end with the unique `id` tiebreaker so element
         emission is deterministic. Without it, sibling elements (same group and data_parent —
         e.g. every top-level node, whose data_parent is NULL) come back in whatever order
@@ -413,7 +435,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         """
         self.assertEqual(CytoElement._meta.ordering[-1], 'id')
 
-    def test_elements_emitted_in_ascending_id_order_within_parent_groups(self):
+    def test_elements_dict__nodes_in_ascending_id_order_within_parent_groups(self):
         """The emitted map JSON must list nodes in a deterministic order: within each compound
         (campaign) parent — and among the top-level nodes — siblings come out in ascending id,
         i.e. creation order. A stable emission order in means a stable dagre layout out (#1977).
@@ -427,7 +449,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         for parent, ids in ids_by_parent.items():
             self.assertEqual(ids, sorted(ids), msg=f"nodes under parent {parent} are not id-ordered")
 
-    def test_regeneration_produces_stable_node_order(self):
+    def test_regenerate__produces_stable_node_order(self):
         """Regenerating a map must yield the same left-to-right node order every time so the
         rendered layout is deterministic (issue #1977). Node ids change on each regeneration but
         their labels don't, so we compare the ordered sequence of labels across two regenerations.
@@ -440,7 +462,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         after = ordered_labels()
         self.assertEqual(before, after)
 
-    def test_maps_dont_include_drafts(self):
+    def test_regenerate__excludes_draft_quests(self):
         """Draft unpublished quests should not appear in maps"""
 
         # default map json includes quest 6: {'data': {'id': 32, 'label': 'Send your teacher a Message (0)', 'href': '/quests/6/', 'Quest': 6}
@@ -455,7 +477,8 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         # should no longer be in the map
         self.assertNotIn("/quests/6/", self.map.elements_json)
 
-    def test_maps_dont_include_archived_quests(self):
+    def test_regenerate__excludes_archived_quests(self):
+        """Archived quests should not appear in maps after regeneration."""
         # default map json includes quest 6: {'data': {'id': 32, 'label': 'Send your teacher a Message (0)', 'href': '/quests/6/', 'Quest': 6}
         self.assertIn("/quests/6/", self.map.elements_json)
 
@@ -469,7 +492,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         # should no longer be in the map
         self.assertNotIn("/quests/6/", self.map.elements_json)
 
-    def test_regenerate_deleted_initial_object_throws_exception_and_deletes_map(self):
+    def test_regenerate__deleted_initial_object_throws_and_deletes_map(self):
         """when regenerating a map that has had its initial object deleted, remove it and raise error."""
         bad_map = CytoScape.objects.create(
             name="bad map",
@@ -483,7 +506,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         # should have been deleted at this point
         self.assertFalse(CytoScape.objects.filter(name="bad map").exists())
 
-    def test_get_related_maps(self):
+    def test_get_related_maps__counts_maps_per_quest(self):
         """ Check if CytoScape.objects.get_related_maps returns the correct maps per quest.
         """
 
@@ -526,7 +549,7 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         self.assertEqual(CytoScape.objects.get_related_maps(self.one_map).count(), 1)
         self.assertEqual(CytoScape.objects.get_related_maps(self.all_maps).count(), 3)
 
-    def test_get_maps_as_formatted_string(self):
+    def test_get_maps_as_formatted_string__formats_by_length(self):
         """ Checks if `get_maps_as_formatted_string` returns the appropriate formatting per length """
         names = [str(x) for x in range(4)]
         # Each scape needs a distinct real initial object: (initial_content_type,

--- a/src/djcytoscape/tests/test_signals.py
+++ b/src/djcytoscape/tests/test_signals.py
@@ -38,13 +38,15 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 2)
 
     def setUp(self):
+        """Grab the tenant's SiteConfig singleton for toggling map_auto_update."""
         self.config = SiteConfig.get()
 
     def tearDown(self):
+        """Restore map_auto_update to its enabled default after each test."""
         self.config.map_auto_update = True
         self.config.save()
 
-    def test_badge_regenerate_related_maps(self, task):
+    def test_regenerate_related_maps__badge(self, task):
         """ Tests if saving and deleting badge triggers `regenerate_map` task.
         """
         # setup a simple map
@@ -53,7 +55,7 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
 
         self.assert_regenerates_map_on_object_change(badge, scape, task)
 
-    def test_quest_regenerate_related_maps(self, task):
+    def test_regenerate_related_maps__quest(self, task):
         """ Tests if saving and deleting quest triggers `regenerate_map` task.
         """
         # setup a simple map
@@ -62,7 +64,7 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
 
         self.assert_regenerates_map_on_object_change(quest, scape, task)
 
-    def test_rank_regenerate_related_maps(self, task):
+    def test_regenerate_related_maps__rank(self, task):
         """ Tests if saving and deleting rank triggers `regenerate_map` task.
         """
         # setup a simple map
@@ -71,7 +73,7 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
 
         self.assert_regenerates_map_on_object_change(rank, scape, task)
 
-    def test_prereq_regenerate_related_maps(self, task):
+    def test_regenerate_related_maps__prereq(self, task):
         """ Tests if saving and deleting quest triggers `regenerate_map` task.
         Cant check if `regenerate_map` made new CytoElements. So checking if task args are accurate
         """
@@ -99,7 +101,7 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
         prereq.save()
         self.assertEqual(task.call_count, 2)
 
-    def test_prereq_signal_handles_all_registered_parent_models(self, task):
+    def test_prereq_signal__handles_all_registered_parent_models(self, task):
         """Saving a Prereq must not crash the map-regeneration signal for any
         registered prereq model as the parent. Loops through every model that
         implements IsAPrereqMixin — the only models that are supposed to be

--- a/src/djcytoscape/tests/test_tasks.py
+++ b/src/djcytoscape/tests/test_tasks.py
@@ -15,6 +15,7 @@ class CytoScapeTaskTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a shared quest used as maps' initial object across the task tests."""
         cls.quest = baker.make('quest_manager.Quest')
 
     def _bad_map(self):
@@ -24,7 +25,7 @@ class CytoScapeTaskTests(ByteDeckTenantTestCase):
             name="Bad Map", initial_content_type=quest_ct, initial_object_id=999999,
         )
 
-    def test_regenerate_all_maps(self):
+    def test_regenerate_all_maps__regenerates_valid_deletes_broken_and_notifies(self):
         """regenerate_all_maps regenerates valid maps, deletes maps whose initial
         object is gone, and notifies the requesting user of the failure and of the
         overall completion."""
@@ -49,8 +50,8 @@ class CytoScapeTaskTests(ByteDeckTenantTestCase):
         regenerate_map.apply(args=[[bad_map.id]], queue='default').get()
         self.assertFalse(CytoScape.objects.filter(id=bad_map.id).exists())
 
-    def test_regenerate_map(self):
-        """ tests if regenerate map task runs successfully """
+    def test_regenerate_map__links_quest_to_related_maps(self):
+        """regenerate_map relinks a quest to every map that references it as a prereq."""
         map_origins = baker.make('quest_manager.Quest', _quantity=3)
 
         # create map for each origin (3 maps)

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -18,6 +18,7 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, and a map pinned to a dedicated initial quest."""
         # need a teacher and a student so tests can log in as each via force_login()
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -43,9 +44,10 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_page_status_codes_for_anonymous(self):
+    def test_all_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to home page  '''
 
         self.assertRedirectsLogin('djcytoscape:index')
@@ -63,7 +65,8 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('djcytoscape:update', args=[1])
         self.assertRedirectsLogin('djcytoscape:delete', args=[1])
 
-    def test_all_page_status_codes_for_students(self):
+    def test_all_page_status_codes__students(self):
+        """Students can view maps but are forbidden from edit/regenerate/generate views."""
         self.client.force_login(self.test_student1)
 
         self.assert200('djcytoscape:index')
@@ -81,7 +84,8 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403('djcytoscape:generate_map', kwargs={'quest_id': 1, 'scape_id': 1})
         self.assert403('djcytoscape:generate_unseeded')
 
-    def test_all_page_status_codes_for_teachers(self):
+    def test_all_page_status_codes__teachers(self):
+        """Teachers can view maps and access the edit/generate views."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -170,7 +174,8 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
 class PrimaryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
-    def test_initial_map_generated_on_first_view(self):
+    def test_primary__generates_initial_map_on_first_view(self):
+        """Viewing the primary map for the first time generates the 'Main' map."""
         # shouldn't be any maps from the start
         self.assertFalse(CytoScape.objects.exists())
 
@@ -191,6 +196,7 @@ class RegenerateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Generate the real primary map and a staff user for the regenerate views."""
         from .test_models import generate_real_primary_map
 
         # regeneration in tests only touches the DB, which is rolled back per test
@@ -198,16 +204,19 @@ class RegenerateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.staff_user = User.objects.create_user(username="test_staff_user", is_staff=True)
 
     def setUp(self):
+        """Set up a tenant client logged in as the staff user."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.staff_user)
 
-    def test_regenerate(self):
+    def test_regenerate__redirects_to_quest_map(self):
+        """Regenerating a good map redirects back to that map's quest_map page."""
         self.assertRedirects(
             response=self.client.get(reverse('djcytoscape:regenerate', args=[self.map.id])),
             expected_url=reverse('djcytoscape:quest_map', args=[self.map.id]),
         )
 
-    def test_regenerate_with_deleted_object(self):
+    def test_regenerate__with_deleted_object(self):
+        """Regenerating a map whose initial object is gone redirects to the primary map."""
         bad_map = CytoScape.objects.create(
             name="bad map",
             initial_content_type=ContentType.objects.get(app_label='quest_manager', model='quest'),
@@ -218,13 +227,15 @@ class RegenerateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             expected_url=reverse('djcytoscape:primary'),
         )
 
-    def test_regenerate_all(self):
+    def test_regenerate_all__redirects_to_primary(self):
+        """Regenerating all maps redirects to the primary map."""
         self.assertRedirects(
             response=self.client.get(reverse('djcytoscape:regenerate_all')),
             expected_url=reverse('djcytoscape:primary'),
         )
 
-    def test_regenerate_all_with_bad_map(self):
+    def test_regenerate_all__with_bad_map(self):
+        """Regenerating all maps still redirects to primary when a broken map is present."""
         CytoScape.objects.create(
             name="bad map",
             initial_content_type=ContentType.objects.get(app_label='quest_manager', model='quest'),

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -19,11 +19,12 @@ class NonPublicOnlyAuthViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """
 
     def setUp(self):
+        """Use a tenant-aware client for each test."""
         self.client = TenantClient(self.tenant)
 
     @patch('hackerspace_online.views.connection', schema_name=get_public_schema_name())
     @patch('tenant.views.connection', schema_name=get_public_schema_name())
-    def test_public_tenant(self, mock_connection1, mock_connection2):
+    def test_public_tenant__allauth_views_return_404(self, mock_connection1, mock_connection2):
         """
         Overriden (decorated) `allauth` view should not be accessible for public tenant schemas,
         ie. return 404 (not found) for general public.
@@ -42,7 +43,7 @@ class NonPublicOnlyAuthViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert404('account_reset_password_from_key', kwargs={'uidb36': '123', 'key': '123'})  # not found
         self.assert404('account_reset_password_from_key_done')  # not found
 
-    def test_non_public_tenant(self):
+    def test_non_public_tenant__allauth_views_accessible(self):
         """
         Overriden (decorated) `allauth` view should be accessible for non-public tenant schemas only,
         ie. return anything except 404 (not found) for non-public tenant.
@@ -66,14 +67,16 @@ class ResetPasswordViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student with a known email for password-reset scenarios."""
         cls.test_email = 'test_email@bytedeck.com'
         cls.test_password = 'password'
         cls.test_student1 = User.objects.create_user('test_student', email=cls.test_email, password=cls.test_password)
 
     def setUp(self):
+        """Use a tenant-aware client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_user_cannot_request_password_reset(self):
+    def test_request_password_reset__fails_for_unassigned_email(self):
         """ User should not be able to request password reset if they registered without an email """
         data = {
             'email': 'nonexistentemail@gmail.com'
@@ -82,7 +85,7 @@ class ResetPasswordViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'error_1_id_email')  # invalid with error message
         self.assertContains(response, 'This e-mail address is not assigned')
 
-    def test_email_sent_to_requesting_user(self):
+    def test_reset_password__email_sent_to_requesting_user(self):
         """ Email should be sent to the requesting user containing the password verification link """
         data = {
             'email': self.test_email

--- a/src/hackerspace_online/tests/test_celery.py
+++ b/src/hackerspace_online/tests/test_celery.py
@@ -86,7 +86,7 @@ class BeatScheduleTest(SimpleTestCase):
     installs app.conf.beat_schedule entries as PeriodicTask rows on startup, so
     presence in the dict is what gets it running in production."""
 
-    def test_clear_expired_sessions_scheduled(self):
+    def test_beat_schedule__includes_clear_expired_sessions(self):
         """The beat schedule includes the daily clearsessions fan-out task."""
         entry = app.conf.beat_schedule["Clear expired sessions in all schemas daily task"]
         self.assertEqual(entry["task"], "tenant.tasks.clear_expired_sessions_in_all_schemas")

--- a/src/hackerspace_online/tests/test_celerybeat_signals.py
+++ b/src/hackerspace_online/tests/test_celerybeat_signals.py
@@ -14,7 +14,7 @@ PUBLIC_SCHEMA = get_public_schema_name()
 
 class PeriodicTaskSignalsTest(ByteDeckTenantTestCase):
 
-    def test_save_CronSchedule_signal(self):
+    def test_save_CronSchedule_signal__also_saves_to_public_schema(self):
         """ Saving a CronSchedule model should also save it in the public schema """
 
         cron_schedule = CrontabSchedule(minute=5, hour=23, day_of_month=26, month_of_year=11)
@@ -34,7 +34,7 @@ class PeriodicTaskSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(cron_schedule.day_of_month, public_cron_schedule.day_of_month)
         self.assertEqual(cron_schedule.month_of_year, public_cron_schedule.month_of_year)
 
-    def test_save_ClockedSchedule_signal(self):
+    def test_save_ClockedSchedule_signal__also_saves_to_public_schema(self):
         """ Saving a ClockedSchedule model should also save it in the public schema """
 
         now = timezone.now()
@@ -50,7 +50,7 @@ class PeriodicTaskSignalsTest(ByteDeckTenantTestCase):
         clocked_schedule.refresh_from_db()
         self.assertEqual(clocked_schedule.clocked_time, public_clocked_schedule.clocked_time)
 
-    def test_save_IntervalSchedule_signal(self):
+    def test_save_IntervalSchedule_signal__also_saves_to_public_schema(self):
         """ Saving an IntervalSchedule model should also save it in the public schema """
 
         interval_schedule = IntervalSchedule(every=5, period=IntervalSchedule.DAYS)
@@ -67,7 +67,7 @@ class PeriodicTaskSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(interval_schedule.period, public_interval_schedule.period)
         self.assertEqual(str(interval_schedule), str(public_interval_schedule))
 
-    def test_save_SolarSchedule_signal(self):
+    def test_save_SolarSchedule_signal__also_saves_to_public_schema(self):
         """ Saving a SolarSchedule model should also save it in the public schema """
 
         params = {
@@ -89,7 +89,7 @@ class PeriodicTaskSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(solar_schedule.latitude, public_solar_schedule.latitude)
         self.assertEqual(solar_schedule.longitude, public_solar_schedule.longitude)
 
-    def test_save_PeriodicTask_signal(self):
+    def test_save_PeriodicTask_signal__also_saves_to_public_schema(self):
         """ Saving a periodic task should also save it in the public schema """
 
         schedule = CrontabSchedule(minute='5')

--- a/src/hackerspace_online/tests/test_conventions.py
+++ b/src/hackerspace_online/tests/test_conventions.py
@@ -9,11 +9,9 @@ module's AST:
 * **Docstrings** — each ``test_*`` method, and each ``setUp`` /
   ``setUpTestData`` / ``tearDown``, has a docstring.
 
-Legacy modules that predate these conventions are listed in
-``LEGACY_UNCONVENTIONAL`` and skipped, so this guard fails only on *new or
-touched* files that don't conform. The list is a burn-down: as an app's tests
-are cleaned up, remove its modules here and this guard locks them in. Do not add
-new entries — write conforming tests instead.
+The whole suite has been brought into conformance, so ``LEGACY_UNCONVENTIONAL``
+is empty and every ``test_*.py`` is enforced. It remains as an escape hatch only:
+never add entries — write conforming tests instead.
 """
 
 import ast
@@ -21,80 +19,9 @@ from pathlib import Path
 
 from django.test import SimpleTestCase
 
-# Repo-relative (to src/) modules still awaiting a conventions cleanup. SHRINK
-# THIS LIST — never grow it. When you clean an app's tests, delete its entries.
-LEGACY_UNCONVENTIONAL = {
-    "announcements/tests/test_models.py",
-    "announcements/tests/test_signals.py",
-    "announcements/tests/test_tasks.py",
-    "announcements/tests/test_views.py",
-    "badges/tests/test_forms.py",
-    "badges/tests/test_models.py",
-    "badges/tests/test_views.py",
-    "bytedeck_summernote/tests/test_admin.py",
-    "bytedeck_summernote/tests/test_css_sanitizier.py",
-    "bytedeck_summernote/tests/test_views.py",
-    "bytedeck_summernote/tests/test_widgets.py",
-    "comments/tests/test_models.py",
-    "comments/tests/test_views.py",
-    "courses/tests/test_models.py",
-    "courses/tests/test_views.py",
-    "djcytoscape/tests/test_fields.py",
-    "djcytoscape/tests/test_models.py",
-    "djcytoscape/tests/test_signals.py",
-    "djcytoscape/tests/test_tasks.py",
-    "djcytoscape/tests/test_views.py",
-    "hackerspace_online/tests/test_auth.py",
-    "hackerspace_online/tests/test_celery.py",
-    "hackerspace_online/tests/test_celerybeat_signals.py",
-    "hackerspace_online/tests/test_forms.py",
-    "hackerspace_online/tests/test_management_commands.py",
-    "hackerspace_online/tests/test_middleware.py",
-    "hackerspace_online/tests/test_settings.py",
-    "hackerspace_online/tests/test_shell_utils.py",
-    "hackerspace_online/tests/test_signals.py",
-    "hackerspace_online/tests/test_utils.py",
-    "hackerspace_online/tests/test_views.py",
-    "library/tests/test_utils.py",
-    "library/tests/test_views.py",
-    "notifications/tests/test_models.py",
-    "notifications/tests/test_tasks.py",
-    "notifications/tests/test_views.py",
-    "portfolios/tests/test_views.py",
-    "prerequisites/tests/test_fields.py",
-    "prerequisites/tests/test_forms.py",
-    "prerequisites/tests/test_models.py",
-    "prerequisites/tests/test_signals.py",
-    "profile_manager/tests/test_forms.py",
-    "profile_manager/tests/test_managers.py",
-    "profile_manager/tests/test_models.py",
-    "profile_manager/tests/test_tasks.py",
-    "profile_manager/tests/test_views.py",
-    "quest_manager/tests/test_forms.py",
-    "quest_manager/tests/test_managers.py",
-    "quest_manager/tests/test_models.py",
-    "quest_manager/tests/test_signals.py",
-    "quest_manager/tests/test_views.py",
-    "siteconfig/tests/test_forms.py",
-    "siteconfig/tests/test_models.py",
-    "siteconfig/tests/test_views.py",
-    "tags/tests/test_models.py",
-    "tags/tests/test_views.py",
-    "tags/tests/test_widgets.py",
-    "tenant/tests/test_admin.py",
-    "tenant/tests/test_forms.py",
-    "tenant/tests/test_initialization.py",
-    "tenant/tests/test_models.py",
-    "tenant/tests/test_schema_aware_user_delete.py",
-    "tenant/tests/test_tasks.py",
-    "tenant/tests/test_views.py",
-    "utilities/tests/test_fields.py",
-    "utilities/tests/test_forms.py",
-    "utilities/tests/test_html.py",
-    "utilities/tests/test_templatetags_filters.py",
-    "utilities/tests/test_views.py",
-    "utilities/tests/test_widgets.py",
-}
+# Empty: the whole suite conforms. Keep it empty — never add entries; fix the
+# test to follow the naming/docstring conventions instead.
+LEGACY_UNCONVENTIONAL = set()
 
 _SETUP_METHODS = {"setUp", "setUpTestData", "tearDown"}
 

--- a/src/hackerspace_online/tests/test_forms.py
+++ b/src/hackerspace_online/tests/test_forms.py
@@ -29,12 +29,15 @@ User = get_user_model()
 class CustomSignUpFormTest(ByteDeckTenantTestCase):
 
     def setUp(self):
+        """No shared setup required for these form tests."""
         pass
 
-    def test_init(self):
+    def test_init__instantiates_without_error(self):
+        """CustomSignupForm can be constructed with no arguments."""
         CustomSignupForm()
 
-    def test_valid_data(self):
+    def test_valid_data__form_is_valid(self):
+        """A sign up form with a correct access code and matching passwords validates."""
         form = CustomSignupForm(
             {
                 'username': "username",
@@ -47,7 +50,7 @@ class CustomSignUpFormTest(ByteDeckTenantTestCase):
         )
         self.assertTrue(form.is_valid())
 
-    def test_bad_access_codecoverage(self):
+    def test_bad_access_code__does_not_validate(self):
         """ Test that a sign up form with the wrong access code doesn't validate """
         form = CustomSignupForm(
             {
@@ -64,7 +67,8 @@ class CustomSignUpFormTest(ByteDeckTenantTestCase):
         with self.assertRaisesMessage(forms.ValidationError, "Access code unrecognized."):
             form.clean()
 
-    def test_sign_up_via_post(self):
+    def test_sign_up_via_post__creates_user(self):
+        """Posting valid sign up data creates the user and redirects to quests."""
         self.client = TenantClient(self.tenant)
         form_data = {
             'username': "username",
@@ -79,7 +83,8 @@ class CustomSignUpFormTest(ByteDeckTenantTestCase):
         user = User.objects.get(username="username")
         self.assertEqual(user.first_name, "firsttest")
 
-    def test_sign_up_via_post_upcase_username(self):
+    def test_sign_up_via_post__upcase_username_lowercased(self):
+        """A mixed-case username is stored lowercased when signing up via POST."""
         self.client = TenantClient(self.tenant)
         form_data = {
             'username': "TestUser",
@@ -99,8 +104,8 @@ class CustomSignUpFormTest(ByteDeckTenantTestCase):
 
         self.assertIsNotNone(user)
 
-    def test_sign_up_via_post_with_email(self):
-
+    def test_sign_up_via_post__with_email_sends_confirmation(self):
+        """Signing up with an email creates the user and sends a confirmation email."""
         self.client = TenantClient(self.tenant)
         form_data = {
             'email': 'email@example.com',
@@ -133,6 +138,7 @@ class CustomSignUpFormTest(ByteDeckTenantTestCase):
 class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
 
     def setUp(self):
+        """No shared setup required; each test builds its own social login."""
         pass
 
     def get_social_login(self, provider=None):
@@ -172,10 +178,11 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
         config = SiteConfig.get()
         config._propagate_google_provider()
 
-    def test_init(self):
+    def test_init__instantiates_without_error(self):
+        """CustomSocialAccountSignupForm can be constructed from a social login."""
         CustomSocialAccountSignupForm(sociallogin=self.get_social_login())
 
-    def test_complete_fields(self):
+    def test_complete_fields__has_expected_fields(self):
         """
         Test in case there are changes from CustomSignupForm
         """
@@ -192,7 +199,8 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
         self.assertEqual(len(form.fields), len(social_signup_form_fields))
         self.assertListEqual(sorted(social_signup_form_fields), sorted(form.fields.keys()))
 
-    def test_valid_data(self):
+    def test_valid_data__form_is_valid(self):
+        """A social sign up form with a correct access code validates."""
         form = CustomSocialAccountSignupForm(
             sociallogin=self.get_social_login(),
             data={
@@ -205,7 +213,7 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
 
         self.assertTrue(form.is_valid())
 
-    def test_bad_access_codecoverage(self):
+    def test_bad_access_code__does_not_validate(self):
         """ Test that a social sign up form with the wrong access code doesn't validate """
         form = CustomSocialAccountSignupForm(
             sociallogin=self.get_social_login(),
@@ -221,7 +229,8 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
         with self.assertRaisesMessage(forms.ValidationError, "Access code unrecognized."):
             form.clean()
 
-    def test_sign_up_via_post(self):
+    def test_sign_up_via_post__creates_user(self):
+        """Completing the social sign up form via POST creates the user and redirects to quests."""
         self.client = TenantClient(self.tenant)
         session = self.client.session
         form_data = {
@@ -254,7 +263,7 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
     @patch('allauth.socialaccount.providers.oauth2.client.OAuth2Client.get_access_token')
     @patch('allauth.socialaccount.providers.google.views.GoogleOAuth2Adapter.complete_login')
     @patch('allauth.socialaccount.internal.statekit.unstash_state')
-    def test_signin_via_post_connect_existing_account_automatically(
+    def test_signin_via_post__connect_existing_account_automatically(
         self,
         mock_unstash_state,
         mock_complete_login,
@@ -492,7 +501,7 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
     @patch('allauth.socialaccount.providers.oauth2.client.OAuth2Client.get_access_token')
     @patch('allauth.socialaccount.providers.google.views.GoogleOAuth2Adapter.complete_login')
     @patch('allauth.socialaccount.internal.statekit.unstash_state')
-    def test_signin_via_post_google_signin_redirects_to_signup_page_on_new_account(
+    def test_signin_via_post__google_signin_redirects_to_signup_on_new_account(
         self,
         mock_unstash_state,
         mock_complete_login,
@@ -543,7 +552,7 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
     @patch('allauth.socialaccount.providers.oauth2.client.OAuth2Client.get_access_token')
     @patch('allauth.socialaccount.providers.google.views.GoogleOAuth2Adapter.complete_login')
     @patch('allauth.socialaccount.internal.statekit.unstash_state')
-    def test_signup_via_post_google_signin_change_email_and_revert_back_to_google_email(
+    def test_signup_via_post__change_email_and_revert_back_to_google_email(
         self,
         mock_unstash_state,
         mock_complete_login,
@@ -659,13 +668,15 @@ class CustomSocialAccountSignUpFormTest(ByteDeckTenantTestCase):
 class CustomLoginFormTest(ByteDeckTenantTestCase):
 
     def setUp(self):
+        """Create a user to authenticate against in login tests."""
         self.user = User.objects.create_user(username='testuser', password='testuser')
 
-    def test_init(self):
+    def test_init__instantiates_without_error(self):
+        """CustomLoginForm can be constructed with no arguments."""
         CustomLoginForm()
 
-    def test_valid_data(self):
-
+    def test_valid_data__form_is_valid(self):
+        """Correct credentials passed with a request make the login form valid."""
         # django-allauth forms require `request` to be passed when instantiating the form
         # normally, forms are used from within a django view and the view passes the request object to the form
         # but in this case, we are just performing a test to the form itself so we need to have access to
@@ -683,7 +694,7 @@ class CustomLoginFormTest(ByteDeckTenantTestCase):
         )
         self.assertTrue(form.is_valid())
 
-    def test_login_with_upcase_username(self):
+    def test_login__with_upcase_username(self):
         """
         User should still be able to login regardless of the username case
         """
@@ -696,7 +707,7 @@ class CustomLoginFormTest(ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('quests:quests'))
 
     @override_settings(SESSION_COOKIE_AGE=60 * 60 * 24)
-    def test_session_expires_based_on_SESSION_COOKIE_AGE(self):
+    def test_session_expires__based_on_SESSION_COOKIE_AGE(self):
         """
         Test that whatever the value of SESSION_COOKIE_AGE expires correctly
         """
@@ -717,7 +728,7 @@ class CustomLoginFormTest(ByteDeckTenantTestCase):
         # probably after a couple of seconds after the `last_login` is set
         self.assertEqual((self.user.last_login + timedelta(seconds=settings.SESSION_COOKIE_AGE)).date(), session.get_expiry_date().date())
 
-    def test_remember_me_session_expires_on_browser_close(self):
+    def test_remember_me__session_expires_on_browser_close(self):
         """
         Test to see that disabling `Remember me` expires on browser close
         """
@@ -733,7 +744,7 @@ class CustomLoginFormTest(ByteDeckTenantTestCase):
         session = response.wsgi_request.session
         self.assertTrue(session.get_expire_at_browser_close())
 
-    def test_remember_me_session_does_not_expire_on_browser_close(self):
+    def test_remember_me__session_does_not_expire_on_browser_close(self):
         """
         Test to see that enabling `Remember me` does not expire immediately even when the browser is closed
         """
@@ -751,19 +762,23 @@ class CustomLoginFormTest(ByteDeckTenantTestCase):
         self.assertFalse(session.get_expire_at_browser_close())
 
     def tearDown(self) -> None:
+        """Remove the login test user after each test."""
         self.user.delete()
 
 
 class PublicContactFormTest(ByteDeckTenantTestCase):
 
     def setUp(self):
+        """No shared setup required for these form tests."""
         pass
 
-    def test_init(self):
+    def test_init__instantiates_without_error(self):
+        """PublicContactForm can be constructed with no arguments."""
         PublicContactForm()
 
     @patch("hackerspace_online.forms.ReCaptchaField.clean", return_value="PASSED")
-    def test_valid_data(self, mock_captcha):
+    def test_valid_data__form_is_valid(self, mock_captcha):
+        """A contact form with valid fields and a passing captcha validates."""
         # django-recaptcha 4 removed the RECAPTCHA_TESTING/'PASSED' test hook,
         # so mock the field like the deck-request tests do
         form = PublicContactForm(

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -53,7 +53,7 @@ class InitDbTest(TestCase, CommandMixin):
     """
     name = "initdb"
 
-    def test_initdb(self):
+    def test_initdb__sets_up_public_tenant(self):
         """ Test that initdb command sets up the public tenant, including:
         - a Tenant object called 'public'
         - a superuser
@@ -79,7 +79,7 @@ class GenerateContentTest(ByteDeckTenantTestCase, CommandMixin):
     """
     name = "generate_content"
 
-    def test_added_rows_to_db(self):
+    def test_generate_content__adds_rows_to_db(self):
         """ test checks if "generate_content" adds objects to the db """
         new_campaigns = 2
         new_quests = 5
@@ -109,6 +109,7 @@ class FullCleanTest(TestCase, CommandMixin):
     name = 'full_clean'
 
     def setUp(self):
+        """Initialize the public tenant and seed a tenant with a validation error."""
         call_command('initdb')
 
         # have to create tenant this way to prevent errors
@@ -132,7 +133,7 @@ class FullCleanTest(TestCase, CommandMixin):
         #     #  ie. `{'semester': ['this field cannot be blank.']}`
         #     qs = baker.make('quest_manager.QuestSubmission')
 
-    def test_full_clean(self):
+    def test_full_clean__captures_validation_errors(self):
         """ Checks if full clean captures expected validation errors from "full_clean" management command
         See setUp for the expected errors.
         """

--- a/src/hackerspace_online/tests/test_middleware.py
+++ b/src/hackerspace_online/tests/test_middleware.py
@@ -48,6 +48,7 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
     """
 
     def setUp(self):
+        """Use a tenant client and ensure RequestDataTooBigMiddleware is enabled."""
         self.client = TenantClient(self.tenant)
 
         # make sure RequestDataTooBig middleware is enabled for a testing purpose
@@ -57,10 +58,11 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
             settings.MIDDLEWARE = list(settings.MIDDLEWARE) + [middleware_class]
 
     def tearDown(self):
+        """Restore the original MIDDLEWARE setting after each test."""
         settings.MIDDLEWARE = self.old_MIDDLEWARE
 
     @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=2621440, ROOT_URLCONF=__name__)
-    def test_default(self):
+    def test_default__passes_request_through(self):
         """
         By default request should pass through middleware as-is, without exceptions.
         """
@@ -73,7 +75,7 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
 
     @without_requestdatatoobig_middleware
     @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=8, ROOT_URLCONF=__name__)
-    def test_request_data_too_big_exception_without_requestdatatoobig_middleware(self):
+    def test_request_data_too_big__without_middleware_returns_400(self):
         """
         Somehow request data exceeds the settings.DATA_UPLOAD_MAX_MEMORY_SIZE limit,
         that raises `RequestDataTooBig` exception.
@@ -90,7 +92,7 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
         self.assertEqual(len(messages), 0)  # nothing, cuz not handled properly
 
     @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=8, ROOT_URLCONF=__name__)
-    def test_request_data_too_big_exception_with_requestdatatoobig_middleware(self):
+    def test_request_data_too_big__with_middleware_redirects(self):
         """
         Somehow request data exceeds the settings.DATA_UPLOAD_MAX_MEMORY_SIZE limit,
         that raises `RequestDataTooBig` exception.
@@ -108,7 +110,7 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
         self.assertIn("requests exceeds the maximum size", str(messages[0]))
 
     @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=8, ROOT_URLCONF=__name__)
-    def test_request_data_too_big_exception_with_requestdatatoobig_middleware_skip_FILES(self):
+    def test_request_data_too_big__with_middleware_skips_files(self):
         """
         Custom middleware should handle uploaded files gracefully by simply skipping them
         """

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -15,18 +15,18 @@ class SecureProxySSLHeaderTest(SimpleTestCase):
     forwards to Django over plain HTTP, so Django must trust the forwarded scheme
     to recognize secure requests and build https:// URLs (e.g. in email links)."""
 
-    def test_secure_proxy_ssl_header_is_configured(self):
+    def test_secure_proxy_ssl_header__is_configured(self):
         """SECURE_PROXY_SSL_HEADER must name the X-Forwarded-Proto header nginx sets."""
         self.assertEqual(settings.SECURE_PROXY_SSL_HEADER, ("HTTP_X_FORWARDED_PROTO", "https"))
 
-    def test_forwarded_https_request_is_secure(self):
+    def test_forwarded_https_request__is_secure(self):
         """A request forwarded with X-Forwarded-Proto: https is treated as secure,
         so build_absolute_uri produces https:// links instead of http://."""
         request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="https")
         self.assertTrue(request.is_secure())
         self.assertTrue(request.build_absolute_uri("/decks/request/new/").startswith("https://"))
 
-    def test_forwarded_http_request_is_not_secure(self):
+    def test_forwarded_http_request__is_not_secure(self):
         """Without the https forwarded scheme, the request stays plain HTTP so the
         header can't be used to fake a secure request."""
         request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="http")
@@ -38,22 +38,22 @@ class DeploymentSettingsGuardTest(SimpleTestCase):
     defaults; `_validate_deployment_settings` raises to prevent it, while leaving
     local development untouched."""
 
-    def test_local_development_is_never_blocked(self):
+    def test_local_development__is_never_blocked(self):
         """localhost is local dev, so the example DEBUG=True + default SECRET_KEY are allowed."""
         # Should not raise.
         _validate_deployment_settings("localhost", True, "Change.Me!")
 
-    def test_real_deployment_rejects_debug_true(self):
+    def test_real_deployment__rejects_debug_true(self):
         """DEBUG=True on a real domain is refused, so debug pages can't leak in production."""
         with self.assertRaises(ImproperlyConfigured):
             _validate_deployment_settings("bytedeck.com", True, "a-real-random-secret-key")
 
-    def test_real_deployment_rejects_default_secret_key(self):
+    def test_real_deployment__rejects_default_secret_key(self):
         """The example 'Change.Me!' SECRET_KEY is refused on a real domain."""
         with self.assertRaises(ImproperlyConfigured):
             _validate_deployment_settings("bytedeck.com", False, "Change.Me!")
 
-    def test_properly_configured_deployment_is_allowed(self):
+    def test_properly_configured_deployment__is_allowed(self):
         """DEBUG=False with a unique SECRET_KEY on a real domain passes the guard."""
         # Should not raise.
         _validate_deployment_settings("bytedeck.com", False, "a-real-random-secret-key")
@@ -90,7 +90,7 @@ class DatabaseConnectionSettingsTest(SimpleTestCase):
     failover, network blip, server-side timeout) surfaces as an intermittent
     error on whatever request draws it."""
 
-    def test_conn_health_checks_enabled(self):
+    def test_conn_health_checks__enabled(self):
         """CONN_HEALTH_CHECKS must be True so dead persistent connections are
         detected and transparently re-established at the start of a request."""
         self.assertTrue(settings.DATABASES["default"]["CONN_HEALTH_CHECKS"])
@@ -125,27 +125,27 @@ class CelerySettingsTest(SimpleTestCase):
     memory leaks, keep quick tasks from queueing behind long all-schema tasks,
     and kill hung tasks instead of losing a worker slot forever."""
 
-    def test_results_ignored(self):
+    def test_task_results__ignored(self):
         """No result backend is configured and nothing reads task results, so
         results must be ignored rather than stored on the broker."""
         self.assertTrue(settings.CELERY_TASK_IGNORE_RESULT)
 
-    def test_worker_recycling_enabled(self):
+    def test_worker_recycling__enabled(self):
         """Workers must recycle after a bounded number of tasks so leaks from
         the per-schema fan-out tasks can't grow without limit."""
         self.assertGreater(settings.CELERY_WORKER_MAX_TASKS_PER_CHILD, 0)
 
-    def test_prefetch_disabled_for_mixed_workload(self):
+    def test_prefetch__disabled_for_mixed_workload(self):
         """Prefetch multiplier must be 1 so seconds-long tasks don't get stuck
         prefetched behind minutes-long all-schema tasks."""
         self.assertEqual(settings.CELERY_WORKER_PREFETCH_MULTIPLIER, 1)
 
-    def test_time_limits_sane(self):
+    def test_time_limits__soft_fires_before_hard(self):
         """A soft limit must exist and fire before the hard kill so tasks get a
         chance to clean up (SoftTimeLimitExceeded) before the worker is killed."""
         self.assertLess(settings.CELERY_TASK_SOFT_TIME_LIMIT, settings.CELERY_TASK_TIME_LIMIT)
 
-    def test_broker_retry_on_startup(self):
+    def test_broker__retry_on_startup(self):
         """The worker must retry the broker connection at startup instead of
         dying if redis is momentarily slower to come up."""
         self.assertTrue(settings.CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP)
@@ -157,6 +157,6 @@ class Select2CacheTest(SimpleTestCase):
     maxmemory+noeviction an unbounded cache eventually makes Redis refuse all
     writes (breaking the shared celery broker too)."""
 
-    def test_select2_cache_has_finite_ttl(self):
+    def test_select2_cache__has_finite_ttl(self):
         """The select2 cache must have a finite TTL (default 24h), never None."""
         self.assertEqual(settings.CACHES["select2"]["TIMEOUT"], 60 * 60 * 24)

--- a/src/hackerspace_online/tests/test_shell_utils.py
+++ b/src/hackerspace_online/tests/test_shell_utils.py
@@ -13,10 +13,11 @@ User = get_user_model()
 
 class ShellUtilsTest(ByteDeckTenantTestCase):
     def setUp(self):
+        """No shared setup required for these shell-util tests."""
         # self.client = TenantClient(self.tenant)
         pass
 
-    def test_generate_students(self):
+    def test_generate_students__creates_requested_number(self):
         """ Generates the provided number of students (20, is_staff = False) """
         create_this_many = 20
         num_students_before = User.objects.filter(is_staff=False).count()
@@ -24,7 +25,7 @@ class ShellUtilsTest(ByteDeckTenantTestCase):
         num_students_after = User.objects.filter(is_staff=False).count()
         self.assertEqual(num_students_after, num_students_before + create_this_many)
 
-    def test_generate_quests(self):
+    def test_generate_quests__creates_requested_quests_and_campaigns(self):
         """ Generates the provided number of students (10) """
         num_quest = 5
         num_campaigns = 2

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -16,6 +16,7 @@ User = get_user_model()
 
 class SignalTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
+        """Use a tenant-aware client for each test."""
         self.client = TenantClient(self.tenant)
 
     def test_handle_tenant_site_domain_update__long_domain_truncates_site_name(self):

--- a/src/hackerspace_online/tests/test_utils.py
+++ b/src/hackerspace_online/tests/test_utils.py
@@ -19,12 +19,14 @@ class Utils_generate_form_data_Test(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher used to authenticate the form-submission requests."""
         cls.teacher = get_user_model().objects.create(username="teacher", is_staff=True,)
 
     def setUp(self):
+        """Use a tenant-aware client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_valid_SiteConfigModel(self):
+    def test_generate_form_data__valid_SiteConfig_model(self):
         """
             Basic test to see if generate_form_data works with SiteConfig model
         """
@@ -40,7 +42,7 @@ class Utils_generate_form_data_Test(ByteDeckTenantTestCase):
         # assert changes
         self.assertEqual(SiteConfig.get().site_name, "NEW SITE NAME")
 
-    def test_valid_RankModel(self):
+    def test_generate_form_data__valid_Rank_model(self):
         """
             Basic test to see if generate_form_data works with Rank model
         """
@@ -56,7 +58,7 @@ class Utils_generate_form_data_Test(ByteDeckTenantTestCase):
         # assert changes
         self.assertTrue(Rank.objects.filter(name="NEW RANK NAME").exists())
 
-    def test_valid_BlockForm(self):
+    def test_generate_form_data__valid_BlockForm(self):
         """
             Basic test to see if generate_form_data works with BlockForm
         """
@@ -82,7 +84,7 @@ class Utils_generate_form_data_Test(ByteDeckTenantTestCase):
     # implemented for redundancy and there are many similarly-functional tests for other near-identical forms across site more suited to
     # this convienience method
     # form_valid_data exists as a dict but is being picked up as an arg instead of a kwarg and kwargs=form_valid_data upon creation does not fix
-    def test_valid_CourseStudentForm(self):
+    def test_generate_form_data__valid_CourseStudentForm(self):
         """
             Basic test to see if generate_form_data works with CourseStudentForm
 
@@ -147,14 +149,14 @@ class ByteDeckTenantTestCaseTest(ByteDeckTenantTestCase):
         """Class-level fixture that would silently never run on stock TenantTestCase."""
         cls.category = baker.make('quest_manager.Category', title='setuptestdata-probe')
 
-    def test_setuptestdata_ran_in_tenant_schema(self):
+    def test_setuptestdata__ran_in_tenant_schema(self):
         """setUpTestData ran, its data is queryable, and it was created in the test tenant's schema."""
         self.assertEqual(connection.schema_name, self.tenant.schema_name)
         self.assertTrue(
             apps.get_model('quest_manager', 'Category').objects.filter(title='setuptestdata-probe').exists()
         )
 
-    def test_a_mutations_of_class_data_are_visible_within_a_test(self):
+    def test_a_mutations_of_class_data__are_visible_within_a_test(self):
         """A test may freely mutate class-level data; changes are visible inside that test."""
         self.category.title = 'mutated'
         self.category.save()
@@ -162,7 +164,7 @@ class ByteDeckTenantTestCaseTest(ByteDeckTenantTestCase):
             apps.get_model('quest_manager', 'Category').objects.filter(title='mutated').exists()
         )
 
-    def test_b_mutations_of_class_data_do_not_leak_between_tests(self):
+    def test_b_mutations_of_class_data__do_not_leak_between_tests(self):
         """DB rows and in-memory attributes are restored between tests (runs after test_a_*)."""
         self.assertEqual(self.category.title, 'setuptestdata-probe')
         Category = apps.get_model('quest_manager', 'Category')

--- a/src/hackerspace_online/tests/test_views.py
+++ b/src/hackerspace_online/tests/test_views.py
@@ -17,15 +17,18 @@ User = get_user_model()
 
 class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
+        """Use a tenant-aware client for each test."""
         # Every test needs access to the request factory.
         # https://docs.djangoproject.com/en/3.0/topics/testing/advanced/#the-request-factory
         # self.factory = RequestFactory()
         self.client = TenantClient(self.tenant)
 
-    def test_secret_view(self):
+    def test_secret_view__returns_200(self):
+        """The 'simple' secret view responds with 200."""
         self.assert200('simple')
 
-    def test_home_view_staff(self):
+    def test_home_view__staff_redirected_to_approvals(self):
+        """A logged-in staff user hitting home is redirected to the approvals page."""
         staff_user = User.objects.create_user(username="test_staff_user", password="password", is_staff=True)
         self.client.force_login(staff_user)
         response = self.client.get(reverse('home'))
@@ -34,12 +37,14 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             reverse('quests:approvals')
         )
 
-    def test_home_view_authenticated(self):
+    def test_home_view__authenticated_redirected_to_quests(self):
+        """A logged-in student hitting home is redirected to the quests page."""
         user = User.objects.create_user(username="test_user", password="password")
         self.client.force_login(user)
         self.assertRedirectsQuests('home')
 
-    def test_home_view_anonymous(self):
+    def test_home_view__anonymous_redirected_to_login(self):
+        """An anonymous visitor hitting home is redirected to the login page."""
         response = self.client.get(reverse('home'))
         self.assertRedirects(
             response,
@@ -48,7 +53,7 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @patch('hackerspace_online.views.connection', schema_name=get_public_schema_name())
     @patch('tenant.views.connection', schema_name=get_public_schema_name())
-    def test_home_public_tenant(self, mock_connection1, mock_connection2):
+    def test_home_view__public_tenant_redirects_to_flatpage(self, mock_connection1, mock_connection2):
         """Home view for public tenant should permanent redirect (301) to the public flatpage called 'home'
         """
         self.assertRedirects(
@@ -59,23 +64,8 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
 
     # Contact Form removed
-    # @patch('hackerspace_online.views.connection', schema_name=get_public_schema_name())
-    # @patch('tenant.views.connection', schema_name=get_public_schema_name())
-    # def test_home_public_contact_form(self, mock_connection1, mock_connection2):
-    #     form_data = {
-    #         'name': 'First Last',
-    #         'email': 'test@example.com',
-    #         'message': 'Test Message',
-    #         'g-recaptcha-response': 'PASSED',
-    #     }
-    #     response = self.client.post(reverse('home'), data=form_data)
-    #     # Form submission redirects to same home page
-    #     self.assertEqual(response.status_code, 302)
-    #     self.assertEqual(response.url, reverse('home'))
-    #     # The view should be sent via email with form info if successfull
-    #     self.assertEqual(len(mail.outbox), 1)
 
-    def test_favicon(self):
+    def test_favicon__redirects_to_site_favicon(self):
         """ Requests for /favicon.ico made by browsers is redirected to the site's favicon """
         response = self.client.get('/favicon.ico')
         self.assertEqual(response.status_code, 301)  # permanent redirect
@@ -83,13 +73,14 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @patch('hackerspace_online.views.connection', schema_name=get_public_schema_name())
     @patch('tenant.views.connection', schema_name=get_public_schema_name())
-    def test_favicon_public_tenant(self, mock_connection1, mock_connection2):
+    def test_favicon__public_tenant_redirects_to_static_favicon(self, mock_connection1, mock_connection2):
         """ Requests for /favicon.ico made by browsers is redirected to the site's favicon """
         response = self.client.get('/favicon.ico')
         self.assertEqual(response.status_code, 301)  # permanent redirect
         self.assertEqual(response.url, static('icon/favicon.ico'))
 
-    def test_achievements_redirect_to_badges_views(self):
+    def test_achievements__redirect_to_badges_views(self):
+        """Legacy /achievements/ URLs redirect to their corresponding badges views."""
         # log in a teacher
         staff_user = User.objects.create_user(username="test_staff_user", password="password", is_staff=True)
         self.client.force_login(staff_user)
@@ -105,9 +96,10 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 class GoogleSigninViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
+        """Use a tenant-aware client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_enable_google_signin_is_False(self):
+    def test_enable_google_signin__False_hides_button(self):
         """
         Test to verify that Google sign in button is not showing in the page when it is disabled
         """
@@ -118,7 +110,7 @@ class GoogleSigninViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('account_signup'))
         self.assertNotIn("btn_google_signin_dark_normal_web", response.content.decode('utf-8'))
 
-    def test_enable_google_signin_is_True(self):
+    def test_enable_google_signin__True_shows_button(self):
         """
         Test to verify that Google sign in button is showing in the page when it is enabled
         """

--- a/src/library/tests/test_utils.py
+++ b/src/library/tests/test_utils.py
@@ -5,8 +5,8 @@ from library.utils import library_schema_context
 
 class QuestLibraryUtilsTestCase(SimpleTestCase):
 
-    def test_library_schema_context(self):
-
+    def test_library_schema_context__switches_and_restores_schema(self):
+        """The context manager switches to the library schema and restores the previous one on exit."""
         previous_schema = connection.schema_name
 
         with library_schema_context():

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -60,6 +60,7 @@ class LibraryTenantTestCaseMixin(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
     @classmethod
     def setUpTestData(cls):
+        """Create library and local quests plus teacher/student users."""
         with library_schema_context():
             # Create a quest in the library tenant
             cls.shared_quest = baker.make(Quest)
@@ -73,18 +74,19 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         cls.test_student = User.objects.create_user('test_student', is_staff=False)
 
     def setUp(self):
+        """Set up a tenant client, site config, and active semester."""
         self.client = TenantClient(self.tenant)
         self.config = SiteConfig.get()
         self.sem = SiteConfig.get().active_semester
 
-    def test_library_tenant_exists(self):
+    def test_library_tenant__exists(self):
         """
         Tests that the library tenant is created and exists in the database.
         """
         self.assertIsNotNone(self.library_tenant)
         self.assertTrue(schema_exists(self.library_tenant.schema_name))
 
-    def test_all_library_quest_page_status_codes_for_anonymous(self):
+    def test_all_library_quest_page_status_codes__for_anonymous(self):
         """
         Tests that the library pages redirect anonymous users to the login page.
         This is important to ensure that only authenticated users can access the library.
@@ -94,7 +96,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.assertRedirectsLogin('library:quest_list')
         self.assertRedirectsLogin('library:import_quest', args=[self.library_quest.import_id])
 
-    def test_all_library_quest_page_status_codes_for_students(self):
+    def test_all_library_quest_page_status_codes__for_students(self):
         """
         Tests that the library pages return the correct status codes for student users.
         """
@@ -104,7 +106,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.assert403('library:quest_list')
         self.assert403('library:import_quest', args=[self.library_quest.import_id])
 
-    def test_all_library_quest_page_status_codes_for_staff(self):
+    def test_all_library_quest_page_status_codes__for_staff(self):
         """
         Tests that the library pages return the correct status codes for staff users.
         """
@@ -131,7 +133,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(len(response.context['library_quests']), non_library_quest_count)
 
-    def test_import_quest_to_current_deck(self):
+    def test_import_quest__to_current_deck(self):
         """
         Tests the quest import view for various scenarios:
 
@@ -425,6 +427,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
 class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
     @classmethod
     def setUpTestData(cls):
+        """Create library and local categories/quests plus teacher/student users."""
         cls.local_category = baker.make(Category)
         cls.shared_category = baker.make(Category)
 
@@ -442,13 +445,14 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         cls.test_student = User.objects.create_user('test_student', is_staff=False)
 
     def setUp(self):
+        """Set up a tenant client, active semester, site config, and deck owner."""
         self.client = TenantClient(self.tenant)
         self.sem = SiteConfig.get().active_semester
 
         self.config = SiteConfig.get()
         self.deck_owner = self.config.deck_owner
 
-    def test_all_library_category_page_status_codes_for_anonymous(self):
+    def test_all_library_category_page_status_codes__for_anonymous(self):
         """
         Tests that the library pages redirect anonymous users to the login page.
         This is important to ensure that only authenticated users can access the library.
@@ -460,7 +464,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         # Category detail view
         self.assertRedirectsLogin('library:category_detail_view', args=[self.library_category.import_id])
 
-    def test_all_library_category_page_status_codes_for_students(self):
+    def test_all_library_category_page_status_codes__for_students(self):
         """
         Tests that the library pages return the correct status codes for student users.
         """
@@ -471,7 +475,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.assert403('library:import_category', args=[self.library_category.import_id])
         self.assert403('library:category_detail_view', args=[self.library_category.import_id])
 
-    def test_all_library_category_page_status_codes_for_staff(self):
+    def test_all_library_category_page_status_codes__for_staff(self):
         """
         Tests that the library pages return the correct status codes for staff users.
         """
@@ -483,6 +487,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.assert200('library:category_detail_view', args=[self.library_category.import_id])
 
     def test_import_campaign___already_exists(self):
+        """Importing a campaign already present on the deck shows a matching-name warning."""
         self.client.force_login(self.test_teacher)
         with library_schema_context():
             # Create a category in the library tenant
@@ -497,6 +502,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.assertContains(response, 'Your deck already contains a campaign with a matching name.')
 
     def test_import_campaign___success(self):
+        """Importing a library campaign copies it and its quests as unpublished onto the deck."""
         self.client.force_login(self.test_teacher)
         # Capture baseline to assert relative change after import
         initial_category_count = Category.objects.count()
@@ -531,7 +537,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
 
         self.assertIn(expected_link, message)
 
-    def test_import_campaign_get_identifies_existing_local_quests(self):
+    def test_import_campaign_get__identifies_existing_local_quests(self):
         """
         Ensure the import campaign view correctly identifies which quests from the
         selected library campaign already exist locally and includes their import IDs
@@ -965,6 +971,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
 class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):
     @classmethod
     def setUpTestData(cls):
+        """Create a published library campaign/quest plus teacher/student users."""
         with library_schema_context():
             # Set up a campaign to test with later
             cls.library_campaign = baker.make(Category, published=True)
@@ -976,9 +983,10 @@ class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):
         cls.test_student = User.objects.create_user('test_student', is_staff=False)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_library_overview_redirects_anonymous(self):
+    def test_library_overview__redirects_anonymous(self):
         """
         Anonymous users should be redirected to the login page when accessing the library overview.
         """
@@ -990,14 +998,14 @@ class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):
         # Should redirect to login page with next param
         self.assertTrue(response.url.startswith('/accounts/login/'))
 
-    def test_library_overview_for_students(self):
+    def test_library_overview__for_students(self):
         """
         Authenticated students should receive a 403 Forbidden when trying to access the library
         """
         self.client.force_login(self.test_student)
         self.assert403('library:quest_list')
 
-    def test_library_overview_for_staff_default_tab(self):
+    def test_library_overview__for_staff_default_tab(self):
         """
         Staff users should see the library overview page with the Quests tab active by default
         """

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -18,14 +18,13 @@ class NotificationModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and a student (a teacher must exist first or student creation fails)."""
         User = get_user_model()
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
-        # cls.assertion = baker.make(BadgeAssertion)
-        # cls.badge = Recipe(Badge, xp=20).make()
-        # cls.badge_assertion_recipe = Recipe(BadgeAssertion, user=cls.student, badge=cls.badge)
 
-    def test_notification_creation(self):
+    def test_notification_creation__creates_and_saves(self):
+        """A Notification can be created, cleaned, saved, and rendered to a string."""
         notification = Notification.objects.create(
             recipient=self.student,
             sender_content_type=ContentType.objects.get_for_model(self.teacher),
@@ -37,7 +36,8 @@ class NotificationModelTest(ByteDeckTenantTestCase):
         self.assertIsInstance(notification, Notification)
         self.assertIsNotNone(str(notification))
 
-    def test_mark_read(self):
+    def test_mark_read__marks_notification_read(self):
+        """mark_read() flips an unread notification to read."""
         notification = baker.make(
             Notification,
             sender_content_type=ContentType.objects.get_for_model(self.teacher), sender_object_id=self.teacher.id,
@@ -46,25 +46,8 @@ class NotificationModelTest(ByteDeckTenantTestCase):
         notification.mark_read()
         self.assertFalse(notification.unread)
 
-    def test_new_notification(self):
-        """
-        def new_notification(sender, **kwargs):
-        Creates notification when a signal is sent with notify.send(sender, **kwargs)
-        :param sender: the object (any Model) initiating/causing the notification
-        :param kwargs:
-            target (any Model): The object being notified about (Submission, Comment, BadgeAssertion, etc.)
-            action (any Model): Used alongside "verb" to create syntax of notification ie. "<user> <verb> with <action>"
-            recipient (User): The receiving User, required (but not used if affected_users are provided ...?)
-            affected_users (list of Users): everyone who should receive the notification
-            verb (string): sender 'verb' [target] [action]. E.g MrC 'commented on' SomeAnnouncement
-            icon (html string): e.g.:
-                "<span class='fa-stack'>" + \
-                "<i class='fa fa-comment-o fa-flip-horizontal fa-stack-1x'></i>" + \
-                "<i class='fa fa-ban fa-stack-2x text-danger'></i>" + \
-                "</span>"
-        :return:
-        """
-
+    def test_new_notification__creates_unread_for_recipient(self):
+        """new_notification() creates a single unread notification for the recipient."""
         # make sure the student doesn't have any notifications yet
         notes_before = self.student.notifications.all()
         self.assertEqual(notes_before.count(), 0)
@@ -155,14 +138,8 @@ class NotificationModelTest(ByteDeckTenantTestCase):
             self.assertTrue(note.unread)
             self.assertIsNone(note.time_read)
 
-    def test_url_correct_comment_hash(self):
-        """ Checks if instances where an url is given. There is a corresponding comment hash with it
-        ie. url...#comment-id.
-
-        So far the only functions that use target_object.get_absolute_url are:
-        - __str__
-        - get_url()
-        """
+    def test_url_correct_comment_hash__appends_comment_anchor(self):
+        """get_url() and str() append a #comment-<id> anchor only when the notification has a comment action."""
         # create notification with comment as an action and corresponding verb
         comment = baker.make('comments.Comment')
         new_notification(
@@ -203,6 +180,7 @@ class NotificationModel_html_strip_Test(TestCase):
     """
 
     def setUp(self):
+        """No per-test setup is required for html_strip() tests."""
         pass
 
     def test_notification_html_strip__check_with_no_html(self):

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -21,6 +21,7 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, two students, the AI user, and course enrollments for notification tasks."""
         cls.sem = SiteConfig.get().active_semester
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
@@ -38,13 +39,14 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         baker.make('courses.CourseStudent', user=cls.test_student2, semester=cls.sem)
 
     def setUp(self):
+        """Set the deck's short name per-test (SiteConfig writes populate the cross-test cache)."""
         # SiteConfig writes populate the cross-test SiteConfig cache, so keep this per-test
         config = SiteConfig.get()
         config.site_name_short = "Deck"
         config.save()
 
-    def test_get_notification_emails(self):
-        """ Test that the correct list of notification emails are generated"""
+    def test_get_notification_emails__respects_prefs_and_enrollment(self):
+        """Only enrolled students with email notifications enabled and unread notifications get an email."""
         root_url = f'https://{self.get_test_tenant_domain()}'
 
         # 0 notifications to start
@@ -110,11 +112,13 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         self.assertEqual(len(emails), 1)
         self.assertEqual(emails[0].to, [self.test_student2.email])
 
-    def test_email_notifications_to_users_on_all_schemas(self):
+    def test_email_notification_to_users_on_all_schemas__runs_successfully(self):
+        """The all-schemas email task completes successfully when applied."""
         task_result = tasks.email_notification_to_users_on_all_schemas.apply()
         self.assertTrue(task_result.successful())
 
-    def test_email_notifications_to_users(self):
+    def test_email_notifications_to_users_on_schema__runs_successfully(self):
+        """The per-schema email task completes successfully when applied."""
         task_result = tasks.email_notifications_to_users_on_schema.apply(
             kwargs={
                 "root_url": "https://test.com",
@@ -171,7 +175,8 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         self.assertIn("Unread notifications:", html_content)
         self.assertIn(str(notification), html_content)  # Links to notifications
 
-    def test_does_not_generate_email_for_inactive_students(self):
+    def test_get_notification_emails__skips_inactive_students(self):
+        """A student not enrolled in any course gets no email even with notifications enabled."""
         root_url = 'https://test.com'
 
         # 0 notifications to start
@@ -197,6 +202,7 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
 class DeleteOldNotificationsTestCase(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create one notification older than 3 months and one within 3 months."""
         cls.old_notification = baker.make(
             Notification,
             timestamp=timezone.now() - timedelta(days=90)  # Older than 3 months
@@ -209,7 +215,7 @@ class DeleteOldNotificationsTestCase(ByteDeckTenantTestCase):
 
         cls.notification_count = Notification.objects.count()
 
-    def test_task_deletes_old_notifications(self):
+    def test_delete_old_notifications__removes_old_keeps_recent(self):
         """Ensure old notifications >90 days are deleted but recent ones remain."""
         delete_old_notifications()
 
@@ -219,7 +225,7 @@ class DeleteOldNotificationsTestCase(ByteDeckTenantTestCase):
         self.recent_notification.refresh_from_db()  # Should still exist
 
     @patch('notifications.tasks.delete_old_notifications.delay')
-    def test_task_is_called_properly(self, mock_task):
+    def test_delete_old_notifications__can_be_scheduled_via_celery(self, mock_task):
         """Ensure the task can be scheduled via Celery."""
         delete_old_notifications.delay()
         mock_task.assert_called_once()

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -21,15 +21,17 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and two students (a teacher must exist first or profile creation fails)."""
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
         cls.test_student2 = baker.make(User)
 
     def setUp(self):
+        """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_notification_page_status_codes_for_anonymous(self):
+    def test_notification_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to home page '''
 
         self.assertRedirectsLogin('notifications:list')
@@ -42,7 +44,8 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 302)
         self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 302)
 
-    def test_all_notification_page_status_codes_for_students(self):
+    def test_notification_page_status_codes__students(self):
+        """A logged-in student can view list pages but not the ajax-only endpoints."""
         # log in student1
         self.client.force_login(self.test_student1)
 
@@ -62,7 +65,8 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
         self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
 
-    def test_all_notification_page_status_codes_for_teachers(self):
+    def test_notification_page_status_codes__teachers(self):
+        """A logged-in teacher can view list pages but not the ajax-only endpoints."""
         # log in student1
         self.client.force_login(self.test_teacher)
 
@@ -88,9 +92,8 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
         self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 404)
 
-    def test_ajax_mark_read(self):
-        """ Marks a Notification as read via Ajax (by setting unread = FALSE)
-        """
+    def test_ajax_mark_read__marks_notification_read(self):
+        """Marks a Notification as read via Ajax (by setting unread = FALSE)."""
         # log in student1
         self.client.force_login(self.test_student1)
 
@@ -112,7 +115,8 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_ajax(self):
+    def test_ajax__returns_200_for_logged_in_student(self):
+        """A logged-in student's ajax POST to the notifications endpoint returns 200."""
         # log in student1
         self.client.force_login(self.test_student1)
 

--- a/src/portfolios/tests/test_views.py
+++ b/src/portfolios/tests/test_views.py
@@ -53,15 +53,17 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student with a portfolio, one artwork, and a commented document."""
         cls.test_student = baker.make(User)
         cls.portfolio = baker.make('portfolios.Portfolio', user=cls.test_student)
         cls.art = baker.make('portfolios.Artwork', image_file=generate_test_png_file(), portfolio=cls.portfolio)
         cls.doc = baker.make('comments.Document', docfile=generate_test_png_file(), comment=baker.make('comments.Comment', user=cls.test_student))
 
     def setUp(self):
+        """Create a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_portfolio_view_status_codes_for_anonymous(self):
+    def test_all_portfolio_view_status_codes__for_anonymous(self):
         ''' If not logged in then all views should redirect to login, EXCEPT the public list and public urls '''
 
         self.assert200('portfolios:public_list')
@@ -77,7 +79,7 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('portfolios:art_update', args=[self.art.pk])
 
     def test_all_portfolio_view_status_codes_for_students__own_portfolio(self):
-
+        """A student can access, edit, and add art to their own portfolio views."""
         self.client.force_login(self.test_student)
 
         self.assert200('portfolios:public_list')
@@ -98,7 +100,7 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
 
     def test_all_portfolio_view_status_codes_for_students__others_portfolio(self):
-
+        """A student cannot access another student's unshared portfolio or art views."""
         # create a new user and try to access the test student's portfolio and art
         self.client.force_login(baker.make(User))
 
@@ -116,8 +118,8 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert404('portfolios:art_update', args=[self.art.pk])
         self.assert404('portfolios:art_add', args=[self.doc.pk])
 
-    def test_all_portfolio_view_status_codes_for_staff(self):
-
+    def test_all_portfolio_view_status_codes__for_staff(self):
+        """Staff can access, edit, and add art to any student's portfolio views."""
         self.client.force_login(baker.make(User, is_staff=True))
 
         self.assert200('portfolios:public_list')
@@ -179,9 +181,6 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             reverse('portfolios:edit', args=[self.portfolio.pk]),
             data=form_data
         )
-        # form = response.context['form']
-        # if not form.is_valid():
-        #     print(form.errors)  # Print the validation errors
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse('portfolios:detail', args=[self.portfolio.pk]))
 

--- a/src/prerequisites/tests/test_fields.py
+++ b/src/prerequisites/tests/test_fields.py
@@ -5,8 +5,8 @@ from prerequisites.models import IsAPrereqMixin
 
 class PrereqGFKChoiceFieldTest(ByteDeckTenantTestCase):
 
-    def test_hardcoded_prereq_model_choice(self):
-        """If this test fails, then probably means a new model implements `IsAPrereqMixin`, or a model was removed."""
+    def test_queryset__matches_registered_prereq_models(self):
+        """The field's queryset covers exactly the models registered via IsAPrereqMixin."""
         from prerequisites.forms import PrereqGFKChoiceField
 
         expected_list = IsAPrereqMixin.all_registered_model_classes()

--- a/src/prerequisites/tests/test_forms.py
+++ b/src/prerequisites/tests/test_forms.py
@@ -18,14 +18,15 @@ class PrereqFormInlineMediaTest(ByteDeckTenantTestCase):
     CSS = 'prerequisites/css/advanced_prereqs_form.css'
 
     def setUp(self):
+        """Create a tenant client and a teacher user for the tests."""
         self.client = TenantClient(self.tenant)
         self.teacher = baker.make(User, is_staff=True)
 
-    def test_form_media_includes_prereq_css(self):
+    def test_media__includes_prereq_css(self):
         """PrereqFormInline declares the layout-fix stylesheet in its Media."""
         self.assertIn(self.CSS, str(PrereqFormInline().media))
 
-    def test_prereq_form_page_loads_the_css(self):
+    def test_advanced_prereqs_form_page__loads_the_css(self):
         """The stylesheet is actually emitted on the advanced prereqs form page — for both the
         quest and badge prereq forms, which share advanced_prereqs_form.html.
         """

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -1,5 +1,3 @@
-# from mock import patch
-
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -19,6 +17,7 @@ User = get_user_model()
 class HasPrereqsMixinTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a parent quest with an OR prereq and a plain prereq."""
         cls.quest_parent = baker.make('quest_manager.Quest', name="parent")
         cls.quest_prereq = baker.make('quest_manager.Quest', name="prereq")
         cls.quest_or_prereq = baker.make('quest_manager.Quest', name="or_prereq")
@@ -36,12 +35,12 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
             prereq_object=cls.quest_prereq2,
         )
 
-    def test_prereqs(self):
+    def test_prereqs__returns_all_prereqs(self):
         """Returns the 2 prereqs created in setup"""
         prereqs = self.quest_parent.prereqs()
         self.assertEqual(len(prereqs), 2)
 
-    def test_add_simple_prereqs(self):
+    def test_add_simple_prereqs__adds_multiple(self):
         """Adds 3 new prereqs using this method"""
         prereq_objects = [
             baker.make('quest_manager.Quest'),
@@ -51,22 +50,23 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
         self.quest_parent.add_simple_prereqs(prereq_objects)
         self.assertEqual(self.quest_parent.prereqs().count(), 5)
 
-    def test_add_simple_prereqs_type_error(self):
+    def test_add_simple_prereqs__type_error(self):
         """Objects that do not implement the `IsAPrereqMixin` should throw a type error"""
         with self.assertRaises(TypeError):
             self.quest_parent.add_simple_prereqs([object()])
 
-    def test_clear_all_prereqs(self):
+    def test_clear_all_prereqs__removes_all(self):
+        """clear_all_prereqs removes every prereq of the parent."""
         self.quest_parent.clear_all_prereqs()
         self.assertEqual(self.quest_parent.prereqs().count(), 0)
 
-    def test_has_or_prereq(self):
+    def test_has_or_prereq__true_for_main_and_or_requirement(self):
         """ When there is an OR prereq, both should return True"""
         self.assertTrue(self.quest_parent.has_or_prereq(self.quest_or_prereq))
         self.assertTrue(self.quest_parent.has_or_prereq(self.quest_prereq))
         self.assertFalse(self.quest_parent.has_or_prereq(self.quest_prereq2))
 
-    def test_has_or_prereq_exclude_NOT(self):
+    def test_has_or_prereq__exclude_NOT(self):
         """ When there is an OR prereq, both should return True, unless it's a NOT"""
         self.prereq_with_or.prereq_invert = True
         self.prereq_with_or.save()
@@ -79,11 +79,12 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
         self.assertTrue(self.quest_parent.has_or_prereq(self.quest_prereq, exclude_NOT=False))
         self.assertFalse(self.quest_parent.has_or_prereq(self.quest_prereq2, exclude_NOT=False))
 
-    def test_has_or_prereq_type_error(self):
+    def test_has_or_prereq__type_error(self):
+        """A non-prereq object passed to has_or_prereq raises a TypeError."""
         with self.assertRaises(TypeError):
             self.quest_parent.has_or_prereq(object())
 
-    def test_has_or_prereq_no_object(self):
+    def test_has_or_prereq__no_object(self):
         """If no object is provided, should check if there are any OR prereqs at all"""
         self.assertTrue(self.quest_parent.has_or_prereq())
 
@@ -93,13 +94,15 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
         )
         self.assertFalse(self.quest_prereq2.has_or_prereq())
 
-    def test_has_or_prereq_no_object_exclude_NOT(self):
+    def test_has_or_prereq__no_object_exclude_NOT(self):
+        """With no object, an inverted OR prereq is only counted when exclude_NOT is False."""
         self.prereq_with_or.prereq_invert = True
         self.prereq_with_or.save()
         self.assertFalse(self.quest_parent.has_or_prereq())
         self.assertTrue(self.quest_parent.has_or_prereq(exclude_NOT=False))
 
-    def test_has_inverted_prereq(self):
+    def test_has_inverted_prereq__reflects_prereq_invert(self):
+        """has_inverted_prereq is True once one of the parent's prereqs is inverted."""
         self.assertFalse(self.quest_parent.has_inverted_prereq())
 
         self.prereq_with_or.prereq_invert = True
@@ -110,6 +113,7 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
 class IsAPrereqMixinTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a parent quest with an OR prereq and a plain prereq."""
         cls.quest_parent = baker.make('quest_manager.Quest', name="parent")
         cls.quest_prereq = baker.make('quest_manager.Quest', name="prereq")
         cls.quest_or_prereq = baker.make('quest_manager.Quest', name="or_prereq")
@@ -127,16 +131,19 @@ class IsAPrereqMixinTest(ByteDeckTenantTestCase):
             prereq_object=cls.quest_prereq2,
         )
 
-    def test_is_used_prereq(self):
+    def test_is_used_prereq__true_when_used(self):
+        """is_used_prereq is True for an object used as a prereq, False otherwise."""
         self.assertTrue(self.quest_prereq.is_used_prereq())
         self.assertFalse(baker.make('quest_manager.Quest').is_used_prereq())
 
-    def test_get_reliant_qs(self):
+    def test_get_reliant_qs__matches_manager(self):
+        """get_reliant_qs returns the same prereqs as the manager's all_reliant_on."""
         reliant = self.quest_prereq.get_reliant_qs()
 
         self.assertListEqual(list(reliant), list(Prereq.objects.all_reliant_on(self.quest_prereq)))
 
-    def test_get_reliant_objects(self):
+    def test_get_reliant_objects__returns_parents(self):
+        """get_reliant_objects returns every parent that relies on the object."""
         reliant_objects = self.quest_prereq.get_reliant_objects()
         self.assertListEqual(list(reliant_objects), [self.quest_parent])
         # try adding another, this time as an OR
@@ -150,6 +157,7 @@ class IsAPrereqMixinTest(ByteDeckTenantTestCase):
         self.assertListEqual(list(reliant_objects), [self.quest_parent, self.quest_prereq2])
 
     def test_get_reliant_objects__exclude_NOT(self):
+        """With exclude_NOT, an inverted main requirement drops its parent from the reliant list."""
         reliant_objects = self.quest_prereq.get_reliant_objects(exclude_NOT=True)
         self.assertListEqual(list(reliant_objects), [self.quest_parent])
 
@@ -242,7 +250,7 @@ class IsAPrereqMixinTest(ByteDeckTenantTestCase):
         for model in prereq_models:
             assert all(isinstance(x, str) for x in model.gfk_search_fields())
 
-    def test_static_content_type_is_registered(self):
+    def test_content_type_is_registered__reflects_registration(self):
         """A content_type representing a model that implements the IsAPrereqMixin returns True
         """
         ct = ContentType.objects.get(app_label='quest_manager', model='quest')
@@ -251,14 +259,14 @@ class IsAPrereqMixinTest(ByteDeckTenantTestCase):
         ct = ContentType.objects.get(app_label='auth', model='user')
         self.assertFalse(IsAPrereqMixin.content_type_is_registered(ct))
 
-    def test_static_all_registered_content_types(self):
+    def test_all_registered_content_types__returns_expected_count(self):
         """There are 6 models that implement the IsAPrereqMixin
         """
         cts = IsAPrereqMixin.all_registered_content_types()
         self.assertEqual(cts.count(), 8)
 
     @isolate_apps('prerequisites')
-    def test_static_model_is_registered(self):
+    def test_model_is_registered__reflects_mixin(self):
         """Any model class that implements IsAPrereqMixin returns True"""
         # isolate_apps keeps these throwaway models out of the global app registry.
         # Otherwise they leak process-wide: their content types get created on the
@@ -279,6 +287,7 @@ class IsAPrereqMixinTest(ByteDeckTenantTestCase):
 class PrereqModelTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a student and an unsaved Prereq linking two quests."""
         cls.student = baker.make(User, username='student', is_staff=False)
         cls.quest_parent = baker.make('quest_manager.Quest')
         cls.quest_prereq = baker.make('quest_manager.Quest')
@@ -287,19 +296,20 @@ class PrereqModelTest(ByteDeckTenantTestCase):
             prereq_object=cls.quest_prereq
         )
 
-    def test_object_creation(self):
+    def test_object_creation__is_prereq_instance(self):
+        """A built Prereq is an instance of both Prereq and IsAPrereqMixin."""
         self.assertIsInstance(self.prereq, Prereq)
         self.assertIsInstance(self.prereq, IsAPrereqMixin)
 
-    def test_parent(self):
+    def test_parent__returns_parent_object(self):
         "returns the parent of the prereq"
         self.assertEqual(self.prereq.parent(), self.quest_parent)
 
-    def test_get_prereq(self):
+    def test_get_prereq__returns_main_requirement(self):
         "returns the main prereq requirement"
         self.assertEqual(self.prereq.get_prereq(), self.quest_prereq)
 
-    def test_get_or_prereq(self):
+    def test_get_or_prereq__returns_none_when_unset(self):
         "returns the alternate prereq requirement"
         self.assertEqual(self.prereq.get_or_prereq(), None)
 
@@ -309,12 +319,13 @@ class PrereqModelTest(ByteDeckTenantTestCase):
     #     print("Call count: ", condition_met_as_prerequisite.call_count)
     #     self.assertTrue(self.prereq.condition_met(self.student))
 
-    def test_cls_add_simple_prereq(self):
+    def test_add_simple_prereq__creates_reliance(self):
+        """add_simple_prereq makes the parent reliant on the given prereq object."""
         quest3 = baker.make('quest_manager.Quest')
         Prereq.add_simple_prereq(self.quest_parent, quest3)
         self.assertIn(self.quest_parent, quest3.get_reliant_objects())
 
-    def test_cls_add_simple_prereq_bad_parent(self):
+    def test_add_simple_prereq__bad_parent(self):
         """A parent_object that does not implement the HasPrereqsMixin should raise an exception
         """
         with self.assertRaises(TypeError):
@@ -322,7 +333,7 @@ class PrereqModelTest(ByteDeckTenantTestCase):
             some_object = object()
             Prereq.add_simple_prereq(some_object, quest3)
 
-    def test_cls_add_simple_prereq_bad_prereq(self):
+    def test_add_simple_prereq__bad_prereq(self):
         """A prereq_object that does not implement the IsAPrereqMixin should raise an exception
         """
         with self.assertRaises(TypeError):
@@ -335,6 +346,7 @@ class PrereqAllConditionsMetModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student and a PrereqAllConditionsMet cache for them."""
         cls.student = baker.make(User, username='student', is_staff=False)
         cls.prereq_cache = baker.make(
             PrereqAllConditionsMet,
@@ -342,7 +354,8 @@ class PrereqAllConditionsMetModelTest(ByteDeckTenantTestCase):
             model_name='fake_model_name'
         )
 
-    def test_object_creation(self):
+    def test_object_creation__defaults(self):
+        """A new cache object stores its user and defaults ids to an empty list."""
         self.assertIsInstance(self.prereq_cache, PrereqAllConditionsMet)
         self.assertEqual(self.prereq_cache.user, self.student)
         self.assertEqual(self.prereq_cache.ids, '[]')
@@ -358,15 +371,18 @@ class PrereqAllConditionsMetModelTest(ByteDeckTenantTestCase):
                 model_name='fake_model_name'
             )
 
-    def test_get_ids_when_empty(self):
+    def test_get_ids__empty(self):
+        """get_ids returns an empty list when no ids are stored."""
         self.assertEqual([], self.prereq_cache.get_ids())
 
-    def test_get_ids(self):
+    def test_get_ids__returns_stored_ids(self):
+        """get_ids parses the stored string back into a list of ids."""
         ids = [1, 2, 3, 4, 5]
         self.prereq_cache.ids = str(ids)
         self.assertEqual(ids, self.prereq_cache.get_ids())
 
-    def test_add_id(self):
+    def test_add_id__appends(self):
+        """add_id appends new ids to the cache in order."""
         self.assertEqual(len(self.prereq_cache.get_ids()), 0)
 
         self.prereq_cache.add_id(100)
@@ -377,14 +393,16 @@ class PrereqAllConditionsMetModelTest(ByteDeckTenantTestCase):
         self.assertEqual(len(self.prereq_cache.get_ids()), 2)
         self.assertEqual(self.prereq_cache.get_ids(), [100, 101])
 
-    def test_remove_id(self):
+    def test_remove_id__removes(self):
+        """remove_id deletes an existing id from the cache."""
         self.prereq_cache.ids = str([1, 2, 3, 4, 5])
         self.assertIn(1, self.prereq_cache.get_ids())
 
         self.prereq_cache.remove_id(1)
         self.assertNotIn(1, self.prereq_cache.get_ids())
 
-    def test_remove_id_that_doesnt_exist(self):
+    def test_remove_id__nonexistent_is_noop(self):
+        """Removing an id that isn't stored leaves the cache unchanged."""
         ids = [1, 2, 3, 4, 5]
         self.prereq_cache.ids = str(ids)
         self.assertNotIn(6, self.prereq_cache.get_ids())
@@ -399,7 +417,7 @@ class AddSimplePrereqAllRegisteredModelsTest(ByteDeckTenantTestCase):
     the models that implement IsAPrereqMixin, which are the only models that
     are supposed to be used in a Prereq's generic foreign keys."""
 
-    def test_add_simple_prereq_for_every_registered_model(self):
+    def test_add_simple_prereq__for_every_registered_model(self):
         """Loops through all registered prereq models, using each as the
         requirement of a new Prereq, and checks the stored generic ids."""
         parent = baker.make('quest_manager.Quest')
@@ -428,20 +446,21 @@ class PrereqPrefetchTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create two parent quests sharing one prereq requirement."""
         cls.parent1 = baker.make('quest_manager.Quest')
         cls.parent2 = baker.make('quest_manager.Quest')
         cls.requirement = baker.make('quest_manager.Quest')
         Prereq.add_simple_prereq(cls.parent1, cls.requirement)
         Prereq.add_simple_prereq(cls.parent2, cls.requirement)
 
-    def test_prereqs_without_prefetch_returns_queryset(self):
+    def test_prereqs__without_prefetch_returns_queryset(self):
         """Objects that were not prefetched keep the normal queryset API."""
         from quest_manager.models import Quest
         quest = Quest.objects.get(pk=self.parent1.pk)
         self.assertEqual(quest.prereqs().count(), 1)
         self.assertTrue(quest.prereqs().exists())
 
-    def test_prefetch_for_parents_serves_prereqs_without_per_object_queries(self):
+    def test_prefetch_for_parents__serves_prereqs_without_per_object_queries(self):
         """After prefetch_for_parents, each object's prereqs() is served from
         its cache with no further per-object query."""
         from quest_manager.models import Quest
@@ -455,12 +474,12 @@ class PrereqPrefetchTest(ByteDeckTenantTestCase):
                 self.assertEqual(len(list(prereqs)), 1)
                 self.assertEqual(prereqs[0].parent_object_id, quest.pk)
 
-    def test_prefetch_for_parents_empty_input(self):
+    def test_prefetch_for_parents__empty_input(self):
         """Empty input is a no-op returning an empty list (no query)."""
         with self.assertNumQueries(0):
             self.assertEqual(Prereq.objects.prefetch_for_parents([]), [])
 
-    def test_prefetch_for_parents_rejects_mixed_models(self):
+    def test_prefetch_for_parents__rejects_mixed_models(self):
         """Mixed-model input is rejected: all parents must share one content
         type, or the query would silently drop some objects' prereqs."""
         badge = baker.make('badges.Badge')

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -22,6 +22,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create teacher/student users and baseline badge, quest, and course records."""
         # the signal-count mocks below are per-test-method, so signals fired by
         # this class-level fixture creation are never included in their counts
         cls.teacher = baker.make(User, username='teacher', is_staff=True)
@@ -41,10 +42,11 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
                                         active=False)
 
     def setUp(self):
+        """Create a tenant client for each test."""
         self.client = TenantClient(self.tenant)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
-    def test_update_conditions_met_for_user_triggered_by_badge_assertion_on_create(self, task):
+    def test_update_conditions_met_for_user__triggered_by_badge_assertion_on_create(self, task):
         """
         Creation of a new badge assertion (granting a badge to a student) should trigger a signal
         """
@@ -52,7 +54,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 1)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
-    def test_update_conditions_met_for_user_triggered_by_badge_assertion_on_update(self, task):
+    def test_update_conditions_met_for_user__triggered_by_badge_assertion_on_update(self, task):
         """
         Updating a new badge assertion (granting a badge to a student) should trigger a signal
         """
@@ -61,7 +63,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 1)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
-    def test_update_conditions_met_for_user_triggered_by_quest_summission_on_create(self, task):
+    def test_update_conditions_met_for_user__triggered_by_quest_summission_on_create(self, task):
         """
         Creation of a new quest_submission (when starting a quest) should NOT trigger a signal
         """
@@ -69,7 +71,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 0)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
-    def test_update_conditions_met_for_user_triggered_by_quest_summission_on_update(self, task):
+    def test_update_conditions_met_for_user__triggered_by_quest_summission_on_update(self, task):
         """
         Updating a quest_submission (when completing a quest) should trigger a signal
         """
@@ -79,14 +81,16 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 1)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
-    def test_update_conditions_met_for_user_triggered_by_course_student_on_create(self, task):
+    def test_update_conditions_met_for_user__triggered_by_course_student_on_create(self, task):
+        """Creating a course-student enrollment triggers the conditions task and cache invalidation."""
         with patch('profile_manager.models.Profile.xp_invalidate_cache') as callback:
             baker.make(CourseStudent, user=self.student, active=False)
             self.assertEqual(task.call_count, 1)
             self.assertEqual(callback.call_count, 1)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
-    def test_update_conditions_met_for_user_triggered_by_course_student_on_update(self, task):
+    def test_update_conditions_met_for_user__triggered_by_course_student_on_update(self, task):
+        """Updating a course-student enrollment triggers the conditions task and cache invalidation."""
         with patch('profile_manager.models.Profile.xp_invalidate_cache') as callback:
             self.course_student.active = True
             self.course_student.save()
@@ -94,7 +98,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
             self.assertEqual(callback.call_count, 1)
 
     @patch('prerequisites.signals.update_quest_conditions_all_users.apply_async')
-    def test_update_prereq_cache_triggered_by_badge(self, task):
+    def test_update_prereq_cache__triggered_by_badge(self, task):
         """
         Creation and Update of a prereq where the parent is not a quest should not trigger a cache update
         """
@@ -104,7 +108,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 2)
 
     @patch('prerequisites.signals.update_quest_conditions_all_users.apply_async')
-    def test_update_cache_triggered_by_quest_without_prereqs(self, task):
+    def test_update_cache__triggered_by_quest_without_prereqs(self, task):
         """
         Creation and Update of a Quest without a prerequisite should trigger a cache update
         """
@@ -114,7 +118,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 2)
 
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
-    def test_update_prereq_cache_triggered_by_quest(self, task):
+    def test_update_prereq_cache__triggered_by_quest(self, task):
         """Creation and Update of a quest should not trigger a cache update, only when a prereq is added to the quest (covered elsewhere).
         """
         quest = baker.make(Quest, verification_required=True)  # creation
@@ -123,7 +127,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 0)
 
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
-    def test_update_prereq_cache_triggered_by_quest_available_outside_course(self, task):
+    def test_update_prereq_cache__triggered_by_quest_available_outside_course(self, task):
         """Creation and Update of a quest should trigger a cache update, only when it is available outside the course.
         """
         quest = baker.make(Quest, verification_required=True)  # creation
@@ -132,7 +136,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 1)
 
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
-    def test_update_cache_triggered_by_non_quest_prereq(self, task):
+    def test_update_cache__triggered_by_non_quest_prereq(self, task):
         """
         Creation and Update of a prereq where the parent is not a quest should not trigger a cache update
         """
@@ -143,7 +147,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 0)
 
     @patch('prerequisites.tasks.grant_badge_assertions_for_badge.apply_async')
-    def test_badge_prereq_changes_do_not_auto_grant(self, task):
+    def test_badge_prereq_changes__do_not_auto_grant(self, task):
         """Creating, updating or deleting a prereq whose parent is a badge must NOT trigger
         the badge-granting task: a teacher may tweak a badge's prereqs while building it,
         so granting is teacher-initiated from the badge page instead (issue #1157).
@@ -158,7 +162,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 0)
 
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
-    def test_update_cache_triggered_by_quest_prereq_changes(self, task):
+    def test_update_cache__triggered_by_quest_prereq_changes(self, task):
         """Creation and Update of a prereq where the parent IS a quest should both trigger a cache update
         """
         quest = baker.make('quest_manager.quest')
@@ -169,7 +173,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         task.assert_called_with(kwargs={'quest_id': quest.id, 'start_from_user_id': 1}, queue='default')
 
     @patch('prerequisites.signals.update_conditions_for_quest.apply_async')
-    def test_update_cache_triggered_by_parent_object_deletion(self, task):
+    def test_update_cache__triggered_by_parent_object_deletion(self, task):
         """When a quest is deleted it will cascade to delete any prereqs for which it is a parent.
         That shouldn't break this signal.
         """
@@ -180,7 +184,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_count, 1)
 
     @patch('djcytoscape.tasks.regenerate_map.apply_async')
-    def test_prereq_regenerate_related_maps(self, task):
+    def test_regenerate_related_maps__on_save_and_delete(self, task):
         """ Tests if saving and deleting quest triggers `regenerate_map` task.
         Cant check if `regenerate_map` made new CytoElements. So checking if task args are accurate
         """

--- a/src/profile_manager/tests/test_forms.py
+++ b/src/profile_manager/tests/test_forms.py
@@ -17,9 +17,11 @@ class ProfileFormTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student user whose profile is used across the form tests."""
         cls.user = User.objects.create_user('test_student')
 
-    def test_init(self):
+    def test_init__with_and_without_request(self):
+        """ProfileForm can be instantiated both with and without a request kwarg."""
         # Without request
         ProfileForm(instance=self.user.profile)
 
@@ -27,7 +29,7 @@ class ProfileFormTest(ByteDeckTenantTestCase):
 
         ProfileForm(instance=self.user.profile, request=request)
 
-    def test_profile_save_without_request(self):
+    def test_save__without_request(self):
         """
         Test to increase coverage for ProfileForm
         """
@@ -37,6 +39,7 @@ class ProfileFormTest(ByteDeckTenantTestCase):
         form.save()
 
     def tearDown(self) -> None:
+        """Remove the test user after each test."""
         self.user.delete()
 
     def test_clean_email__valid(self):
@@ -97,7 +100,7 @@ class ProfileFormTest(ByteDeckTenantTestCase):
                     self.assertTrue(form.is_valid())
                     self.assertEqual(form.cleaned_data['email'], 'example@gmail.com')
 
-    def test_profile_with_custom_profile_field(self):
+    def test_save__with_custom_profile_field(self):
         """ tests if user can create a profile with `custom_profile_field` when SiteConfig.custom_profile_field
         is filled/not filled
         """

--- a/src/profile_manager/tests/test_managers.py
+++ b/src/profile_manager/tests/test_managers.py
@@ -15,6 +15,7 @@ class ProfileManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create staff plus active/inactive students in and out of the active semester."""
         cls.course = baker.make(Course)
         cls.active_semester = SiteConfig.get().active_semester
 
@@ -49,21 +50,24 @@ class ProfileManagerTest(ByteDeckTenantTestCase):
                 semester=cls.active_semester
             )
 
-    def test_all_for_active_semester_qs(self):
+    def test_all_for_active_semester__returns_active_students(self):
+        """all_for_active_semester() returns only active students registered in the active semester."""
         qs = Profile.objects.all_for_active_semester().values_list('user__username', flat=True)
         expected_qs = self.active_active_semester_students
         expected_qs = [user.username for user in expected_qs]
 
         self.assertEqual(set(qs), set(expected_qs))
 
-    def test_get_active_qs(self):
+    def test_all_active__returns_active_users(self):
+        """all_active() returns every active user, including staff, regardless of semester."""
         qs = Profile.objects.all_active().values_list('user__username', flat=True)
         expected_qs = self.active_inactive_semester_students + self.active_active_semester_students + self.staff_set
         expected_qs = [user.username for user in expected_qs]
 
         self.assertEqual(set(qs), set(expected_qs))
 
-    def test_get_inactive_qs(self):
+    def test_all_inactive__returns_inactive_users(self):
+        """all_inactive() returns only the deactivated users."""
         qs = Profile.objects.all_inactive().values_list('user__username', flat=True)
         expected_qs = self.inactive_inactive_semester_students + self.inactive_active_semester_students
         expected_qs = [user.username for user in expected_qs]

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -24,6 +24,7 @@ class ProfileTestModel(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student user/profile, and active/inactive semesters."""
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.user = baker.make(User)
         # Profiles are created automatically with each user, so we only need to access profiles via users
@@ -38,17 +39,18 @@ class ProfileTestModel(ByteDeckTenantTestCase):
     def create_active_course_registration(self):
         return baker.make('courses.CourseStudent', user=self.user, semester=self.active_sem, course=baker.make('courses.Course'))
 
-    def test_profile_creation(self):
+    def test_profile_creation__on_user_create(self):
         """Profile is automatically created when a user is created in setUp()"""
         self.assertIsInstance(self.user.profile, Profile)
         self.assertEqual(str(self.user.profile), self.user.username)
 
-    def test_profile_deletion(self):
+    def test_profile_deletion__cascades_to_user(self):
         """When a profile is deleted, via queryset (admin) or directly, the user should be deleted too. """
         Profile.objects.filter(pk=self.profile.pk).delete()
         self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
 
-    def test_profile_alias_clipped(self):
+    def test_alias_clipped__truncates_long_alias(self):
+        """alias_clipped() returns a placeholder when empty and truncates aliases past the max length."""
         max_len = 16
         self.assertEqual(self.profile.alias_clipped(), "-")
 
@@ -58,13 +60,16 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         self.profile.alias = "Super duper duper long alias that's super duper long"
         self.assertEqual(len(self.profile.alias_clipped()), max_len)
 
-    def test_profile_num_hidden_quests(self):
+    def test_num_hidden_quests__zero_by_default(self):
+        """A new profile has no hidden quests."""
         self.assertEqual(self.profile.num_hidden_quests(), 0)
 
-    def test_profile_get_hidden_quests_as_list(self):
+    def test_get_hidden_quests_as_list__empty_by_default(self):
+        """A new profile's hidden quest list is empty."""
         self.assertEqual(self.profile.get_hidden_quests_as_list(), [])
 
-    def test_profile_hidden_quests(self):
+    def test_hidden_quests__hide_unhide_and_count(self):
+        """Hiding, unhiding, and querying hidden quests behave consistently."""
         self.create_active_course_registration()
         num_to_hide = 3
         quests_to_hide = baker.make('quest_manager.quest', _quantity=num_to_hide)
@@ -87,7 +92,7 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         self.profile.unhide_quest(quest_hidden.id)
         self.assertFalse(self.profile.is_quest_hidden(quest_hidden))
 
-    def test_num_hidden_quests_doesnt_include_unavailable(self):
+    def test_num_hidden_quests__excludes_unavailable(self):
         """If a hidden quest has been made unavailable for some reason (published=False, etc) then it shouldn't count"""
         self.create_active_course_registration()
         quest = baker.make('quest_manager.quest', name='Hide Me')
@@ -101,7 +106,8 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         quest.save()
         self.assertEqual(self.profile.num_hidden_quests(), 0)
 
-    def test_profile_current_courses(self):
+    def test_current_courses__returns_active_registrations(self):
+        """current_courses() returns each active-semester course registration for the profile."""
         # no current courses to start
         self.assertFalse(self.profile.current_courses().exists())
         # add one and test
@@ -114,25 +120,29 @@ class ProfileTestModel(ByteDeckTenantTestCase):
             [course_registration, course_registration2]
         )
 
-    def test_profile_has_current_course(self):
+    def test_has_current_course__true_when_registered(self):
+        """has_current_course is False until the student registers in the active semester."""
         self.assertFalse(self.profile.has_current_course)
         self.create_active_course_registration()
         profile = Profile.objects.get(pk=self.profile.id)  # Refresh profile to avoid cached_property
         self.assertTrue(profile.has_current_course)
 
-    def test_profile_has_past_courses(self):
+    def test_has_past_courses__true_when_registered_in_inactive_semester(self):
+        """has_past_courses becomes True once the student has a registration in an inactive semester."""
         self.assertFalse(self.profile.has_past_courses)
         baker.make('courses.CourseStudent', user=self.user, semester=self.inactive_sem)
         profile = Profile.objects.get(pk=self.profile.id)  # Refresh profile to avoid cached_property
         self.assertTrue(profile.has_past_courses)
 
-    def test_profile_blocks(self):
+    def test_blocks__none_until_registered(self):
+        """blocks() is None until the student registers in a course."""
         self.assertIsNone(self.profile.blocks())
         self.create_active_course_registration()
         self.assertIsNotNone(self.profile.blocks())
         # TODO fully test this with multiple blocks
 
-    def test_profile_teachers(self):
+    def test_teachers__empty_until_registered(self):
+        """teachers() is empty until the student has a course registration."""
         self.assertEqual(list(self.profile.teachers()), [])
         course_registration = self.create_active_course_registration()
         # Still no teachers since no teacher assign to this course's block yet
@@ -145,7 +155,8 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         # TODO should have teachers now... why not working? Should not be None...
         # self.assertEqual(list(self.profile.teachers()), [None])
 
-    def test_profile_current_teachers(self):
+    def test_current_teachers__empty_until_teacher_assigned(self):
+        """current_teachers() stays empty until a teacher is assigned to the student's block."""
         self.assertFalse(self.profile.current_teachers().exists())
 
         course_registration = self.create_active_course_registration()
@@ -158,7 +169,7 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         # print(course_registration)
         # print(self.profile.current_teachers()) # why is this empty?!?!
 
-    def test_rank(self):
+    def test_rank__default_for_new_user(self):
         """ By default a new user has a rank"""
         default_starting_rank = "Digital Noob"
         self.assertEqual(self.profile.rank().name, default_starting_rank)
@@ -171,6 +182,7 @@ class ProfileTestModel(ByteDeckTenantTestCase):
 
     @patch('profile_manager.models.Profile.current_courses')
     def test_mark__single_course(self, mock_current_courses):
+        """mark() returns the single course's calculated mark."""
         mock_coursestudent = Mock()
         mock_coursestudent.calc_mark.return_value = 125
         mock_current_courses.return_value = [mock_coursestudent]
@@ -178,6 +190,7 @@ class ProfileTestModel(ByteDeckTenantTestCase):
 
     @patch('profile_manager.models.Profile.current_courses')
     def test_mark__multiple_courses(self, mock_current_courses):
+        """mark() divides the first course's mark by the number of courses."""
         mock_coursestudent1 = Mock()
         mock_coursestudent1.calc_mark.return_value = 87
         # The mark() method currently only checks the length of the list, and only uses the first course
@@ -213,28 +226,35 @@ class ProfileTestModel(ByteDeckTenantTestCase):
 
 class SmartListTests(SimpleTestCase):
 
-    def test_smart_list_empty(self):
+    def test_smart_list__empty_inputs(self):
+        """smart_list() returns an empty list for empty/None-like inputs."""
         self.assertEqual(smart_list(''), [])
         self.assertEqual(smart_list([]), [])
         self.assertEqual(smart_list('[]'), [])
         self.assertEqual(smart_list(None), [])
 
-    def test_smart_list_csv(self):
+    def test_smart_list__csv_string(self):
+        """smart_list() splits a comma-separated string into a list of strings."""
         self.assertEqual(smart_list('1,2,3'), ['1', '2', '3'])
 
-    def test_smart_list_csv_delimeter(self):
+    def test_smart_list__custom_delimiter(self):
+        """smart_list() splits on a custom delimiter when provided."""
         self.assertEqual(smart_list('1;2;3', delimiter=';'), ['1', '2', '3'])
 
-    def test_smart_list_csv_to_int(self):
+    def test_smart_list__with_func(self):
+        """smart_list() applies the given func to each element."""
         self.assertEqual(smart_list('1,2,3', func=lambda x: int(x)), [1, 2, 3])
 
-    def test_smart_list_tuple(self):
+    def test_smart_list__tuple_input(self):
+        """smart_list() converts a tuple into a list."""
         self.assertEqual(smart_list((1, 2, 3)), [1, 2, 3])
 
-    def test_smart_list_list(self):
+    def test_smart_list__list_input(self):
+        """smart_list() returns a list unchanged."""
         self.assertEqual(smart_list([1, 2, 3]), [1, 2, 3])
 
-    def test_smart_list_int(self):
+    def test_smart_list__single_int(self):
+        """smart_list() wraps a single int in a list."""
         self.assertEqual(smart_list(1), [1])
 
 
@@ -242,6 +262,7 @@ class UserDeletionTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student and related objects (badge, comment, notification, etc.) to test cascade deletion."""
         # Create a student user to be deleted
         cls.student = baker.make(User)
 
@@ -259,7 +280,8 @@ class UserDeletionTest(ByteDeckTenantTestCase):
         cls.portfolio = baker.make('Portfolio', user=cls.student)
         cls.quest_submission = baker.make('QuestSubmission', user=cls.student)
 
-    def test_delete_student_and_cascade(self):
+    def test_delete_student__cascades_to_related_objects(self):
+        """Deleting a student also deletes their badge, comment, registration, notification, portfolio, and submission."""
         # Ensure that the related objects exist before deletion
         self.assertTrue(self.badge_assertion.pk)
         self.assertTrue(self.comment.pk)

--- a/src/profile_manager/tests/test_tasks.py
+++ b/src/profile_manager/tests/test_tasks.py
@@ -21,7 +21,8 @@ class ProfleTasksTests(ByteDeckTenantTestCase):
     """
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    def test_recalculate_current_xp_profile_on_all_schemas(self):
+    def test_invalidate_profile_xp_cache_in_all_schemas__resets_cached_values(self):
+        """Running the task resets each active-semester profile's cached xp and mark to 0."""
         self.course = baker.make(Course)
         self.active_semester = SiteConfig().get().active_semester
 

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -26,6 +26,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, two students (one with a known password), and the active semester."""
         User = get_user_model()
 
         # test_student1 needs a known password so tests can POST the real login form (e.g. test_profile_update_email);
@@ -42,12 +43,14 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.active_sem = SiteConfig.get().active_semester
 
     def setUp(self):
+        """Create a tenant-aware test client for each test."""
         self.client = TenantClient(self.tenant)
 
     def tearDown(self):
+        """Clear the cache after each test."""
         cache.clear()
 
-    def test_all_profile_page_status_codes_for_anonymous(self):
+    def test_profile_pages__redirect_anonymous_to_login(self):
         """ If not logged in then all views should redirect to home page  """
 
         self.assertRedirectsLogin('profiles:profile_list')
@@ -57,8 +60,8 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('profiles:profile_list_block', args='1')
         self.assertRedirectsLogin('profiles:profile_delete', args=[1])
 
-    def test_all_profile_page_status_codes_for_students(self):
-
+    def test_profile_pages__student_access(self):
+        """Students can view their own profile pages but are blocked from staff/list/delete views."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -88,7 +91,8 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assert404('profiles:profile_update', args=[s2_pk])
 
-    def test_all_profile_page_status_codes_for_teachers(self):
+    def test_profile_pages__teacher_access(self):
+        """Teachers can access all profile detail, list, and management views."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -238,7 +242,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             site_config.show_all_tags_on_profiles = original_setting
             site_config.save()
 
-    def test_student_view_marks_404_if_disabled(self):
+    def test_student_view_marks__404_if_disabled(self):
         """
         Student marks should return 404 if disabled by admin.
         """
@@ -248,7 +252,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assert404('courses:my_marks')
 
-    def test_student_view_marks_200_if_enabled(self):
+    def test_student_view_marks__200_if_enabled(self):
         """
         Student marks page should be accessible if site admin has enabled it.
         """
@@ -361,11 +365,13 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(user_instance.profile.is_TA, form_data["is_TA"])
 
     def test_password_change_status_code__anonymous(self):
+        """Anonymous users are redirected to login from the change-password view."""
         self.assertRedirectsLogin("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
         self.assertRedirectsLogin("profiles:change_password", kwargs={"pk": self.test_student1.pk})
         self.assertRedirectsLogin("profiles:change_password", kwargs={"pk": self.test_student2.pk})
 
     def test_password_change_status_code__student(self):
+        """Students are forbidden from the change-password view for any user."""
         self.client.force_login(self.test_student1)
 
         self.assert403("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
@@ -373,13 +379,14 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403("profiles:change_password", kwargs={"pk": self.test_student2.pk})
 
     def test_password_change_status_code__staff(self):
+        """Staff can change students' passwords but not another staff member's."""
         self.client.force_login(self.test_teacher)
 
         self.assert403("profiles:change_password", kwargs={"pk": self.test_teacher.pk})
         self.assert200("profiles:change_password", kwargs={"pk": self.test_student1.pk})
         self.assert200("profiles:change_password", kwargs={"pk": self.test_student2.pk})
 
-    def test_update_password(self):
+    def test_update_password__staff_changes_user_password(self):
         """
             quick test to see if staff can change their user's password using passwordchange form
         """
@@ -400,7 +407,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         success = self.client.login(username=user_instance.username, password=form_data['new_password1'])
         self.assertTrue(success)
 
-    def test_profile_list(self):
+    def test_profile_list__view_type_and_queryset(self):
         """
             quick test for ProfileList to see...
             - if profile_lists have the correct view_type
@@ -422,7 +429,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         filtered_qs = qs.filter(user__is_active=False) | qs.filter(user__is_staff=True)
         self.assertFalse(filtered_qs.exists())
 
-    def test_profile_list_current(self):
+    def test_profile_list_current__view_type(self):
         """
             quick test for ProfileListCurrent to see...
             - if profile_lists have the correct view_type
@@ -434,7 +441,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse("profiles:profile_list_current"))
         self.assertEqual(response.context['view_type'], response.context['VIEW_TYPES'].CURRENT)
 
-    def test_profile_list_inactive(self):
+    def test_profile_list_inactive__view_type(self):
         """
             quick test for ProfileListInactive to see...
             - if profile_lists have the correct view_type
@@ -446,7 +453,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse("profiles:profile_list_inactive"))
         self.assertEqual(response.context['view_type'], response.context['VIEW_TYPES'].INACTIVE)
 
-    def test_profile_list_staff(self):
+    def test_profile_list_staff__view_type_and_queryset(self):
         """
             quick test for ProfileListStaff to see...
             - if profile_lists have the correct view_type
@@ -487,7 +494,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # queryset specifications: profile objects that are: part of active semester, a part of a coursestudent object that's in the desired block
         self.assertQuerySetEqual(testblock_queryset, Profile.objects.all_for_active_semester().filter(user__coursestudent__block=testblock))
 
-    def test_profile_update_email(self):
+    def test_profile_update__email_confirmation_flow(self):
         """
         Test that updating your email sends a confirmation link and logging in will
         have a reminder to verify email address if not yet verified.
@@ -690,9 +697,10 @@ class ProfileDeleteTests(ByteDeckTenantTestCase):
         cls.delete_url = reverse("profiles:profile_delete", kwargs={"pk": cls.student.profile.pk})
 
     def setUp(self):
+        """Create a tenant-aware test client for each test."""
         self.client = TenantClient(self.tenant)
 
-    def test_teacher_can_delete_profile(self):
+    def test_profile_delete__teacher_can_delete(self):
         """Ensure that teacher (staff) users can delete a profile and its associated user."""
         self.client.force_login(self.teacher)
 
@@ -705,9 +713,8 @@ class ProfileDeleteTests(ByteDeckTenantTestCase):
         # Ensure redirect to success_url after deletion
         self.assertRedirects(response, reverse("profiles:profile_list"))
 
-    def test_student_cannot_delete_profile(self):
+    def test_profile_delete__student_cannot_delete(self):
         """Ensure that student (non-staff) users cannot delete profiles."""
-        # student2 = baker.make(self.User)
         self.client.force_login(self.student)  # Log in as student (non-staff user)
 
         response = self.client.post(self.delete_url)
@@ -719,7 +726,7 @@ class ProfileDeleteTests(ByteDeckTenantTestCase):
         # Ensure access is denied (403 Forbidden)
         self.assertEqual(response.status_code, 403)
 
-    def test_deleting_non_existent_profile_returns_404(self):
+    def test_profile_delete__non_existent_returns_404(self):
         """Ensure that trying to delete a non-existent profile results in a 404 error."""
         self.client.force_login(self.teacher)
 

--- a/src/quest_manager/tests/test_forms.py
+++ b/src/quest_manager/tests/test_forms.py
@@ -14,6 +14,7 @@ class QuestFormTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Provide a minimal set of valid QuestForm data shared across tests."""
         cls.minimal_valid_data = {
             "name": "Test Quest",
             "xp": 0,
@@ -26,12 +27,12 @@ class QuestFormTest(ByteDeckTenantTestCase):
             "tags": "",
         }
 
-    def test_minimal_valid_data(self):
+    def test_QuestForm__minimal_valid_data_is_valid(self):
         """The minimal_valid_data provided in the setup method should be valid!"""
         form = QuestForm(data=self.minimal_valid_data)
         self.assertTrue(form.is_valid())
 
-    def test_hideable_blocking_both_true(self):
+    def test_QuestForm__hideable_and_blocking_both_true_is_invalid(self):
         """If a quest is Blocking then it should not validate if it is also Hideable"""
         form_data = self.minimal_valid_data
 
@@ -42,7 +43,7 @@ class QuestFormTest(ByteDeckTenantTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("Blocking quests cannot be Hideable.", form.errors['__all__'][0])
 
-    def test_repeat_per_semester_with_unlimited_repeats(self):
+    def test_QuestForm__repeat_per_semester_with_unlimited_repeats_is_invalid(self):
         """A quest with unlimited repeats (max_repeats=-1) should not validate if it
         also has repeat_per_semester: unlimited repeats never run out, so there is
         nothing for a new semester to reset, and the combination previously caused
@@ -57,7 +58,7 @@ class QuestFormTest(ByteDeckTenantTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("unlimited repeats", form.errors['__all__'][0])
 
-    def test_repeat_per_semester_with_limited_repeats(self):
+    def test_QuestForm__repeat_per_semester_with_limited_repeats_is_valid(self):
         """A quest with a limited number of repeats can use repeat_per_semester."""
         form_data = self.minimal_valid_data
 
@@ -67,7 +68,7 @@ class QuestFormTest(ByteDeckTenantTestCase):
         form = QuestForm(data=form_data)
         self.assertTrue(form.is_valid())
 
-    def test_unlimited_repeats_without_repeat_per_semester(self):
+    def test_QuestForm__unlimited_repeats_without_repeat_per_semester_is_valid(self):
         """A quest with unlimited repeats is valid as long as repeat_per_semester is off."""
         form_data = self.minimal_valid_data
 

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -22,6 +22,7 @@ class CategoryManagerTests(LibraryTenantTestCaseMixin):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a published campaign with published, invisible, and archived quests in the library schema."""
         # Create campaign (category) and quests in library schema
         with library_schema_context():
             cls.category = baker.make(Category, title="Test Campaign", published=True)
@@ -65,7 +66,7 @@ class CategoryManagerTests(LibraryTenantTestCaseMixin):
             self.assertEqual(category.quest_count, 1)
             self.assertEqual(category.xp_sum, 100)
 
-    def test_excludes_categories_without_importable_quests(self):
+    def test_all_published_with_importable_quests__excludes_categories_without_importable_quests(self):
         """
         Ensures that published campaigns with no importable quests are excluded
         from the queryset.
@@ -121,9 +122,10 @@ class QuestQuerysetTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student user shared across the queryset tests."""
         cls.student = baker.make(User, username='student', is_staff=False)
 
-    def test_not_in_progress_completed_or_cooldown(self):
+    def test_not_in_progress_completed_or_cooldown__all_five_conditions(self):
         """ Test that all 5 conditions are met for this queryset method:
         it should remove quests that are:
           1. already inprogress for the user (is_completed=False)
@@ -286,6 +288,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Capture the seed quests and create a teacher and student before tests add more quests."""
         # get a list all quests created in data migrations
         # convert to list for ease of comparison, and also to force
         #  evaluation before additional quests are created within tests
@@ -298,7 +301,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
         cls.teacher = baker.make(User, username='teacher', is_staff=True)
         cls.student = baker.make(User, username='student', is_staff=False)
 
-    def test_quest_qs_exclude_hidden(self):
+    def test_exclude_hidden__omits_users_hidden_quests(self):
         """QuestQuerySet.datetime_available should return all quests that are not
         on a user profile's hidden quest list."""
 
@@ -320,7 +323,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
         # a couple hidden
         self.assertSetEqual(set(qs), set(expected_result))
 
-    def test_quest_qs_block_if_needed(self):
+    def test_block_if_needed__returns_only_blocking_quests_when_present(self):
         """QuestQuerySet.block_if_needed should return only blocking quests if one or more exist,
         otherwise, return full qs """
         baker.make(Quest, name='Quest-blocking', blocking=True)
@@ -333,7 +336,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
 
         # Test the user specific part via QuestManager.get_available test"
 
-    def test_quest_qs_datetime_available(self):
+    def test_datetime_available__returns_currently_available_quests(self):
         """QuestQuerySet.datetime_available should return quests available for curent"""
         cur_datetime = localtime()
         cur_date = cur_datetime.date()
@@ -358,7 +361,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
             set(['Quest-curent', 'Quest-earlier-today', 'Quest-yesterday'] + self.initial_quest_name_list)
         )
 
-    def test_quest_qs_not_expired(self):
+    def test_not_expired__returns_unexpired_quests(self):
         """
         QuestQuerySet.not_expired should return not expired quests including:
             If date_expired and time_expired are null: quest never expires
@@ -391,28 +394,28 @@ class QuestManagerTest(ByteDeckTenantTestCase):
         result = ['Quest-never-expired', 'Quest-expired-now', 'Quest-expired-today-midnight', 'Quest-expired-tomorrow']
         self.assertSetEqual(set(qs), set(result + self.initial_quest_name_list))
 
-    def test_quest_qs_visible(self):
+    def test_published__returns_only_published_quests(self):
         """QuestQuerySet.published should return published for students quests"""
         # baker.make(Quest, name='Quest-visible', published=True)
         baker.make(Quest, name='Quest-invisible', published=False)
         # self.assertListEqual(list(Quest.objects.all().published().values_list('name', flat=True)), ['Quest-visible'])
         self.assertListEqual(list(Quest.objects.all().published()), self.initial_quest_list)
 
-    def test_quest_qs_not_archived(self):
+    def test_not_archived__returns_unarchived_quests(self):
         """QuestQuerySet.not_archived should return not_archived quests"""
         baker.make(Quest, name='Quest-not-archived', archived=False)
         baker.make(Quest, name='Quest-archived', archived=True)
         qs = Quest.objects.all().not_archived().values_list('name', flat=True)
         self.assertSetEqual(set(qs), set(['Quest-not-archived'] + self.initial_quest_name_list))
 
-    def test_quest_qs_available_without_course(self):
+    def test_available_without_course__returns_quests_available_outside_course(self):
         """QuestQuerySet.available_without_course should return quests available_outside_course"""
         baker.make(Quest, name='Quest-available-without-course', available_outside_course=True)
         baker.make(Quest, name='Quest-not-available-without-course', available_outside_course=False)
         qs = Quest.objects.all().available_without_course().values_list('name', flat=True)
         self.assertQuerySetEqual(qs, ['Quest-available-without-course', 'Send your teacher a Message'], ordered=False)
 
-    def test_quest_qs_editable(self):
+    def test_editable__returns_quests_user_may_edit(self):
         """
         QuestQuerySet.editable should return quests allowed to edit for given user,
         when user is_staff or editor for the quest
@@ -426,49 +429,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(Quest.objects.all().editable(student1).count(), 1)
         self.assertEqual(Quest.objects.all().editable(student2).count(), 0)
 
-    # def test_quest_qs_get_list_not_submitted_or_inprogress(self):
-    #     """
-    #     QuestQuerySet.get_list_not_submitted_or_inprogress should return quests that
-    #     have not been started (in progress or submitted for approval),
-    #     or if it has been completed already, that it is a repeatable quest past the repeat time
-    #     """
-    #     self.make_test_quests_and_submissions_stack()
-
-    #     # jump ahead an hour so repeat cooldown is over
-    #     with freeze_time(localtime() + timedelta(hours=1, minutes=1)):
-    #         qs = Quest.objects.all().get_list_not_submitted_or_inprogress(self.student)
-    #     self.assertListEqual(
-    #         list(qs.values_list('name', flat=True)),
-    #         ['Quest-1hr-cooldown', 'Quest-blocking', 'Quest-not-started']
-    #     )
-
-    # def test_quest_qs_not_submitted_or_inprogress(self):
-    #     self.make_test_quests_and_submissions_stack()
-
-    #     # jump ahead an hour so repeat cooldown is over
-    #     with freeze_time(localtime() + timedelta(hours=1, minutes=1)):
-    #         qs = Quest.objects.all().not_submitted_or_inprogress(self.student)
-    #     # compare sets so order doesn't matter
-    #     self.assertSetEqual(
-    #         set(qs.values_list('name', flat=True)),
-    #         set(['Quest-1hr-cooldown', 'Quest-blocking', 'Quest-not-started'] + self.initial_quest_name_list)
-    #     )
-
-    # def test_quest_qs_not_completed(self):
-    #     """Should return all the quests that do NOT have a completed submission (during active semester)"""
-    #     active_semester = self.make_test_quests_and_submissions_stack()
-    #     SiteConfig.get().set_active_semester(active_semester.id)
-    #     qs = Quest.objects.order_by('id').not_completed(self.student)
-    #     # compare sets so order doesn't matter
-    #     self.assertSetEqual(
-    #         set(qs.values_list('name', flat=True)),
-    #         set(
-    #             ['Quest-inprogress-sem2', 'Quest-completed-sem2', 'Quest-not-started', 'Quest-blocking', 'Quest-inprogress']
-    #             + self.initial_quest_name_list
-    #         )
-    #     )
-
-    def test_quest_qs_not_in_progress(self):
+    def test_not_in_progress__excludes_inprogress_submissions(self):
         """Should return all the quests that do NOT have an inprogress submission"""
         active_semester = self.make_test_quests_and_submissions_stack()
         SiteConfig.get().set_active_semester(active_semester.id)
@@ -480,7 +441,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
                  'Quest-1hr-cooldown'] + self.initial_quest_name_list)
         )
 
-    def test_get_available(self):
+    def test_get_available__excludes_unavailable_quests(self):
         """ DESCRIPTION FROM METHOD:
         Quests that should appear in the user's Available quests tab.   Should exclude:
         1. Quests whose available date & time has not past, or quest that have expired <<<< COVERED HERE
@@ -652,10 +613,11 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and a student shared across the submission queryset tests."""
         cls.teacher = baker.make(User, username='teacher', is_staff=True)
         cls.student = baker.make(User, username='student', is_staff=False)
 
-    def test_quest_submission_qs_get_user(self):
+    def test_get_user__returns_submissions_for_user(self):
         """QuestSubmissionQuerySet.get_user should return all quest submissions for given user"""
         first = baker.make(QuestSubmission, user=self.student)
         baker.make(QuestSubmission, user=self.teacher)
@@ -663,7 +625,7 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.all().get_user(self.student).values_list('id', flat=True)
         self.assertListEqual(list(qs), [first.id])
 
-    def test_quest_submission_qs_block_if_needed(self):
+    def test_block_if_needed__returns_only_blocking_submissions_when_present(self):
         """QuestSubmissionQuerySet.block_if_needed:
         if there are blocking quests, only return them.  Otherwise, return full qs """
         first = baker.make(QuestSubmission)
@@ -678,7 +640,7 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.all().block_if_needed().values_list('id', flat=True)
         self.assertListEqual(list(qs), [blocked_sub.id])
 
-    def test_quest_submission_qs_get_quest(self):
+    def test_get_quest__returns_submissions_for_quest(self):
         """QuestSubmissionQuerySet.get_quest should return all quest submissions for given quest"""
         quest = baker.make(Quest, name='Sub')
         first, second = baker.make(QuestSubmission, quest=quest), baker.make(QuestSubmission, quest=quest)
@@ -686,7 +648,7 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.order_by('id').get_quest(quest).values_list('id', flat=True)
         self.assertListEqual(list(qs), [first.id, second.id])
 
-    def test_quest_submission_qs_get_semester(self):
+    def test_get_semester__returns_submissions_for_semester(self):
         """QuestSubmissionQuerySet.get_semester should return all quest submissions for given semester"""
         semester = baker.make(Semester)
         first = baker.make(QuestSubmission, semester=semester)
@@ -694,7 +656,7 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.order_by('id').get_semester(semester).values_list('id', flat=True)
         self.assertListEqual(list(qs), [first.id])
 
-    def test_quest_submission_qs_exclude_archived_quests(self):
+    def test_exclude_archived_quests__omits_archived_quest_submissions(self):
         """
         QuestSubmissionQuerySet.exclude_archived_quests should return quest submissions
         without submissions for archived_quests
@@ -704,7 +666,7 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.order_by('id').exclude_archived_quests().values_list('id', flat=True)
         self.assertListEqual(list(qs), [first.id])
 
-    def test_quest_submission_qs_exclude_quests_not_published(self):
+    def test_exclude_quests_not_published__omits_unpublished_quest_submissions(self):
         """
         QuestSubmissionQuerySet.exclude_quests_not_published should return quest submissions
         without submissions for invisible quests
@@ -714,7 +676,7 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.order_by('id').exclude_quests_not_published().values_list('id', flat=True)
         self.assertListEqual(list(qs), [first.id])
 
-    def test_for_teacher_only(self):
+    def test_for_teacher_only__includes_block_students_and_notify_teacher(self):
         """Returned qs should only include sub my students in the teacher's block(s).  Also
         add a specific_teacher_to_notify and make sure that one appears too
         """
@@ -767,6 +729,7 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, and a stack of submissions spanning two semesters."""
         cls.teacher = baker.make(User, username='teacher', is_staff=True)
         cls.student = baker.make(User, username='student', is_staff=False)
 
@@ -774,23 +737,26 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         cls.active_semester = cls.sub1.semester
 
     def setUp(self):
+        """Set the active semester to the one holding sub1 before each test."""
         SiteConfig.get().set_active_semester(self.active_semester.id)
 
-    def test_get_queryset_default(self):
+    def test_get_queryset__default_returns_published_unarchived(self):
         """QuestSubmissionManager.get_queryset by default should return all published, not archived quest submissions"""
         qs = QuestSubmission.objects.get_queryset()
         self.assertQuerySetEqual(qs, [self.sub1, self.sub2], ordered=False)
 
-    def test_get_queryset_for_active_semester(self):
+    def test_get_queryset__active_semester_only(self):
+        """get_queryset with active_semester_only limits results to the active semester's submissions."""
         qs = QuestSubmission.objects.get_queryset(active_semester_only=True)
         self.assertQuerySetEqual(qs, [self.sub1])
 
-    def test_get_queryset_for_all_quests(self):
+    def test_get_queryset__includes_archived_and_unpublished(self):
+        """get_queryset returns every submission when archived and unpublished filters are disabled."""
         qs = QuestSubmission.objects.get_queryset(
             exclude_archived_quests=False, exclude_quests_not_published=False)
         self.assertEqual(qs.count(), 7)
 
-    def test_all_for_user_quest(self):
+    def test_all_for_user_quest__returns_active_semester_submissions(self):
         """
         QuestSubmissionManager.all_for_user_quest should return all published not archived quest submissions
         for active semester, given user and quest
@@ -821,7 +787,7 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
 
         return sub1, sub2
 
-    def test_calculate_xp(self):
+    def test_calculate_xp__sums_approved_submissions(self):
         """QuestSubmissionManager.calculate_xp should return the correct amount of xp for some approved submissions"""
 
         # Create some approved submissions
@@ -831,7 +797,7 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         xp = QuestSubmission.objects.calculate_xp(self.student)
         self.assertEqual(xp, 13)
 
-    def test_calculate_xp_to_date(self):
+    def test_calculate_xp_to_date__excludes_xp_after_date(self):
         """QuestSubmissionManager.calculate_xp_to_date should not include xp earned up to and including the date.
         """
         # Create some approved submissions from after the `to_date``, should show up in XP

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -396,9 +396,7 @@ class QuestManagerTest(ByteDeckTenantTestCase):
 
     def test_published__returns_only_published_quests(self):
         """QuestQuerySet.published should return published for students quests"""
-        # baker.make(Quest, name='Quest-visible', published=True)
         baker.make(Quest, name='Quest-invisible', published=False)
-        # self.assertListEqual(list(Quest.objects.all().published().values_list('name', flat=True)), ['Quest-visible'])
         self.assertListEqual(list(Quest.objects.all().published()), self.initial_quest_list)
 
     def test_not_archived__returns_unarchived_quests(self):

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -22,16 +22,19 @@ User = get_user_model()
 class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
     @classmethod
     def setUpTestData(cls):
+        """Create a test campaign (Category) shared across the tests."""
         cls.category = baker.make(Category, title="Test Campaign")
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_category_type_creation(self):
+    def test_category__creation_and_str(self):
+        """Creating a Category yields a Category instance whose str is its title."""
         self.assertIsInstance(self.category, Category)
         self.assertEqual(str(self.category), self.category.title)
 
-    def test_condition_met_as_prerequisite(self):
+    def test_condition_met_as_prerequisite__all_unique_quests_completed(self):
         """ Test that all unique quests in a campaign are completed before the campaign is considered completed
         for prerequisite purposes. Make sure multiple completions of repeatable quests don't count. """
 
@@ -82,10 +85,11 @@ class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
         baker.make(QuestSubmission, quest=quest1, user=user, is_completed=True, is_approved=True)
         self.assertTrue(self.category.condition_met_as_prerequisite(user))
 
-    def test_category_url(self):
+    def test_get_absolute_url__category_page_loads(self):
+        """The campaign's absolute URL is reachable and returns 200."""
         self.assertEqual(self.client.get(self.category.get_absolute_url(), follow=True).status_code, 200)
 
-    def test_current_quests(self):
+    def test_current_quests__returns_published_unarchived_quests(self):
         """ Test that the queryset of all quests in a campaign is returned correctly """
 
         # assert that the current campaign has no quests
@@ -101,7 +105,7 @@ class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
         # assert that the current campaign has 2 valid quests after additions
         self.assertEqual(self.category.current_quests().count(), 2)
 
-    def test_xp_sum(self):
+    def test_xp_sum__sums_quest_xp(self):
         """ Test that the XP sum of all quests in a campaign is returned correctly """
 
         # create some quests as part of the test campaign
@@ -111,7 +115,7 @@ class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
         # check that the XP sum is correct
         self.assertEqual(self.category.xp_sum(), 3)
 
-    def test_quest_count(self):
+    def test_quest_count__counts_quests(self):
         """ Test that the number of all quests in a campaign is returned correctly """
 
         # assert that the current campaign has no quests
@@ -128,9 +132,11 @@ class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
 class CommonDataTestModel(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a CommonData instance shared across the tests."""
         cls.common_data = baker.make(CommonData)
 
-    def test_badge_series_creation(self):
+    def test_common_data__creation_and_str(self):
+        """Creating CommonData yields a CommonData instance whose str is its title."""
         self.assertIsInstance(self.common_data, CommonData)
         self.assertEqual(str(self.common_data), self.common_data.title)
 
@@ -139,19 +145,23 @@ class QuestTestModel(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a Quest shared across the tests."""
         cls.quest = baker.make(Quest)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_quest_creation(self):
+    def test_quest__creation_and_str(self):
+        """Creating a Quest yields a Quest instance whose str is its name."""
         self.assertIsInstance(self.quest, Quest)
         self.assertEqual(str(self.quest), self.quest.name)
 
-    def test_quest_url(self):
+    def test_get_absolute_url__quest_page_loads(self):
+        """The quest's absolute URL is reachable and returns 200."""
         self.assertEqual(self.client.get(self.quest.get_absolute_url(), follow=True).status_code, 200)
 
-    def test_active(self):
+    def test_active__false_for_unavailable_expired_or_hidden_quests(self):
         """
         The active method of the Quest model's parent "XPItem" should return the correct values based on a quest object's settings.
 
@@ -254,7 +264,8 @@ class QuestTestModel(ByteDeckTenantTestCase):
         with freeze_time(dt + timezone.timedelta(hours=12)):
             self.assertTrue(quest.expired())
 
-    def test_quest_html_formatting(self):
+    def test_quest_html_formatting__no_linebreaks_around_span(self):
+        """Saving a quest reformats instructions without adding line breaks around span tags."""
         test_markup = "<p>this <span>span</span> tag should not break</p>"
         self.quest.instructions = test_markup
         # Auto formatting on save
@@ -266,7 +277,7 @@ class QuestTestModel(ByteDeckTenantTestCase):
         self.assertIsNone(matches_found)
 
     @freeze_time('2018-10-12 00:54:00', tz_offset=0)
-    def test_is_repeat_available(self):
+    def test_is_repeat_available__various_repeat_settings(self):
         """
         QuestManager.is_repeat_available should return True if:
             1. it is repeatable (is_repeatable != 0)
@@ -371,7 +382,8 @@ class QuestTestModel(ByteDeckTenantTestCase):
         # No repeat left this semester
         self.assertFalse(quest_semester.is_repeat_available(student))
 
-    def test_correct_ordinal_submission(self):
+    def test_ordinal__increments_and_continues_after_delete(self):
+        """Submission ordinals increment and keep counting up even after an earlier submission is deleted."""
         student = baker.make('user')
         quest = baker.make(Quest, max_repeats=-1)
 
@@ -397,12 +409,14 @@ class SubmissionManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Capture the active semester shared across the tests."""
         cls.active_semester = SiteConfig.get().active_semester
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_approved(self):
+    def test_all_approved__filters_by_semester_quest_and_user(self):
         """ Tests of QuestSubmissionManager.all_approved()
         def all_approved(self, user=None, quest=None, up_to_date=None, active_semester_only=True):
         """
@@ -458,25 +472,27 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a semester, teacher, student, and a base submission shared across the tests."""
         cls.semester = baker.make(Semester)
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
         cls.submission = baker.make(QuestSubmission, quest__name="Test")
-        # cls.badge = Recipe(Badge, xp=20).make()
-
-        # cls.badge_assertion_recipe = Recipe(QuestSubmission, user=cls.student, badge=cls.badge)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_submission_creation(self):
+    def test_submission__creation_and_quest_name(self):
+        """Creating a QuestSubmission yields a QuestSubmission linked to its quest."""
         self.assertIsInstance(self.submission, QuestSubmission)
         self.assertEqual("Test", self.submission.quest.name)
 
-    def test_submission_url(self):
+    def test_get_absolute_url__submission_page_loads(self):
+        """The submission's absolute URL is reachable and returns 200."""
         self.assertEqual(self.client.get(self.submission.get_absolute_url(), follow=True).status_code, 200)
 
-    def test_submission_mark_completed(self):
+    def test_mark_completed__sets_state_and_clears_draft(self):
+        """mark_completed sets completion state, records the submission time, and clears the draft comment."""
         user = baker.make(User)
         sub = baker.make(QuestSubmission, user=user)
         draft_comment = Comment.objects.create_comment(
@@ -497,7 +513,7 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         self.assertIsNotNone(sub.first_time_completed)
         self.assertIsNone(sub.draft_comment)
 
-    def test_submission_get_previous(self):
+    def test_get_previous__returns_prior_submission(self):
         """ If this is a repeatable quest and has been completed already, return that previous submission """
         repeat_quest = baker.make(Quest, name="repeatable-quest", max_repeats=-1)
         first_sub = baker.make(QuestSubmission, user=self.student, quest=repeat_quest, semester=self.semester)
@@ -508,7 +524,7 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         second_sub = QuestSubmission.objects.create_submission(user=self.student, quest=repeat_quest)
         self.assertEqual(first_sub, second_sub.get_previous())
 
-    def test_submission_get_previous_automatic_fix_ordinal(self):
+    def test_get_previous__fixes_duplicate_ordinals(self):
         """Submissions that have the same ordinals will be automatically fixed"""
         repeat_quest = baker.make(Quest, name="repeatable-quest", max_repeats=-1)
         first_sub = baker.make(QuestSubmission, user=self.student, quest=repeat_quest, semester=self.semester)
@@ -557,7 +573,7 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         third_sub.refresh_from_db()
         self.assertEqual(third_sub.ordinal, old_third_submission_ordinal)
 
-    def test_get_minutes_to_complete(self):
+    def test_get_minutes_to_complete__returns_minutes_between_timestamps(self):
         """Completed quests should return the difference between the timestamp (creation) and time completed, in minutes."""
         minutes = 5
         time_delta = datetime.timedelta(0, minutes * 60)
@@ -573,7 +589,7 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         self.submission.mark_completed()
         self.assertEqual(self.submission.get_minutes_to_complete(), minutes)
 
-    def test_get_minutes_to_complete_if_not_completed(self):
+    def test_get_minutes_to_complete__none_if_not_completed(self):
         """Return None if the submission has not been completed yet."""
         # the setup submission should not be completed yet, but make sure
         self.assertFalse(self.submission.is_completed, False)
@@ -586,6 +602,7 @@ class QuestExpiredAnnotationTest(ByteDeckTenantTestCase):
     instead of issuing a query per call."""
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def test_expired__prefers_is_expired_annotation(self):
@@ -616,11 +633,13 @@ class QuestManagerPrefetchTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher (staff caller and quest editor) and a campaign shared across the tests."""
         # a teacher is needed both as staff caller and as each quest's editor
         cls.teacher = User.objects.create_user('teacher', is_staff=True)
         cls.campaign = baker.make(Category, title="Test Campaign")
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def _make_quests(self, **kwargs):

--- a/src/quest_manager/tests/test_signals.py
+++ b/src/quest_manager/tests/test_signals.py
@@ -11,8 +11,8 @@ from comments.models import Comment
 
 class TestSubmissionSignals(ByteDeckTenantTestCase):
 
-    def test_pre_delete_signal(self):
-        """ test the pre delete signal for QuestSubmission """
+    def test_pre_delete_signal__removes_only_own_comments(self):
+        """Deleting a QuestSubmission removes only its own comments, not those of other submissions."""
         # create two submissions delete 1 and see if pre_delete
         # did not remove more comments than it needed to
 
@@ -52,6 +52,7 @@ class TestTidyHtml(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_tidy_html__formatting_math(self):
+        """KaTeX math markup is preserved and not mangled into template braces."""
         markup = r"""<span class="note-math"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><mrow><mi>x</mi></mrow></mrow><annotation encoding="application/x-tex">{x}</annotation></semantics></math></span>"""  # noqa
         result = tidy_html(markup)
         self.assertIn(markup, result)
@@ -59,7 +60,8 @@ class TestTidyHtml(unittest.TestCase):
         matches_found = re.search('({{)|(}})', result)
         self.assertIsNone(matches_found)
 
-    def test_quest_html_formatting_tabs(self):
+    def test_tidy_html__formatting_tabs(self):
+        """Various markup inputs are indented and repaired as expected."""
         markup_tests = [  # test, expected out come
             ("<p>some text</p>", "<p>\n  some text\n</p>\n"),
             ("<p>some text\n\n</p>", "<p>\n  some text\n</p>\n"),

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -66,6 +66,7 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, two students (one enrolled), and a few quests shared across the tests."""
         cls.sem = SiteConfig.get().active_semester
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -84,13 +85,15 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # cls.sub2 = baker.make(QuestSubmission, quest=cls.quest1)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_quest_page_status_codes_for_anonymous(self):
+    def test_all_quest_pages__anonymous_redirected_to_login(self):
         """ If not logged in then all views should redirect to home page  """
         self.assertRedirectsLogin('quests:quests')
 
-    def test_all_quest_page_status_codes_for_students(self):
+    def test_all_quest_pages__student_access_codes(self):
+        """Students can reach their own quest pages but are forbidden from staff-only views."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -144,7 +147,8 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.client.get(reverse('quests:quest_delete', args=[q_pk])).status_code, 403)
         self.assertEqual(self.client.get(reverse('quests:unarchive', args=[archived_quest_pk])).status_code, 403)
 
-    def test_all_quest_page_status_codes_for_teachers(self):
+    def test_all_quest_pages__teacher_access_codes(self):
+        """Teachers can reach the staff quest management and summary views."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -184,7 +188,8 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIsNotNone(match, "Sidebar approvals menu not found in the rendered page")
         self.assertEqual(match.group(1), reverse('quests:approvals'))
 
-    def test_start(self):
+    def test_start__creates_or_reuses_submission(self):
+        """Starting a quest 404s when unavailable, otherwise creates one submission and reuses it on repeat starts."""
         # log in a student from setUp
         self.client.force_login(self.test_student1)
 
@@ -213,7 +218,7 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # the view should have redirect to the same submission:
         self.assertRedirects(response, sub.get_absolute_url())
 
-    def test_student_no_quests_help_text(self):
+    def test_student_no_quests_help_text__varies_by_situation(self):
         """
             When student has no quests but have:
 
@@ -314,7 +319,7 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, "You have no new quests available")
         self.assertContains(response, "but you do have hidden quests which you can view by hitting the 'Show Hidden Quests' button above.")
 
-    def test_teacher_can_unarchive_quest(self):
+    def test_unarchive__teacher_can_unarchive_quest(self):
         """
         Test that staff users can successfully unarchive an archived quest.
 
@@ -354,6 +359,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, two students, three quests, and several submissions shared across the tests."""
         User = get_user_model()
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -377,9 +383,11 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         )
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_submission_page_status_codes_for_students(self):
+    def test_all_submission_pages__student_access_codes(self):
+        """Students can reach their own submission pages but are forbidden or 404 on others' and staff-only actions."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -419,7 +427,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         # These Needs to be completed via POST
         self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
 
-    def test_student_can_view_completed_submission_when_hidden(self):
+    def test_submission__student_can_view_completed_submission_when_hidden(self):
         """
         Make sure user can view quest even when published is False
         and a student has a submission to it.
@@ -446,7 +454,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
         self.assertNotContains(response, status_url)
 
-    def test_student_can_drop_completed_submission_when_hidden(self):
+    def test_drop__student_can_drop_completed_submission_when_hidden(self):
         """
         Make sure student can drop a submission from a quest when an admin decides
         to hide it.
@@ -459,7 +467,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:drop', args=[s4_pk]))
         self.assertEqual(response.status_code, 200)
 
-    def test_hidden_submission_does_not_contain_submit_button(self):
+    def test_submission__hidden_quest_hides_submit_button(self):
         """
         Make sure that submit for approval button is hidden since it's not available
         for students to submit anymore.
@@ -471,7 +479,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[s4_pk]))
         self.assertNotContains(response, 'Submit Quest for Approval')
 
-    def test_drop_button_not_visible_when_submission_approved(self):
+    def test_submission__drop_button_hidden_when_approved(self):
         """
         Make sure drop button is not visible when quest submission is already approved
         """
@@ -484,7 +492,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[s4_pk]))
         self.assertNotContains(response, 'Drop Quest')
 
-    def test_drop_approved_submission_results_to_404(self):
+    def test_drop__approved_submission_returns_404(self):
         """
         Make sure a student cannot drop an approved submission
         """
@@ -497,7 +505,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:drop', args=[s4_pk]))
         self.assertEqual(response.status_code, 404)
 
-    def test_drop_deletes_comment_and_submission(self):
+    def test_drop__deletes_comment_and_submission(self):
         """Ensure that the draft_comment (foreignkey to Comment object) is deleted
         when a submission is dropped. Also ensure the QuestSubmission object is deleted."""
         self.client.force_login(self.test_student1)
@@ -515,7 +523,8 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertFalse(Comment.objects.filter(id=draft_comment_id).exists())
         self.assertFalse(QuestSubmission.objects.filter(id=sub_id).exists())
 
-    def test_all_submission_page_status_codes_for_teachers(self):
+    def test_all_submission_pages__teacher_access_codes(self):
+        """Teachers can view, flag, unflag, and skip submissions, with 404s for nonexistent ones."""
         # log in a teacher
         self.client.force_login(self.test_teacher)
 
@@ -556,7 +565,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertEqual(self.client.get(reverse('quests:skip', args=[s1_pk])).status_code, 302)
         self.assertEqual(self.client.get(reverse('quests:approve', args=[s1_pk])).status_code, 404)
 
-    def test_submission_when_quest_not_visible(self):
+    def test_submission__quest_not_visible_returns_404(self):
         """When a quest is hidden from students, they should still be able to to see their submission in a static way"""
         # log in a student
         self.client.force_login(self.test_student1)
@@ -569,8 +578,8 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         # TODO: should redirect, not 404?
         self.assertEqual(self.client.get(reverse('quests:submission', args=[self.sub1.pk])).status_code, 404)
 
-    def test_submission_xp_entered_remains_even_when_submission_returned(self):
-
+    def test_submission__xp_entered_remains_when_submission_returned(self):
+        """A student's requested XP is preserved on the form after a submission is returned."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -587,7 +596,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
 
         self.assertEqual(response.context['form']['xp_requested'].value(), self.sub1.xp_requested)
 
-    def test_ajax_save_draft_has_changes(self):
+    def test_ajax_save_draft__has_changes(self):
         """Should save if there are changes in the draft text"""
         # loging required for this view
         self.client.force_login(self.test_student1)
@@ -614,7 +623,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         sub.refresh_from_db()
         self.assertEqual(draft_text, sub.draft_comment.text)  # fAILS CUS MODEL DIDN'T SAVE! aRGH..
 
-    def test_ajax_save_draft_no_submission_draft_comment(self):
+    def test_ajax_save_draft__no_submission_draft_comment(self):
         """If a draft comment is not associated with the submission, then there is no submission in progress,
         so return 404"""
         self.client.force_login(self.test_student1)
@@ -633,7 +642,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_ajax_save_draft_no_changes(self):
+    def test_ajax_save_draft__no_changes(self):
         """Should not save if there are no changes in the draft text"""
         # loging required for this view
         self.client.force_login(self.test_student1)
@@ -660,7 +669,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         sub.refresh_from_db()
         self.assertEqual(draft_text, sub.draft_comment.text)
 
-    def test_ajax_save_draft_blank_comment(self):
+    def test_ajax_save_draft__blank_comment(self):
         """Should not cause an error if the comment is blank"""
         # loging required for this view
         self.client.force_login(self.test_student1)
@@ -698,6 +707,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, a quest, and an in-progress submission shared across the tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
 
@@ -708,6 +718,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
                              draft_comment=cls.draft_comment, semester=cls.semester)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the student for all tests."""
         self.client = TenantClient(self.tenant)
 
         # log in the student for all tests here
@@ -726,7 +737,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             )
         return response
 
-    def test_complete_quick_reply_form(self):
+    def test_complete__quick_reply_form(self):
         """ Students can complete quests that are available to them.  Form is submitted with the 'complete' button
         Are redirected to their available quests page, submission is marked completed and has a completion time.
         Tests for file-less submissions are labeled under the quick reply form because of the form selection
@@ -850,7 +861,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         submission.refresh_from_db()
         self.assertEqual(submission.xp_requested, 10)  # Ensure XP wasn't updated
 
-    def test_no_comment_verification_not_required_quick_reply_form(self):
+    def test_complete__no_comment_when_verification_not_required(self):
         """ When a quest is automatically approved, it does not require a comment
         """
         self.sub.quest.verification_required = False
@@ -863,7 +874,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertSuccessMessage(response)
 
-    def test_no_comment_but_verification_required_quick_reply_form(self):
+    def test_complete__no_comment_but_verification_required(self):
         """ When a quest requires teacher's approval, it means they must include either files or a comment
         """
         self.sub.quest.verification_required = True
@@ -925,7 +936,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         staff_sub.refresh_from_db()
         self.assertFalse(staff_sub.is_completed)
 
-    def test_notifications_own_student(self):
+    def test_complete__no_notification_for_own_teacher(self):
         """ Teacher should NOT be notified when their student complete's a quest, because it
         will appear in there approvals tab anyway, so redundant
         """
@@ -937,7 +948,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 0)
 
-    def test_notifications_comment_when_verification_not_required(self):
+    def test_complete__notifies_teacher_on_comment_when_no_verification(self):
         """ Teacher SHOULD be notified when their student complete's a quest if:
         1. it has a comment, AND
         2. it does not require verification
@@ -951,7 +962,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 1)
 
-    def test_notifications_no_comment_when_verification_not_required(self):
+    def test_complete__no_notification_when_no_comment_and_no_verification(self):
         """ Teacher should NOT be notified when there is no comment and it's auto-approved (verification_required=False):
         """
         self.sub.quest.verification_required = False
@@ -962,7 +973,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 0)
 
-    def test_specific_teacher_to_notify_own_teacher(self):
+    def test_complete__specific_teacher_is_own_teacher_no_notification(self):
         """
         If a quest has a specific teacher set to notify and that teacher is also the student's current teacher,
         then no notification should be sent, because the submission will already appear in their "Approvals" tab.
@@ -975,7 +986,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 0)
 
-    def test_specific_teacher_to_notify_other_teacher(self):
+    def test_complete__specific_teacher_is_other_teacher_no_notification(self):
         """
         If a quest has a specific teacher set to notify who is not the student's current teacher,
         the submission should appear in that teacher's "Approvals" tab, and no notification should be sent
@@ -999,7 +1010,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 0)
 
-    def test_comment_completed(self):
+    def test_comment__on_completed_quest(self):
         """ Students can comment on already completed quests.
         """
         comment = "test submission comment"
@@ -1012,7 +1023,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments[0].text, f'<p>{comment}</p>')
 
-    def test_comment_button_no_comment_verification_not_required(self):
+    def test_comment__no_comment_verification_not_required(self):
         """ When commenting on an already completed quest, needs to actually comment with something
         whether or not verification was required originally
         """
@@ -1024,7 +1035,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, expected_url=self.sub.get_absolute_url())
         self.assertErrorMessage(response)
 
-    def test_comment_button_no_comment_but_verification_required(self):
+    def test_comment__no_comment_but_verification_required(self):
         """ When commenting on an already completed quest, needs to actually comment with something
         whether or not verification was required originally
         """
@@ -1040,7 +1051,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertErrorMessage(response)
 
-    def test_comment_button_notifications_own_student(self):
+    def test_comment__notifies_own_teacher(self):
         """ Teacher should be notified when their student comments on an already complete's a quest
         """
         self.sub.quest.verification_required = True  # default anyway, but make it explicit
@@ -1062,7 +1073,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 1)
 
-    def test_comment_button_specific_teacher_to_notify_own_teacher(self):
+    def test_comment__specific_teacher_is_own_teacher_notifies_once(self):
         """ If comment is left on an already completed quest that has a specific teacher linked to it,
         both of them should be notified of the comment (the specific teacher, and the normal teacher)
 
@@ -1076,7 +1087,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 1)
 
-    def test_comment_button_specific_teacher_to_notify_other_teacher(self):
+    def test_comment__specific_teacher_is_other_teacher_notifies_both(self):
         """ If comment is left on an already completed quest that has a specific teacher linked to it,
         both of them should be notified of the comment (the specific teacher, and the normal teacher)
         """
@@ -1093,7 +1104,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 1)
 
-    def test_notification_when_teacher_comments(self):
+    def test_comment__teacher_comment_notifies_student(self):
         """ When a teacher comments on submission and student gets notified
         """
         # log in a teacher to comment on the submission
@@ -1108,7 +1119,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_student, self.sub)
         self.assertEqual(notifications.count(), 1)
 
-    def test_comment_button_files_in_form(self):
+    def test_comment__files_attached_in_form(self):
         """ Files can be uploaded and attached to comments when completing or commenting on quests
         and a link to the file is included in the comment.
         """
@@ -1134,7 +1145,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(os.path.basename(comment_files[0].docfile.name), test_files[0].name)
         self.assertEqual(os.path.basename(comment_files[1].docfile.name), test_files[1].name)
 
-    def test_comment_multiple_comments_from_user(self):
+    def test_comment__multiple_comments_from_user(self):
         """ Tests the functionality of comments made by user using standard and quick reply forms.
         """
         # complete quest as the only way user can comment is if they complete
@@ -1159,7 +1170,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.sub.draft_comment, None)
         self.assertTrue(Comment.objects.filter(text__contains='comment from quick reply #1').exists())
 
-    def test_unrecognized_submit_button(self):
+    def test_complete__unrecognized_submit_button_returns_404(self):
         """ Unrecognized form submit button should 404.
         In some views Summernote was causing problems by submitting the form via ajax """
         response = self.post_complete(button="non_existant_button")
@@ -1169,6 +1180,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and an unpublished and a published quest shared across the tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
         cls.url = reverse("quests:bulk_edit_quests")
@@ -1177,6 +1189,7 @@ class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.quest2 = baker.make(Quest, published=True)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the teacher."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_teacher)
 
@@ -1254,7 +1267,7 @@ class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertFalse(Quest.objects.filter(id=self.quest1.id).exists())
 
-    def test_bulk_edit_mode_flag(self):
+    def test_bulk_edit__mode_flag_reflects_query_param(self):
         """
         bulk_edit_mode should be True when '?bulk_edit' param is present,
         and False when missing.
@@ -1306,6 +1319,7 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a staff user, a quest, and three enrolled students shared across the tests."""
         # staff user to login as
         cls.staff_user = baker.make(User, username='staff', is_staff=True)
 
@@ -1320,10 +1334,11 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             baker.make('courses.CourseStudent', user=u, semester=SiteConfig.get().active_semester)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the staff user."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.staff_user)
 
-    def test_view_displays_users_and_statuses(self):
+    def test_quest_user_status__displays_users_and_statuses(self):
         """
         Verify that the quest_user_status view:
         - Lists all relevant users with the correct status label
@@ -1396,7 +1411,8 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(stats_dict['Returned']['percent'], "33%")
         self.assertEqual(stats_dict['Awaiting Approval']['percent'], "33%")
 
-    def test_users_with_no_submission_show_not_started(self):
+    def test_quest_user_status__users_with_no_submission_show_not_started(self):
+        """Students without a submission are listed with the 'Not Started' status and no submission."""
         url = reverse('quests:quest_user_status', args=[self.quest.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -1407,7 +1423,7 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertEqual(entry['status'], 'Not Started')
             self.assertIsNone(entry['submission'])
 
-    def test_latest_attempt_is_used_when_multiple_submissions_exist(self):
+    def test_quest_user_status__latest_attempt_used_when_multiple_submissions_exist(self):
         """
         If a student has an older approved submission and then makes a new attempt
         (awaiting approval), the status should reflect the newest attempt.
@@ -1450,6 +1466,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, and minimal valid quest form data shared across the tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
 
@@ -1466,9 +1483,11 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         }
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_teacher_can_create_and_delete_quests(self):
+    def test_quest_create__teacher_can_create_and_delete(self):
+        """Teachers can create quests and delete both live and archived quests."""
         # simulate a logged in teacher
         self.client.force_login(self.test_teacher)
 
@@ -1504,7 +1523,8 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         with self.assertRaises(Quest.DoesNotExist):
             Quest.objects.get(id=archived_quest.id)
 
-    def test_TA_can_create_draft_quests_and_delete_own(self):
+    def test_quest_create__TA_creates_drafts_and_deletes_own(self):
+        """TAs can create draft quests (as editor) and delete their own but not others'."""
         # simulate a logged in TA (teaching assistant = a student with extra permissions)
         test_ta = User.objects.create_user('test_ta')
         test_ta.profile.is_TA = True  # profiles are create automatically via User post_save signal
@@ -1542,7 +1562,8 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.post(reverse('quests:quest_delete', args=[other_quest.id]))
         self.assertEqual(response.status_code, 403)
 
-    def test_teacher_can_update_quests(self):
+    def test_quest_update__teacher_can_update(self):
+        """Teachers can access the update view and save changes to any quest."""
         # simulate a logged in teacher
         self.client.force_login(self.test_teacher)
 
@@ -1570,7 +1591,8 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         quest_to_update.refresh_from_db()
         self.assertEqual(quest_to_update.name, "Updated Name")
 
-    def test_ta_can_update_their_own_quests(self):
+    def test_quest_update__ta_can_update_own_draft(self):
+        """TAs can update only their own unpublished quests, not published ones or others'."""
         # simulate a logged in TA (teaching assistant = a student with extra permissions)
         test_ta = User.objects.create_user('test_ta')
         test_ta.profile.is_TA = True  # profiles are create automatically via User post_save signal
@@ -1614,7 +1636,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         quest_to_update.refresh_from_db()
         self.assertEqual(quest_to_update.name, "Updated Name")
 
-    def test_scape_update_message_on_update_delete(self):
+    def test_quest_update__scape_message_on_update_and_delete(self):
         """ Checks if delete and update function gives a success message when a quest is related to map """
         # setup
         quest = baker.make(Quest)
@@ -1643,7 +1665,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     # TAs should not be able to make a quest published
     # When a quest is published by a teacher, the editor should be removed
 
-    def test_create_with_new_prereqs(self):
+    def test_quest_create__with_new_prereqs(self):
         """ Add a quest and badge prereq during quest creation """
         self.client.force_login(self.test_teacher)
         self.minimal_valid_form_data['new_quest_prerequisite'] = baker.make(Quest).id
@@ -1653,7 +1675,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, new_quest.get_absolute_url())
         self.assertEqual(new_quest.prereqs().count(), 2)
 
-    def test_update_with_new_prereqs(self):
+    def test_quest_update__with_new_prereqs(self):
         """ Add a quest and badge prereq during quest editing, also overwrite existing prereqs with new ones on update """
         self.client.force_login(self.test_teacher)
         quest_to_update = baker.make(Quest)
@@ -1707,6 +1729,7 @@ class QuestPrereqsUpdate(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.existing_prereq = cls.parent_quest.prereqs().first()
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def build_formset_form_data(self, form_prefix, form_number, **data):
@@ -1730,7 +1753,7 @@ class QuestPrereqsUpdate(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             formset_dict.update(form_dict)
         return formset_dict
 
-    def test_post_cancel_button(self):
+    def test_post__cancel_button_redirects_to_detail(self):
         """ Cancel button should redirect to the quest detail view """
         self.client.force_login(self.test_teacher)
         response = self.client.post(
@@ -1859,6 +1882,7 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student, teacher, TA, a tagged quest, and valid copy form data shared across the tests."""
         cls.test_student = User.objects.create_user('test_student')
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
@@ -1885,9 +1909,10 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         })
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_teacher_copy_quest_GET(self):
+    def test_quest_copy__teacher_get_initial_values(self):
         """ initial values in form GET is the same as the self.quest (quest that is being copied)  """
         self.client.force_login(self.test_teacher)
 
@@ -1904,7 +1929,7 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # And by default form should have prereq set
         self.assertEqual(form_data['new_quest_prerequisite'], self.quest)
 
-    def test_teacher_copy_quest_POST(self):
+    def test_quest_copy__teacher_post_creates_copy(self):
         """ values after being saved is the same as copied quest + '- COPY' being appended to name """
         self.client.force_login(self.test_teacher)
 
@@ -1926,8 +1951,8 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Copied quest should have tag
         self.assertEqual(new_quest.tags.count(), 1)
 
-    def test_TA_can_copy_quest_GET(self):
-
+    def test_quest_copy__ta_get_initial_values(self):
+        """A TA copying a quest sees the same copied initial form values as a teacher."""
         self.client.force_login(self.test_ta)
         get_response = self.client.get(reverse('quests:quest_copy', args=[self.quest.id]))
         self.assertEqual(get_response.status_code, 200)
@@ -1946,7 +1971,8 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Also, TA's should not be able to set published, but it is by default
         # just make sure it is published, and then check again after form is posted
 
-    def test_TA_copy_quest_POST(self):
+    def test_quest_copy__ta_post_forces_draft(self):
+        """A TA's copied quest is forced unpublished with the TA set as editor."""
         self.client.force_login(self.test_ta)
         response = self.client.post(
             reverse('quests:quest_copy', args=[self.quest.id]),
@@ -1973,7 +1999,7 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Copied quest should have tag
         self.assertEqual(new_quest.tags.count(), 1)
 
-    def test_copy_with_new_prereqs(self):
+    def test_quest_copy__with_new_prereqs(self):
         """ When copying a quest should be able to set new prereqs """
         self.client.force_login(self.test_teacher)
 
@@ -2007,15 +2033,17 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, and a quest shared across the tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
 
         cls.quest1 = baker.make(Quest)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_quest_id_provided_to_view(self):
+    def test_quest_list__quest_id_provided_to_view(self):
         """
         This test handles the view when accessed via:
         url(r'^list/(?P<quest_id>[0-9]+)/$', views.quest_list, name='quest_active'
@@ -2049,13 +2077,14 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # should now see the quest
         self.assertContains(response, f'id="heading-quest-{self.quest1.id}')
 
-    def test_student_sees_quests_available_outside_course(self):
+    def test_quest_list__student_sees_quests_available_outside_course(self):
+        """A quest flagged available_outside_course appears for a student not in a course."""
         self.client.force_login(self.test_student)
         quest_avail_outside_course = baker.make(Quest, available_outside_course=True)
         response = self.client.get(reverse('quests:quest_active', args=[quest_avail_outside_course.id]))
         self.assertContains(response, f'id="heading-quest-{quest_avail_outside_course.id}')
 
-    def test_student_does_not_see_quick_reply_form(self):
+    def test_quest_list__student_does_not_see_quick_reply_form(self):
         """Regression for #1886 / #1759: the student quick reply form (which
         404'd when resubmitting a returned quest) was removed. A returned
         submission must still render on the quests page, but without the inline
@@ -2083,7 +2112,7 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotContains(response, f'quick_reply{returned_sub.id}')
         self.assertNotContains(response, 'Re-Submit Quest')
 
-    def test_show_hidden(self):
+    def test_quest_list__show_hidden_button_visibility(self):
         """ Test of:
         url(r'^available/all/$', views.quest_list, name='available_all'),
         """
@@ -2123,7 +2152,7 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # and no button when already viewing hidden quests
         self.assertNotContains(response, 'Show Hidden Quests')
 
-    def test_available_quest_list_ordering(self):
+    def test_quest_list__available_ordering(self):
         """Parses for queryset used as context for "Available Quests" list and asserts equal to a
         manually ordered queryset.
         """
@@ -2146,7 +2175,7 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             # assert ordered view is unchanged from displayed view
             self.assertQuerySetEqual(displayed_order, intended_order)
 
-    def test_context_correct_tab_types(self):
+    def test_quest_list__context_correct_tab_types(self):
         """ Checks each possible tab for student and teacher individually if it can be activated
         by accessing the tabs corresponding url
         """
@@ -2223,6 +2252,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and a student shared across the tests."""
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
@@ -2230,9 +2260,10 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # cls.category = baker.make('quests_manager.category', name="testcat")
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_page_status_codes_for_anonymous(self):
+    def test_all_category_pages__anonymous_redirected_to_login(self):
         ''' If not logged in then all views should redirect to home page '''
 
         self.assertRedirectsLogin('quests:categories')
@@ -2241,7 +2272,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('quests:category_update', args=[1])
         self.assertRedirectsLogin('quests:category_delete', args=[1])
 
-    def test_all_page_status_codes_for_students(self):
+    def test_all_category_pages__student_access_codes(self):
         ''' If not logged in then all views should redirect to 403'''
         self.client.force_login(self.test_student1)
 
@@ -2254,20 +2285,20 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Student access
         self.assert200('quests:category_detail', kwargs={"pk": 1})
 
-    def test_all_page_status_codes_for_staff(self):
+    def test_all_category_pages__staff_access_codes(self):
         ''' If not logged in then all views should redirect to home page or admin login '''
         self.client.force_login(self.test_teacher)
 
         # Staff access only
         self.assert200('quests:categories')
 
-    def test_CategoryList_view(self):
+    def test_CategoryList_view__staff_can_view(self):
         """ Admin should be able to view course list """
         self.client.force_login(self.test_teacher)
         response = self.client.get(reverse('quests:categories'))
         self.assertEqual(response.status_code, 200)
 
-    def test_CategoryDetail_view(self):
+    def test_CategoryDetail_view__student_vs_admin_visibility(self):
         """ Admin and students should be able to view course details
 
         Students accessing the category detail view should only see active quests
@@ -2344,7 +2375,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:category_detail', kwargs={"pk": campaign.pk}))
         self.assertContains(response, "Published: True")
 
-    def test_CategoryCreate_view(self):
+    def test_CategoryCreate_view__staff_can_create(self):
         """ Admin should be able to create a course """
         self.client.force_login(self.test_teacher)
         data = {
@@ -2360,7 +2391,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # map_order is a writable create field (issue #1977), so the posted value persists
         self.assertEqual(course.map_order, data['map_order'])
 
-    def test_CategoryUpdate_view(self):
+    def test_CategoryUpdate_view__staff_can_update(self):
         """ Admin should be able to update a course. Saving returns to the campaign's
         detail view (the page the edit was started from), not the campaigns list
         (issue #1931). """
@@ -2401,7 +2432,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:category_create'))
         self.assertContains(response, f'href="{reverse("quests:categories")}"')
 
-    def test_CategoryDelete_view(self):
+    def test_CategoryDelete_view__blocked_when_published_quests(self):
         """
         Staff should be able to delete a campaign *only* if it has no published quests.
 
@@ -2483,7 +2514,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             "You can't delete this campaign because it contains published quests"
         )
 
-    def test_CategoryPublish_view(self):
+    def test_CategoryPublish_view__publishes_campaign_and_quests(self):
         """
         Test CategoryPublish end-to-end:
         - Staff can see the "Publish Campaign and all its Quests" button on an unpublished campaign.
@@ -2630,6 +2661,7 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student, a teacher, a quest, and enroll the student in the teacher's block."""
         cls.test_student = User.objects.create_user('test_student')
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.quest = baker.make(Quest, name="Test Quest")
@@ -2639,14 +2671,15 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
                    user=cls.test_student, semester=SiteConfig.get().active_semester)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_get_returns_403(self):
+    def test_ajax_submission_count__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.client.force_login(self.test_teacher)
         self.assert403('quests:ajax_submission_count')
 
-    def test_non_ajax_post_returns_403(self):
+    def test_ajax_submission_count__non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.client.force_login(self.test_teacher)
         response = self.client.post(
@@ -2654,7 +2687,7 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    def test_student_access_granted(self):
+    def test_ajax_submission_count__student_access_granted(self):
         """ The current behavior is that students can access the view.
         This test acknowledges that behavior."""
         self.client.force_login(self.test_student)
@@ -2665,7 +2698,8 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_ajax_returns_json(self):
+    def test_ajax_submission_count__returns_json(self):
+        """An ajax POST returns a JsonResponse with a 200 status."""
         self.client.force_login(self.test_teacher)
         response = self.client.post(
             reverse('quests:ajax_submission_count'),
@@ -2676,7 +2710,7 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(type(response), JsonResponse)
 
-    def test_ajax_returns_correct_count(self):
+    def test_ajax_submission_count__returns_correct_count(self):
         """ Should return the number of pending submissions for the quest"""
         self.client.force_login(self.test_teacher)
         # Only submissions that are "completed" but not "approved" should be counted.
@@ -2720,26 +2754,28 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student, a quest, and a teacher shared across the tests."""
         cls.test_student = User.objects.create_user('test_student')
         cls.quest = baker.make(Quest)
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the student."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
-    def test_get_returns_403(self):
+    def test_ajax_quest_info__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.assert403('quests:ajax_quest_info', args=[self.quest.id])
 
-    def test_non_ajax_post_returns_403(self):
+    def test_ajax_quest_info__non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.post(
             reverse('quests:ajax_quest_info', args=[self.quest.id])
         )
         self.assertEqual(response.status_code, 403)
 
-    def test_ajax_get_returns_404(self):
+    def test_ajax_quest_info__ajax_get_returns_404(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.get(
             reverse('quests:ajax_quest_info', args=[self.quest.id]),
@@ -2748,7 +2784,8 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_ajax_returns_json(self):
+    def test_ajax_quest_info__returns_json(self):
+        """An ajax POST (with or without a quest id) returns a JsonResponse with a 200 status."""
         response = self.client.post(
             reverse('quests:ajax_quest_info', args=[self.quest.id]),
             content_type='application/json',
@@ -2768,7 +2805,7 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(type(response), JsonResponse)
 
-    def test_can_export_student_false(self):
+    def test_ajax_quest_info__can_export_student_false(self):
         """
         Students should never see can_export=True in the rendered preview.
         """
@@ -2784,7 +2821,7 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # The export button is rendered only if can_export=True
         self.assertNotIn('id="export-quest"', html)
 
-    def test_can_export_staff_true(self):
+    def test_ajax_quest_info__can_export_staff_true(self):
         """
         Staff should see can_export=True if allowed by site config and schema is not library.
         """
@@ -2805,7 +2842,7 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # There should be something in the HTML rendered only if can_export=True
         self.assertIn('title="Export this quest to the Library"', html)
 
-    def test_can_export_false_on_library_schema(self):
+    def test_ajax_quest_info__can_export_false_on_library_schema(self):
         """
         When on the Library, should not be able to export to the Library
         """
@@ -2834,27 +2871,29 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student, a quest, and a submission shared across the tests."""
         cls.test_student = User.objects.create_user('test_student')
         cls.quest = baker.make(Quest)
         cls.submission = baker.make(QuestSubmission)
         # cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the student."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
-    def test_get_returns_403(self):
+    def test_ajax_approval_info__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.assert403('quests:ajax_approval_info', args=[self.submission.id])
 
-    def test_non_ajax_post_returns_403(self):
+    def test_ajax_approval_info__non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.post(
             reverse('quests:ajax_approval_info', args=[self.submission.id])
         )
         self.assertEqual(response.status_code, 403)
 
-    def test_ajax_get_returns_404(self):
+    def test_ajax_approval_info__ajax_get_returns_404(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.get(
             reverse('quests:ajax_quest_info', args=[self.quest.id]),
@@ -2863,7 +2902,8 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_ajax_returns_json(self):
+    def test_ajax_approval_info__returns_json(self):
+        """An ajax POST returns a JsonResponse with the submission in context; missing id 404s."""
         response = self.client.post(
             reverse('quests:ajax_approval_info', args=[self.submission.id]),
             content_type='application/json',
@@ -2900,27 +2940,30 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student, a quest, and one of the student's submissions shared across the tests."""
         cls.test_student = User.objects.create_user('test_student')
         cls.quest = baker.make(Quest)
         cls.submission = baker.make(QuestSubmission, user=cls.test_student)
         # cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the student."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
-    def test_get_returns_403(self):
+    def test_ajax_submission_info__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         self.assert403('quests:ajax_info_in_progress', args=[self.submission.id])
 
-    def test_non_ajax_post_returns_403(self):
+    def test_ajax_submission_info__non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
         response = self.client.post(
             reverse('quests:ajax_info_in_progress', args=[self.submission.id])
         )
         self.assertEqual(response.status_code, 403)
 
-    def test_ajax_info_in_progress(self):
+    def test_ajax_submission_info__in_progress(self):
+        """An in-progress submission returns JSON with completed and past both False; missing id 404s."""
         response = self.client.post(
             reverse('quests:ajax_info_in_progress', args=[self.submission.id]),
             content_type='application/json',
@@ -2943,7 +2986,7 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_ajax_info_completed(self):
+    def test_ajax_submission_info__completed(self):
         """ url(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/completed/$', views.ajax_submission_info,
         name='ajax_info_completed')
         """
@@ -2974,7 +3017,7 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.context['completed'], True)
         self.assertEqual(response.context['past'], False)
 
-    def test_ajax_info_past(self):
+    def test_ajax_submission_info__past(self):
         """ Completed and in a past semester
 
         url(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/past/$', views.ajax_submission_info, name='ajax_info_past')
@@ -3006,23 +3049,27 @@ class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, and a quest shared across the tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
 
         cls.quest = baker.make(Quest, name="Test Quest")
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the student."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
-    def test_quest_is_available(self):
+    def test_detail__quest_is_available(self):
+        """When the quest is available, the detail view renders with available=True."""
         with patch('quest_manager.models.Quest.is_available', return_value=True):
             response = self.client.get(reverse('quests:quest_detail', args=[self.quest.id]))
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['available'])
 
-    def test_quest_preview_is_available_to_student_without_course(self):
+    def test_detail__preview_available_to_student_without_course(self):
+        """A quest available outside a course is shown as available to a student with no current course."""
         self.client.force_login(self.test_student)
 
         quest_avail_outside_course = baker.make(Quest, available_outside_course=True)
@@ -3032,14 +3079,15 @@ class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertTrue(response.context['available'])
 
-    def test_quest_is_editable(self):
+    def test_detail__quest_is_editable(self):
+        """When the quest is editable, the detail view renders with available=True."""
         with patch('quest_manager.models.Quest.is_editable', return_value=True):
             response = self.client.get(reverse('quests:quest_detail', args=[self.quest.id]))
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['available'])
 
-    def test_quest_is_not_available_nor_editable(self):
+    def test_detail__not_available_nor_editable_shows_preview(self):
         """ Should only display a preview version of the quest
         """
 
@@ -3054,7 +3102,7 @@ class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, "Quest Preview")  # Should be something on the page indicating it's a preview
         self.assertNotContains(response, "Start Quest")  # Definitely no "Start Quest" button
 
-    def test_quest_is_not_available_nor_editable_but_submission_exists(self):
+    def test_detail__not_available_but_submission_exists_redirects(self):
         """ If they have a submission, it should redirect to that,
         otherwise only display a (preview) version of the quest
         """
@@ -3069,7 +3117,7 @@ class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Should redirect them to the submission's page
         self.assertRedirects(response, reverse('quests:submission', args=[sub.id]))
 
-    def test_can_export_in_detail_view(self):
+    def test_detail__can_export_context(self):
         """
         Verify 'can_export' context variable is correctly set in quest detail view
         for staff and students, and that it is disabled in the library schema.
@@ -3111,6 +3159,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a student, a teacher, a quest, and a submission shared across the tests."""
         cls.test_student = User.objects.create_user('test_student')
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
 
@@ -3118,14 +3167,16 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.sub = baker.make(QuestSubmission, quest=cls.quest, user=cls.test_student)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the teacher."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_teacher)
 
-    def test_get_404(self):
+    def test_approve__get_returns_404(self):
         """ This view is only accessible via POST """
         self.assert404('quests:approve', args=[self.sub.id])
 
-    def test_approve_with_comment_only_quick_reply_form(self):
+    def test_approve__with_comment_quick_reply_form(self):
+        """Approving via the quick reply form approves the submission, adds the comment, and notifies the student."""
         comment_text = "Lorum Ipsum"
         quick_reply_form_data = {
             'comment_text': comment_text,
@@ -3160,7 +3211,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # self.assertEqual(len(messages), 1)
         # self.assertEqual(messages[0].tags, 'success')
 
-    def test_approve_with_badge_quick_reply_form(self):
+    def test_approve__with_badge_quick_reply_form(self):
         """ Test that the badge is granted """
         test_badge = baker.make('badges.Badge')
         comment_text = "Lorum Ipsum"
@@ -3184,7 +3235,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         badges_earned = self.test_student.badgeassertion_set.filter(badge=test_badge)
         self.assertEqual(badges_earned.count(), 1)
 
-    def test_approve_other_teachers_student(self):
+    def test_approve__other_teachers_student_notifies_current_teacher(self):
         """ When a teacher approves/rejects/comments on another teacher's student
         The student's actual teacher(s) should get notified
 
@@ -3229,7 +3280,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notification_for_sub = Notification.objects.get_user_target(current_teacher, self.sub)
         self.assertTrue(notification_for_sub)
 
-    def test_approve_without_comment(self):
+    def test_approve__without_comment_uses_default_text(self):
         """ If no comment is provided when approving a quest, then the default approval comment from SiteConfig should be used"""
         quick_reply_form_data = {'comment_text': "", 'approve_button': True}
         self.client.post(reverse('quests:approve', args=[self.sub.id]), data=quick_reply_form_data)
@@ -3240,7 +3291,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments.first().text, f"<p>{SiteConfig.get().blank_approval_text}</p>")
 
-    def test_approve_with_mutiple_badges_staff_submission_form(self):
+    def test_approve__with_multiple_badges_staff_form(self):
         """ Test that multiple badges can be granted from the SubmissionFormStaff form"""
         test_badge1 = baker.make('badges.Badge')
         test_badge2 = baker.make('badges.Badge')
@@ -3282,7 +3333,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notification_for_sub = Notification.objects.get_user_target(self.test_student, self.sub)
         self.assertTrue(notification_for_sub)  # not empty or blank or None...etc
 
-    def test_approve_with_files_submission_form(self):
+    def test_approve__with_files_staff_form(self):
         """ Files can be uploaded and attached to comments when approving/commenting/rejecting quests
         and a link to the file is included in the comment.
         """
@@ -3319,7 +3370,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(os.path.basename(comment_files[0].docfile.name), test_files[0].name)
         self.assertEqual(os.path.basename(comment_files[1].docfile.name), test_files[1].name)
 
-    def test_comment_button(self):
+    def test_approve__comment_button_only_comments(self):
         """ The comment button should only leave a comment and not change the status of the submission """
         comment_text = "Lorum Ipsum"
         quick_reply_form_data = {
@@ -3348,7 +3399,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notification_for_sub = Notification.objects.get_user_target(self.test_student, self.sub)
         self.assertTrue(notification_for_sub)  # not empty or blank or None...etc
 
-    def test_return_button(self):
+    def test_approve__return_button_marks_returned(self):
         """ The return button should mark the submission as returned """
         comment_text = "Lorum Ipsum"
         form_data = {'comment_text': comment_text, 'return_button': True}
@@ -3360,7 +3411,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.sub.refresh_from_db()
         self.assertTrue(self.sub.is_returned)
 
-    def test_no_comment_return_button(self):
+    def test_approve__return_button_without_comment_uses_default(self):
         """ When a submission is returned without comment, the SiteConfig's blank_return_text should be inserted """
 
         form_data = {'comment_text': "", 'return_button': True}
@@ -3373,13 +3424,13 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments.first().text, f"<p>{SiteConfig.get().blank_return_text}</p>")
 
-    def test_non_existant_submit_button(self):
+    def test_approve__nonexistent_submit_button_404(self):
         """Can this even happen?  Somehow the form was submitted with a button that doesn't exist"""
         form_data = {'non_existant_submit_button': True}
         response = self.client.post(reverse('quests:approve', args=[self.sub.id]), data=form_data)
         self.assertEqual(response.status_code, 404)
 
-    def test_skip_button(self):
+    def test_approve__skip_button_marks_no_xp(self):
         """ The skip button should mark the submission as approved and leave a comment,
             but not grant XP to the user
         """
@@ -3407,7 +3458,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments.first().text, "<p>(Skipped - You were not granted XP for this quest)</p>")
 
-    def test_ajax_approve(self):
+    def test_approve__ajax_all_button_types(self):
         """ Checks functionality of approve using ajax for all valid button types using ajax
         """
         post_request = {
@@ -3470,6 +3521,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, a quest, and a submission shared across the tests."""
         # A teacher with a student (connected by the Block in the CourseStudent)
         cls.test_student = User.objects.create_user('test_student')
         cls.current_teacher = User.objects.create_user('test_current_teacher', is_staff=True)
@@ -3488,10 +3540,11 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.sub = baker.make(QuestSubmission, quest=cls.quest)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the teacher."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.current_teacher)
 
-    def test_submitted(self):
+    def test_approvals__submitted_tab(self):
         """ Completed quests awaiting approval for current teacher (teachers are connected by Block)
         A student in a course (StudentCourse) in the teacher's block (Block) should have their submissions
         appear here
@@ -3507,7 +3560,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIsNone(response.context['quest'])
         self.assertURLEqual(response.context['tab_list'][1]['url'], reverse('quests:submitted'))
 
-    def test_submitted_all(self):
+    def test_approvals__submitted_all_tab(self):
         """ All completed quests awaiting approvel, even for students with another teacher (teachers are connected by Block)
         """
         with patch('quest_manager.views.QuestSubmission.objects.all_awaiting_approval', return_value=[self.sub]):
@@ -3520,7 +3573,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIsNone(response.context['quest'])
         self.assertURLEqual(response.context['tab_list'][1]['url'], reverse('quests:submitted'))
 
-    def test_returned(self):
+    def test_approvals__in_progress_tab(self):
         """ Completed quests for current teacher that have been returned to the student. """
         with patch('quest_manager.views.QuestSubmission.objects.all_not_completed', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:in_progress'))
@@ -3532,7 +3585,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIsNone(response.context['quest'])
         self.assertURLEqual(response.context['tab_list'][0]['url'], reverse('quests:in_progress'))
 
-    def test_approved(self):
+    def test_approvals__approved_tab(self):
         """ Completed quests (submissions) that have been approved by a teacher """
 
         with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=[self.sub]):
@@ -3601,7 +3654,8 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.test_student.refresh_from_db()
         self.assertEqual(self.test_student.profile.xp_cached, 80)
 
-    def test_flagged(self):
+    def test_approvals__flagged_tab(self):
+        """The flagged tab lists flagged submissions and activates the Flagged tab."""
         with patch('quest_manager.views.QuestSubmission.objects.flagged', return_value=[self.sub]):
             response = self.client.get(reverse('quests:flagged'))
         self.assertEqual(response.status_code, 200)
@@ -3612,18 +3666,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIsNone(response.context['quest'])
         self.assertURLEqual(response.context['tab_list'][3]['url'], reverse('quests:flagged'))
 
-    # def test_skipped(self):
-    #     with patch('quest_manager.views.QuestSubmission.objects.all_skipped', return_value=[self.sub]):
-    #         response = self.client.get(reverse('quests:skipped'))
-    #     self.assertEqual(response.status_code, 200)
-    #     self.assertContains(response, str(self.sub))
-    #     # Tabs: 0-In Progress, 1-Submitted, 2-Approved, 3- Flagged
-    #     self.assertTrue(response.context['tab_list'][3]['active'])
-    #     self.assertTrue(response.context['current_teacher_only'])
-    #     self.assertIsNone(response.context['quest'])
-    #     self.assertURLEqual(response.context['tab_list'][3]['url'], reverse('quests:skipped'))
-
-    def test_approved_for_quest(self):
+    def test_approvals__approved_for_quest(self):
         """ Approved submissions of only this specific quest, regardless of teacher """
 
         with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=[self.sub]):
@@ -3663,7 +3706,7 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:approvals'))
         self.assertNotContains(response, 'My groups')
 
-    def test_context_correct_tab_types(self):
+    def test_approvals__context_correct_tab_types(self):
         """ Checks each possible tab if it can be activated by accessing the tabs corresponding url
         """
 
@@ -3693,6 +3736,7 @@ class Is_staff_or_TA_test(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a user shared across the tests."""
         cls.user = baker.make(User)
 
     def test_is_staff_or_TA___staff(self):
@@ -3726,20 +3770,24 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and a CommonData instance shared across the tests."""
         cls.teacher = baker.make(User, is_staff=True)
 
         cls.cqi = baker.make(CommonData)
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def test_page_status_code__anonymous(self):
+        """Anonymous users are redirected to login for all CommonData views."""
         self.assertRedirectsLogin("quest_manager:commonquestinfo_list")
         self.assertRedirectsLogin("quest_manager:commonquestinfo_create")
         self.assertRedirectsLogin("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
         self.assertRedirectsLogin("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
 
     def test_page_status_code__student(self):
+        """Students are forbidden (403) from all CommonData views."""
         stu = baker.make(User)
         self.client.force_login(stu)
 
@@ -3749,6 +3797,7 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
 
     def test_page_status_code__teacher(self):
+        """Teachers can access all CommonData views (200)."""
         self.client.force_login(self.teacher)
 
         self.assert200("quest_manager:commonquestinfo_list")
@@ -3756,7 +3805,7 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200("quest_manager:commonquestinfo_update", args=[self.cqi.pk])
         self.assert200("quest_manager:commonquestinfo_delete", args=[self.cqi.pk])
 
-    def test_CommonDataList_view(self):
+    def test_CommonDataList_view__lists_all(self):
         """
             Test if CommonData displays all CQI obj
         """
@@ -3771,7 +3820,7 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         for model_obj, ctx_obj in zip(CommonData.objects.all(), object_list):
             self.assertEqual(model_obj.pk, ctx_obj.pk)
 
-    def test_CommonDataCreate_view(self):
+    def test_CommonDataCreate_view__creates(self):
         """
             Test if CQI can be created using CreateView via form_data
         """
@@ -3782,7 +3831,7 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(CommonData.objects.count(), 2)
 
-    def test_CommonDataUpdate_view(self):
+    def test_CommonDataUpdate_view__updates(self):
         """
             Test if CQI can be updated using UpdateView via form_data
         """
@@ -3800,7 +3849,7 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotEqual(new.title, old.title)
         self.assertEqual(new.instructions, old.instructions)
 
-    def test_CommonDataDelete_view(self):
+    def test_CommonDataDelete_view__deletes(self):
         """
             Test if CQI can be deleted using DeleteView
         """
@@ -3817,6 +3866,7 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 class QuestArchiveViewTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Create a staff user and two quests where Quest B has Quest A as a prerequisite."""
         cls.staff_user = User.objects.create_user(username='staff', is_staff=True)
 
         # Quest A: This quest will be used as a prerequisite for another quest (Quest B).
@@ -3831,6 +3881,7 @@ class QuestArchiveViewTest(ByteDeckTenantTestCase):
         Prereq.add_simple_prereq(parent_object=cls.quest_b, prereq_object=cls.quest_a)
 
     def setUp(self):
+        """Set up a tenant-aware test client and log in the staff user."""
         self.client = TenantClient(self.tenant)
         self.client.force_login(self.staff_user)
 

--- a/src/siteconfig/tests/test_forms.py
+++ b/src/siteconfig/tests/test_forms.py
@@ -19,10 +19,8 @@ class SiteConfigFormTest(ByteDeckTenantTestCase):
         """
         self.config = SiteConfig.get()
 
-    def test_clean_custom_stylesheet_method(self):
-        """
-        Tests CSS validation for form uploads done by `clean_custom_stylesheet` method.
-        """
+    def test_clean_custom_stylesheet__validates_css(self):
+        """Tests CSS validation for form uploads done by `clean_custom_stylesheet` method."""
         form_data = model_to_form_data(self.config, SiteConfigForm)
         del form_data["custom_stylesheet"]
 
@@ -70,14 +68,10 @@ class SiteConfigFormTest(ByteDeckTenantTestCase):
             charset="utf-8",
         )
         form = SiteConfigForm(form_data, files={"custom_stylesheet": custom_stylesheet}, instance=self.config, is_deck_owner=True)
-        # print(form.errors)
         self.assertTrue(form.is_valid())
 
-    def test_custom_stylesheet_file_submission_removal(self):
-        """
-        Custom CSS file can be uploaded (submitted) and attached to `SiteConfig` model,
-        and existing file can be cleared.
-        """
+    def test_custom_stylesheet__submission_and_removal(self):
+        """Custom CSS file can be uploaded and attached to `SiteConfig`, and an existing file can be cleared."""
         valid_css = b"""body { color: black; }"""
         custom_stylesheet = InMemoryUploadedFile(
             BytesIO(valid_css),
@@ -114,8 +108,8 @@ class SiteConfigFormTest(ByteDeckTenantTestCase):
         with self.assertRaises(ValueError):
             SiteConfig.get().custom_stylesheet.read()
 
-    def test_clean_clean_custom_profile_field_method(self):
-        """ Test if `clean_clean_custom_profile_field()` strips whitespace'd ends """
+    def test_clean_custom_profile_field__strips_whitespace(self):
+        """Test if `clean_clean_custom_profile_field()` strips whitespace'd ends."""
         form_data = model_to_form_data(self.config, SiteConfigForm)
 
         # check with whitespace only

--- a/src/siteconfig/tests/test_models.py
+++ b/src/siteconfig/tests/test_models.py
@@ -30,43 +30,44 @@ class SiteConfigModelTest(ByteDeckTenantTestCase):
         self.config = SiteConfig.get()
 
     def tearDown(self):
+        """Clear the cache after each test so cached SiteConfig data does not leak."""
         cache.clear()
 
-    def test_get(self):
-        """ Each tenant should have a single SiteConfig object
-        that is created upon first access via the get() method
-        """
+    def test_get__returns_singleton(self):
+        """Each tenant should have a single SiteConfig object created on first get()."""
         self.assertIsInstance(self.config, SiteConfig)
         self.assertEqual(SiteConfig.objects.count(), 1)
 
-    def test_semester_created(self):
-        """ If one doesn't exists yet, a semester should be created
-        to act as the active semester """
+    def test_active_semester__created_by_default(self):
+        """If one doesn't exist yet, a semester is created to act as the active semester."""
         self.assertIsNotNone(self.config.active_semester)
 
-    def test_get_absolute_url(self):
-        """ Provides url to the update form """
+    def test_get_absolute_url__returns_update_form_url(self):
+        """Provides url to the update form."""
         self.assertEqual(reverse('config:site_config_update_own'), self.config.get_absolute_url())
 
-    def test_get_site_logo(self):
-        """ Returns a default logo """
+    def test_get_site_logo_url__returns_default(self):
+        """Returns a default logo."""
         self.assertEqual(self.config.get_site_logo_url(), static('img/default_icon.png'))
 
-    def test_get_default_icon_url(self):
-        """ By default should return the site logo """
+    def test_get_default_icon_url__returns_site_logo(self):
+        """By default should return the site logo."""
         self.assertEqual(self.config.get_default_icon_url(), static('img/default_icon.png'))
 
-    def test_get_favicon_url(self):
-        """ Returns default if no favicon set """
+    def test_get_favicon_url__returns_default(self):
+        """Returns default if no favicon set."""
         self.assertEqual(self.config.get_favicon_url(), static('icon/favicon.ico'))
 
-    def test_get_banner_image_url(self):
+    def test_get_banner_image_url__returns_default(self):
+        """Returns the default banner image when none is set."""
         self.assertEqual(self.config.get_banner_image_url(), static('img/banner.png'))
 
-    def test_get_banner_image_dark_url(self):
+    def test_get_banner_image_dark_url__returns_default(self):
+        """Returns the default dark banner image when none is set."""
         self.assertEqual(self.config.get_banner_image_dark_url(), static('img/banner.png'))
 
-    def test_set_active_semester(self):
+    def test_set_active_semester__updates_active_semester(self):
+        """set_active_semester() switches the config's active semester to the given one."""
         # make sure default active semester is created first
         default_active_sem = self.config.active_semester
         new_semester = baker.make('courses.Semester')
@@ -78,15 +79,15 @@ class SiteConfigModelTest(ByteDeckTenantTestCase):
         # make sure it is now the active semester
         self.assertEqual(self.config.active_semester.id, new_semester.id)
 
-    def test_SiteConfig_get_caches(self):
-        """ SiteConfig should be in cache """
+    def test_get__caches_config(self):
+        """SiteConfig should be in cache after get()."""
         cached_config = cache.get(SiteConfig.cache_key())
 
         self.assertIsNotNone(cached_config)
         self.assertEqual(self.config, cached_config)
 
-    def test_SiteConfig_save_sets_new_cache_properly(self):
-        """ SiteConfig.save should invalidate previous cache and set newer cache """
+    def test_save__resets_cache(self):
+        """SiteConfig.save should invalidate previous cache and set newer cache."""
         old_config_cache = cache.get(SiteConfig.cache_key())
 
         new_site_name = 'My New Site Name'
@@ -100,8 +101,8 @@ class SiteConfigModelTest(ByteDeckTenantTestCase):
         # Cache should be set after calling SiteConfig.get()
         self.assertEqual(cache.get(SiteConfig.cache_key()).site_name, new_config_cache.site_name)
 
-    def test_SiteConfig_cache_expires(self):
-        """ SiteConfig cache should expire after a certain period """
+    def test_get__cache_expires(self):
+        """SiteConfig cache should expire after a certain period."""
 
         # Cache should not be empty as of this moment
         self.assertIsNotNone(cache.get(SiteConfig.cache_key()))
@@ -140,7 +141,7 @@ class SiteConfigModelTest(ByteDeckTenantTestCase):
         self.assertNotEqual(get_default_deck_owner(), old_owner_pk)
         self.assertEqual(get_default_deck_owner(), User.objects.last().pk)  # since it gets created it should be at the back. Assume sorted by pk
 
-    def test_can_user_export_to_library(self):
+    def test_can_user_export_to_library__respects_permissions(self):
         """Verify can_user_export_to_library respects deck owner, staff settings, and schema."""
 
         current_schema = "test"

--- a/src/siteconfig/tests/test_views.py
+++ b/src/siteconfig/tests/test_views.py
@@ -31,26 +31,29 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.config = SiteConfig.get()
         self.client = TenantClient(self.tenant)
 
-    def test_all_siteconfig_page_status_codes_for_anonymous(self):
+    def test_siteconfig_page_status_codes__anonymous(self):
+        """Anonymous users are redirected to login from the siteconfig update views."""
         self.assertRedirectsLogin('config:site_config_update', args=[self.config.get().id])
         self.assertRedirectsLogin('config:site_config_update_own')
 
-    def test_all_siteconfig_page_status_codes_for_students(self):
+    def test_siteconfig_page_status_codes__students(self):
+        """Students are forbidden (403) from the siteconfig update views."""
         student = baker.make(User)
         self.client.force_login(student)
 
         self.assert403('config:site_config_update', args=[self.config.get().id])
         self.assert403('config:site_config_update_own')
 
-    def test_all_siteconfig_page_status_codes_for_staff(self):
+    def test_siteconfig_page_status_codes__staff(self):
+        """Staff can access (200) the siteconfig update views."""
         teacher = baker.make(User, is_staff=True)
         self.client.force_login(teacher)
 
         self.assert200('config:site_config_update', args=[self.config.get().id])
         self.assert200('config:site_config_update_own')
 
-    def testSiteConfigUpdate_uses_newly_saved_cache_data(self):
-
+    def test_siteconfig_update__uses_newly_saved_cache_data(self):
+        """After a form update, SiteConfig.get() rebuilds the cache with the saved data."""
         self.client.force_login(User.objects.create_user(username='staff_test', is_staff=True))
 
         old_cache = cache.get(SiteConfig.cache_key())
@@ -84,10 +87,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Comparing the `site_name` since Django's Model.__eq__ is comparing `pk`
         self.assertNotEqual(old_cache.site_name, cache.get(SiteConfig.cache_key()).site_name)
 
-    def test_SiteConfigForm_basic_tests(self):
-        """
-            Basic test for SiteConfigForm
-        """
+    def test_siteconfig_form__basic_submission_and_owner_change(self):
+        """Only the deck owner can change the deck_owner field, and the new owner is made a superuser."""
         owner_user = self.config.deck_owner
         staff_user = baker.make(User, is_staff=True)
 
@@ -137,12 +138,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         config.save()
         self.assertEqual(owner_user.pk, SiteConfig.get().deck_owner.pk)
 
-    def test_form_helper_required_fields(self):
-        """
-        Tests whether `form.helper.layout` includes all required fields or not.
-
-        There is an issue with `FormHelper` that breaks form submission, if required fields are not listed explicitly.
-        """
+    def test_form_helper__includes_required_fields(self):
+        """Tests whether `form.helper.layout` includes all required fields (missing ones break submission)."""
         owner_user = self.config.deck_owner
 
         URL = reverse("config:site_config_update_own")
@@ -187,10 +184,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.client.post(URL, data=form_data)
         self.assertEqual(SiteConfig.get().site_name, "site_name")  # should be equal and prove the case
 
-    def test_custom_javascript_mimetypes(self):
-        """
-        Tests all permitted mimetypes for `custom_javascript` file uploads.
-        """
+    def test_custom_javascript__permitted_mimetypes(self):
+        """Tests all permitted mimetypes for `custom_javascript` file uploads."""
         owner_user = self.config.deck_owner
 
         URL = reverse("config:site_config_update_own")
@@ -250,10 +245,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.client.post(URL, data=data)
         self.assertEqual(SiteConfig.get().custom_javascript.read(), valid_js)  # form success should have updated model
 
-    def test_owner_only_fields_can_only_be_changed_by_owner(self):
-        """ Checks if staff users that isnt the owner can change any of the advanced fields.
-        Which are only editable by the deck_owner
-        """
+    def test_owner_only_fields__changed_only_by_owner(self):
+        """Advanced/owner-only fields can be changed by the deck owner but not by other staff."""
         URL = reverse("config:site_config_update_own")
 
         # create form data. remove any file uploads

--- a/src/tags/tests/test_models.py
+++ b/src/tags/tests/test_models.py
@@ -67,9 +67,10 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, ByteDeckT
     """
     @classmethod
     def setUpTestData(cls):
+        """Create a shared user for the tag/xp helper tests."""
         cls.user = baker.make(User)
 
-    def test_multiple_quest_submission_tagged(self):
+    def test_get_quest_submission_by_tag__multiple_tags(self):
         """  check if multiple tags can be caught by get_quest_submission_by_tag """
 
         for _i in range(2):
@@ -87,7 +88,7 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, ByteDeckT
         quest_submission_qs = get_quest_submission_by_tag(self.user, ['tag0', 'tag1', 'tag2'])
         self.assertEqual(quest_submission_qs.count(), 6)
 
-    def test_multiple_badge_assertion_tagged(self):
+    def test_get_badge_assertion_by_tags__multiple_tags(self):
         """  check if multiple tags can be caught by get_badge_assertion_by_tags """
 
         for _i in range(2):
@@ -170,9 +171,10 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a shared user for the tag/xp helper tests."""
         cls.user = baker.make(User)
 
-    def test_unique_tag_quest_badges(self):
+    def test_get_user_tags_and_xp__unique_tag_quest_badges(self):
         """
             Unique tags per quest and badge, xp representing tag's index
         """
@@ -194,7 +196,7 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
 
         self.assertEqual(expected_order, calculated_order)
 
-    def test_same_tag_per_quest_badges(self):
+    def test_get_user_tags_and_xp__same_tag_per_quest_badges(self):
         """
             Same tag for quest and badges, xp representing tag's index
         """
@@ -214,7 +216,7 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
 
         self.assertEqual(expected_order, calculated_order)
 
-    def test_multiple_tags_per_quest_badges(self):
+    def test_get_user_tags_and_xp__multiple_tags_per_quest_badges(self):
         """
             Two tags per generated quest and badges, xp representing tag_tuples's index
         """
@@ -238,7 +240,7 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
 
         self.assertEqual(expected_order, calculated_order)
 
-    def test_query_tag_from_approved_quest(self):
+    def test_get_user_tags_and_xp__only_approved_submissions(self):
         """
             When getting all quests related to tag and user, check if only submitted and approved tags show
         """
@@ -262,7 +264,7 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
         self.assertTrue('approved' in tags)
         self.assertFalse('submitted' in tags)
 
-    def test_total_xp_is_correct(self):
+    def test_get_user_tags_and_xp__total_xp_is_correct(self):
         """ check if get_user_tags_and_xp's xp adds up correctly """
 
         # quest only
@@ -291,9 +293,10 @@ class Tag_get_tags_from_user_Tests(TagHelper, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a shared user for the tag/xp helper tests."""
         cls.user = baker.make(User)
 
-    def test_unique_tag_per_quest_badges(self):
+    def test_get_tags_from_user__unique_tag_per_quest_badges(self):
         """
             Unique tags per quest and badge
         """
@@ -313,7 +316,7 @@ class Tag_get_tags_from_user_Tests(TagHelper, ByteDeckTenantTestCase):
         tag_names = list(get_tags_from_user(self.user).order_by('name').values_list('name', flat=True))
         self.assertEqual(tag_names, tag_list)
 
-    def test_same_tag_per_quest_badges(self):
+    def test_get_tags_from_user__same_tag_per_quest_badges(self):
         """
             Same tag for quest and badges
         """
@@ -330,7 +333,7 @@ class Tag_get_tags_from_user_Tests(TagHelper, ByteDeckTenantTestCase):
         tag_names = list(get_tags_from_user(self.user).order_by('name').values_list('name', flat=True))
         self.assertEqual(tag_names, tag_list)
 
-    def test_multiple_tags_per_quest_badges(self):
+    def test_get_tags_from_user__multiple_tags_per_quest_badges(self):
         """
             Two tags per generated quest and badges
         """
@@ -365,11 +368,12 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
     @classmethod
     def setUpTestData(cls):
+        """Create a shared user for the tag/xp helper tests."""
         cls.user = baker.make(User)
 
     # MISC. TEST
 
-    def test_list_input(self):
+    def test_total_xp_by_tags__list_input(self):
         """
             check if total_xp_by_tags can accept test without exception
         """
@@ -381,7 +385,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         except ProgrammingError:
             self.fail("total_xp_by_tags raised ProgrammingError when using list as input")
 
-    def test_queryset_input(self):
+    def test_total_xp_by_tags__queryset_input(self):
         """
             check if total_xp_by_tags can accept a queryset without exception
         """
@@ -395,7 +399,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
     # QUEST ONLY TESTS
 
-    def test_submission_with_xp_requested(self):
+    def test_total_xp_by_tags__submission_with_xp_requested(self):
         """
             Verify that the xp_requested value is being used instead of quest.xp.
             This could happen when `quest.xp_can_be_entered_by_students = True`, which means the
@@ -420,7 +424,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         # Method should recognize the 100 XP requested and approved, instead of quest.xp = 50:
         self.assertEqual(total_xp_by_tags(self.user, ["TEST"]), 100)
 
-    def test_submission_with_max_xp_surpassed(self):
+    def test_total_xp_by_tags__submission_with_max_xp_surpassed(self):
         """
             Verify that no more than quest.max_xp is counted toward a tag's XP when there are multiple submissions of the same quest.
             Create 3 submissions of a 50XP quest, but quest.max_xp=100 so this method should return 100
@@ -444,7 +448,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         # Method should recognize a max of 100XP, instead of 150 (3 * quest.xp):
         self.assertEqual(total_xp_by_tags(self.user, ["TEST"]), 100)
 
-    def test_one_tag_quests_only(self):
+    def test_total_xp_by_tags__one_tag_quests_only(self):
         """
             See if correct xp is returned using only 1 tag added to Quest objects
         """
@@ -458,7 +462,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         self.assertEqual(total_xp_by_tags(self.user, ["TAG"]), sum(xp_list))
         self.assertEqual(get_quest_submission_total_xp(self.user, ["TAG"]), sum(xp_list))
 
-    def test_multiple_separate_tags_quests_only(self):
+    def test_total_xp_by_tags__multiple_separate_tags_quests_only(self):
         """
             See if correct xp is returned using only multiple tags added to Quest objects
             only 1 unique tag per quest
@@ -474,7 +478,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         self.assertEqual(total_xp_by_tags(self.user, tag_list), sum(xp_list))
         self.assertEqual(get_quest_submission_total_xp(self.user, tag_list), sum(xp_list))
 
-    def test_multiple_crossing_tags_quests_only(self):
+    def test_total_xp_by_tags__multiple_crossing_tags_quests_only(self):
         """
             See if correct xp is returned using only multiple tags added to Quest objects
             each quest object should have multiple tags
@@ -492,7 +496,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         self.assertEqual(total_xp_by_tags(self.user, unpacked_tag_tuples), sum(xp_list))
         self.assertEqual(get_quest_submission_total_xp(self.user, unpacked_tag_tuples), sum(xp_list))
 
-    def test_one_tag_multiple_quests_only(self):
+    def test_total_xp_by_tags__one_tag_multiple_quests_only(self):
         """
             See if correct xp is returned using only one tag + quests with multiple questsubmissions
         """
@@ -535,7 +539,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
     # BADGE ONLY TESTS
 
-    def test_one_tag_badges_only(self):
+    def test_total_xp_by_tags__one_tag_badges_only(self):
         """
             See if correct xp is returned using only 1 tag added to Badge objects
         """
@@ -549,7 +553,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         self.assertEqual(total_xp_by_tags(self.user, ["TAG"]), sum(xp_list))
         self.assertEqual(get_badge_assertion_total_xp(self.user, ["TAG"]), sum(xp_list))
 
-    def test_multiple_separate_tags_badges_only(self):
+    def test_total_xp_by_tags__multiple_separate_tags_badges_only(self):
         """
             See if correct xp is returned using only multiple tags added to Badge objects
             only 1 unique tag per badge
@@ -565,7 +569,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         self.assertEqual(total_xp_by_tags(self.user, tag_list), sum(xp_list))
         self.assertEqual(get_badge_assertion_total_xp(self.user, tag_list), sum(xp_list))
 
-    def test_multiple_crossing_tags_badges_only(self):
+    def test_total_xp_by_tags__multiple_crossing_tags_badges_only(self):
         """
             See if correct xp is returned using only multiple tags added to Badge objects
             each Badge object should have multiple tags
@@ -583,7 +587,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         self.assertEqual(total_xp_by_tags(self.user, unpacked_tag_tuples), sum(xp_list))
         self.assertEqual(get_badge_assertion_total_xp(self.user, unpacked_tag_tuples), sum(xp_list))
 
-    def test_one_tag_multiple_badges_only(self):
+    def test_total_xp_by_tags__one_tag_multiple_badges_only(self):
         """
             See if correct xp is returned using only one tag + badges with multiple BadgeAssertions
         """
@@ -626,7 +630,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
     # QUEST + BADGE TESTS
 
-    def test_one_tag_quests_badges(self):
+    def test_total_xp_by_tags__one_tag_quests_badges(self):
         """
             See if correct xp is returned using only 1 tag added to Quest and Badge objects
         """
@@ -645,7 +649,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
         self.assertEqual(total_xp_by_tags(self.user, ["TAG"]), sum(xp_list))
 
-    def test_multiple_separate_tags_quests_badges(self):
+    def test_total_xp_by_tags__multiple_separate_tags_quests_badges(self):
         """
             See if correct xp is returned using only 1 tag added to Quest and Badge objects
             only 1 unique tag per quest and badge
@@ -663,7 +667,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
         self.assertEqual(total_xp_by_tags(self.user, tag_list), sum(xp_list))
 
-    def test_multiple_crossing_tags_quest_badges(self):
+    def test_total_xp_by_tags__multiple_crossing_tags_quest_badges(self):
         """
             See if correct xp is returned using two tags per Quest and Badge object
             each Quest and Badge object should have multiple tags
@@ -687,7 +691,7 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
         unpacked_tag_tuples = [tag_tuple[index] for tag_tuple in tag_tuples for index in range(len(tag_tuple))]
         self.assertEqual(total_xp_by_tags(self.user, unpacked_tag_tuples), sum(xp_list))
 
-    def test_one_tag_multiple_quests_badges(self):
+    def test_total_xp_by_tags__one_tag_multiple_quests_badges(self):
         """
              See if correct xp is returned using only one tag + quests and badges with multiple QuestSubmissions and BadgeAssertions
         """

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -34,12 +34,14 @@ class AutoResponseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a tag for the autocomplete view tests."""
         Tag.objects.create(name="test-tag")
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_autocomplete_view(self):
+    def test_autocomplete_view__accessible(self):
         """ Make sure our custom django-select2 view for tag widget is accessible"""
         url = reverse('tags:auto-json')
         form = TaggitSelect2WidgetForm()
@@ -78,12 +80,14 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create teacher/student users and a tag for the CRUD view tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
 
         cls.tag = Tag.objects.create(name="test-tag")
 
     def setUp(self):
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def test_page_status_code__anonymous(self):
@@ -117,7 +121,7 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('tags:update', args=[self.tag.pk])
         self.assert200('tags:delete', args=[self.tag.pk])
 
-    def test_ListView(self):
+    def test_ListView__displays_all_tags(self):
         """Make sure list view displays all tags correctly"""
         baker.make(Tag, _quantity=5)
 
@@ -307,7 +311,7 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
 
-    def test_CreateView(self):
+    def test_CreateView__creates_tag(self):
         """Make sure create view can create tags"""
         form_data = generate_form_data(model_form=TagForm)
 
@@ -341,7 +345,7 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'Tag name too similar to existing tag: test-tag')
         self.assertFalse(Tag.objects.filter(name='TEST-TAG').exists())
 
-    def test_UpdateView(self):
+    def test_UpdateView__changes_name_and_slug(self):
         """Make sure update view can change name + update slug"""
         form_data = generate_form_data(model_form=TagForm)
 
@@ -353,7 +357,7 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(form_data['name'].lower(), tag.name)
         self.assertEqual(form_data['name'].lower(), tag.slug)
 
-    def test_DeleteView(self):
+    def test_DeleteView__deletes_tag(self):
         """Make sure delete view can delete tag"""
         self.client.force_login(self.test_teacher)
         self.client.post(reverse('tags:delete', args=[self.tag.pk]))

--- a/src/tags/tests/test_widgets.py
+++ b/src/tags/tests/test_widgets.py
@@ -6,17 +6,20 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 class TestTaggitSelect2Widget(ByteDeckTenantTestCase):
 
-    def test_get_url(self):
+    def test_get_url__returns_string(self):
+        """The widget's get_url returns a string URL."""
         widget = TaggitSelect2Widget()
         assert isinstance(widget.get_url(), str)
 
-    def test_tag_attrs(self):
+    def test_render__default_tag_attrs(self):
+        """Rendered widget includes the default select2 tag data attributes."""
         widget = TaggitSelect2Widget()
         output = widget.render('name', 'value')
         assert 'data-minimum-input-length="1"' in output
         assert 'data-tags=","' in output
 
-    def test_custom_tag_attrs(self):
+    def test_render__custom_tag_attrs(self):
+        """Custom attrs passed to the widget override the rendered defaults."""
         widget = TaggitSelect2Widget(attrs={'data-minimum-input-length': '3'})
         output = widget.render('name', 'value')
         assert 'data-minimum-input-length="3"' in output

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -65,7 +65,8 @@ class NonPublicTenantAdminTest(ByteDeckTenantTestCase):
 
     """
 
-    def test_nonpublic_tenant_admin_save_model(self):
+    def test_save_model__non_public_schema_raises(self):
+        """save_model raises when a tenant is created outside the public schema."""
         tenant_model_admin = TenantAdmin(model=Tenant, admin_site=AdminSite())
 
         # Can't create tenant outside the `public` schema. Current schema is `test`, so should throw exception
@@ -76,24 +77,9 @@ class NonPublicTenantAdminTest(ByteDeckTenantTestCase):
 class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
     """TenantTestCase comes with a tenant: tenant.test.com"""
 
-    ###############################################################################
-    # Not sure why this doesn't work, but seems like TenantTestCase is
-    # stops using the test databse and is looking for the real databse? or something...
-    # So it fails on TravisCI where there is no database names `postgress`
-    ###############################################################################
-    # fixtures = ['tenant/tenants.json']
-
-    # # This doesn't seem to work when placed in SetUp, so make them class variables.
-    # tenant_model_admin = TenantAdmin(model=Tenant, admin_site=AdminSite())
-    # public_tenant = Tenant.objects.get(schema_name="public")
-
-    # def test_public_tenant_exists(self):
-    #     self.assertIsInstance(self.public_tenant, Tenant)
-    #     self.assertEqual(self.public_tenant.domain_url, "localhost")
-    #################################################################################
-
     @classmethod
     def setUpTestData(cls):
+        """Build the public schema with a superuser and an extra tenant, and seed owner emails (verified/unverified)."""
         # create the public schema
         cls.public_tenant = Tenant(schema_name="public", name="public")
         with tenant_context(cls.public_tenant):
@@ -149,10 +135,11 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
                 email_address.save()
 
     def setUp(self):
+        """Build a TenantAdmin instance and a public-tenant client for each test."""
         self.tenant_model_admin = TenantAdmin(model=Tenant, admin_site=AdminSite())
         self.client = TenantClient(self.public_tenant)
 
-    def test_owner_full_name_text_column(self):
+    def test_owner_full_name_text__shown_in_changelist(self):
         """
         Test whether content of custom column "owner_full_name_text" is present in admin list view or not.
         """
@@ -170,7 +157,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "John Doe")
 
-    def test_owner_email_text_column(self):
+    def test_owner_email_text__shown_in_changelist(self):
         """
         Test whether content of custom column "owner_email_text" is present in admin list view or not.
         """
@@ -189,7 +176,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         self.assertContains(response, "john@doe.com")  # verified email
         self.assertContains(response, "jane@doe.com")  # unverified email
 
-    def test_paid_until_text_column(self):
+    def test_paid_until_text__shown_in_changelist(self):
         """
         Test whether content of htmlized column "paid_until_text" is present in admin list view or not.
         """
@@ -207,7 +194,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "<span data-date=\"2032-01-01\">Jan. 1, 2032</span>")
 
-    def test_trial_end_date_text_column(self):
+    def test_trial_end_date_text__shown_in_changelist(self):
         """
         Test whether content of htmlized column "trial_end_date" is present in admin list view or not.
         """
@@ -225,7 +212,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "<span data-date=\"2022-01-01\">Jan. 1, 2022</span>")
 
-    def test_search_on_custom_fields(self):
+    def test_search__on_custom_fields(self):
         """
         Test whether content of custom fields is searchable in admin list view or not.
         """
@@ -280,7 +267,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         self.assertContains(response, "0 result")
 
     @patch("tenant.admin.messages.add_message")
-    def test_enable_google_signin_admin_without_config(self, mock_add_message):
+    def test_enable_google_signin__without_public_config(self, mock_add_message):
         """
         Test where we attempt to enable google sign in but the public tenant has not yet configured
         the Google Provider Social App
@@ -308,7 +295,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
     # Getting this error django.contrib.messages.api.MessageFailure:
     #           You cannot add messages without installing django.contrib.messages.middleware.MessageMiddleware
     @patch("tenant.admin.messages.add_message")
-    def test_enable_and_disable_google_signin_admin(self, mock_add_message):
+    def test_enable_and_disable_google_signin__via_admin(self, mock_add_message):
         """
         Test where we enable/disable google signin for clients via admin
         """
@@ -366,8 +353,8 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
 
         mock_add_message.assert_called()
 
-    def test_public_tenant_admin_save_model(self):
-
+    def test_save_model__public_tenant_creates_schema(self):
+        """save_model on the public tenant creates a new tenant with a sanitized schema name."""
         with tenant_context(self.public_tenant):
             non_public_tenant = Tenant(
                 name="Non-Public",  # Not a valid name, but not validated in this test
@@ -422,6 +409,7 @@ class TenantAdminFormTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Build baseline valid form data reused across the form validation tests."""
         cls.form_data = {
             'name': 'test',  # This is the name of the already existing test tenant
             # 'owner_full_name': None,
@@ -432,30 +420,33 @@ class TenantAdminFormTest(ByteDeckTenantTestCase):
             'trial_end_date': timezone.now()
         }
 
-    def test_public_tenant_not_editable(self):
+    def test_clean__public_tenant_not_editable(self):
+        """The reserved 'public' name is rejected by the admin form."""
         self.form_data["name"] = "public"
         form = TenantAdminForm(self.form_data)
         self.assertFalse(form.is_valid())
 
-    def test_new_non_public_tenant_valid(self):
+    def test_clean__new_non_public_tenant_valid(self):
+        """A new non-public tenant name validates on the admin form."""
         self.form_data["name"] = "non-public"
         form = TenantAdminForm(self.form_data)
         self.assertTrue(form.is_valid())
 
-    def test_existing_non_public_tenant_valid(self):
+    def test_clean__existing_non_public_tenant_valid(self):
         """ test tenant already exists as a part of the TenantTestCase """
         form = TenantAdminForm(self.form_data)
         form.instance = Tenant.get()  # test tenant with schema 'test'
         self.assertTrue(form.is_valid())
 
-    def test_cant_change_existing_name(self):
+    def test_clean__cant_change_existing_name(self):
+        """Renaming an existing tenant via the admin form is rejected."""
         # test tenant already exists and is connected in TenantTestCase
         self.form_data["name"] = "nottest"
         form = TenantAdminForm(self.form_data)
         form.instance = Tenant.get()  # test tenant with schema 'test'
         self.assertFalse(form.is_valid())
 
-    def test_cant_create_if_schema_still_exists(self):
+    def test_clean__cant_create_if_schema_still_exists(self):
         """
         Creating new tenant object with a name of existing schema, should fail with form (validation) error
         """
@@ -471,6 +462,7 @@ class TenantAdminViewPermissionsTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Build the public schema plus view/add/change/delete staff users with matching permissions and an extra tenant."""
         # create the public schema
         cls.public_tenant = Tenant(schema_name="public", name="public")
         with tenant_context(cls.public_tenant):
@@ -535,10 +527,17 @@ class TenantAdminViewPermissionsTest(ByteDeckTenantTestCase):
         cls.lib = 1 if Tenant.objects.filter(schema_name='library').exists() else 0
 
     def setUp(self):
+        """Build a public-tenant client for each test."""
         self.client = TenantClient(self.public_tenant)
 
+    # NOTE: this test's name sorts first in the class on purpose. It opens with an
+    # anonymous request through the public TenantClient, which leaves the DB
+    # connection on the public schema so the sibling tests' force_login() (their
+    # first DB touch) resolves the public-schema users. Renaming it to sort after a
+    # force_login-first sibling reintroduces "Save with update_fields did not affect
+    # any rows" on update_last_login.
     @override_settings(ROOT_URLCONF=__name__)
-    def test_delete_view(self):
+    def test_delete_view__enforces_permissions(self):
         """
         Delete view should restrict access and actually delete items.
 
@@ -613,7 +612,7 @@ class TenantAdminViewPermissionsTest(ByteDeckTenantTestCase):
         logged = LogEntry.objects.get(content_type=tenant_ct, action_flag=DELETION)
         self.assertEqual(logged.object_id, str(self.extra_tenant.pk))
 
-    def test_delete_view_uses_delete_model(self):
+    def test_delete_view__uses_delete_model(self):
         """
         The delete view uses ModelAdmin.delete_model() method, that delete items, but leaves schemas in database.
         """
@@ -631,7 +630,8 @@ class TenantAdminViewPermissionsTest(ByteDeckTenantTestCase):
         # ...but schema still in database
         self.assertTrue(schema_exists("extra"))
 
-    def test_delete_view_nonexistent_obj(self):
+    def test_delete_view__nonexistent_obj(self):
+        """Deleting a nonexistent tenant redirects to the admin index with a not-found message."""
         self.client.force_login(self.deleteuser)
         url = reverse("admin:tenant_tenant_delete", args=("nonexistent",))
         response = self.client.get(url, follow=True)
@@ -647,6 +647,7 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Build the public schema, a superuser, an extra tenant, and seed owner emails (verified/unverified)."""
         # create the public schema
         cls.public_tenant = Tenant(schema_name="public", name="public")
         with tenant_context(cls.public_tenant):
@@ -700,15 +701,17 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
                 email_address.save()
 
     def setUp(self):
+        """Build a public-tenant client and force Celery tasks to run eagerly."""
         self.client = TenantClient(self.public_tenant)
 
         self.old_celery_always_eager = app.conf.task_always_eager
         app.conf.task_always_eager = True
 
     def tearDown(self):
+        """Restore the original Celery eager-execution setting."""
         app.conf.task_always_eager = self.old_celery_always_eager
 
-    def test_model_admin_message_unverified_action(self):
+    def test_message_unverified_action__emails_verified_and_unverified_owners(self):
         """
         The message_unverified action on public tenant sends emails to selected tenant "owners",
         using both *verified* and *unverified* email addresses.
@@ -795,7 +798,7 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
         # one *unverified* object was selected (tenant)
         self.assertContains(response, ACTION_CHECKBOX_NAME, count=1)
 
-    def test_model_admin_message_verified_action(self):
+    def test_message_verified_action__emails_verified_owners_only(self):
         """
         The message_verified action on public tenant sends emails to selected tenant "owners",
         using *verified* only email addresses.

--- a/src/tenant/tests/test_forms.py
+++ b/src/tenant/tests/test_forms.py
@@ -17,7 +17,7 @@ User = get_user_model()
 class DeckRequestFormTest(ByteDeckTenantTestCase):
     """Tests for the public `DeckRequestForm`."""
 
-    def test_captcha_uses_invisible_recaptcha_widget(self):
+    def test_captcha__uses_invisible_recaptcha_widget(self):
         """The deck request captcha must use the same reCAPTCHA widget type as the rest
         of the site (v2 invisible). A single key pair is configured globally
         (RECAPTCHA_PUBLIC_KEY/RECAPTCHA_PRIVATE_KEY) and Google's keys are widget-type
@@ -30,7 +30,7 @@ class DeckRequestFormTest(ByteDeckTenantTestCase):
 class TenantFormTest(ByteDeckTenantTestCase):
     """Various tests for `TenantForm` form class."""
 
-    def test_default(self):
+    def test_is_valid__complete_and_incomplete_data(self):
         """
         Creating new tenant object with valid data, should pass without errors.
         """
@@ -66,7 +66,7 @@ class TenantFormTest(ByteDeckTenantTestCase):
         form = TenantForm(data)
         self.assertTrue(form.is_valid())
 
-    def test_form_max_length(self):
+    def test_max_length__fields_enforce_user_field_limits(self):
         """
         Test if form fields has set correct `max_length` property.
         """
@@ -107,7 +107,7 @@ class TenantFormTest(ByteDeckTenantTestCase):
         form = TenantForm(data)
         self.assertTrue(form.is_valid())
 
-    def test_cant_use_public_name(self):
+    def test_clean_name__cant_use_public_name(self):
         """
         Creating new tenant object with reserved "public" name, should fail with form (validation) error
         """
@@ -120,7 +120,7 @@ class TenantFormTest(ByteDeckTenantTestCase):
         form = TenantForm(data)
         self.assertFalse(form.is_valid())
 
-    def test_cant_create_if_schema_still_exists(self):
+    def test_clean_name__cant_create_if_schema_still_exists(self):
         """
         Creating new tenant object with a name of existing schema, should fail with form (validation) error
         """

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -16,7 +16,7 @@ User = get_user_model()
 
 class TenantInitializationTest(ByteDeckTenantTestCase):
 
-    def test_admin_created(self):
+    def test_initialization__admin_superuser_created(self):
         """ Check if admin superuser is created upon initialization """
         username = "admin"
         password = settings.TENANT_DEFAULT_ADMIN_PASSWORD
@@ -31,7 +31,7 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         success = self.client.login(username=username, password=password)
         self.assertTrue(success)
 
-    def test_owner_created(self):
+    def test_initialization__deck_owner_created(self):
         """ Check if deck_owner is created upon initialization """
         username = "owner"
         password = settings.TENANT_DEFAULT_OWNER_PASSWORD
@@ -51,20 +51,20 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         success = self.client.login(username=username, password=password)
         self.assertTrue(success)
 
-    def test_default_course_created(self):
+    def test_initialization__default_course_created(self):
         """ Initialization script should create a default Course object. """
         self.assertTrue(Course.objects.filter(title="Default").exists())
 
-    def test_default_block_created(self):
+    def test_initialization__default_block_created(self):
         """ Initialization scripts should create a default Block object. """
         self.assertTrue(Block.objects.filter(name="Default").exists())
 
-    def test_default_mark_ranges_created(self):
+    def test_initialization__default_mark_ranges_created(self):
         """ Initialization script should create 3 default MarkRange objects. """
         for name in ["A", "B", "Pass"]:
             self.assertTrue(MarkRange.objects.filter(name=name).exists())
 
-    def test_default_ranks_created(self):
+    def test_initialization__default_ranks_created(self):
         """
             Initialization script should create 13 default Rank objects.
             Test shortened for brevity.
@@ -72,22 +72,22 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         self.assertTrue(Rank.objects.filter(name="Digital Noob").exists())
         self.assertEqual(Rank.objects.count(), 13)
 
-    def test_default_grades_created(self):
+    def test_initialization__default_grades_created(self):
         """ Initialization script should create 5 default Grade objects. """
         for name in ["8", "9", "10", "11", "12"]:
             self.assertTrue(Grade.objects.filter(name=name).exists())
 
-    def test_default_menu_items_created(self):
+    def test_initialization__default_menu_items_created(self):
         """ Initialization script should create a default MenuItem object. """
         self.assertTrue(MenuItem.objects.filter(label="Ranks List").exists())
 
-    def test_default_badge_types_created(self):
+    def test_initialization__default_badge_types_created(self):
         """ Initialization script should create 3 default BadgeType objects. """
         self.assertTrue(BadgeType.objects.filter(name="Talent").exists())
         self.assertTrue(BadgeType.objects.filter(name="Award").exists())
         self.assertTrue(BadgeType.objects.filter(name="Team").exists())
 
-    def test_default_badge_rarities_created(self):
+    def test_initialization__default_badge_rarities_created(self):
         """ Initialization script should create 6 default BadgeRarity objects. """
         self.assertTrue(BadgeRarity.objects.filter(name="Common").exists())
         self.assertTrue(BadgeRarity.objects.filter(name="Uncommon").exists())
@@ -96,14 +96,14 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         self.assertTrue(BadgeRarity.objects.filter(name="Legendary").exists())
         self.assertTrue(BadgeRarity.objects.filter(name="Mythic").exists())
 
-    def test_only_default_rarities_created(self):
+    def test_initialization__only_default_rarities_created(self):
         """
             Badge rarities shouldn't have overlapping values, and the default rarities cover every percentage value.
             Any additional BadgeRarity objects existing at initialization could cause conflicts.
         """
         self.assertEqual(BadgeRarity.objects.count(), 6)
 
-    def test_default_badges_created(self):
+    def test_initialization__default_badges_created(self):
         """ Initialization script should create 7 default Badge objects. """
         self.assertTrue(Badge.objects.filter(name="Penny").exists())
         self.assertTrue(Badge.objects.filter(name="Nickel").exists())
@@ -113,11 +113,11 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         self.assertTrue(Badge.objects.filter(name="Green Team").exists())
         self.assertTrue(Badge.objects.filter(name="Blue Team").exists())
 
-    def test_default_campaign_created(self):
+    def test_initialization__default_campaign_created(self):
         """ Initialization script should create a default Category (Campaign) object. """
         self.assertTrue(Category.objects.filter(title="Orientation").exists())
 
-    def test_default_quests_created(self):
+    def test_initialization__default_quests_created(self):
         """ Initialization script should create 6 default Quest objects. """
         self.assertTrue(Quest.objects.filter(name="Welcome to ByteDeck!").exists())
         self.assertTrue(Quest.objects.filter(name="ByteDeck Class Contract").exists())
@@ -126,7 +126,7 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         self.assertTrue(Quest.objects.filter(name="Who owns your creations?").exists())
         self.assertTrue(Quest.objects.filter(name="Send your teacher a Message").exists())
 
-    def test_default_message_quest_notifies_owner(self):
+    def test_initialization__message_quest_notifies_owner(self):
         """ The quest "Send your teacher a Message" should have the deck owner assigned as the specific teacher to notify by default. """
         message_quest = Quest.objects.filter(name="Send your teacher a Message").first()
         owner = User.objects.filter(username="owner", is_staff=True).first()
@@ -153,7 +153,7 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         self.assertEqual(b_intro.count(), 1)
         self.assertTrue(b_intro.filter(name="ByteDeck Proficiency").exists())
 
-    def test_site_config_created(self):
+    def test_initialization__site_config_created(self):
         """ Test that the SiteConfig object exists and the Deck name has expected defaults.
         """
         site_config = SiteConfig.get()

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -16,6 +16,7 @@ class TenantModelTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Build an extra tenant on a localhost domain to exercise dev-domain behavior."""
         # TenantTestCase comes with a `cls.tenant` already, but let make another so we can test development
         # stuff on localhost domain
         with schema_context(get_public_schema_name()):
@@ -28,7 +29,7 @@ class TenantModelTest(ByteDeckTenantTestCase):
             domain.domain = 'my-dev-schema.localhost'
             domain.save()
 
-    def test_tenant_test_case(self):
+    def test_tenant_test_case__provides_configured_tenant(self):
         """ From docs: https://django-tenant-schemas.readthedocs.io/en/latest/test.html
         If you want a test to happen at any of the tenant’s domain, you can use the test case TenantTestCase.
         It will automatically create a tenant for you, set the connection’s schema to tenant’s schema and
@@ -38,14 +39,16 @@ class TenantModelTest(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.schema_name, 'test')
         self.assertEqual(str(self.tenant), f'{self.tenant.schema_name} - {self.tenant.primary_domain_url}')
 
-    def test_tenant_creation(self):
+    def test_tenant_creation__localhost_tenant_created(self):
+        """A tenant created on a localhost domain is a valid Tenant instance."""
         self.assertIsInstance(self.tenant_localhost, Tenant)
 
-    def test_tenant_get_root_url(self):
+    def test_get_root_url__https_and_localhost(self):
+        """get_root_url returns an https URL for a real domain and an http localhost URL for a dev tenant."""
         self.assertEqual(self.tenant.get_root_url(), "https://tenant.test.com")
         self.assertEqual(self.tenant_localhost.get_root_url(), "http://my-dev-schema.localhost:8000")
 
-    def test_tenant_last_staff_login_populated(self):
+    def test_last_staff_login__populated_excluding_admin(self):
         """ When a staff logins to a tenant, the last_staff_login should have the correct value,
         should not include the admin account
         """
@@ -73,32 +76,42 @@ class CheckTenantNameTest(SimpleTestCase):
     tenant's domain_url field, so {name} it must be valid for a schema and a url.
     """
 
-    def test_underscore_invalid(self):
+    def test_check_tenant_name__underscore_invalid(self):
+        """A name containing underscores is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, 'tenant_name_with_underscores')
 
-    def test_special_chars_invalid(self):
+    def test_check_tenant_name__special_chars_invalid(self):
+        """A name containing special characters is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, 'tenant@')
 
-    def test_number_start_invalid(self):
+    def test_check_tenant_name__number_start_invalid(self):
+        """A name starting with a number is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, '9tenant')
 
-    def test_uppercase_invalid(self):
+    def test_check_tenant_name__uppercase_invalid(self):
+        """A name containing uppercase letters is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, 'Tenant')
 
-    def test_start_dash_invalid(self):
+    def test_check_tenant_name__start_dash_invalid(self):
+        """A name starting with a dash is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, '-tenant')
 
-    def test_end_dash_invalid(self):
+    def test_check_tenant_name__end_dash_invalid(self):
+        """A name ending with a dash is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, 'tenant-')
 
-    def test_multidash_invalid(self):
+    def test_check_tenant_name__multidash_invalid(self):
+        """A name with consecutive dashes is rejected."""
         self.assertRaises(ValidationError, check_tenant_name, 'ten--ant')
 
-    def test_mid_dash_valid(self):
+    def test_check_tenant_name__mid_dash_valid(self):
+        """A name with a single mid-string dash is accepted."""
         check_tenant_name('ten-ant')
 
-    def test_multi_mid_dash_valid(self):
+    def test_check_tenant_name__multi_mid_dash_valid(self):
+        """A name with multiple non-consecutive mid-string dashes is accepted."""
         check_tenant_name('ten-an-t')
 
-    def test_mid_number_valid(self):
+    def test_check_tenant_name__mid_number_valid(self):
+        """A name with numbers after the first character is accepted."""
         check_tenant_name('t3nan4')

--- a/src/tenant/tests/test_schema_aware_user_delete.py
+++ b/src/tenant/tests/test_schema_aware_user_delete.py
@@ -50,6 +50,7 @@ class SchemaAwareUserDeleteAdminPublicTest(ByteDeckTenantTestCase):
     """
 
     def setUp(self):
+        """Build the public tenant, a superuser, and a target user (with EmailAddress) to delete."""
         # Build the public tenant + a superuser to drive the admin, mirroring
         # tenant.tests.test_admin.PublicTenantTestAdminPublic.
         self.public_tenant = Tenant(schema_name="public", name="public")
@@ -172,6 +173,7 @@ class SchemaAwareUserDeleteAdminTenantTest(ByteDeckTenantTestCase):
     still removes related tenant rows (e.g. QuestSubmission)."""
 
     def setUp(self):
+        """Build a tenant-schema client and a superuser to drive the admin."""
         self.client = TenantClient(self.tenant)
         self.superuser = User.objects.create_superuser(
             username="tenant_admin", email="ta@example.com", password="pw",

--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -8,7 +8,7 @@ from tenant import tasks
 class TenantTasksTests(ByteDeckTenantTestCase):
     """ Run tasks (from tenant module) asyncronously with apply() """
 
-    def test_send_email_message(self):
+    def test_send_email_message__delivers_to_recipients(self):
         """Async. task "send_email_message" sends email messages as expected."""
         # outbox is empty before executing the task
         self.assertEqual(len(mail.outbox), 0)

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -39,6 +39,7 @@ def view_accessible_by_non_public_only(request):
 
 class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
+        """Build a request factory and an empty request for calling the views directly."""
         self.factory = RequestFactory()
         # generate an empty request instance so we can call our views directly
         self.request = self.factory.get('/does/not/exist/')
@@ -110,13 +111,13 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Create client for the tenant
         self.client = TenantClient(self.public_tenant, host="testserver")
 
-    def test_anonymous_denied_without_verified_deck_request(self):
+    def test_get__anonymous_denied_without_verified_deck_request(self):
         """Anonymous users without a verified deck request are denied access."""
         response = self.client.get(reverse("tenant:new"))
         self.assertEqual(response.status_code, 403)
         self.assertTemplateUsed(response, "tenant/deck_request_denied.html")
 
-    def test_create_deck_page_extends_public_base_and_keeps_progress_modal(self):
+    def test_get__create_deck_page_extends_public_base_and_keeps_progress_modal(self):
         """The Create New Deck page shares the public onboarding chrome: it renders
         through public/base.html (same navbar/branding as the Request a New Deck
         page) rather than as a standalone document, and still includes the
@@ -172,7 +173,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @patch("tenant.forms.ReCaptchaField.clean", return_value="PASSED")
     @patch.object(DeckRequestService, "send_verification_email")
-    def test_deck_request_throttled_per_email(self, mock_send_email, mock_captcha):
+    def test_deck_request__throttled_per_email(self, mock_send_email, mock_captcha):
         """The request endpoint sends at most one verification email per address
         within the cooldown, so it can't be used to flood an inbox."""
         form_data = {
@@ -244,7 +245,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotContains(response, "5 minutes")
 
     @patch("tenant.models.Tenant.full_clean")
-    def test_form_save_persists_tenant_without_touching_owner(self, mock_full_clean):
+    def test_form_save__persists_tenant_without_touching_owner(self, mock_full_clean):
         """TenantForm.save persists and returns the Tenant only. Owner setup is
         the view's job (done in the tenant's own schema), so the form must not
         touch the owner — it previously mutated SiteConfig.get().deck_owner in
@@ -266,7 +267,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     @patch("tenant.models.Tenant.full_clean")
     @patch("tenant.views.DeckRequestService.send_welcome_email")
     @patch("tenant.views.generate_default_owner_password", return_value="known-secret-123")
-    def test_owner_password_generated_once_and_emailed(self, mock_pw, mock_welcome, mock_full_clean):
+    def test_form_valid__owner_password_generated_once_and_emailed(self, mock_pw, mock_welcome, mock_full_clean):
         """The owner's password is generated once: the value set on the account
         is the same one handed to the welcome email (a random password would
         otherwise diverge between set and emailed values)."""
@@ -293,7 +294,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn("known-secret-123", mock_welcome.call_args.args)
 
     @patch("tenant.models.Tenant.full_clean")
-    def test_form_valid_creates_tenant_and_redirects(self, mock_full_clean):
+    def test_form_valid__creates_tenant_and_redirects(self, mock_full_clean):
         """TenantCreate.form_valid should save tenant, assign deck owner, redirect,
         and consume the single-use verification nonce."""
         nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
@@ -323,7 +324,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertEqual(site_config.deck_owner.email, "john.doe@example.com")
 
     @patch("tenant.models.Tenant.full_clean")
-    def test_verification_nonce_is_single_use(self, mock_full_clean):
+    def test_form_valid__verification_nonce_is_single_use(self, mock_full_clean):
         """A verification nonce provisions at most one deck: a successful creation
         consumes it, and a second attempt with the same nonce is rejected
         (redirected back to the request form) before anything is saved."""
@@ -362,7 +363,7 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response2.url, reverse("decks:request_new_deck"))
 
     @patch("tenant.models.Tenant.full_clean")
-    def test_staff_can_create_deck_without_nonce(self, mock_full_clean):
+    def test_form_valid__staff_can_create_deck_without_nonce(self, mock_full_clean):
         """Staff reach TenantCreate without email verification (mixin bypass), so
         form_valid must not require or consume a nonce for them."""
         request = self.factory.post(reverse("tenant:new"), data=self.form_data)
@@ -399,7 +400,7 @@ class HumanizeSecondsTest(TestCase):
             with self.subTest(seconds=seconds):
                 self.assertEqual(_humanize_seconds(seconds), expected)
 
-    def test_verify_deck_request_valid_token_populates_session(self):
+    def test_verify_deck_request__valid_token_populates_session(self):
         """A valid nonce stores the verified request (including the nonce) in the
         session and redirects to the deck creation form."""
         nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
@@ -413,7 +414,7 @@ class HumanizeSecondsTest(TestCase):
         self.assertEqual(verified["nonce"], nonce)
         self.assertIn("verified_at", verified)
 
-    def test_verify_deck_request_invalid_token_denied(self):
+    def test_verify_deck_request__invalid_token_denied(self):
         """An invalid/expired nonce stores nothing and redirects back to the
         request form."""
         response = self.client.get(reverse("decks:verify_deck_request", args=["not-a-real-nonce"]))
@@ -429,7 +430,7 @@ class DeckRequestServiceTest(TestCase):
         """Isolate the nonce cache between tests."""
         cache.clear()
 
-    def test_create_and_peek_request_roundtrip(self):
+    def test_create_and_peek_request__roundtrip(self):
         """A freshly created nonce peeks back to the original requester data."""
         nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
         self.assertEqual(
@@ -437,29 +438,29 @@ class DeckRequestServiceTest(TestCase):
             {"first_name": "John", "last_name": "Doe", "email": "john.doe@example.com"},
         )
 
-    def test_peek_unknown_nonce_returns_none(self):
+    def test_peek_request__unknown_nonce_returns_none(self):
         """An unknown/expired nonce (or None) peeks to None."""
         self.assertIsNone(DeckRequestService.peek_request("not-a-real-nonce"))
         self.assertIsNone(DeckRequestService.peek_request(None))
 
-    def test_peek_does_not_consume(self):
+    def test_peek_request__does_not_consume(self):
         """Peeking leaves the nonce usable; only creation consumes it."""
         nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
         self.assertIsNotNone(DeckRequestService.peek_request(nonce))
         self.assertIsNotNone(DeckRequestService.peek_request(nonce))
 
-    def test_consume_request_is_single_use(self):
+    def test_consume_request__is_single_use(self):
         """The first consume succeeds and removes the nonce; later ones fail."""
         nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
         self.assertTrue(DeckRequestService.consume_request(nonce))
         self.assertFalse(DeckRequestService.consume_request(nonce))
         self.assertIsNone(DeckRequestService.peek_request(nonce))
 
-    def test_consume_none_returns_false(self):
+    def test_consume_request__none_returns_false(self):
         """Consuming a missing nonce is a no-op that returns False."""
         self.assertFalse(DeckRequestService.consume_request(None))
 
-    def test_verification_link_contains_no_pii(self):
+    def test_verification_link__contains_no_pii(self):
         """The verification URL carries only the opaque nonce, never the
         requester's name or email (unlike a signed token, which would)."""
         nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
@@ -494,7 +495,7 @@ class EmailVerificationRequiredMixinTest(TestCase):
         self.view = DummyView.as_view()
 
     @patch("tenant.views.render")  # patch render to avoid template DB queries
-    def test_verified_at_allows_or_denies_access(self, mock_render):
+    def test_dispatch__verified_at_allows_or_denies_access(self, mock_render):
         """A recent verified_at timestamp grants access (200); a timestamp older
         than TOKEN_MAX_AGE is denied (403)."""
         # make render() just return a dummy response

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -23,6 +23,7 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
         cls.group1 = Group.objects.create(name="Editors")
 
     def _ct_pk(self, obj):
+        """Return the "<content_type_pk>-<object_pk>" string the GFK choice field uses to identify obj."""
         return f"{ContentType.objects.get_for_model(obj).pk}-{obj.pk}"
 
     def test_GFKChoiceField__choices_and_clean(self):

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -17,6 +17,7 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create two users and a group spanning two content types for choice building."""
         cls.user1 = User.objects.create(username="johndoe", first_name="John", last_name="Doe")
         cls.user2 = User.objects.create(username="janedoe", first_name="Jane", last_name="Doe")
         cls.group1 = Group.objects.create(name="Editors")
@@ -24,7 +25,8 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
     def _ct_pk(self, obj):
         return f"{ContentType.objects.get_for_model(obj).pk}-{obj.pk}"
 
-    def test_basics(self):
+    def test_GFKChoiceField__choices_and_clean(self):
+        """Field groups choices by content type and clean() validates and resolves GFK values."""
         f = GFKChoiceField(
             queryset=QuerySetSequence(
                 User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]),
@@ -64,10 +66,11 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
 class RestrictedFileFieldTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Build a default and a content-type-restricted RestrictedFileField."""
         cls.default_file_field = RestrictedFileField()
         cls.image_file_field = RestrictedFileField(content_types=['image/jpeg', 'image/png'])
 
-    def test_content_type(self):
+    def test_content_type__default_and_custom(self):
         "Ensure the default content type is 'All', and that the content type can be set correctly."
 
         # ensure default content type is 'All'
@@ -80,10 +83,11 @@ class RestrictedFileFieldTest(ByteDeckTenantTestCase):
 class RestrictedFileFormFieldTest(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
+        """Build a default and a content-type-restricted RestrictedFileFormField."""
         cls.default_file_field = RestrictedFileFormField()
         cls.image_file_field = RestrictedFileFormField(content_types=['image/jpeg', 'image/png'])
 
-    def test_content_type(self):
+    def test_content_type__default_and_custom(self):
         "Ensure the default content type is 'All', and that the content type can be set correctly."
 
         # ensure default content type is 'All'
@@ -106,7 +110,7 @@ class AllowedGFKChoiceFieldRebuildTest(ByteDeckTenantTestCase):
     forms to accept valid selections regardless of import timing.
     """
 
-    def test_deepcopy_rebuilds_empty_import_time_queryset(self):
+    def test_deepcopy__rebuilds_empty_import_time_queryset(self):
         """A field left empty at construction repopulates its choices when copied."""
         import copy
 
@@ -128,7 +132,7 @@ class AllowedGFKChoiceFieldRebuildTest(ByteDeckTenantTestCase):
         self.assertTrue(models, "deepcopy should have rebuilt a non-empty choice list")
         self.assertEqual(models, IsAPrereqMixin.all_registered_model_classes())
 
-    def test_form_instance_has_valid_choices_even_if_declared_field_is_empty(self):
+    def test_form_instance__has_valid_choices_even_if_declared_field_is_empty(self):
         """A form using the field accepts a valid GFK selection through its copied field."""
         import copy
 

--- a/src/utilities/tests/test_forms.py
+++ b/src/utilities/tests/test_forms.py
@@ -10,7 +10,7 @@ User = get_user_model()
 
 class MenuItemFormTest(ByteDeckTenantTestCase):
 
-    def test_MenuItem_form_allow_relative_urls(self):
+    def test_MenuItemForm__allow_relative_urls(self):
         """ Form accepts a relative (path-only) url. """
         form_data = {
             'label': 'New Menu Item',
@@ -23,7 +23,7 @@ class MenuItemFormTest(ByteDeckTenantTestCase):
         form = MenuItemForm(data=form_data)
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_MenuItem_form_allow_absolute_urls(self):
+    def test_MenuItemForm__allow_absolute_urls(self):
         """ Form accepts an absolute url. """
         form_data = {
             'label': 'New Menu Item',

--- a/src/utilities/tests/test_html.py
+++ b/src/utilities/tests/test_html.py
@@ -9,7 +9,7 @@ class TestUtilsText(SimpleTestCase):
     Various tests for `utilities.html` module.
     """
 
-    def test_textify(self):
+    def test_textify__converts_html_to_markdown(self):
         """
         Generate a plain text version of an html content using html2text library.
         """
@@ -17,7 +17,7 @@ class TestUtilsText(SimpleTestCase):
         output = textify(html)
         self.assertEqual(output, """**Zed's** dead baby, _Zed's_ dead.\n\n""")
 
-    def test_textify_donot_ignore_links(self):
+    def test_textify__does_not_ignore_links(self):
         """
         Don't ignore links anymore, I like links
         """
@@ -39,7 +39,7 @@ class LinkTextExtractor(HTMLParser):
 
 
 class UrlizeTests(SimpleTestCase):
-    def test_basic(self):
+    def test_urlize__basic(self):
         """
         Test that a simple URL is correctly converted into an anchor tag
         and the URL text is preserved.
@@ -73,7 +73,7 @@ class UrlizeTests(SimpleTestCase):
         result = urlize(text)
         self.assertTrue(result.startswith('a.<a href="http://example.com"'))
 
-    def test_empty(self):
+    def test_urlize__empty_or_none(self):
         """
         Test that empty string or None input returns an empty string without error.
 
@@ -86,7 +86,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertEqual(urlize(""), "")
         self.assertEqual(urlize(None), "")
 
-    def test_trim_url_limit(self):
+    def test_urlize__trim_url_limit(self):
         """
         Test that long URLs are visually trimmed in the anchor text,
         while the href attribute retains the full URL.
@@ -115,7 +115,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn(url, result)
         self.assertNotIn("...", result)
 
-    def test_multiple_urls(self):
+    def test_urlize__multiple_urls(self):
         """
         Test that multiple URLs in the input text are all converted into anchor tags.
 
@@ -129,7 +129,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn('href="https://bar.com/page"', result)
         self.assertEqual(result.count('<a '), 2)
 
-    def test_url_positions(self):
+    def test_urlize__url_positions(self):
         """
         Test that URLs are correctly linkified regardless of their position
         in the input string (start, middle, or end).
@@ -145,7 +145,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn('<a href="http://middle.com"', urlize("Text before http://middle.com text after"))
         self.assertIn('<a href="http://end.com"', urlize("Ends with http://end.com"))
 
-    def test_non_url_text(self):
+    def test_urlize__non_url_text(self):
         """
         Test that plain text without any URLs is returned unmodified.
         """
@@ -153,7 +153,7 @@ class UrlizeTests(SimpleTestCase):
         result = urlize(text)
         self.assertEqual(result, text)
 
-    def test_trailing_punctuation(self):
+    def test_urlize__trailing_punctuation(self):
         """
         Test that trailing punctuation such as periods is excluded
         from the anchor tag.
@@ -165,7 +165,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn('href="http://example.com"', result)
         self.assertTrue(result.endswith("</a>."))
 
-    def test_already_linked_html(self):
+    def test_urlize__already_linked_html(self):
         """
         Test that pre-existing <a> tags are preserved and not double-processed.
 
@@ -179,7 +179,7 @@ class UrlizeTests(SimpleTestCase):
         result = urlize(html)
         self.assertEqual(result, html)
 
-    def test_no_javascript_links(self):
+    def test_urlize__no_javascript_links(self):
         """
         Test that javascript: links are not linkified for security reasons.
         """
@@ -187,7 +187,7 @@ class UrlizeTests(SimpleTestCase):
         result = urlize(text)
         self.assertNotIn("href=", result)  # Should not linkify
 
-    def test_clean_html_url_integration(self):
+    def test_clean_html__urlize_integration(self):
         """
         Ensure that clean_html applies urlize logic to plain text URLs.
         """
@@ -196,7 +196,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn('<a href="http://www.example.com"', result)
         self.assertIn('target="_blank"', result)
 
-    def test_clean_html_trims_long_urls(self):
+    def test_clean_html__trims_long_urls(self):
         """
         Test that clean_html trims long URLs in display text.
         """
@@ -205,7 +205,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn("...", result)
         self.assertIn('href="http://example.com/this/is/a/very/long/path/that/needs/to/be/trimmed"', result)
 
-    def test_clean_html_ignores_existing_links(self):
+    def test_clean_html__ignores_existing_links(self):
         """
         Test that clean_html doesn't re-process existing anchor tags.
         """
@@ -215,7 +215,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn('href="http://example.com"', result)
         self.assertIn('target="_blank"', result)
 
-    def test_clean_html_multiple_urls(self):
+    def test_clean_html__multiple_urls(self):
         """
         Ensure that multiple unformatted URLs are handled correctly.
         """
@@ -225,7 +225,7 @@ class UrlizeTests(SimpleTestCase):
         self.assertIn('href="http://www.bar.com"', result)
         self.assertEqual(result.count("<a "), 2)
 
-    def test_clean_html_does_not_link_javascript(self):
+    def test_clean_html__does_not_link_javascript(self):
         """
         Ensure javascript: links are not linkified.
         """
@@ -233,7 +233,8 @@ class UrlizeTests(SimpleTestCase):
         result = clean_html(text)
         self.assertNotIn('<a ', result)
 
-    def test_numbered_list_with_br(self):
+    def test_urlize__numbered_list_with_br(self):
+        """Numbered list items separated by <br> are linkified with prefixes kept outside the anchors."""
         # Input simulating comment input with <br> instead of newlines
         input_text = (
             "1.www.testing.com<br>"

--- a/src/utilities/tests/test_templatetags_filters.py
+++ b/src/utilities/tests/test_templatetags_filters.py
@@ -3,7 +3,8 @@ from django.template import Template, Context
 
 
 class PossessiveFilterTest(TestCase):
-    def test_possessive_filter(self):
+    def test_add_possessive__various_name_endings(self):
+        """Filter appends the correct possessive suffix for names ending in s, 's, 's, and other letters."""
         template = Template("{% load filters %}{{ name|add_possessive }}")
 
         # Test a name that ends with "s"

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -65,6 +65,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.client = TenantClient(self.tenant)
 
     def _ct_pk(self, obj):
+        """Return the "<content_type_pk>-<object_pk>" string the GFK choice field uses to identify obj."""
         return f"{ContentType.objects.get_for_model(obj).pk}-{obj.pk}"
 
     def test_autoresponse__valid_field_id_returns_group(self):

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -55,17 +55,20 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create 100 groups to search over via the auto-response JSON endpoint."""
         cls.groups = Group.objects.bulk_create(
             [Group(pk=pk, name=random_string(50)) for pk in range(100)]
         )
 
     def setUp(self):
+        """Build a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def _ct_pk(self, obj):
         return f"{ContentType.objects.get_for_model(obj).pk}-{obj.pk}"
 
-    def test_get(self):
+    def test_autoresponse__valid_field_id_returns_group(self):
+        """A valid signed field_id returns matching group results as JSON."""
         group = self.groups[0]
         form = GFKSelect2WidgetForm()
         assert form.as_p()
@@ -77,26 +80,30 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         assert data['results']
         assert {'id': self._ct_pk(group), 'text': smart_str(group)} in data['results'][0]['children']
 
-    def test_no_field_id(self):
+    def test_autoresponse__no_field_id_returns_404(self):
+        """A request missing field_id returns 404."""
         group = self.groups[0]
         url = reverse('utilities:querysetsequence_auto-json')
         response = self.client.get(url, {'term': group.name})
         assert response.status_code == 404
 
-    def test_wrong_field_id(self):
+    def test_autoresponse__wrong_field_id_returns_404(self):
+        """An unsigned/invalid field_id returns 404."""
         group = self.groups[0]
         url = reverse('utilities:querysetsequence_auto-json')
         response = self.client.get(url, {'field_id': 123, 'term': group.name})
         assert response.status_code == 404
 
-    def test_field_id_not_found(self):
+    def test_autoresponse__field_id_not_found_returns_404(self):
+        """A validly signed field_id with no cached widget returns 404."""
         group = self.groups[0]
         field_id = signing.dumps(123456789)
         url = reverse('utilities:querysetsequence_auto-json')
         response = self.client.get(url, {'field_id': field_id, 'term': group.name})
         assert response.status_code == 404
 
-    def test_pagination(self):
+    def test_autoresponse__pagination(self):
+        """Results are paginated, reporting 'more' and 404ing on out-of-range pages."""
         url = reverse('utilities:querysetsequence_auto-json')
         widget = GFKSelect2Widget(
             max_results=10,
@@ -121,7 +128,8 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         data = json.loads(response.content.decode('utf-8'))
         assert data['more'] is False
 
-    def test_label_from_instance(self):
+    def test_autoresponse__label_from_instance(self):
+        """A custom widget's label_from_instance is applied to the returned option text."""
         url = reverse('utilities:querysetsequence_auto-json')
 
         form = GFKSelect2WidgetForm()
@@ -129,7 +137,6 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         assert form.as_p()
         field_id = signing.dumps(form.fields['f'].widget.uuid)
 
-        # artist = artists[0]
         group = self.groups[0]
         response = self.client.get(url, {'field_id': field_id, 'term': group.name})
         assert response.status_code == 200
@@ -138,7 +145,8 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         assert data['results']
         assert {'id': self._ct_pk(group), 'text': smart_str(group.name.upper())} in data['results'][0]['children']
 
-    def test_url_check(self):
+    def test_autoresponse__url_mismatch_returns_404(self):
+        """A cached widget whose URL no longer matches the endpoint returns 404."""
         from django_select2.cache import cache
 
         group = self.groups[0]
@@ -158,6 +166,7 @@ class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher and a student for role-based access checks."""
         # need a teacher and a student so tests can log in as each via force_login()
 
         # need a teacher before students can be created or the profile creation will fail when trying to notify
@@ -165,16 +174,17 @@ class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_student = User.objects.create_user('test_student')
 
     def setUp(self):
+        """Build a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_page_status_codes_for_anonymous(self):
+    def test_all_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to login '''
         self.assertRedirectsLogin('utilities:menu_items')
         self.assertRedirectsLogin('utilities:menu_item_create')
         self.assertRedirectsLogin('utilities:menu_item_update', args=[1])
         self.assertRedirectsLogin('utilities:menu_item_delete', args=[1])
 
-    def test_all_page_status_codes_for_students(self):
+    def test_all_page_status_codes__students(self):
         ''' If not logged in as admin then all views should redirect to 403 '''
         self.client.force_login(self.test_student)
 
@@ -184,13 +194,13 @@ class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403('utilities:menu_item_update', args=[1])
         self.assert403('utilities:menu_item_delete', args=[1])
 
-    def test_MenuItemList_view(self):
+    def test_MenuItemListView__admin_can_view(self):
         ''' Admin should be able to view menu item list '''
         self.client.force_login(self.test_teacher)
         response = self.client.get(reverse('utilities:menu_items'))
         self.assertEqual(response.status_code, 200)
 
-    def test_MenuItemCreate_view(self):
+    def test_MenuItemCreateView__admin_can_create(self):
         ''' Admin should be able to create a menu item '''
         self.client.force_login(self.test_teacher)
         data = {
@@ -222,7 +232,7 @@ class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         leading_slash_error = "Enter a valid URL."
         self.assertContains(response, leading_slash_error)
 
-    def test_MenuItemUpdate_view(self):
+    def test_MenuItemUpdateView__admin_can_update(self):
         """ Admin should be able to update a Menu Item """
         self.client.force_login(self.test_teacher)
         # set label and icon to something they wouldn't normally be
@@ -286,6 +296,7 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create a teacher, a student, and login-required and public flatpages."""
         User = get_user_model()
 
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
@@ -295,9 +306,10 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.flatpage_login = [FlatPageViewTests.create_flatpage(registration_required=True) for i in range(3)]
 
     def setUp(self):
+        """Build a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
-    def test_all_page_status_codes_for_anonymous(self):
+    def test_all_page_status_codes__anonymous(self):
         """
             Redirects to admin or returns 200 if user is not logged in
         """
@@ -308,7 +320,7 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('utilities:flatpage_edit', args=[1])
         self.assertRedirectsLogin('utilities:flatpage_delete', args=[1])
 
-    def test_all_page_status_codes_for_students(self):
+    def test_all_page_status_codes__students(self):
         """
             Redirects to 403 or returns 200 if user is is_staff=False
         """
@@ -321,7 +333,7 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert403('utilities:flatpage_edit', args=[1])
         self.assert403('utilities:flatpage_delete', args=[1])
 
-    def test_all_page_status_codes_for_staff(self):
+    def test_all_page_status_codes__staff(self):
         """
             Should return 200 for all cases
         """
@@ -334,7 +346,7 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('utilities:flatpage_edit', args=[pk])
         self.assert200('utilities:flatpage_delete', args=[pk])
 
-    def test_login_requirements_for_flatpage(self):
+    def test_flatpage_access__login_requirements(self):
         """
             Flatpage with login required can only be accessed by users,
             while flatpages without can be accessed by all

--- a/src/utilities/tests/test_widgets.py
+++ b/src/utilities/tests/test_widgets.py
@@ -50,22 +50,26 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        """Create 100 groups for the widget to render and filter over."""
         cls.groups = Group.objects.bulk_create(
             [Group(pk=pk, name=random_string(50)) for pk in range(100)]
         )
 
     def setUp(self):
+        """Build a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
     def _ct_pk(self, obj):
         return f'{ContentType.objects.get_for_model(obj).pk}-{obj.pk}'
 
-    def test_initial_data(self):
+    def test_widget__renders_initial_data(self):
+        """Widget renders the initial GFK value's string in the form output."""
         group = self.groups[0]
         form = self.form.__class__(initial={'f': group})
         assert str(group) in form.as_p()
 
-    def test_label_from_instance_initial(self):
+    def test_label_from_instance__initial(self):
+        """Custom label_from_instance is applied to the initial value's rendered label."""
         group = self.groups[0]
         group.name = group.name.lower()
         group.save()
@@ -74,7 +78,8 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         assert group.name not in form.as_p(), form.as_p()
         assert group.name.upper() in form.as_p()
 
-    def test_selected_option(self):
+    def test_selected_option__marked_selected(self):
+        """Rendered output marks the chosen value as selected and leaves others unselected."""
         group = self.groups[0]
         another_group = self.groups[1]
         not_required_field = self.form.fields['f']
@@ -91,7 +96,8 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         assert selected_option in widget_output or selected_option_a in widget_output, widget_output
         assert unselected_option not in widget_output
 
-    def test_selected_option_label_from_instance(self):
+    def test_selected_option__label_from_instance(self):
+        """The selected option's label reflects the custom label_from_instance transform."""
         group = self.groups[0]
         group.name = group.name.lower()
         group.save()
@@ -109,14 +115,16 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
 
         assert any(o in widget_output for o in get_selected_options(group))
 
-    def test_get_queryset(self):
+    def test_get_queryset__raises_without_queryset(self):
+        """get_queryset raises NotImplementedError until a queryset is assigned."""
         widget = GFKSelect2Widget()
         with self.assertRaises(NotImplementedError):
             widget.get_queryset()
         widget.queryset = QuerySetSequence(Group.objects.all())
         assert isinstance(widget.get_queryset(), QuerySetSequence)
 
-    def test_get_search_fields(self):
+    def test_get_search_fields__raises_without_config(self):
+        """get_search_fields raises NotImplementedError until search_fields is configured."""
         widget = GFKSelect2Widget()
         with self.assertRaises(NotImplementedError):
             widget.get_search_fields(Group)
@@ -125,7 +133,8 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         assert isinstance(widget.get_search_fields(Group), collections.abc.Iterable)
         assert all(isinstance(x, str) for x in widget.get_search_fields(Group))
 
-    def test_filter_queryset(self):
+    def test_filter_queryset__matches_search_term(self):
+        """filter_queryset returns results matching a full or space-split search term."""
         widget = CustomGFKSelect2Widget()
         assert widget.filter_queryset(None, self.groups[0].name[:3]).exists()
 
@@ -133,14 +142,16 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         qs = widget.filter_queryset(None, " ".join([self.groups[0].name[:3], self.groups[0].name[3:]]))
         assert qs.exists()
 
-    def test_queryset_kwarg(self):
+    def test_filter_queryset__queryset_kwarg(self):
+        """A queryset passed via kwarg is searchable through filter_queryset."""
         widget = GFKSelect2Widget(
             queryset=QuerySetSequence(Group.objects.all()), search_fields={'auth': {'group': ['name__icontains']}})
         group = Group.objects.last()
         result = widget.filter_queryset(None, group.name)
         assert result.exists()
 
-    def test_queryset_is_filterable(self):
+    def test_filter_queryset__respects_queryset_constraints(self):
+        """filter_queryset honors the underlying queryset's include/exclude constraints."""
         group = self.groups[0]
 
         queryset = QuerySetSequence(Group.objects.filter(~Q(name__icontains=group.name)))
@@ -155,7 +166,8 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         result = widget.filter_queryset(None, group.name)
         assert result.exists()
 
-    def test_ajax_view_registration(self):
+    def test_render__registers_ajax_view(self):
+        """Rendering the widget registers it so the AJAX endpoint returns its results."""
         widget = GFKSelect2Widget(
             queryset=QuerySetSequence(Group.objects.all()), search_fields={'auth': {'group': ['name__icontains']}})
         widget.render('name', '1-1')
@@ -171,7 +183,8 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         assert data['results']
         assert self._ct_pk(group) in [result['id'] for result in data['results'][0]['children']]
 
-    def test_render(self):
+    def test_render__caches_widget_config(self):
+        """Rendering caches the widget's max_results, search_fields, and queryset."""
         from django_select2.cache import cache
 
         widget = GFKSelect2Widget(
@@ -184,12 +197,13 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         assert isinstance(cached_widget['queryset'][0][0], qs.get_querysets()[0].__class__)
         assert str(cached_widget['queryset'][0][1]) == str(qs.get_querysets()[0].query)
 
-    def test_get_url(self):
+    def test_get_url__returns_string(self):
+        """get_url returns the AJAX endpoint URL as a string."""
         widget = GFKSelect2Widget(
             queryset=QuerySetSequence(Group.objects.all()), search_fields={'auth': {'group': ['name__icontains']}})
         assert isinstance(widget.get_url(), str)
 
-    def test_order(self):
+    def test_get_queryset__preserves_id_ordering(self):
         """ Tests if there isn't any unexpected ordering issues when getting the queryset. """
         queryset_random = Quest.objects.order_by('name')
         queryset_expected = queryset_random.order_by('id')

--- a/src/utilities/tests/test_widgets.py
+++ b/src/utilities/tests/test_widgets.py
@@ -60,6 +60,7 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         self.client = TenantClient(self.tenant)
 
     def _ct_pk(self, obj):
+        """Return the "<content_type_pk>-<object_pk>" string the GFK choice field uses to identify obj."""
         return f'{ContentType.objects.get_for_model(obj).pk}-{obj.pk}'
 
     def test_widget__renders_initial_data(self):


### PR DESCRIPTION
### What?

Completes the convention burn-down started in #2025. **Every** `test_*.py` module now conforms to the project's test conventions, so the guard's `LEGACY_UNCONVENTIONAL` denylist is **emptied** — naming + docstrings are now enforced across the entire suite, with no grandfathered files.

Across all 17 apps (71 modules) this:
- **renames ~800 test methods** to `test_<subject>__<specific_case>`,
- **adds ~500 missing docstrings** (test methods + `setUp`/`setUpTestData`/`tearDown`), and
- **prunes a handful of dead commented-out test blocks**.

No test logic, assertions, fixtures, imports, or behavior were changed.

### Why?

You asked to do the full burn at once. Only ~29% of the suite's 1,165 test methods followed the convention before this; now 100% do, and the guard (`hackerspace_online/tests/test_conventions.py`) locks it in so it can't regress.

### How?

The work was fanned out across the apps and then verified centrally. The mechanical edits were name/docstring/dead-code only.

**One case needed real care.** Renaming reorders methods (they run alphabetically), which surfaced a *pre-existing* order dependence in `TenantAdminViewPermissionsTest`: `test_delete_view` opens with an anonymous request through the public `TenantClient`, which leaves the DB connection on the public schema so the sibling tests' `force_login()` (their first DB touch) can resolve the public-schema users. When a rename pushed it to sort after a `force_login`-first sibling, that sibling ran first and hit `Save with update_fields did not affect any rows` in `update_last_login`. I renamed it to `test_delete_view__enforces_permissions` so it keeps sorting first, and added a comment documenting the dependency. (The root fragility is pre-existing; this PR preserves develop's passing behavior rather than rewriting the tenant-admin tests.)

### Testing?

- **Full suite green: 1,168 tests pass** (serial, run twice — once to find the ordering issue, once to confirm the fix).
- `ruff check src` clean.
- The convention guard passes with an **empty** `LEGACY_UNCONVENTIONAL`, i.e. it now validates every module.

### Screenshots (if front end is affected)

N/A — tests only.

### Anything Else?

This is a large diff by line count, but it's almost entirely method renames and one-line docstrings; there are no logic changes. Reviewing per-file (or trusting the green suite + guard) should be straightforward.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test names across announcements, badges, courses, quests, notifications, tenants, and other areas to clearly describe scenarios and expected outcomes.
  * Added explanatory test documentation and streamlined shared setup descriptions.
  * Expanded coverage for configuration caching, HTML sanitization, widget behavior, and quest formatting.
  * Confirmed the test suite now conforms to naming conventions without legacy exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->