### PR TITLE
Test suite: tighten assertions to specific variants + fix vacuous no-op assertions

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -396,7 +396,7 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
         response = self.client.get(oldest_announcement.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['archived'], True)
+        self.assertTrue(response.context['archived'])
         self.assertContains(response, oldest_announcement.title)
 
         # create enough announcements to create a second page, oldest should be on second page

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -36,7 +36,7 @@ class BadgeRarityModelTest(ByteDeckTenantTestCase):
         self.assertEqual(BadgeRarity.objects.get_rarity(79.0), self.rare)
         self.assertEqual(BadgeRarity.objects.get_rarity(80.0), self.rare)
         self.assertEqual(BadgeRarity.objects.get_rarity(90.0), self.common)
-        self.assertEqual(BadgeRarity.objects.get_rarity(91), None)
+        self.assertIsNone(BadgeRarity.objects.get_rarity(91))
 
         ubercommon = baker.make(BadgeRarity, percentile=100.0)
         self.assertEqual(BadgeRarity.objects.get_rarity(100), ubercommon)

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -146,7 +146,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         form_data = response.context['form'].initial
 
         # Badge name should have changed
-        self.assertEqual(form_data['name'], "Copy of " + self.test_badge.name)
+        self.assertEqual(form_data['name'], f"Copy of {self.test_badge.name}")
         # Tags should be the same as original
         self.assertEqual(list(form_data['tags'].values_list('name', flat=True)), ['tag'])
 
@@ -234,7 +234,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse("badges:list"))
 
         new_assertion = BadgeAssertion.objects.latest('timestamp')
-        self.assertEqual(new_assertion.do_not_grant_xp, True)
+        self.assertTrue(new_assertion.do_not_grant_xp)
 
     def test_bulk_assertion_create__grants_to_all_selected(self):
         """Bulk granting a badge to multiple students creates one assertion per student."""
@@ -413,7 +413,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 302)
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
         self.assertEqual(len(messages), 1)
-        self.assertTrue(scape.name in str(messages[0]))
+        self.assertIn(scape.name, str(messages[0]))
 
         # to clear any messages before next test
         self.assert200('badges:badge_list')
@@ -423,7 +423,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 302)
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
         self.assertEqual(len(messages), 1)
-        self.assertTrue(scape.name in str(messages[0]))
+        self.assertIn(scape.name, str(messages[0]))
 
     # Custom label tests
     def test_badge_views__header_custom_label_displayed(self):

--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -23,7 +23,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
 
         self.assertEqual(comment.user, user)
         self.assertEqual(comment.text, text)
-        self.assertEqual(comment.path, path + "#comment-" + str(comment.id))
+        self.assertEqual(comment.path, f"{path}#comment-{comment.id}")
         self.assertIsNone(comment.target_content_type)
         self.assertIsNone(comment.target_object_id)
         self.assertIsNone(comment.parent)
@@ -55,7 +55,7 @@ class CommentManagerTest(ByteDeckTenantTestCase):
 
         self.assertEqual(comment.user, user)
         self.assertEqual(comment.text, text)
-        self.assertEqual(comment.path, path + "#comment-" + str(comment.id))
+        self.assertEqual(comment.path, f"{path}#comment-{comment.id}")
         self.assertEqual(comment.target_content_type, ContentType.objects.get_for_model(target))
         self.assertEqual(comment.target_object_id, target.id)
         self.assertEqual(comment.parent, parent)

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -47,7 +47,7 @@ class MarkRangeManagerTest(ByteDeckTenantTestCase):
         """get_range() returns the highest range whose minimum the mark meets."""
         mr_100 = baker.make(MarkRange, minimum_mark=100.0)
 
-        self.assertEqual(MarkRange.objects.get_range(25.0), None)
+        self.assertIsNone(MarkRange.objects.get_range(25.0))
         self.assertEqual(MarkRange.objects.get_range(50.0), self.mr_50)
         self.assertEqual(MarkRange.objects.get_range(74.9), self.mr_50)
         self.assertEqual(MarkRange.objects.get_range(75.0), self.mr_75)
@@ -61,7 +61,7 @@ class MarkRangeManagerTest(ByteDeckTenantTestCase):
         mr_50_c2 = baker.make(MarkRange, minimum_mark=50.0, courses=[c2])
         mr_100_c1 = baker.make(MarkRange, minimum_mark=100.0, courses=[c1])
 
-        self.assertEqual(MarkRange.objects.get_range(25.0), None)
+        self.assertIsNone(MarkRange.objects.get_range(25.0))
         self.assertEqual(MarkRange.objects.get_range(50.0), self.mr_50)
         self.assertEqual(MarkRange.objects.get_range(50.0, [c1]), mr_50_c1)
         self.assertEqual(MarkRange.objects.get_range(74.9, [c2]), mr_50_c2)
@@ -583,7 +583,7 @@ class RankManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(rank_2000, Rank.objects.get_next_rank(1999))
         self.assertEqual(rank_3000, Rank.objects.get_next_rank(2000))
         self.assertEqual(rank_3000, Rank.objects.get_next_rank(2999))
-        self.assertEqual(None, Rank.objects.get_next_rank(3000))
+        self.assertIsNone(Rank.objects.get_next_rank(3000))
 
     def test_get_next_rank__when_deleted(self):
         """Method can handle if ranks were deleted """

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -139,7 +139,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(messages), 1)
-        self.assertTrue(scape.name in str(messages[0]))
+        self.assertIn(scape.name, str(messages[0]))
 
         # to clear any messages before next test
         self.assert200('courses:ranks')
@@ -149,7 +149,7 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(messages), 1)
-        self.assertTrue(scape.name in str(messages[0]))
+        self.assertIn(scape.name, str(messages[0]))
 
 
 class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
@@ -767,7 +767,7 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertTrue(semester.excludeddate_set.exists())
         for ed in semester.excludeddate_set.all():
-            self.assertTrue(ed.date in exclude_dates)
+            self.assertIn(ed.date, exclude_dates)
 
     def test_SemesterCreate__add_without_required_fields__view(self):
         """
@@ -818,7 +818,7 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertTrue(semester.excludeddate_set.exists())
         for ed in semester.excludeddate_set.all():
-            self.assertTrue(ed.date in exclude_dates)
+            self.assertIn(ed.date, exclude_dates)
 
     def test_SemesterUpdate__update_data__view(self):
         """
@@ -851,7 +851,7 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # assert data is correct
         for ed in semester.excludeddate_set.all():
-            self.assertTrue(ed.date in updated_exclude_dates)
+            self.assertIn(ed.date, updated_exclude_dates)
 
     def test_SemesterUpdate__delete_data__view(self):
         """
@@ -995,7 +995,7 @@ class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(CourseStudent.objects.first().pk, course_student.pk)
 
         # confirm block existence
-        self.assertTrue(Block.objects.filter(id=block.pk).first() is not None)
+        self.assertIsNotNone(Block.objects.filter(id=block.pk).first())
 
         # confirm deletion prevention text shows up
         response = self.client.get(reverse('courses:block_delete', args=[block.pk]))

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -148,12 +148,12 @@ class FullCleanTest(TestCase, CommandMixin):
             log = buf.getvalue()
 
             # capture schema name
-            self.assertTrue('test_schema1' in log)
+            self.assertIn('test_schema1', log)
 
             # will cause an error because author is None because of
             # `null=True` without `blank=True`
             #  ie. `{'author': ['this field cannot be blank.']}`
-            self.assertTrue("'author': ['This field cannot be blank.']" in log)
+            self.assertIn("'author': ['This field cannot be blank.']", log)
             self.assertEqual(log.count("ValidationError"), 1)
 
         # Speed up tests

--- a/src/hackerspace_online/tests/test_utils.py
+++ b/src/hackerspace_online/tests/test_utils.py
@@ -129,7 +129,7 @@ class Utils_generate_form_data_Test(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 302)
 
         # assert changes
-        self.assertTrue(CourseStudent.objects.count(), 1)
+        self.assertEqual(CourseStudent.objects.count(), 1)
 
 
 class ByteDeckTenantTestCaseTest(ByteDeckTenantTestCase):

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -165,13 +165,13 @@ class NotificationModelTest(ByteDeckTenantTestCase):
         base_notification.full_clean()
         base_notification.save()
 
-        self.assertFalse('#comment-' in base_notification.get_url())
-        self.assertFalse('#comment-' in str(base_notification))
+        self.assertNotIn('#comment-', base_notification.get_url())
+        self.assertNotIn('#comment-', str(base_notification))
 
         # check if notification with comment has a hash
         comment_hash = f'#comment-{comment.id}'
-        self.assertTrue(comment_hash in notification.get_url())
-        self.assertTrue(comment_hash in str(notification))
+        self.assertIn(comment_hash, notification.get_url())
+        self.assertIn(comment_hash, str(notification))
 
 
 class NotificationModel_html_strip_Test(TestCase):

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -311,7 +311,7 @@ class PrereqModelTest(ByteDeckTenantTestCase):
 
     def test_get_or_prereq__returns_none_when_unset(self):
         "returns the alternate prereq requirement"
-        self.assertEqual(self.prereq.get_or_prereq(), None)
+        self.assertIsNone(self.prereq.get_or_prereq())
 
     # Todo: need some massive mocking for this one
     # @patch('prereq_object.condition_met_as_prerequisite', return_value=True)

--- a/src/profile_manager/tests/test_forms.py
+++ b/src/profile_manager/tests/test_forms.py
@@ -48,7 +48,7 @@ class ProfileFormTest(ByteDeckTenantTestCase):
         """
         form = ProfileForm(instance=self.user.profile, data={'email': 'example@gmail.com'})
         with patch('dns.resolver.resolve') as mock_resolve:
-            mock_resolve.return_value = MagicMock()  # Mocking resolve() because we may not have interent access during tests.
+            mock_resolve.return_value = MagicMock()  # Mocking resolve() because we may not have internet access during tests.
             form.is_valid()
             cleaned_email = form.cleaned_data['email']
             self.assertEqual(cleaned_email, 'example@gmail.com')
@@ -107,15 +107,15 @@ class ProfileFormTest(ByteDeckTenantTestCase):
         config = SiteConfig.get()
 
         self.assertEqual(config.custom_profile_field, '')
-        self.assertEqual(self.user.profile.custom_profile_field, None)
+        self.assertIsNone(self.user.profile.custom_profile_field)
 
         form = ProfileForm(instance=self.user.profile, data={'custom_profile_field': 'test'})
         form.save()
 
         # should not affect profile because SiteConfig.custom_profile_field is empty
         # form's custom_profile_field should not exist either
-        self.assertEqual(form.fields.get('custom_profile_field'), None)
-        self.assertEqual(self.user.profile.custom_profile_field, None)
+        self.assertIsNone(form.fields.get('custom_profile_field'))
+        self.assertIsNone(self.user.profile.custom_profile_field)
 
         config.custom_profile_field = 'FIELD'
         config.save()

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -425,7 +425,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.context['view_type'], response.context['VIEW_TYPES'].LIST)
 
         qs = response.context['object_list']  # should not have usernames: 1 and 2 in the qs
-        self.assertTrue(qs.count(), 2)  # these are the test students
+        self.assertEqual(qs.count(), 2)  # these are the test students
         filtered_qs = qs.filter(user__is_active=False) | qs.filter(user__is_staff=True)
         self.assertFalse(filtered_qs.exists())
 

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -194,7 +194,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             quest_set = baker.make('quest_manager.quest', _quantity=quest_count)
 
             # add unique tag for each quest
-            [quest.tags.add(f'TAG-{str(count)}') for count, quest in enumerate(quest_set)]
+            [quest.tags.add(f'TAG-{count}') for count, quest in enumerate(quest_set)]
 
             # have a submission for one of the quests
             baker.make(
@@ -221,7 +221,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             # should only show the tag with the approved submission
             self.assertContains(response, 'TAG-0')
             for i in range(1, quest_count, 1):
-                self.assertNotContains(response, f'TAG-{str(i)}')
+                self.assertNotContains(response, f'TAG-{i}')
 
             # for sanity check (its true by default)
             site_config = SiteConfig.get()
@@ -234,7 +234,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
             # should contains all tags including the ones that don't have a submission from the user
             for i in range(quest_count):
-                self.assertContains(response, f'TAG-{str(i)}')
+                self.assertContains(response, f'TAG-{i}')
 
         finally:
             # Ensure the setting is reverted back to its original state

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1155,19 +1155,19 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('quests:submission', args=[self.sub.id])  # simulate user going to submission to comment
         self.post_complete(button='comment', submission_comment='comment from submission #1')
         self.sub.refresh_from_db()
-        self.assertEqual(self.sub.draft_comment, None)
+        self.assertIsNone(self.sub.draft_comment)
         self.assertTrue(Comment.objects.filter(text__contains='comment from submission #1').exists())
 
         self.assert200('quests:submission', args=[self.sub.id])  # simulate user going to submission to comment
         self.post_complete(button='comment', submission_comment='comment from submission #2')
         self.sub.refresh_from_db()
-        self.assertEqual(self.sub.draft_comment, None)
+        self.assertIsNone(self.sub.draft_comment)
         self.assertTrue(Comment.objects.filter(text__contains='comment from submission #2').exists())
 
         # comments using quick reply
         self.post_complete(button='comment', submission_comment='comment from quick reply #1')
         self.sub.refresh_from_db()
-        self.assertEqual(self.sub.draft_comment, None)
+        self.assertIsNone(self.sub.draft_comment)
         self.assertTrue(Comment.objects.filter(text__contains='comment from quick reply #1').exists())
 
     def test_complete__unrecognized_submit_button_returns_404(self):
@@ -1649,7 +1649,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(messages), 1)
-        self.assertTrue(scape.name in str(messages[0]))
+        self.assertIn(scape.name, str(messages[0]))
 
         # to clear any messages before next test
         self.assert200('quests:')
@@ -1659,7 +1659,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         messages = list(response.wsgi_request._messages)  # unittest dont carry messages when redirecting
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(messages), 1)
-        self.assertTrue(scape.name in str(messages[0]))
+        self.assertIn(scape.name, str(messages[0]))
 
     # TODO
     # TAs should not be able to make a quest published
@@ -2130,7 +2130,7 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         response = self.client.get(reverse('quests:available'))
         self.assertEqual(response.context['view_type'], response.context['VIEW_TYPES'].AVAILABLE)
-        self.assertEqual(response.context['remove_hidden'], True)
+        self.assertTrue(response.context['remove_hidden'])
 
         # Still not there though, because student doesn't have an active course
         self.assertNotContains(response, 'Show Hidden Quests')
@@ -2975,8 +2975,8 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # Check context variables
         self.assertEqual(response.context['s'], self.submission)
-        self.assertEqual(response.context['completed'], False)
-        self.assertEqual(response.context['past'], False)
+        self.assertFalse(response.context['completed'])
+        self.assertFalse(response.context['past'])
 
         # Without a submission ID fails, 404:
         response = self.client.post(
@@ -3014,8 +3014,8 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # Check context variables
         self.assertEqual(response.context['s'], self.submission)
-        self.assertEqual(response.context['completed'], True)
-        self.assertEqual(response.context['past'], False)
+        self.assertTrue(response.context['completed'])
+        self.assertFalse(response.context['past'])
 
     def test_ajax_submission_info__past(self):
         """ Completed and in a past semester
@@ -3033,8 +3033,8 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # Check context variables
         self.assertEqual(response.context['s'], self.submission)
-        self.assertEqual(response.context['completed'], False)
-        self.assertEqual(response.context['past'], True)
+        self.assertFalse(response.context['completed'])
+        self.assertTrue(response.context['past'])
 
 
 class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
@@ -3470,19 +3470,19 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.post(**post_request, data={'approve_button': ''})
         self.assertEqual(response.status_code, 200)
         self.sub.refresh_from_db()
-        self.assertEqual(self.sub.is_approved, True)
+        self.assertTrue(self.sub.is_approved)
 
         # 'return_button' self.sub.is_approved is False
         response = self.client.post(**post_request, data={'return_button': ''})
         self.assertEqual(response.status_code, 200)
         self.sub.refresh_from_db()
-        self.assertEqual(self.sub.is_approved, False)
+        self.assertFalse(self.sub.is_approved)
 
         # 'skip_button' self.sub.is_approved is True
         response = self.client.post(**post_request, data={'skip_button': ''})
         self.assertEqual(response.status_code, 200)
         self.sub.refresh_from_db()
-        self.assertEqual(self.sub.is_approved, True)
+        self.assertTrue(self.sub.is_approved)
 
         # 'comment_button' new comment should exist
         response = self.client.post(**post_request, data={

--- a/src/siteconfig/tests/test_views.py
+++ b/src/siteconfig/tests/test_views.py
@@ -274,8 +274,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.config.site_name, 'site name changed to prove form was successful')
         self.assertEqual(self.config.custom_stylesheet.name, '')  # use `.name` because field files are never empty (ie. <FieldFile: None>)
         self.assertEqual(self.config.custom_javascript.name, '')
-        self.assertEqual(self.config.enable_shared_library, False)
-        self.assertEqual(self.config.allow_staff_export, False)
+        self.assertFalse(self.config.enable_shared_library)
+        self.assertFalse(self.config.allow_staff_export)
 
         # test deck owner fields on staff (non deck owner)
         # should not be affected by form data
@@ -289,8 +289,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         })
         self.assertEqual(response.status_code, 302)
         self.config.refresh_from_db()
-        self.assertFalse('staff' in self.config.custom_stylesheet.name)  # file fields modify name
-        self.assertFalse('staff' in self.config.custom_javascript.name)
+        self.assertNotIn('staff', self.config.custom_stylesheet.name)  # file fields modify name
+        self.assertNotIn('staff', self.config.custom_javascript.name)
         self.assertNotEqual(self.config.deck_owner, staff)
         self.assertNotEqual(self.config.enable_shared_library, True)
         self.assertFalse(self.config.allow_staff_export)
@@ -308,8 +308,8 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         })
         self.assertEqual(response.status_code, 302)
         self.config.refresh_from_db()
-        self.assertTrue('owner' in self.config.custom_stylesheet.name)  # file fields modify name
-        self.assertTrue('owner' in self.config.custom_javascript.name)
+        self.assertIn('owner', self.config.custom_stylesheet.name)  # file fields modify name
+        self.assertIn('owner', self.config.custom_javascript.name)
         self.assertEqual(self.config.deck_owner, staff)
-        self.assertEqual(self.config.enable_shared_library, True)
+        self.assertTrue(self.config.enable_shared_library)
         self.assertTrue(self.config.allow_staff_export)

--- a/src/tags/tests/test_models.py
+++ b/src/tags/tests/test_models.py
@@ -131,8 +131,8 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, ByteDeckT
         self.assertEqual(quest_submission_qs.count(), 2)
 
         # check if the submissions are the correct ones
-        self.assertTrue(submission_1 in quest_submission_qs)
-        self.assertTrue(submission_2 in quest_submission_qs)
+        self.assertIn(submission_1, quest_submission_qs)
+        self.assertIn(submission_2, quest_submission_qs)
 
     def test_get_badge_assertion_by_tags__correct_badge_assertion_tagged(self):
         """ check if 'correct tag' is retrieved and no other assertion from a different tag or no tag """
@@ -160,8 +160,8 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, ByteDeckT
         self.assertEqual(badge_assertion_qs.count(), 2)
 
         # check if the submissions are the correct ones
-        self.assertTrue(assertion_1 in badge_assertion_qs)
-        self.assertTrue(assertion_2 in badge_assertion_qs)
+        self.assertIn(assertion_1, badge_assertion_qs)
+        self.assertIn(assertion_2, badge_assertion_qs)
 
 
 class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
@@ -260,9 +260,9 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
         # check if only q_approved is in the query
         tags = [tag_tuple[0].name for tag_tuple in get_user_tags_and_xp(self.user)]
 
-        self.assertFalse('unrelated' in tags)
-        self.assertTrue('approved' in tags)
-        self.assertFalse('submitted' in tags)
+        self.assertNotIn('unrelated', tags)
+        self.assertIn('approved', tags)
+        self.assertNotIn('submitted', tags)
 
     def test_get_user_tags_and_xp__total_xp_is_correct(self):
         """ check if get_user_tags_and_xp's xp adds up correctly """

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -281,7 +281,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         public_client.force_login(admin)
 
         self.tenant_model_admin.enable_google_signin(request=request, queryset=queryset)
-        mock_add_message.assert_called
+        mock_add_message.assert_called()
 
         for tenant in queryset:
             with tenant_context(tenant):

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -602,7 +602,7 @@ class TenantAdminViewPermissionsTest(ByteDeckTenantTestCase):
         # fifth case, delete user can delete, using correct confirmation keyword/phrase
         # should returns 302 (redirect to admin homepage)
         response = self.client.get(delete_url)
-        self.assertContains(response, "tenant/tenant/%s/" % self.extra_tenant.pk)
+        self.assertContains(response, f"tenant/tenant/{self.extra_tenant.pk}/")
         self.assertContains(response, "Summary")
         self.assertContains(response, "Tenants: 1")
         post = self.client.post(delete_url, delete_dict)

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -22,7 +22,7 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         password = settings.TENANT_DEFAULT_ADMIN_PASSWORD
 
         user = User.objects.filter(username=username).first()
-        self.assertTrue(user is not None)
+        self.assertIsNotNone(user)
         self.assertEqual(user.email, settings.TENANT_DEFAULT_ADMIN_EMAIL)
 
         self.assertTrue(user.is_staff)
@@ -38,7 +38,7 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
 
         # user model test
         user = User.objects.filter(username=username).first()
-        self.assertTrue(user is not None)
+        self.assertIsNotNone(user)
 
         self.assertTrue(user.is_staff)
         self.assertFalse(user.is_superuser)
@@ -157,7 +157,7 @@ class TenantInitializationTest(ByteDeckTenantTestCase):
         """ Test that the SiteConfig object exists and the Deck name has expected defaults.
         """
         site_config = SiteConfig.get()
-        self.assertTrue(site_config is not None)
+        self.assertIsNotNone(site_config)
         self.assertEqual(site_config.site_name, "My Byte Deck")
         self.assertEqual(site_config.site_name_short, "Deck")
 

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -66,7 +66,7 @@ class TenantModelTest(ByteDeckTenantTestCase):
         admin = User.objects.get(username=settings.TENANT_DEFAULT_ADMIN_USERNAME)
         self.client.force_login(admin)
         self.tenant.update_cached_fields()
-        admin.refresh_from_db
+        admin.refresh_from_db()
         # should still return the staff user's last log in, ignoring the admin user
         self.assertEqual(self.tenant.last_staff_login, staff.last_login)
 


### PR DESCRIPTION
### What?

A conservative best-practices / readability sweep of the test suite, in two commits:

**1. Tighten assertions to their specific variant (behavior-preserving).** Across 16 files (64 line-swaps):
- `assertEqual(x, True/False)` → `assertTrue`/`assertFalse`
- `assertEqual(x, None)` / `assertTrue(x is not None)` → `assertIsNone`/`assertIsNotNone`
- `assertTrue(a in b)` → `assertIn(a, b)` — **bare-membership cases only** (`assertTrue(any(... in ...))` and comprehension checks were left as-is)
- a few string concatenations / `%`-formats → f-strings, redundant `str()` inside f-strings removed, two comment typos fixed

These change no assertion's pass/fail semantics — only which helper reports the failure (so diagnostics are clearer).

**2. Fix four vacuous no-op assertions (a real correctness improvement).** These silently asserted nothing:
- `tenant/test_admin`: `mock_add_message.assert_called` → `assert_called()` (attribute access never asserts)
- `tenant/test_models`: `admin.refresh_from_db` → `admin.refresh_from_db()` (method never called)
- `hackerspace_online/test_utils`: `assertTrue(qs.count(), 1)` → `assertEqual(qs.count(), 1)`
- `profile_manager/test_views`: `assertTrue(qs.count(), 2)` → `assertEqual(qs.count(), 2)`

The `assertTrue(count, N)` calls passed `N` as the *message* arg and only checked the count was truthy, not `== N`. All four now assert for real and still pass, so no behavior was masked.

### Why?

Continues the test-suite cleanup (after the naming/docstring conventions landed in #2025/#2026). The suite was already in good shape — no deprecated `assertEquals` aliases, no bare `except:` — so this is a targeted polish: specific assertion variants give better failure messages, and the four no-op assertions were quietly not testing what they claimed.

### How?

Fanned out per-app subagents for the assertion sweep (each self-verified against `ruff` + the convention guard), then verified centrally by running the full set of touched modules. The no-op fixes were made and verified separately.

Deliberately **not** changed (to avoid churn / behavior changes): `len(...)`/`.count()` equality assertions (already clear), `assertTrue(any(... in ...))` message checks, and `.format()` HTML-template strings.

### Testing?

- 566 tests across the touched modules pass for the assertion sweep; another 69 for the no-op-fix modules.
- `ruff check src` clean; the `test_conventions` guard still passes (`ALL CLEAN`).

### Screenshots (if front end is affected)

N/A — tests only.

### Anything Else?

No production code changed.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_