### PR TITLE
Cap deck name at the URL/schema limit, not 20 chars; show the limit — Closes #1975

### DIFF
--- a/src/tenant/forms.py
+++ b/src/tenant/forms.py
@@ -9,14 +9,6 @@ from .models import Tenant
 
 User = get_user_model()
 
-# The deck name is used verbatim as SiteConfig.site_name_short (max_length 20)
-# and also seeds the other name-derived display fields (site_name, the Site
-# name). Capping the name here — at the shortest of those limits — means the
-# user gets a clear error at form time instead of a valid-looking long name
-# being silently truncated when the deck is created. (The creation code still
-# truncates defensively for non-form paths like the admin / management commands.)
-MAX_DECK_NAME_LENGTH = 20
-
 
 class TenantBaseForm(ModelForm):
     """
@@ -27,28 +19,35 @@ class TenantBaseForm(ModelForm):
         model = Tenant
         fields = ["name"]
 
+    def __init__(self, *args, **kwargs):
+        """Initialize the form and surface the deck-name length limit in its help text.
+
+        The deck name becomes the deck's subdomain/schema, so the only real cap is the
+        model field's ``max_length`` (the longest a Postgres schema — and therefore the
+        URL — can be). It is no longer tied to the shorter ``site_name_short`` display
+        field, which is truncated from the name at creation time instead. Appending the
+        limit to the help text tells requesters the cap up front (#1975).
+        """
+        super().__init__(*args, **kwargs)
+        max_len = Tenant._meta.get_field("name").max_length
+        self.fields["name"].help_text += f". The name can be at most {max_len} characters long."
+
     def clean_name(self):
         """Validate the deck name.
 
-        Enforces the deck-name length cap (``MAX_DECK_NAME_LENGTH``), rejects the
-        reserved ``public`` name, and rejects a name whose schema already exists in
-        the database without a matching tenant object.
+        Rejects the reserved ``public`` name and a name whose schema already exists in
+        the database without a matching tenant object. The length and format are already
+        enforced by the model field (``max_length`` and ``check_tenant_name``).
 
         Returns:
             str: The cleaned deck name.
 
         Raises:
-            forms.ValidationError: If the name is too long, is reserved, or collides
-                with an existing orphaned schema.
+            forms.ValidationError: If the name is reserved or collides with an existing
+                orphaned schema.
         """
         name = self.cleaned_data["name"]
-        # has already validated the model field (format, uniqueness) at this point
-        if len(name) > MAX_DECK_NAME_LENGTH:
-            raise forms.ValidationError(
-                f"Deck names can be at most {MAX_DECK_NAME_LENGTH} characters "
-                "(your deck name is also shown as your site's short name). "
-                "Please choose a shorter name for your deck."
-            )
+        # has already validated the model field (format, length, uniqueness) at this point
         if name == "public":
             raise forms.ValidationError("The public tenant is restricted and cannot be used.")
         else:

--- a/src/tenant/tests/test_forms.py
+++ b/src/tenant/tests/test_forms.py
@@ -156,7 +156,7 @@ class TenantFormTest(ByteDeckTenantTestCase):
         form = TenantForm({**base, "name": long_but_valid})
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_name_help_text_includes_length_limit(self):
+    def test_name_help_text__includes_length_limit(self):
         """The deck-name field's help text states the character limit (#1975)."""
         max_len = Tenant._meta.get_field("name").max_length
         form = TenantForm()

--- a/src/tenant/tests/test_forms.py
+++ b/src/tenant/tests/test_forms.py
@@ -8,7 +8,7 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 from django_recaptcha.widgets import ReCaptchaV2Invisible
 
-from tenant.forms import MAX_DECK_NAME_LENGTH, DeckRequestForm, TenantForm
+from tenant.forms import DeckRequestForm, TenantForm
 from tenant.models import Tenant
 
 User = get_user_model()
@@ -136,24 +136,31 @@ class TenantFormTest(ByteDeckTenantTestCase):
         form = TenantForm(data)
         self.assertFalse(form.is_valid())
 
-    def test_clean_name__deck_name_too_long(self):
-        """A deck name longer than MAX_DECK_NAME_LENGTH is rejected on the form with a
-        clear error, so the user gets feedback instead of the name being silently
-        truncated (into SiteConfig.site_name_short etc.) when the deck is created.
+    def test_clean_name__deck_name_length_capped_at_url_limit(self):
+        """The deck name may be as long as the URL/schema allows — the model field's
+        max_length — not the old 20-char short-name cap (#1975). Only a name longer
+        than the field limit is rejected; the short name is truncated from it instead.
         """
         base = {"first_name": "John", "last_name": "Doe", "email": "john.doe@example.com"}
+        max_len = Tenant._meta.get_field("name").max_length
 
-        # one over the limit: rejected with a message that names the limit
-        too_long = "a" * (MAX_DECK_NAME_LENGTH + 1)
+        # one over the field limit: rejected
+        too_long = "a" * (max_len + 1)
         form = TenantForm({**base, "name": too_long})
         self.assertFalse(form.is_valid())
         self.assertIn("name", form.errors)
-        self.assertIn(str(MAX_DECK_NAME_LENGTH), form.errors["name"][0])
 
-        # exactly at the limit: accepted
-        at_limit = "a" * MAX_DECK_NAME_LENGTH
-        form = TenantForm({**base, "name": at_limit})
+        # longer than the old 20-char cap but within the field limit: accepted
+        self.assertGreater(max_len, 20)
+        long_but_valid = "a" * max_len
+        form = TenantForm({**base, "name": long_but_valid})
         self.assertTrue(form.is_valid(), form.errors)
+
+    def test_name_help_text_includes_length_limit(self):
+        """The deck-name field's help text states the character limit (#1975)."""
+        max_len = Tenant._meta.get_field("name").max_length
+        form = TenantForm()
+        self.assertIn(str(max_len), form.fields["name"].help_text)
 
     def test_clean_name__duplicate_deck_name_is_rejected(self):
         """A deck name that already exists is rejected on the form (via the unique


### PR DESCRIPTION
### What?

Deck names are no longer capped at 20 characters. The limit is now the real one — how long the deck's subdomain/schema can be (the `Tenant.name` field's `max_length`) — and that limit is stated in the field's help text.

Closes #1975.

### Why?

The 20-char cap existed only because the deck name was reused verbatim as `SiteConfig.site_name_short` (`max_length=20`). But as the issue notes, 20 is too short — the name doesn't need to match the short/long display names, it only needs to fit the URL (`<name>.bytedeck.com`). The display fields are already truncated from the name at creation time (`tenant/initialization.py` truncates into `site_name`/`site_name_short`), so a longer name is safe. The help text also didn't mention any character limit, so requesters only found out by hitting a validation error.

### How?

- **`src/tenant/forms.py`**: removed the `MAX_DECK_NAME_LENGTH = 20` cap and its length check in `TenantBaseForm.clean_name`. Length (and format) are already enforced by the model field's `max_length` (62, the Postgres schema/URL limit) and `check_tenant_name` validator, so the extra 20-cap was the only thing holding names down. `clean_name` still rejects the reserved `public` name and orphaned-schema collisions.
- Added a `TenantBaseForm.__init__` that appends the limit to the name field's help text (e.g. "… The name can be at most 62 characters long."), derived from the model field so it stays correct if the field ever changes. No model change → no migration.

### Testing?

- Rewrote `test_clean_name__deck_name_length_capped_at_url_limit`: a name one over the field limit is rejected; a name **longer than the old 20-char cap** but within the field limit is now accepted (would have failed before this change).
- Added `test_name_help_text_includes_length_limit`: the name field's help text contains the limit.

`ruff check src` passes.

### Screenshots (if front end is affected)

The only rendered change is the deck-name field's help text on the deck-creation form gaining a trailing sentence stating the character limit (e.g. "… The name can be at most 62 characters long."). No layout/visual change beyond that added text, so I haven't attached a screenshot — happy to add one if you'd like to see it rendered.

### Anything Else?

`site_name_short` (20) and `site_name` (50) are still truncated from the deck name at creation, which is already covered by the initialization tests — so a long deck name produces a truncated short name rather than an error.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_