### PR TITLE
Fix notification preview mangling multiple images — Closes #1761

### DIFF
--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -6,8 +6,7 @@ from django.db import models
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import strip_tags
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString, Tag
 
 from tenant.utils import get_root_url
 
@@ -129,75 +128,65 @@ class Notification(models.Model):
     objects = NotificationManager()
 
     def html_strip(string, char_limit=50, tag_size=1, resize_image=True, image_height=20, **kwargs) -> str:
-        """
-            Strips all html tags except img tags and imposes a length limit. Returns the input text without html tags save for img tag
+        """Return a short, dropdown-safe preview of ``string``.
 
-            tag_size: how many letters an image should count as
+        Strips every HTML tag except ``<img>`` (keeping the text of the stripped tags)
+        and truncates to ``char_limit`` visible characters, where each surviving image
+        counts as ``tag_size`` characters. Surviving images are resized to a fixed
+        height so a notification's content can't blow out the notification dropdown's
+        layout. A trailing ``"..."`` is added when the text was truncated.
 
-            resize_image: enables image resizing
-            image_height: image height after resizing in pixels
+        tag_size: how many characters an image counts as toward the limit
+        resize_image: enables image resizing
+        image_height: image height after resizing, in pixels
+
+        The document is walked in order rather than having image tags reinserted by
+        character index: the old index-based approach mangled the markup (splicing one
+        image tag into the middle of another, and dropping the resize) whenever a
+        notification contained more than one image, which is what broke the dropdown
+        (issue #1761).
         """
         if not string:
             return ""
-        if type(string) is not str:
+        if not isinstance(string, str):
             string = str(string)
 
-        limit_imposed = False
-        HTML_tags = []
-        tag_index = []
+        soup = BeautifulSoup(string, "html.parser")
 
-        # store HTML tags and index to lists
-        cache_open_index = None
-        for index in range(len(string)):
-            char = string[index]
+        # Drop every tag except <img>, keeping its text. find_all() returns a static list
+        # in document order (parents before children), and unwrap() promotes a tag's
+        # children in place, so this flattens the tree to a run of text nodes and <img>
+        # tags without disturbing their order.
+        for tag in soup.find_all(True):
+            if tag.name != "img":
+                tag.unwrap()
 
-            # check for open img
-            if char == "<" and string[index:].startswith("<img"):
-                cache_open_index = index
+        result = BeautifulSoup("", "html.parser")
+        remaining = char_limit
+        truncated = False
 
-            # check for closed if open already found
-            elif cache_open_index is not None and char == ">":
-                # position img tag would be without html tags
-                offset = cache_open_index - len(strip_tags(string[:cache_open_index]))
+        for node in list(soup.contents):
+            if remaining <= 0:
+                truncated = True
+                break
+            if isinstance(node, Tag) and node.name == "img":
+                if resize_image:
+                    node["style"] = ""  # drop width/height styles that would overflow the dropdown
+                    node["height"] = f"{image_height}px"
+                    node["width"] = "auto"
+                result.append(node)
+                remaining -= tag_size
+            else:
+                text = str(node)
+                if len(text) > remaining:
+                    result.append(NavigableString(text[:remaining]))
+                    remaining = 0
+                    truncated = True
+                else:
+                    result.append(NavigableString(text))
+                    remaining -= len(text)
 
-                start = cache_open_index
-                end = index + 1
-
-                # save the html tag and index to list
-                HTML_tags.append(string[start:end])
-                tag_index.append(cache_open_index - offset)
-
-                cache_open_index = None
-
-        # dict of html tag and its position in the string
-        html_index = {HTML_tags[i]: tag_index[i] for i in range(len(HTML_tags))}
-
-        # index count of images that will be shown
-        shown_tag_count = len([index for _, index in html_index.items() if index < char_limit])
-        # tags should count towards the character limit
-        char_limit -= shown_tag_count * tag_size
-
-        # strip all the tags and apply char limit to TEXT
-        stripped = strip_tags(string)
-        text = stripped[:char_limit]
-        limit_imposed = len(stripped) > char_limit
-
-        # reinsert tags with new stripped text
-        for tag, index in html_index.items():
-            if index < char_limit:
-                text = text[:index] + tag + text[index:]
-
-        # resizes all images in string
-        if resize_image:
-            soup = BeautifulSoup(text, features="html.parser")
-            for img in soup.findAll('img'):
-                img['style'] = ""  # remove style as it always comes with width/height modifiers
-                img['height'] = f"{image_height}px"
-                img['width'] = "auto"
-
-            text = str(soup)
-
-        return text + ("..." if limit_imposed else "")
+        return str(result) + ("..." if truncated else "")
 
     def __str__(self):
         try:

--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, Comment, NavigableString, Tag
 
 from tenant.utils import get_root_url
 
@@ -169,6 +169,10 @@ class Notification(models.Model):
             if remaining <= 0:
                 truncated = True
                 break
+            # Comment is a NavigableString subclass that survives unwrap(); skip it so a
+            # pasted HTML comment never leaks into the preview or eats into the limit.
+            if isinstance(node, Comment):
+                continue
             if isinstance(node, Tag) and node.name == "img":
                 if resize_image:
                     node["style"] = ""  # drop width/height styles that would overflow the dropdown

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -231,3 +231,25 @@ class NotificationModel_html_strip_Test(TestCase):
             Notification.html_strip(test_case),
             expected_case
         )
+
+    def test_notification_html_strip__multiple_img_tags_are_not_mangled(self):
+        """Content with more than one <img> keeps every image well-formed and resized.
+
+        Regression for issue #1761: the previous index-based implementation spliced one
+        image tag into the middle of another and dropped the resize, leaving oversized
+        images and broken markup that wrecked the notification dropdown's layout.
+        """
+        test_case = (
+            'A <img src="one.png" style="width: 50%;"> B <img src="two.png" style="width: 25%;"> C'
+        )
+        expected_case = (
+            'A <img height="20px" src="one.png" style="" width="auto"/> '
+            'B <img height="20px" src="two.png" style="" width="auto"/> C'
+        )
+        self.assertEqual(Notification.html_strip(test_case), expected_case)
+
+    def test_notification_html_strip__truncates_long_text_with_ellipsis(self):
+        """Text longer than the character limit is cut and gets a trailing ellipsis."""
+        long_text = "x" * 200
+        result = Notification.html_strip(long_text, char_limit=50)
+        self.assertEqual(result, "x" * 50 + "...")

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -253,3 +253,30 @@ class NotificationModel_html_strip_Test(TestCase):
         long_text = "x" * 200
         result = Notification.html_strip(long_text, char_limit=50)
         self.assertEqual(result, "x" * 50 + "...")
+
+    def test_notification_html_strip__empty_and_none_return_empty_string(self):
+        """Falsy input (empty string or None) yields an empty string, not an error."""
+        self.assertEqual(Notification.html_strip(""), "")
+        self.assertEqual(Notification.html_strip(None), "")
+
+    def test_notification_html_strip__coerces_non_string_input(self):
+        """A non-string value is coerced to str before stripping (e.g. an int)."""
+        self.assertEqual(Notification.html_strip(12345), "12345")
+
+    def test_notification_html_strip__strips_html_comments(self):
+        """HTML comments are dropped, not rendered as visible text or counted toward the limit."""
+        self.assertEqual(Notification.html_strip("a<!-- hidden -->b"), "ab")
+
+    def test_notification_html_strip__resize_image_false_keeps_original_img(self):
+        """With resize_image=False the <img> is preserved but not resized."""
+        self.assertEqual(
+            Notification.html_strip('<img src="SOURCE">', resize_image=False),
+            '<img src="SOURCE"/>',
+        )
+
+    def test_notification_html_strip__truncation_drops_trailing_content(self):
+        """Once the character limit is hit, later nodes (text and images) are dropped
+        and the result is ellipsised."""
+        test_case = 'ab <img src="x.png"> cd'
+        # char_limit=1 is consumed by "a"; everything after is dropped.
+        self.assertEqual(Notification.html_strip(test_case, char_limit=1), "a...")

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -241,6 +241,16 @@ button.btn-mobile-navbar.btn-mobile-navbar-left {
     width: 100%;
 }
 
+/* Notifications can embed images from quest/badge content. html_strip() already
+   shrinks them to ~20px tall, but cap them here too so an unusually wide image can
+   never push the dropdown out of shape (issue #1761). */
+.notification-dropdown img {
+    max-width: 100%;
+    max-height: 24px;
+    width: auto;
+    height: auto;
+}
+
 .navbar-mobile-xp > li > a, .navbar-nav > li.navbar-xp > a {
     padding-top: 14px;
     padding-bottom: 13px;


### PR DESCRIPTION
### What?
Notifications whose content contains **more than one image** no longer break the notifications dropdown.

### Why?
Reported in #1761. The notifications dropdown injects each notification's `get_link()` HTML, which builds a short preview via `Notification.html_strip()`. That method strips all tags except `<img>`, resizes surviving images to ~20px tall, and truncates to a character limit.

It did this by recording each image tag's character position, stripping everything, then **re-inserting the image tags by index**. With more than one image the indices didn't account for the length of already-reinserted tags, so it spliced one `<img>` into the middle of another **and** skipped the resize — leaving broken markup and full-size images that wrecked the dropdown layout.

Reproduced exactly with the issue's two-image content:
```
Input:  1. ``&lt;img src="a.png" style="width: 50%;"&gt;``2. ``&lt;img src="b.png" style="width: 25%;"&gt;``3.
Before: 1. <im``&lt;img src="b.png" style="width: 25%;"&gt;``g src="a.png" style="width: 50%;">2. 3.   (mangled, still full-size)
After:  1. ``&lt;img height="20px" src="a.png" style="" width="auto"/&gt;``2. ``&lt;img height="20px" src="b.png" style="" width="auto"/&gt;``3.
```

### How?
- Rewrote `html_strip()` to **walk the parsed document in order** instead of reinserting by index: unwrap every non-`<img>` tag (keeping its text), then rebuild the preview node by node, resizing each image and counting it toward the character limit. Multiple images now stay well-formed and shrunk; the single-image / plain-text behaviour is unchanged. (Also removed the now-unused `strip_tags` import.)
- Added a CSS cap (`max-height`/`max-width`) on `.notification-dropdown img` so even an unusually wide image can't push the dropdown out of shape.

### Testing?
Added to the existing `html_strip` test class:
- `..._multiple_img_tags_are_not_mangled` — two images stay well-formed and resized (the regression).
- `..._truncates_long_text_with_ellipsis` — long text is cut and gets a trailing `...`.

The existing single-image / plain-text / html-stripping tests still pass unchanged. `python manage.py test notifications` → green; `test_conventions` guard passes; `ruff check` clean.

### Screenshots (if front end is affected)
The rendered markup is the fix; before/after strings are shown in **Why?** above. Visual result: notification previews show small inline thumbnails instead of oversized/broken images that overflowed the dropdown.

### Anything Else?
- `html_strip()` is also used by `Notification.__str__` (the emailed digest), which benefits from the same correctness fix.
- No model or schema change.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification HTML truncation while preserving readable text and supported images.
  * Fixed handling of multiple images and ensured truncated notifications end with an ellipsis when appropriate.
  * Added safeguards for non-text notification content.

* **Style**
  * Constrained notification dropdown images to prevent layout distortion while preserving their aspect ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->