### PR TITLE
Don't 403 course registration when an old semester is still open — Closes #1893

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -511,6 +511,27 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.post(reverse('courses:create'), data=self.valid_form_data)
         self.assertEqual(response.status_code, 403)
 
+    def test_CourseStudentCreate_view__active_registration_in_old_semester_does_not_block(self):
+        """A student with an active registration left over in an old (not-yet-closed) semester can
+        still reach the registration view for the new active semester — no 403 (#1893). Previously
+        any active registration blocked registration, so an unclosed old semester locked students
+        out of joining courses in the new one."""
+        self.client.force_login(self.test_student1)
+
+        # Active registration left over in the original (now-old) semester.
+        old_semester = SiteConfig.get().active_semester
+        baker.make('courses.coursestudent', user=self.test_student1, semester=old_semester, active=True)
+
+        # A new semester becomes active while the old one stays open (not closed).
+        new_semester = baker.make('courses.semester')
+        config = SiteConfig.get()
+        config.active_semester = new_semester
+        config.save()
+
+        # The stale active registration is in a different, still-open semester, so it must not 403.
+        response = self.client.get(reverse('courses:create'))
+        self.assertNotEqual(response.status_code, 403)
+
     def test_CourseStudentCreate__simple_registration_hidden_fields(self):
         """
         If simplified_course_registration is enabled in siteconfig, fields in student registration form with only one viable option should be

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -526,6 +526,7 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         new_semester = baker.make('courses.semester')
         config = SiteConfig.get()
         config.active_semester = new_semester
+        config.full_clean()
         config.save()
 
         # The stale active registration is in a different, still-open semester, so it must not 403.

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -299,10 +299,18 @@ class CourseStudentUpdate(NonPublicOnlyViewMixin, UpdateView):
 # Student Course Registration View
 class CourseStudentCreate(NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
-    # Block the registration view only when the student is already actively registered for the
-    # CURRENT (active) semester. A registration left active in an old, not-yet-closed semester
-    # must not 403 them out of joining a course in the new semester (#1893).
     def test_func(self):
+        """Allow the registration view only when the student is not already actively registered
+        for the current (active) semester.
+
+        A registration left active in an old, not-yet-closed semester must not 403 them out of
+        joining a course in the new semester (#1893), so the check is scoped to the active
+        semester rather than any active registration.
+
+        Returns:
+            bool: True if the user may access the registration view (they are not yet actively
+                registered for the active semester), False otherwise.
+        """
         return not CourseStudent.objects.filter(
             user=self.request.user, active=True, semester=SiteConfig.get().active_semester
         ).exists()

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -299,9 +299,13 @@ class CourseStudentUpdate(NonPublicOnlyViewMixin, UpdateView):
 # Student Course Registration View
 class CourseStudentCreate(NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
-    # if an active CourseStudent object assigned to student exists when student accesses registration view (user already enrolled), page will 403
+    # Block the registration view only when the student is already actively registered for the
+    # CURRENT (active) semester. A registration left active in an old, not-yet-closed semester
+    # must not 403 them out of joining a course in the new semester (#1893).
     def test_func(self):
-        return not CourseStudent.objects.filter(user=self.request.user, active=True).exists()
+        return not CourseStudent.objects.filter(
+            user=self.request.user, active=True, semester=SiteConfig.get().active_semester
+        ).exists()
 
     model = CourseStudent
     form_class = CourseStudentForm


### PR DESCRIPTION
### What?

A student who has an active course registration left over in an **old, not-yet-closed** semester can now register for a course in the **new active** semester without getting a 403.

Closes #1893.

### Why?

`CourseStudentCreate.test_func` (the registration view's permission gate) blocked the view whenever the student had **any** active `CourseStudent`. A `CourseStudent` stays `active=True` until its semester is *closed*, so if a teacher started a new semester without closing the old one, the student's stale active registration in the old semester 403'd them out of joining a course in the new semester. The only workaround was to close the old semester first (exactly what the issue reports).

### How?

Scoped the check to the **current (active) semester**: registration is blocked only when the student is already actively registered *for the active semester*. A registration that's still active in a different, still-open semester no longer counts.

```python
def test_func(self):
    return not CourseStudent.objects.filter(
        user=self.request.user, active=True, semester=SiteConfig.get().active_semester
    ).exists()
```

This takes the issue's "just let them join the course in the new semester anyway" option — cleaner than surfacing a "close the old semester first" message and requiring teacher action.

### Testing?

- New `test_CourseStudentCreate_view__active_registration_in_old_semester_does_not_block`: gives the student an active registration in the original semester, makes a **new** semester active while leaving the old one open, and asserts the registration view no longer 403s. Fails without the fix (the old-semester registration used to block it).
- The existing `test_CourseStudentCreate_view__student_self_registers` still passes: registering in the active semester and then re-accessing the view still returns 403, so students can't double-register for the current semester.

`ruff check src` passes.

### Screenshots (if front end is affected)

N/A — permission/logic change on an existing view; no template or rendered-output change.

### Anything Else?

Double-registration within the active semester is still prevented (the unique constraint on semester/group/user and the scoped `test_func` both hold). This only stops a *different* semester's stale registration from blocking the current one.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Students can register for courses in the current semester even if they have an active registration from a previous semester.
  * Existing active registrations in the current semester continue to prevent duplicate registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->