### PR TITLE
Production logging: always-on stdout config + bounded Docker log files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,23 @@ ADMINS=Admin Name:admin@exmaple.com,Admin2 Name:admin2@exmaple.com
 #EMAIL_SUBJECT_PREFIX=
 
 
+## LOGGING #####################################
+
+# Minimum level sent to stdout (captured by `docker compose logs`).
+# One of DEBUG, INFO, WARNING, ERROR, CRITICAL. Defaults to INFO
+# (WARNING under the test runner).
+#DJANGO_LOG_LEVEL=INFO
+
+# Developer tool: trace every DB query to a rotating file in /tmp/bytedeck.
+# Leave off outside of local query debugging.
+#DB_LOGS_ENABLED=False
+
+# Docker json-file log rotation for the prod/staging compose (per service):
+# each container keeps at most DOCKER_LOG_MAX_FILE files of DOCKER_LOG_MAX_SIZE.
+#DOCKER_LOG_MAX_SIZE=10m
+#DOCKER_LOG_MAX_FILE=5
+
+
 ## MEDIA AND STATIC FILES ##############################
 
 #MEDIA_ROOT=

--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -8,8 +8,22 @@
 # https://docs.docker.com/compose/extends/
 ################################################################################
 
+# Bound every container's log file so unbounded stdout/stderr can't fill the
+# host disk. Docker's default json-file driver keeps ONE log file that grows
+# forever; on this single EC2 host a chatty or looping process would eventually
+# consume all disk. max-size rotates each file and max-file caps how many are
+# kept (so ~max-size * max-file per service). Tunable via .env; the anchor is
+# applied to every service below. (Extension fields -- keys starting with "x-"
+# -- are ignored by Compose, so this only takes effect where aliased in.)
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "${DOCKER_LOG_MAX_SIZE:-10m}"
+    max-file: "${DOCKER_LOG_MAX_FILE:-5}"
+
 services:
   web:
+    logging: *default-logging
     command: bash -c "cd /app/src/ &&
                       python manage.py migrate_schemas --shared &&
                       python manage.py migrate_schemas --executor=multiprocessing &&
@@ -27,10 +41,12 @@ services:
     restart: unless-stopped
 
   celery:
+    logging: *default-logging
     user: $WUID:$WGID
     restart: unless-stopped
 
   celery-beat:
+    logging: *default-logging
     restart: unless-stopped
 
   # Production/staging additions to the shared redis service (image, healthcheck,
@@ -38,6 +54,7 @@ services:
   # AWS ElastiCache: reachable ONLY on the internal backend-network with no
   # published port, so it needs no password in this single-host setup.
   redis:
+    logging: *default-logging
     restart: unless-stopped
     # - maxmemory caps RAM so Redis can't OOM the shared app host (override with
     #   REDIS_MAXMEMORY in .env; size it to the instance and working set).
@@ -58,6 +75,7 @@ services:
       - "no"
 
   nginx:
+    logging: *default-logging
     build:
       context: ./nginx
       args:

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -285,6 +285,78 @@ MIDDLEWARE = [
 # the intended cap. 16 MiB leaves headroom under the nginx limit.
 DATA_UPLOAD_MAX_MEMORY_SIZE = env.int('DATA_UPLOAD_MAX_MEMORY_SIZE', default=16 * 1024 * 1024)
 
+# LOGGING #########################################################
+#
+# With DEBUG=False (production/staging) Django's built-in logging emits almost
+# nothing to the container: its default `console` handler is filtered to
+# DEBUG-only, so it's silenced, and app loggers (getLogger(__name__)) fall back
+# to Python's WARNING-level "last resort" stderr handler -- so INFO and most app
+# logs vanish and `docker compose logs web` shows little between startup and a
+# 5xx. This config always ships leveled, timestamped logs to stdout (captured by
+# Docker's json-file driver, which the prod compose rotates), while preserving
+# Django's default "email ADMINS on an unhandled 5xx" behaviour.
+#
+# Level is env-tunable (DJANGO_LOG_LEVEL, default INFO). Under the test runner we
+# keep it at WARNING to match the pre-existing signal-to-noise (the old last-
+# resort handler only surfaced WARNING+), so the suite output isn't flooded with
+# INFO lines; assertLogs still works regardless since it sets its own level.
+LOG_LEVEL = env('DJANGO_LOG_LEVEL', default='WARNING' if 'test' in sys.argv else 'INFO')
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname} | {asctime} | {process:d} | {name} | {message}',
+            'style': '{',
+        },
+    },
+    'filters': {
+        # AdminEmailHandler must only fire in real deployments -- never in local
+        # DEBUG, where email is printed to the console / _sent_mail dir.
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stdout',
+            'formatter': 'verbose',
+        },
+        # Mirrors Django's default so an unhandled 5xx (django.request ERROR)
+        # still emails ADMINS. Complements the celery task_failure alerter.
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'filters': ['require_debug_false'],
+        },
+    },
+    # Root catches app loggers (prerequisites.tasks, hackerspace_online.*, etc.),
+    # which use getLogger(__name__) and share no common prefix, via propagation.
+    'root': {
+        'handlers': ['console'],
+        'level': LOG_LEVEL,
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console', 'mail_admins'],
+            'level': LOG_LEVEL,
+            'propagate': False,
+        },
+        # Every SQL statement logs here at DEBUG; pin it to WARNING so
+        # DJANGO_LOG_LEVEL=DEBUG doesn't flood stdout with queries. Use the
+        # opt-in DB_LOGS_ENABLED tracer below to see queries instead.
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+            'propagate': False,
+        },
+    },
+}
+
+# Opt-in developer tool: trace every DB query to a rotating file (off by
+# default). Augments the base LOGGING above rather than replacing it.
 DB_LOGS_ENABLED = env('DB_LOGS_ENABLED', default=False)
 
 if DB_LOGS_ENABLED:
@@ -294,35 +366,17 @@ if DB_LOGS_ENABLED:
     if not os.path.exists(LOGS_PATH):
         os.mkdir(LOGS_PATH)
 
-    LOGGING = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'verbose': {
-                'format': '{levelname} | {asctime} | {process:d} {thread:d} | {message}',
-                'style': '{',
-            },
-        },
-        'handlers': {
-            'console': {
-                'level': 'DEBUG',
-                'class': 'logging.StreamHandler',
-                'formatter': 'verbose',
-            },
-            'file': {
-                'level': 'DEBUG',
-                'class': 'logging.handlers.TimedRotatingFileHandler',
-                'when': 'M',  # Every minute (so that it would be much easier to view queries rather than by hour or day)
-                'filename': os.path.join(LOGS_PATH, 'queries.log'),
-                'formatter': 'verbose',
-            }
-        },
-        'loggers': {
-            'django.db.backends': {
-                'handlers': ['file'],
-                'level': 'DEBUG',
-            },
-        }
+    LOGGING['handlers']['db_queries_file'] = {
+        'level': 'DEBUG',
+        'class': 'logging.handlers.TimedRotatingFileHandler',
+        'when': 'M',  # Every minute (so that it would be much easier to view queries rather than by hour or day)
+        'filename': os.path.join(LOGS_PATH, 'queries.log'),
+        'formatter': 'verbose',
+    }
+    LOGGING['loggers']['django.db.backends'] = {
+        'handlers': ['db_queries_file'],
+        'level': 'DEBUG',
+        'propagate': False,
     }
 
 

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -370,6 +370,9 @@ if DB_LOGS_ENABLED:
         'level': 'DEBUG',
         'class': 'logging.handlers.TimedRotatingFileHandler',
         'when': 'M',  # Every minute (so that it would be much easier to view queries rather than by hour or day)
+        # Bound retention: without backupCount, minute-rotation keeps a file
+        # forever, so an enabled tracer slowly fills /tmp. 60 = ~1h of history.
+        'backupCount': env.int('DB_LOGS_BACKUP_COUNT', default=60),
         'filename': os.path.join(LOGS_PATH, 'queries.log'),
         'formatter': 'verbose',
     }

--- a/src/hackerspace_online/tests/test_settings.py
+++ b/src/hackerspace_online/tests/test_settings.py
@@ -160,3 +160,45 @@ class Select2CacheTest(SimpleTestCase):
     def test_select2_cache__has_finite_ttl(self):
         """The select2 cache must have a finite TTL (default 24h), never None."""
         self.assertEqual(settings.CACHES["select2"]["TIMEOUT"], 60 * 60 * 24)
+
+
+class LoggingConfigTest(SimpleTestCase):
+    """Production/staging (DEBUG=False) previously shipped no LOGGING config, so
+    Django's default silenced the console handler and app logs fell back to the
+    WARNING-level last-resort stderr -- INFO and most app logs vanished. A base
+    LOGGING config must always be defined (not gated on DB_LOGS_ENABLED) sending
+    leveled logs to stdout while preserving the 5xx-emails-ADMINS path. That the
+    process started at all proves dictConfig accepted it; these lock in intent."""
+
+    def test_logging__always_defined(self):
+        """LOGGING must exist unconditionally, independent of DB_LOGS_ENABLED
+        (the query-tracer only augments it)."""
+        self.assertIsInstance(settings.LOGGING, dict)
+        self.assertEqual(settings.LOGGING["version"], 1)
+
+    def test_console_handler__writes_to_stdout(self):
+        """App/Django logs must reach container stdout (captured by Docker's
+        json-file driver) instead of being dropped."""
+        console = settings.LOGGING["handlers"]["console"]
+        self.assertEqual(console["class"], "logging.StreamHandler")
+        self.assertEqual(console["stream"], "ext://sys.stdout")
+
+    def test_root_logger__routes_to_console(self):
+        """App loggers (getLogger(__name__), no shared prefix) reach the console
+        handler by propagating to root."""
+        self.assertIn("console", settings.LOGGING["root"]["handlers"])
+
+    def test_unhandled_5xx__still_emails_admins(self):
+        """The AdminEmailHandler path (Django's default) must be preserved and
+        gated to real deployments via require_debug_false."""
+        mail_admins = settings.LOGGING["handlers"]["mail_admins"]
+        self.assertEqual(mail_admins["class"], "django.utils.log.AdminEmailHandler")
+        self.assertIn("require_debug_false", mail_admins["filters"])
+        self.assertIn("mail_admins", settings.LOGGING["loggers"]["django"]["handlers"])
+
+    def test_db_backends__not_flooded_by_default(self):
+        """With the query-tracer off, django.db.backends must stay above DEBUG so
+        DJANGO_LOG_LEVEL=DEBUG can't flood stdout with every SQL statement."""
+        # DB_LOGS_ENABLED is off under the test runner, so the base pin applies.
+        self.assertFalse(settings.DB_LOGS_ENABLED)
+        self.assertEqual(settings.LOGGING["loggers"]["django.db.backends"]["level"], "WARNING")


### PR DESCRIPTION
### What?
Gives the deployed stack real, bounded logging. Two changes:

1. An **always-on Django `LOGGING` config** that ships leveled, timestamped logs to **stdout**.
2. **Docker json-file log rotation** on every prod/staging service.

### Why?
Two gaps in how production currently logs:

- **No production `LOGGING` config existed.** The only one in `settings.py` was gated behind `DB_LOGS_ENABLED` (a dev query-tracer, off by default). So with `DEBUG=False`, Django's built-in config *silenced* the `console` handler (it's filtered to DEBUG-only) and app loggers (`getLogger(__name__)`) fell back to Python's WARNING-level "last resort" stderr. Net effect: `INFO` and most app logs vanished, and `docker compose logs web` showed almost nothing between startup and a 5xx.
- **Container logs were unbounded.** The prod compose set no `logging:` driver, so Docker's default `json-file` kept one ever-growing file per service. On the single EC2 host, a chatty or looping process could fill the disk.

### How?
**`settings.py`** — base `LOGGING` defined unconditionally:
- `console` handler → `ext://sys.stdout`, formatter `LEVEL | time | pid | logger | message`.
- Level env-tunable via `DJANGO_LOG_LEVEL` (default `INFO`; drops to `WARNING` under the test runner to preserve the pre-existing signal/noise — `assertLogs` still works since it sets its own level).
- Preserves Django's default **"email `ADMINS` on an unhandled 5xx"** via `AdminEmailHandler` + a `require_debug_false` filter (so it never fires in local DEBUG). This complements the celery `task_failure` alerter added in #2003.
- `django.db.backends` pinned to `WARNING` so `DJANGO_LOG_LEVEL=DEBUG` can't flood stdout with every SQL statement.
- The `DB_LOGS_ENABLED` query-tracer now **augments** the base config instead of replacing it.

**`docker-compose.prod.aws.yml`** — a shared `x-logging` YAML anchor (`json-file`, `max-size`/`max-file`, env-tunable via `DOCKER_LOG_MAX_SIZE`/`DOCKER_LOG_MAX_FILE`, defaults `10m`/`5`) applied to `web`, `celery`, `celery-beat`, `redis`, `nginx`.

**`.env.example`** — documents the four new env vars.

### Testing?
- New `LoggingConfigTest` locks in the intent: stdout console handler, the root→console route for app loggers, the preserved 5xx-emails-`ADMINS` path, and the `db.backends` WARNING pin. Follows the `test_subject__case` + docstring conventions (passes `test_conventions`).
- `test_settings` → 25/25 pass locally.
- `manage.py check --deploy --fail-level WARNING` with `DEBUG=False` → clean (proves the config is a valid `dictConfig` on the production path; if it weren't, the process wouldn't start).
- Validated the merged prod compose (`docker compose -f … config`) renders rotation on all five services; `ruff` clean.

### Screenshots (if front end is affected)
n/a

### Anything Else?
- Behavior in local dev (`DEBUG=True`, `runserver`) is unchanged in spirit — logs still go to the console; they're just now leveled/formatted and `mail_admins` stays disabled via `require_debug_false`.
- No new dependency. JSON/structured logging (for a log aggregator) was considered and deferred — plain text is the right fit while logs are read directly on the host.
- This is the "no production `LOGGING`" item from the round-2 infrastructure review.

- Claude Code

### Review request
@tylerecouture

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-controlled logging verbosity (via `DJANGO_LOG_LEVEL`) with sensible defaults for production vs test runs.
  * Added optional, opt-in database query logging with timed rotation (`DB_LOGS_ENABLED`).
  * Added Docker JSON log rotation settings and applied bounded logging across key services.
  * Preserved email notifications for unhandled 5xx errors when running with `DEBUG=False`.
* **Bug Fixes**
  * Reduced default SQL log noise by keeping database backend logging at warning level unless query tracing is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->