### PR TITLE
Prevent the deck owner from removing their email address — Closes #1502

### DIFF
--- a/src/profile_manager/forms.py
+++ b/src/profile_manager/forms.py
@@ -68,6 +68,15 @@ class ProfileForm(forms.ModelForm):
     def clean_email(self):
         email = self.cleaned_data['email']
 
+        # The deck owner must always keep an email on file so ByteDeck can contact them: they may
+        # change it (once verified) but may not remove it entirely (#1502). Compare by id so this
+        # holds even when the deck owner is the one editing their own profile.
+        if not email and self.instance.user_id == SiteConfig.get().deck_owner_id:
+            raise forms.ValidationError(
+                "As the deck owner, you can't remove your email address — ByteDeck needs a way to "
+                "contact you. You can change it, but it can't be left blank."
+            )
+
         # Verify the domain is real
         if '@' in email:
             domain = email.split('@')[1]  # ["myemail", "gmail.com"]

--- a/src/profile_manager/tests/test_forms.py
+++ b/src/profile_manager/tests/test_forms.py
@@ -100,6 +100,43 @@ class ProfileFormTest(ByteDeckTenantTestCase):
                     self.assertTrue(form.is_valid())
                     self.assertEqual(form.cleaned_data['email'], 'example@gmail.com')
 
+    def test_clean_email__deck_owner_cannot_remove(self):
+        """The deck owner may not clear their email — ByteDeck needs to contact them (#1502)."""
+        config = SiteConfig.get()
+        config.deck_owner = self.user
+        config.save()
+
+        form = ProfileForm(instance=self.user.profile, data={'email': ''})
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "As the deck owner, you can't remove your email address — ByteDeck needs a way to "
+            "contact you. You can change it, but it can't be left blank.",
+            form.errors['email'],
+        )
+
+    def test_clean_email__deck_owner_can_change(self):
+        """The deck owner can still change their email to another valid address (#1502)."""
+        config = SiteConfig.get()
+        config.deck_owner = self.user
+        config.save()
+
+        form = ProfileForm(instance=self.user.profile, data={'email': 'owner@gmail.com'})
+        with patch('dns.resolver.resolve') as mock_resolve:
+            mock_resolve.return_value = MagicMock()  # no internet during tests
+            form.is_valid()
+        self.assertNotIn('email', form.errors)
+        self.assertEqual(form.cleaned_data['email'], 'owner@gmail.com')
+
+    def test_clean_email__non_owner_can_remove(self):
+        """A regular user (not the deck owner) may still clear their email (#1502)."""
+        # self.user is not the deck owner by default.
+        self.assertNotEqual(self.user.id, SiteConfig.get().deck_owner_id)
+
+        form = ProfileForm(instance=self.user.profile, data={'email': ''})
+        form.is_valid()
+        self.assertNotIn('email', form.errors)
+        self.assertEqual(form.cleaned_data['email'], '')
+
     def test_save__with_custom_profile_field(self):
         """ tests if user can create a profile with `custom_profile_field` when SiteConfig.custom_profile_field
         is filled/not filled

--- a/src/profile_manager/tests/test_forms.py
+++ b/src/profile_manager/tests/test_forms.py
@@ -102,11 +102,14 @@ class ProfileFormTest(ByteDeckTenantTestCase):
 
     def test_clean_email__deck_owner_cannot_remove(self):
         """The deck owner may not clear their email — ByteDeck needs to contact them (#1502)."""
+        # Use a separate user as the deck owner: SiteConfig.deck_owner is a PROTECT FK, so
+        # making self.user the owner would break tearDown's self.user.delete().
+        owner = User.objects.create_user('deck_owner_user', is_staff=True)
         config = SiteConfig.get()
-        config.deck_owner = self.user
+        config.deck_owner = owner
         config.save()
 
-        form = ProfileForm(instance=self.user.profile, data={'email': ''})
+        form = ProfileForm(instance=owner.profile, data={'email': ''})
         self.assertFalse(form.is_valid())
         self.assertIn(
             "As the deck owner, you can't remove your email address — ByteDeck needs a way to "
@@ -116,11 +119,12 @@ class ProfileFormTest(ByteDeckTenantTestCase):
 
     def test_clean_email__deck_owner_can_change(self):
         """The deck owner can still change their email to another valid address (#1502)."""
+        owner = User.objects.create_user('deck_owner_user', is_staff=True)
         config = SiteConfig.get()
-        config.deck_owner = self.user
+        config.deck_owner = owner
         config.save()
 
-        form = ProfileForm(instance=self.user.profile, data={'email': 'owner@gmail.com'})
+        form = ProfileForm(instance=owner.profile, data={'email': 'owner@gmail.com'})
         with patch('dns.resolver.resolve') as mock_resolve:
             mock_resolve.return_value = MagicMock()  # no internet during tests
             form.is_valid()


### PR DESCRIPTION
### What?

The deck owner can no longer clear their email address when editing their profile. They can still **change** it to another valid address — it just can't be left blank.

Closes #1502.

### Why?

The deck owner is ByteDeck's point of contact for a deck (owner confirmation emails, subscription/renewal notices, etc.), so they must always have an email on file. Previously a deck owner could blank out their email from their profile, leaving ByteDeck no way to reach them.

### How?

`ProfileForm.clean_email` now raises a `ValidationError` when the submitted email is empty **and** the profile being edited belongs to the current deck owner. The check compares `self.instance.user_id` against `SiteConfig.get().deck_owner_id`, so it holds specifically for the owner (including when the owner is editing their own profile) and never affects other users. The message explains they can change but not remove it.

### Testing?

Added three `ProfileFormTest` cases:
- `test_clean_email__deck_owner_cannot_remove` — owner submitting a blank email is rejected with the explanatory message (fails without the fix).
- `test_clean_email__deck_owner_can_change` — owner can still switch to another valid address.
- `test_clean_email__non_owner_can_remove` — a regular user can still clear their email.

`ruff check src` passes.

### Screenshots (if front end is affected)

N/A — server-side form validation only; no template/rendered-output change (the error surfaces through the existing form-error display).

### Anything Else?

This covers the **self-serve profile form**, which is the path a deck owner would use to accidentally remove their email. The issue also mentions the Django **admin**; email editing there goes through the default `UserAdmin` and superusers only, so I left it out of this small change — happy to add an admin-side guard as a follow-up if you'd like it covered too.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_