### PR TITLE
Don't recalculate the prereq cache for a user being deleted — Closes #1754

### DIFF
--- a/src/prerequisites/signals.py
+++ b/src/prerequisites/signals.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -14,6 +15,23 @@ from quest_manager.models import Quest, QuestSubmission
 from djcytoscape.models import CytoScape
 
 User = get_user_model()
+
+
+def _delete_originated_from_user(origin):
+    """True when a delete cascade was started by deleting a User (issue #1754).
+
+    Django's pre_delete/post_delete signals carry an ``origin`` kwarg: the instance or
+    queryset ``.delete()`` was called on. When a user is deleted the cascade removes all
+    their QuestSubmissions/BadgeAssertions/CourseStudents, and every one of those
+    post_delete signals carries the User as the origin. Recomputing the available-quest
+    cache for a user who is being removed is pointless (and the cascade would otherwise
+    queue dozens of tasks), so we use the origin to tell a user-deletion cascade apart
+    from a direct delete of a single submission/badge (which should still recompute).
+    """
+    if origin is None:
+        return False
+    origin_model = origin.model if isinstance(origin, QuerySet) else type(origin)
+    return issubclass(origin_model, User)
 
 
 # @receiver([post_save, post_delete], sender=BadgeAssertion)
@@ -47,6 +65,12 @@ def update_cache_triggered_by_task_completion(sender, instance, *args, **kwargs)
         # When both conditions are met, that would be the only time we want to update available quests
         # for the user.
         if isinstance(instance, QuestSubmission) and (instance.is_completed is False or instance.is_approved is False):
+            return
+
+        # Skip when this row is being removed as part of deleting its user: recomputing the
+        # available-quest cache for a user who is being deleted is pointless, and the delete
+        # cascade fires this signal once per submission/badge/course-student (issue #1754).
+        if _delete_originated_from_user(kwargs.get('origin')):
             return
 
         update_quest_conditions_for_user.apply_async(args=[instance.user_id], queue='default')

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -97,6 +97,41 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
             self.assertEqual(task.call_count, 1)
             self.assertEqual(callback.call_count, 1)
 
+    @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
+    def test_update_cache_triggered_by_task_completion__skips_user_deletion_cascade(self, task):
+        """Deleting a user cascades to delete their submissions/badges/course-students, and
+        each of those deletions would normally queue update_quest_conditions_for_user. For a
+        user being removed that recompute is pointless, so the cascade must queue no such
+        task (issue #1754).
+        """
+        # self.student already has a BadgeAssertion, a QuestSubmission and a CourseStudent
+        # (created in setUpTestData). Make the submission complete+approved so that, absent
+        # the fix, its deletion WOULD fire the task -- proving the suppression is doing work.
+        self.quest_submission.is_completed = True
+        self.quest_submission.is_approved = True
+        self.quest_submission.save()
+        task.reset_mock()  # ignore the task the save above triggers
+
+        self.student.delete()
+
+        task.assert_not_called()
+
+    @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
+    def test_update_cache_triggered_by_task_completion__fires_on_direct_submission_delete(self, task):
+        """The user-deletion guard must not suppress the normal case: deleting a single
+        complete+approved submission (while its user remains) still recalculates that user's
+        available quests (issue #1754 regression guard).
+        """
+        self.quest_submission.is_completed = True
+        self.quest_submission.is_approved = True
+        self.quest_submission.save()
+        task.reset_mock()
+
+        self.quest_submission.delete()
+
+        self.assertEqual(task.call_count, 1)
+        self.assertEqual(task.call_args.kwargs['args'], [self.student.id])
+
     @patch('prerequisites.signals.update_quest_conditions_all_users.apply_async')
     def test_update_prereq_cache__triggered_by_badge(self, task):
         """


### PR DESCRIPTION
### What?
When a user is deleted, the cascade that removes their submissions, badges and course enrollments no longer fires a flood of `update_quest_conditions_for_user` Celery tasks.

### Why?
Reported in #1754. Deleting a user cascades to delete all their `QuestSubmission`s, `BadgeAssertion`s and `CourseStudent`s. Each of those deletions triggers the shared `post_delete` signal `update_cache_triggered_by_task_completion`, which queued an `update_quest_conditions_for_user` task per row — dozens of pointless tasks recomputing the available-quest cache for a user who is being removed (see the celery log in the issue).

### How?
Django's `pre_delete`/`post_delete` signals carry an `origin` kwarg: the instance or queryset that `.delete()` was called on. Every `post_delete` emitted while deleting a user carries that `User` as the origin, so the signal now skips queuing the task when the delete originated from a `User` (instance **or** queryset delete). Deleting a single submission/badge directly still recomputes, because its origin is the row itself, not a `User`.

A new helper `_delete_originated_from_user(origin)` encapsulates the check (handles both a `User` instance and a `User` queryset).

**Why `origin` and not a "users being deleted" set?** I first tried tracking deleting-user ids in a thread-local (mark on `User.pre_delete`, clear on `post_delete`). Tracing the cascade showed it emits `post_delete` in several passes and the User's own `post_delete` is **not** guaranteed to be last, so clearing the marker there wiped it mid-cascade and let later rows (e.g. a `BadgeAssertion`) slip through and queue the task. Deferring cleanup to `transaction.on_commit` fixed production but leaked across rolled-back tests. The `origin` kwarg needs no bookkeeping and has none of these ordering hazards.

### Testing?
Added two tests to `PrerequisitesSignalsTest`:
- `..._skips_user_deletion_cascade`: a user with a complete+approved submission (which would otherwise fire the task on delete) is deleted → **no** task is queued.
- `..._fires_on_direct_submission_delete`: deleting that submission on its own still queues exactly one task for its user (regression guard so the fix doesn't over-suppress).

`python manage.py test prerequisites` → all green (81 incl. the user-deletion tests); `test_conventions` guard passes; `ruff check` clean.

### Screenshots (if front end is affected)
N/A — background-task / signal behavior.

### Anything Else?
- No model or schema change; purely a guard in the existing signal.
- The tasks that were being queued were themselves harmless no-ops once the user was gone, but there could be dozens per deletion — this removes that queue pressure entirely.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_