### PR TITLE
Refresh stale in-code Django doc links to 5.2; align django-recaptcha cap

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -17,7 +17,7 @@ django-environ>=0.14.0,<0.15
 django-grappelli>=4.0.4,<5  # compat cap: 4.0.x targets Django 5.x, 5.0.0 requires Django 6.x
 django-import-export>=4.4.1,<5.0
 django-querysetsequence>=0.18,<0.19
-django-recaptcha>=4.1.0,<4.2  # 4.0 renamed the package module from `captcha` to `django_recaptcha`
+django-recaptcha>=4.1.0,<5.0  # 4.0 renamed the package module from `captcha` to `django_recaptcha`
 django-redis>=7.0.0,<8.0  # 7.0 requires Django >= 5.2
 django-resized>=1.0.3,<2.0
 django-select2>=8.4.8,<9.0

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -376,7 +376,7 @@ class BadgeAssertionManager(models.Manager):
         """
         Return a list of distinct badges the user has earned, as an assertion queryset
         This only works in a postgresql database, but the app is designed around postgres
-        https://docs.djangoproject.com/en/1.10/ref/models/querysets/#distinct
+        https://docs.djangoproject.com/en/5.2/ref/models/querysets/#distinct
         """
         # the secondary ordering by id makes DISTINCT ON deterministic: it always keeps
         # the earliest assertion of each badge (postgres returns the first row per group)

--- a/src/hackerspace_online/management/commands/find_replace.py
+++ b/src/hackerspace_online/management/commands/find_replace.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
                         field: Field
                         for field in model._meta.get_fields():
                             if type(field) in self.field_types_to_check:
-                                # https://docs.djangoproject.com/en/2.2/ref/models/database-functions/#replace
+                                # https://docs.djangoproject.com/en/5.2/ref/models/database-functions/#replace
                                 model.objects.update(**{field.name: Replace(field.name, Value(find_str), Value(replace_str))})
                                 # print("Updated: ", num_updates)
                                 print("Field: ", field)

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -2,10 +2,10 @@
 Django settings for hackerspace_online project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/topics/settings/
+https://docs.djangoproject.com/en/5.2/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.8/ref/settings/
+https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -189,7 +189,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',  # for allauth
     'django.contrib.staticfiles',
 
-    'django.contrib.flatpages',  # https://docs.djangoproject.com/en/1.10/ref/contrib/flatpages/
+    'django.contrib.flatpages',  # https://docs.djangoproject.com/en/5.2/ref/contrib/flatpages/
 
     # third party apps
 
@@ -262,7 +262,7 @@ TAGGIT_CASE_INSENSITIVE = True
 
 MIDDLEWARE = [
     'django_tenants.middleware.TenantMiddleware',
-    # caching: https://docs.djangoproject.com/en/1.10/topics/cache/
+    # caching: https://docs.djangoproject.com/en/5.2/topics/cache/
     # 'django.middleware.cache.UpdateCacheMiddleware',
     # 'django.middleware.cache.FetchFromCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -477,7 +477,7 @@ DATABASES = {
         # died while idle (RDS failover, network blip, server-side timeout).
         # Without this, a dead pooled connection surfaces as an intermittent
         # InterfaceError/OperationalError on whatever request draws it.
-        # https://docs.djangoproject.com/en/4.2/ref/settings/#conn-health-checks
+        # https://docs.djangoproject.com/en/5.2/ref/settings/#conn-health-checks
         'CONN_HEALTH_CHECKS': True,
     }
 }
@@ -994,7 +994,7 @@ PRODUCTION_SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 # (staging mirrors prod). These are intentionally NOT applied in local
 # development, where the site is served over plain http://localhost, nor
 # during tests. Django's `manage.py check --deploy` verifies these.
-# Docs: https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+# Docs: https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 if not DEBUG and not TESTING:
 
     # We run behind nginx, which terminates TLS and reverse-proxies to uwsgi.

--- a/src/hackerspace_online/tests/test_views.py
+++ b/src/hackerspace_online/tests/test_views.py
@@ -19,7 +19,7 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
         """Use a tenant-aware client for each test."""
         # Every test needs access to the request factory.
-        # https://docs.djangoproject.com/en/3.0/topics/testing/advanced/#the-request-factory
+        # https://docs.djangoproject.com/en/5.2/topics/testing/advanced/#the-request-factory
         # self.factory = RequestFactory()
         self.client = TenantClient(self.tenant)
 

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -503,7 +503,7 @@ class ViewTestUtilsMixin():
     def get_message_list(self, response):
         """ Django messages missing from context of redirected views, so get another way
         https://stackoverflow.com/questions/2897609/how-can-i-unit-test-django-messages
-        https://docs.djangoproject.com/en/3.0/ref/contrib/messages/
+        https://docs.djangoproject.com/en/5.2/ref/contrib/messages/
         """
         return list(response.wsgi_request._messages)
 

--- a/src/hackerspace_online/urls.py
+++ b/src/hackerspace_online/urls.py
@@ -1,7 +1,7 @@
 """hackerspace_online URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.2/topics/http/urls/
+    https://docs.djangoproject.com/en/5.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/src/hackerspace_online/wsgi.py
+++ b/src/hackerspace_online/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for hackerspace_online project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 """
 
 import os

--- a/src/portfolios/models.py
+++ b/src/portfolios/models.py
@@ -38,7 +38,7 @@ class Artwork(models.Model):
                                    help_text="OPTION 1. Your artwork or photograph to display. "
                                              "If a video file is also uploaded, "
                                              "this will be used as the video's preview image.")
-    # TODO: set custom validator: https://docs.djangoproject.com/en/1.10/ref/validators/
+    # TODO: set custom validator: https://docs.djangoproject.com/en/5.2/ref/validators/
     video_file = models.FileField(upload_to='portfolios/video/%Y/%m', null=True, blank=True,
                                   help_text='OPTION 2. HTML5 Video types supported by all browsers are: '
                                             'MP4 (H.264 video +AAC or +MP3 audio) and WebM (VP8 video +Vorbis audio).'

--- a/src/quest_manager/urls.py
+++ b/src/quest_manager/urls.py
@@ -1,7 +1,7 @@
 """quest_manager URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.2/topics/http/urls/
+    https://docs.djangoproject.com/en/5.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -324,7 +324,7 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """
         Invalid slug names provided to Tag CreateView should be rejected
         validators that must be passed:
-        validate_slug https://docs.djangoproject.com/en/4.2/ref/validators/#validate-slug
+        validate_slug https://docs.djangoproject.com/en/5.2/ref/validators/#validate-slug
         validate_unique_slug (custom validator, located at tags.forms.validate_unique_slug)
         """
 

--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -292,7 +292,7 @@ class RestrictedMultiFileFormField(RestrictedFileFormField):
     """Adds multi-file upload capability to the RestrictedFileFormField
 
     To use this the form will need to deal with the files as suggested in
-    https://docs.djangoproject.com/en/4.2/topics/http/file-uploads/#uploading-multiple-files
+    https://docs.djangoproject.com/en/5.2/topics/http/file-uploads/#uploading-multiple-files
 
     """
     def __init__(self, *args, **kwargs):

--- a/src/utilities/templatetags/utility_tags.py
+++ b/src/utilities/templatetags/utility_tags.py
@@ -54,7 +54,7 @@ def group_name():
     return SiteConfig.get().custom_name_for_group
 
 
-# https://docs.djangoproject.com/en/1.11/howto/custom-template-tags/#inclusion-tags
+# https://docs.djangoproject.com/en/5.2/howto/custom-template-tags/#inclusion-tags
 
 @register.inclusion_tag('utilities/list_of_links.html')
 def menu_list():


### PR DESCRIPTION
### What?

Two small, non-functional cleanups now that the project is on Django 5.2 (4.2 support was already dropped in #2015):

1. Updated every in-code documentation link that still pointed at an old Django docs version (1.8, 1.10, 1.11, 2.2, 3.0, 4.2) to `/en/5.2/`.
2. Relaxed the `django-recaptcha` ceiling from `<4.2` to `<5.0`.

### Why?

- The docstring/comment links were pointing readers at Django docs several majors out of date (some as old as 1.8). They're purely informational, but a link to the 1.8 settings reference from a 5.2 codebase is misleading. All the paths are stable and resolve unchanged under `/en/5.2/`.
- `django-recaptcha` was capped at `<4.2`, which is tighter than the requirements file's own stated policy ("ceilings block the next MAJOR"). Aligning it to `<5.0` makes it consistent with every other package in the file. No actual version bump today — 4.1.0 is the current latest, so both caps resolve to the same installed version.

### How?

- Rewrote the version segment of each `docs.djangoproject.com/en/<ver>/…` link in `src/` (excluding auto-generated migration headers) to `5.2`. 12 files, comment/docstring lines only — no code semantics touched.
- Changed one line in `requirements-production.txt`; the floor (`>=4.1.0`) and its module-rename rationale comment are unchanged.

Migration file headers (`# Generated by Django 4.2.x …`) are intentionally **left as-is** — they're a historical record of the Django version that generated each migration, not live documentation.

### Testing?

- `ruff check src` — all checks passed.
- `python src/manage.py check` — no issues.
- Comment/docstring + requirements-ceiling changes only; no runtime behaviour changes.

### Screenshots (if front end is affected)

N/A — no UI changes.

### Anything Else?

The only Django-version-driven cap still in the file is `django-grappelli<5` (grappelli 5.0 requires Django 6), which is correct to hold on 5.2 LTS. Nothing else is being held back for compatibility.

### Review request
@tylerecouture

- Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_