### PR TITLE
Show a "Loading content..." spinner in place of bootstrap-tables while they load — Closes #1981

### DIFF
--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -114,6 +114,7 @@
 
     </div>
   </h3>
+  {% include 'snippets/table_loading.html' %}
   <table
         data-toggle='table'
         data-search='true'

--- a/src/library/templates/library/tab_library_quests.html
+++ b/src/library/templates/library/tab_library_quests.html
@@ -4,6 +4,7 @@
     The Library contains quests created and shared by Bytedeck and its community, for you to use by importing them into your own deck.
     Documentation for this feature can be found on the <a href="https://github.com/bytedeck/bytedeck/wiki/Library">Bytedeck Wiki</a>.
   </p>
+  {% include 'snippets/table_loading.html' %}
   <table id="accordion-available"
          class="accordian-table"
          data-classes="table table-hover table-responsive"

--- a/src/portfolios/templates/portfolios/edit.html
+++ b/src/portfolios/templates/portfolios/edit.html
@@ -20,6 +20,7 @@
     </h3>
 
 
+    {% include 'snippets/table_loading.html' %}
     <table data-toggle='table'
             data-sort-name='title'
             data-sort-order='asc'

--- a/src/portfolios/templates/portfolios/list.html
+++ b/src/portfolios/templates/portfolios/list.html
@@ -9,6 +9,7 @@
           href="{% url 'portfolios:current_user' %}">View Your Portfolio</a></p>
 
     <!-- <table class="table table-striped"> -->
+    {% include 'snippets/table_loading.html' %}
     <table data-toggle='table'
             data-sort-name='username'
             data-sort-order='asc'

--- a/src/profile_manager/templates/profile_manager/profile_list.html
+++ b/src/profile_manager/templates/profile_manager/profile_list.html
@@ -46,6 +46,7 @@
 {{ block_object.description }}
 {% endif %}
 
+{% include 'snippets/table_loading.html' %}
 <table data-toggle='table'
 data-sort-name='first'
 data-sort-order='asc'

--- a/src/quest_manager/templates/quest_manager/category_detail_content.html
+++ b/src/quest_manager/templates/quest_manager/category_detail_content.html
@@ -33,6 +33,7 @@
 </div>
 {% if category_displayed_quests %}
   <div id="available">
+    {% include 'snippets/table_loading.html' %}
     <table id="accordion-available"
            class="accordian-table"
            data-classes="table table-hover"

--- a/src/quest_manager/templates/quest_manager/quest_user_status.html
+++ b/src/quest_manager/templates/quest_manager/quest_user_status.html
@@ -75,6 +75,7 @@
   </table>
 
   {% if user_status_list %}
+    {% include 'snippets/table_loading.html' %}
     <table id="user-status-table"
           class="user-status-table"
           data-toggle="table"

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -5,6 +5,7 @@
     Documentation for this feature can be found on the <a href="https://github.com/bytedeck/bytedeck/wiki/Library">Bytedeck Wiki</a>.
   </p>
 {% endif %}
+{% include 'snippets/table_loading.html' %}
 <table data-toggle='table'
        data-search='true'
        data-classes="table"

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -10,6 +10,7 @@
 {% load utility_tags %}
 
 {% if tab.submissions %}
+  {% include 'snippets/table_loading.html' %}
   <table id="accordion-available"
          class="accordian-table"
          data-classes="table table-hover"

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -40,6 +40,7 @@
 {% endif %}
 
 {% if quests %}
+  {% include 'snippets/table_loading.html' %}
   <table id="accordion-available"
          class="accordian-table"
          data-classes="table table-hover table-responsive"

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -8,6 +8,7 @@
 {% load crispy_forms_tags %}
 {% if submissions %}
 
+  {% include 'snippets/table_loading.html' %}
   <table id="accordian-{% if completed %}completed{% else %}inprogress{% endif %}"
     class="accordian-table"
     data-classes="table table-hover"

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -1120,60 +1120,41 @@ div.btn-group.action-btn-group {
 
 
 /* === #1981: prevent the bootstrap-table "flash of unstyled table" ================= */
-/* Data tables (data-toggle="table") are server-rendered as a plain <table>, so the
-   browser paints the raw, unstyled table first and then — a second or two later on large
-   tables — bootstrap-table tears it down and rebuilds it (pagination, search, fixed layout).
-   That rebuild is the visible "jump", and on a large table the raw parse leaves the page
-   looking blank/broken until it happens. This file is loaded in the render-blocking <head>,
-   so the rules here turn each raw table into a "Loading content…" spinner from the very first
-   paint — no JS needed — matching the spinner shown inside collapsed quest rows. Once
-   bootstrap-table wraps the table (or the custom.js fallback fires) the real table is
-   revealed. */
+/* Data tables (data-toggle="table") are server-rendered as a plain <table>, so the browser
+   paints the raw, unstyled table first and then — a second or two later on large tables —
+   bootstrap-table tears it down and rebuilds it (pagination, search, fixed layout). That
+   rebuild is the visible "jump", and while a large table parses the page looks blank/broken.
+   A "Loading content..." spinner (.bt-loading) is server-rendered right before each such
+   table (snippets/table_loading.html), so it's on screen from the very first paint — a
+   JS-inserted spinner would arrive too late, after the raw table has already been parsed.
+   This <head> CSS hides the raw table until bootstrap-table formats it, and hides the spinner
+   the moment its table is ready. */
 table[data-toggle="table"] {
-    /* Center the placeholder spinner (its ::before/::after) and take the raw rows out of the
-       picture, so the huge unstyled table is never painted and reserves no tall blank gap. */
+    /* Out of flow while hidden so a big table reserves no tall blank gap under the spinner. */
+    position: absolute;
+    visibility: hidden;
+}
+/* Once bootstrap-table wraps the table in .bootstrap-table it is fully formatted — put it
+   back in flow and show it. The .bt-reveal fallback (custom.js) covers any table
+   bootstrap-table never initializes, so data is never left hidden. */
+.bootstrap-table table[data-toggle="table"],
+table[data-toggle="table"].bt-reveal {
+    position: static;
+    visibility: visible;
+}
+
+/* Server-rendered loading spinner shown in the table's place, using the same
+   fa-spinner / "Loading content..." markup as the collapsed quest rows. */
+.bt-loading {
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 120px;
+    color: #999;
 }
-/* Hide the raw table's own content (thead/tbody) while it stands in as a spinner. */
-table[data-toggle="table"] > * {
+/* Hide the spinner the moment its table is formatted (wrapped in .bootstrap-table) or
+   force-revealed (.bt-reveal). custom.js also hides it, covering browsers without :has(). */
+.bt-loading:has(+ .bootstrap-table),
+.bt-loading:has(+ table[data-toggle="table"].bt-reveal) {
     display: none;
-}
-/* Spinning icon — fa-spinner fa-pulse, the same icon/animation as the "Loading content…"
-   rows (Font Awesome 4.7, glyph \f110). */
-table[data-toggle="table"]::before {
-    content: "\f110";
-    font-family: FontAwesome;
-    font-size: 2em;
-    color: #999;
-    -webkit-animation: fa-spin 1s infinite steps(8);
-    animation: fa-spin 1s infinite steps(8);
-}
-/* Label next to the icon, spaced like the fa-fw gap in the row spinner. */
-table[data-toggle="table"]::after {
-    content: "Loading content\2026"; /* \2026 = … */
-    color: #999;
-    margin-left: 0.5em;
-}
-
-/* Once bootstrap-table wraps the table in .bootstrap-table it is fully formatted — restore
-   the real table and drop the placeholder spinner. Version-independent and JS-free, so the
-   table always appears. The .bt-reveal fallback (custom.js) covers any table bootstrap-table
-   never initializes, so data is never left hidden behind the spinner. */
-.bootstrap-table table[data-toggle="table"],
-table[data-toggle="table"].bt-reveal {
-    display: table;
-    min-height: 0;
-}
-.bootstrap-table table[data-toggle="table"] > *,
-table[data-toggle="table"].bt-reveal > * {
-    display: revert;
-}
-.bootstrap-table table[data-toggle="table"]::before,
-.bootstrap-table table[data-toggle="table"]::after,
-table[data-toggle="table"].bt-reveal::before,
-table[data-toggle="table"].bt-reveal::after {
-    content: none;
 }

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -1123,32 +1123,57 @@ div.btn-group.action-btn-group {
 /* Data tables (data-toggle="table") are server-rendered as a plain <table>, so the
    browser paints the raw, unstyled table first and then — a second or two later on large
    tables — bootstrap-table tears it down and rebuilds it (pagination, search, fixed layout).
-   That rebuild is the visible "jump". This file is loaded in the render-blocking <head>, so
-   hiding the raw table here stops it from ever being painted; custom.js drops a spinner into
-   its place and the rules below reveal the finished table. */
+   That rebuild is the visible "jump", and on a large table the raw parse leaves the page
+   looking blank/broken until it happens. This file is loaded in the render-blocking <head>,
+   so the rules here turn each raw table into a "Loading content…" spinner from the very first
+   paint — no JS needed — matching the spinner shown inside collapsed quest rows. Once
+   bootstrap-table wraps the table (or the custom.js fallback fires) the real table is
+   revealed. */
 table[data-toggle="table"] {
-    /* take the raw table out of flow while hidden so a big table doesn't reserve a tall
-       blank gap under the spinner */
-    position: absolute;
-    visibility: hidden;
-}
-
-/* Once bootstrap-table wraps the table in .bootstrap-table it is fully formatted — put it
-   back in flow and show it. Version-independent and JS-free, so the table always appears. */
-.bootstrap-table table[data-toggle="table"],
-table[data-toggle="table"].bt-reveal {
-    position: static;
-    visibility: visible;
-}
-
-/* Spinner shown in the table's place while it formats (inserted by custom.js). */
-.bt-loading {
+    /* Center the placeholder spinner (its ::before/::after) and take the raw rows out of the
+       picture, so the huge unstyled table is never painted and reserves no tall blank gap. */
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 120px;
-    color: #999;
 }
-.bt-loading .fa {
-    opacity: 0.6;
+/* Hide the raw table's own content (thead/tbody) while it stands in as a spinner. */
+table[data-toggle="table"] > * {
+    display: none;
+}
+/* Spinning icon — fa-spinner fa-pulse, the same icon/animation as the "Loading content…"
+   rows (Font Awesome 4.7, glyph \f110). */
+table[data-toggle="table"]::before {
+    content: "\f110";
+    font-family: FontAwesome;
+    font-size: 2em;
+    color: #999;
+    -webkit-animation: fa-spin 1s infinite steps(8);
+    animation: fa-spin 1s infinite steps(8);
+}
+/* Label next to the icon, spaced like the fa-fw gap in the row spinner. */
+table[data-toggle="table"]::after {
+    content: "Loading content\2026"; /* \2026 = … */
+    color: #999;
+    margin-left: 0.5em;
+}
+
+/* Once bootstrap-table wraps the table in .bootstrap-table it is fully formatted — restore
+   the real table and drop the placeholder spinner. Version-independent and JS-free, so the
+   table always appears. The .bt-reveal fallback (custom.js) covers any table bootstrap-table
+   never initializes, so data is never left hidden behind the spinner. */
+.bootstrap-table table[data-toggle="table"],
+table[data-toggle="table"].bt-reveal {
+    display: table;
+    min-height: 0;
+}
+.bootstrap-table table[data-toggle="table"] > *,
+table[data-toggle="table"].bt-reveal > * {
+    display: revert;
+}
+.bootstrap-table table[data-toggle="table"]::before,
+.bootstrap-table table[data-toggle="table"]::after,
+table[data-toggle="table"].bt-reveal::before,
+table[data-toggle="table"].bt-reveal::after {
+    content: none;
 }

--- a/src/static/js/custom.js
+++ b/src/static/js/custom.js
@@ -36,40 +36,26 @@ $(document).ready(function() {
        window.location.href = $(this).attr("href");
      });
 
-    // #1981: bootstrap-table reformats server-rendered tables on load, briefly showing the raw
-    // table before it "jumps" into the styled/paginated version. The head CSS (custom_common.css)
-    // hides those tables until they're formatted; here we show a spinner in the gap and make sure
-    // the table is revealed even if bootstrap-table's script never runs.
+    // #1981: bootstrap-table reformats server-rendered tables on load. The head CSS
+    // (custom_common.css) replaces each raw table with a "Loading content…" spinner from the
+    // first paint and reveals the real table once bootstrap-table wraps it in .bootstrap-table.
+    // This is only a fallback: if bootstrap-table never initializes a table (e.g. one its
+    // script doesn't auto-handle), reveal the raw table after a timeout so its data is never
+    // left hidden behind the spinner.
     $('table[data-toggle="table"]').each(function() {
         var $table = $(this);
 
-        // If bootstrap-table already initialized this table (its script ran before this one),
-        // it is wrapped and the CSS has already revealed it — nothing to do.
+        // Already wrapped/formatted (bootstrap-table's script ran first) — CSS revealed it.
         if ($table.closest('.bootstrap-table').length) {
             return;
         }
 
-        var $spinner = $(
-            '<div class="bt-loading" role="status" aria-label="Loading table">' +
-            '<i class="fa fa-spinner fa-spin fa-2x" aria-hidden="true"></i></div>'
-        );
-        $table.before($spinner);
-
-        // Poll for bootstrap-table to wrap the table (robust to script load order and to the
-        // different bootstrap-table versions loaded across the site). Drop the spinner once
-        // wrapped — or after a timeout, so a failed/late bootstrap-table can never leave the
-        // data hidden (the fallback class reveals the raw table).
-        var start = Date.now();
-        var poll = setInterval(function() {
-            var wrapped = $table.closest('.bootstrap-table').length;
-            if (wrapped || Date.now() - start > 6000) {
-                clearInterval(poll);
-                $spinner.remove();
-                if (!wrapped) {
-                    $table.addClass('bt-reveal');
-                }
+        // Give bootstrap-table time to wrap the table; if it never does, reveal the raw table.
+        setTimeout(function() {
+            if (!$table.closest('.bootstrap-table').length) {
+                $table.addClass('bt-reveal');
             }
-        }, 50);
+        }, 6000);
     });
 
 });

--- a/src/static/js/custom.js
+++ b/src/static/js/custom.js
@@ -36,26 +36,34 @@ $(document).ready(function() {
        window.location.href = $(this).attr("href");
      });
 
-    // #1981: bootstrap-table reformats server-rendered tables on load. The head CSS
-    // (custom_common.css) replaces each raw table with a "Loading content…" spinner from the
-    // first paint and reveals the real table once bootstrap-table wraps it in .bootstrap-table.
-    // This is only a fallback: if bootstrap-table never initializes a table (e.g. one its
-    // script doesn't auto-handle), reveal the raw table after a timeout so its data is never
-    // left hidden behind the spinner.
-    $('table[data-toggle="table"]').each(function() {
-        var $table = $(this);
+    // #1981: bootstrap-table reformats server-rendered tables on load. A "Loading content..."
+    // spinner (.bt-loading) is server-rendered right before each data-toggle="table", so it's
+    // visible from the first paint; the head CSS (custom_common.css) hides the raw table until
+    // bootstrap-table formats it. Here we hide each spinner once its table is wrapped in
+    // .bootstrap-table — and, if bootstrap-table never initializes a table, reveal the raw
+    // table after a timeout so its data is never left hidden behind the spinner.
+    $('.bt-loading').each(function() {
+        var $spinner = $(this);
 
-        // Already wrapped/formatted (bootstrap-table's script ran first) — CSS revealed it.
-        if ($table.closest('.bootstrap-table').length) {
-            return;
+        // The table this spinner covers is the next sibling — still the raw <table>, or, if
+        // bootstrap-table already ran, the .bootstrap-table wrapper it was replaced with.
+        function findTable() {
+            var $next = $spinner.next();
+            return $next.is('table[data-toggle="table"]') ? $next : $next.find('table[data-toggle="table"]').first();
         }
 
-        // Give bootstrap-table time to wrap the table; if it never does, reveal the raw table.
-        setTimeout(function() {
-            if (!$table.closest('.bootstrap-table').length) {
-                $table.addClass('bt-reveal');
+        var start = Date.now();
+        var poll = setInterval(function() {
+            var $table = findTable();
+            var wrapped = $table.length && $table.closest('.bootstrap-table').length;
+            if (wrapped || Date.now() - start > 6000) {
+                clearInterval(poll);
+                if (!wrapped && $table.length) {
+                    $table.addClass('bt-reveal');
+                }
+                $spinner.hide();
             }
-        }, 6000);
+        }, 50);
     });
 
 });

--- a/src/tags/templates/tags/list.html
+++ b/src/tags/templates/tags/list.html
@@ -17,6 +17,7 @@
 
 {% block content %}
 
+    {% include 'snippets/table_loading.html' %}
     <table
         data-toggle='table'
         data-search='true'

--- a/src/templates/snippets/table_loading.html
+++ b/src/templates/snippets/table_loading.html
@@ -1,0 +1,9 @@
+<!--
+  #1981: loading spinner shown in place of a bootstrap-table until it finishes formatting.
+  Include this immediately BEFORE a <table data-toggle="table"> element. It is server-rendered
+  so it appears from the first paint; custom.js / custom_common.css hide it once the table is
+  ready. Uses the same fa-spinner markup as the "Loading content..." rows elsewhere.
+-->
+<div class="bt-loading" role="status" aria-label="Loading table">
+  <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>&nbsp;Loading content...
+</div>


### PR DESCRIPTION
### What?

Shows a **"Loading content..." spinner in place of each `data-toggle="table"`** while bootstrap-table formats it, using the same `<i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>&nbsp;Loading content...` markup already used for the collapsed quest rows. The real table is revealed the moment bootstrap-table finishes.

Closes #1981.

### Why?

#1981 was reopened because the previous fix (#2018) still flashed a blank/broken area on large tables. That fix hid each raw table with `visibility:hidden` and let `custom.js` drop a spinner in on `document.ready`. On a large table the browser spends a second or two **parsing the huge raw table before that JS runs**, so during the gap the page looked blank — the spinner arrived too late.

The slow part is the browser parsing the raw table markup, and that finishes *before* `DOMContentLoaded`, so any JS-inserted spinner is inherently too late. The spinner has to be present at first paint.

### How?

- **`src/templates/snippets/table_loading.html`** (new) — a shared include holding the standard spinner: `<div class="bt-loading">…<i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>&nbsp;Loading content...</div>`. Because it's server-rendered it's on screen from the very first paint — no dependency on JS timing.
- Included immediately before each of the 12 `data-toggle="table"` tables (`{% include 'snippets/table_loading.html' %}`).
- **`src/static/css/custom_common.css`** — the render-blocking `<head>` CSS hides the raw table (`position:absolute; visibility:hidden`) until bootstrap-table wraps it in `.bootstrap-table` (or the JS fallback adds `.bt-reveal`), then puts it back in flow. The spinner is hidden the instant its table is ready via `.bt-loading:has(+ .bootstrap-table)`.
- **`src/static/js/custom.js`** — belt-and-suspenders: hides each spinner once its table is wrapped (covers browsers without `:has()`), and if bootstrap-table never initializes a table, reveals the raw table after a timeout so its data is never left hidden.

This is the same "hide raw table until formatted" mechanism as #2018, but the spinner is now real server-rendered `fa-spinner` markup (consistent with the rest of the app) shown from first paint, instead of a JS-injected element that arrived after the blank flash.

### Testing?

Front-end-only change (templates + CSS + JS). Verified headless with Playwright + Chromium against the real `.bt-loading` markup + table (rendering with the repo's own FontAwesome webfont + the actual `#1981` CSS block):

- **Before init:** the `.bt-loading` spinner is visible with its "Loading content..." label, and the table computes `visibility:hidden` / `position:absolute` — spinner shown, raw table hidden from first paint.
- **After the `.bootstrap-table` wrap:** the spinner computes `display:none` (via `:has(+ .bootstrap-table)`) and the table computes `visibility:visible` / `position:static` with its rows visible — spinner gone, real table restored.

`ruff check src` is unaffected (no Python changed). The full suite (run in CI) renders all 12 templates via their view tests, exercising the new include.

### Screenshots (if front end is affected)

> Headless reproduction of the exact `#1981` CSS/JS behaviour (not the live app — this is a synthetic harness rendered with the repo's FontAwesome webfont), showing the spinner-then-table transition.

**Before — spinner shown from first paint (in place of the still-parsing table):**

![before — Loading content spinner](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1981/before.png)

**After — bootstrap-table formatted, spinner gone:**

![after — formatted bootstrap-table](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1981/after.png)

### Anything Else?

Uses `:has()` for the instant, JS-free spinner hide; `custom.js` covers older browsers and any table bootstrap-table never initializes, so no table is ever left hidden. Supersedes the JS-inserted-spinner approach from #2018.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi