### PR TITLE
Make the 1.29.0 changelog user-actionable; document changelog conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ This file chronologically records all notable changes to this website, including
 
 ### [1.29.0] 2026-07-21 Claude I
 * New Features:
-  - Grant a badge to every qualifying student at once, from a teacher-confirmed page [#1925](https://github.com/bytedeck/bytedeck/issues/1925)
-  - New "Completion Statuses" button on submissions, showing each student's status on that quest [#1934](https://github.com/bytedeck/bytedeck/issues/1934)
-  - Set the left-to-right order of campaigns on quest maps [#1977](https://github.com/bytedeck/bytedeck/issues/1977)
-  - Requesting a new deck now ends on a confirmation page explaining the next steps [#1946](https://github.com/bytedeck/bytedeck/issues/1946)
+  - **Grant a badge to everyone who qualifies, on demand.** When you change a badge's prerequisites, you're now asked whether to check for students who newly qualify. Say yes and a confirmation page shows how many students would receive it; confirm and it's granted to all of them at once (their teachers are notified). Because it only runs when you ask, a badge is never handed out while you're still setting up its prerequisites [#1925](https://github.com/bytedeck/bytedeck/issues/1925)
+  - **New "Completion Statuses" button on a quest.** Opens a page listing every student's status on that quest — In Progress, Returned, Submitted, Approved, etc. — so you can see at a glance where each student is [#1934](https://github.com/bytedeck/bytedeck/issues/1934)
+  - **Order campaigns left-to-right on quest maps.** Edit a campaign and set its "Map order" field; campaigns with a lower number sit further to the left on the map [#1977](https://github.com/bytedeck/bytedeck/issues/1977)
 * Tweaks:
   - YouTube (and other) video embeds load again [#1896](https://github.com/bytedeck/bytedeck/issues/1896)
   - Data tables now show a loading spinner instead of a flash of unstyled/blank table while they load [#1981](https://github.com/bytedeck/bytedeck/issues/1981)
@@ -18,20 +17,23 @@ This file chronologically records all notable changes to this website, including
   - A quest can no longer be set to both "unlimited repeats" and "repeat per semester" — pick one [#1531](https://github.com/bytedeck/bytedeck/issues/1531)
   - Removed the student-facing quick reply form [#1886](https://github.com/bytedeck/bytedeck/issues/1886)
 * Bugfixes:
-  - The sidebar "Quest Approvals" button now opens the Submitted tab [#1895](https://github.com/bytedeck/bytedeck/issues/1895)
-  - Comment text is fully escaped, closing a stored-XSS hole [#1343](https://github.com/bytedeck/bytedeck/issues/1343)
-  - Starting the same quest twice at once no longer grants double XP [#1964](https://github.com/bytedeck/bytedeck/issues/1964)
-  - Changing your profile email no longer errors on some networks [#1976](https://github.com/bytedeck/bytedeck/issues/1976)
-  - Notification previews with more than one image are no longer mangled [#1761](https://github.com/bytedeck/bytedeck/issues/1761)
-  - Requesting a deck with a long name no longer crashes deck creation [#1948](https://github.com/bytedeck/bytedeck/issues/1948)
-  - Also fixed: the blank "Published:" line on unpublished campaigns [#1930](https://github.com/bytedeck/bytedeck/issues/1930), the prerequisites-form checkbox layout [#1978](https://github.com/bytedeck/bytedeck/issues/1978), the badge action-button row [#1988](https://github.com/bytedeck/bytedeck/issues/1988), and a crash on semesters with a missing date [#912](https://github.com/bytedeck/bytedeck/issues/912)
-* Codebase (no user-facing change):
+  - The sidebar "Quest Approvals" button opened the wrong approvals tab; it now opens Submitted [#1895](https://github.com/bytedeck/bytedeck/issues/1895)
+  - HTML typed into a comment was rendered as-is, so a crafted comment could run script for anyone who viewed it (stored XSS); comment text is now fully escaped [#1343](https://github.com/bytedeck/bytedeck/issues/1343)
+  - Racing/double-clicking "Start Quest" could create two submissions and award XP twice; starting the same quest twice at once no longer double-grants [#1964](https://github.com/bytedeck/bytedeck/issues/1964)
+  - Editing your profile email could error out (500) when the network's DNS lookup of the email's domain failed; validation now tolerates those lookup failures [#1976](https://github.com/bytedeck/bytedeck/issues/1976)
+  - A notification preview with more than one image spliced the images together and broke the notifications dropdown; multi-image previews now render correctly [#1761](https://github.com/bytedeck/bytedeck/issues/1761)
+  - Unpublished campaigns showed a blank value after "Published:"; it now reads correctly [#1930](https://github.com/bytedeck/bytedeck/issues/1930)
+  - Checkboxes on the prerequisites form were misaligned and overlapping; the layout is fixed [#1978](https://github.com/bytedeck/bytedeck/issues/1978)
+  - The badge action-button row wrapped awkwardly and its status button pointed at the wrong place; both are fixed [#1988](https://github.com/bytedeck/bytedeck/issues/1988)
+  - A semester with a missing start or end date crashed the pages that display it; those are now guarded [#912](https://github.com/bytedeck/bytedeck/issues/912)
+* Codebase:
   - Upgraded to Django 5.2 LTS and Python 3.12, with a dependency-modernization pass [#2015](https://github.com/bytedeck/bytedeck/issues/2015) [#2017](https://github.com/bytedeck/bytedeck/issues/2017) [#1916](https://github.com/bytedeck/bytedeck/issues/1916)
   - Test suite ~6–8× faster, brought up to conventions, and broadly expanded; linting moved from flake8 to ruff [#1997](https://github.com/bytedeck/bytedeck/issues/1997) [#2026](https://github.com/bytedeck/bytedeck/issues/2026) [#1993](https://github.com/bytedeck/bytedeck/issues/1993)
   - Reduced N+1 queries across the campaign, tag, mark-chart, and notification pages [#1940](https://github.com/bytedeck/bytedeck/issues/1940) [#1941](https://github.com/bytedeck/bytedeck/issues/1941) [#1942](https://github.com/bytedeck/bytedeck/issues/1942) [#1943](https://github.com/bytedeck/bytedeck/issues/1943)
   - Internal correctness/perf: prerequisite-cache uniqueness and skip-on-user-delete, XP-cache overflow, GFK choice caching, no-op prereq saves, comments `full_clean()` [#520](https://github.com/bytedeck/bytedeck/issues/520) [#1754](https://github.com/bytedeck/bytedeck/issues/1754) [#2035](https://github.com/bytedeck/bytedeck/issues/2035) [#1967](https://github.com/bytedeck/bytedeck/issues/1967) [#1989](https://github.com/bytedeck/bytedeck/issues/1989) [#2006](https://github.com/bytedeck/bytedeck/issues/2006)
 * Devops:
   - Automated production/staging deploys via self-hosted runners (gated on green CI), self-hosted Redis, persistent DB connections, a templated nginx config, and ops-reliability/CI improvements [#1962](https://github.com/bytedeck/bytedeck/issues/1962) [#1954](https://github.com/bytedeck/bytedeck/issues/1954) [#1965](https://github.com/bytedeck/bytedeck/issues/1965) [#1950](https://github.com/bytedeck/bytedeck/issues/1950) [#2003](https://github.com/bytedeck/bytedeck/issues/2003) [#2004](https://github.com/bytedeck/bytedeck/issues/2004)
+  - Public-site deck requests (visitors start at `/decks/request/`): the flow now ends on a confirmation page explaining the next steps, and requesting a deck with a very long name no longer crashes deck creation [#1946](https://github.com/bytedeck/bytedeck/issues/1946) [#1948](https://github.com/bytedeck/bytedeck/issues/1948)
 
 
 ### [1.28.0] 2026-07-12 Marcus III

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,3 +115,15 @@ Celery (with `tenant-schemas-celery` for schema awareness) handles background ta
   git push origin $C:refs/heads/pr-assets
   ```
   Prefer this for still images; note GitHub only renders `.webm`/`.mp4` as an inline player for *uploaded* attachments (drag-and-drop), not for raw URLs, so screen recordings still have to be handed to the user to attach.
+
+### Changelog conventions (`CHANGELOG.md`)
+
+The audience is **end users** (teachers/students on a deck), not developers — write for someone deciding whether a release affects them and what they now need to do differently. Detailed rationale lives in the linked PRs, so keep entries short and outcome-focused.
+
+* **Format**: newest entry on top, headed `### [x.y.z] YYYY-MM-DD Codename` (h3), with two blank lines between version entries. Each item links its issue(s) as `[#NNNN](https://github.com/bytedeck/bytedeck/issues/NNNN)`.
+* **Categories** (omit any that are empty): `New Features`, `Tweaks`, `Bugfixes`, `Codebase`, `Devops`.
+* **New Features** — say *how and when* a user would actually use it, not just that it exists. Name the button/field and where it lives, and describe the flow. E.g. don't write "added a badge-grant action"; write "when you change a badge's prerequisites, you're asked whether to check for students who newly qualify; confirm and a page shows how many, then grants them all at once".
+* **Tweaks** — brief is fine; one line on what visibly changed.
+* **Bugfixes** — describe the **actual problem the user hit** (why the change was needed), not just what code changed. E.g. "HTML typed into a comment was rendered as-is, so a crafted comment could run script for anyone who viewed it; comment text is now escaped" — not "escaped comment HTML".
+* **Codebase** — non-user-facing internal work (dependency/framework upgrades, test/lint/perf/refactor). No "(no user-facing change)" parenthetical — the heading already implies it.
+* **Devops** — deploys, CI, infrastructure, and public-tenant / project-operator concerns that don't affect a regular deck's users (e.g. the new-deck request flow starting at `/decks/request/`, which only the people running the project touch). Include the relevant URL when the change lives on a specific page.


### PR DESCRIPTION
### What?

Follow-up to the 1.29.0 ("Claude I") changelog. Rewrites the entry so an end user (teacher/student) can tell what changed and what to do with it, and records the guidelines that shaped it so future entries are consistent.

**`CHANGELOG.md` (1.29.0 entry):**
- **New Features** now explain *how and when* to use each one:
  - Badge grant — when you change a badge's prerequisites you're prompted to check for students who newly qualify; a confirmation page shows how many, then grants them all at once. [#1925]
  - "Completion Statuses" button — opens a page showing every student's status on that quest (In Progress, Returned, Submitted, Approved, …). [#1934]
  - Campaign order — set the "Map order" field on a campaign's edit page; lower numbers sit further left. [#1977]
- **Bugfixes** now describe the actual problem the user hit (why the change was needed), not just what code changed.
- **Codebase** heading loses the "(no user-facing change)" parenthetical.
- The public-tenant **deck-request** items (confirmation page [#1946], long-name crash [#1948]) move out of New Features/Bugfixes into **Devops** — they only concern the people running the project, not a deck's users — with the entry URL `/decks/request/`.
- **Tweaks** unchanged (brief is fine there).

**`CLAUDE.md`:** adds a "Changelog conventions" subsection capturing the above — audience is end users; New Features say how/when to use; Bugfixes state the actual problem; Tweaks brief; non-user-facing → Codebase; deploy/CI/public-tenant → Devops; plus the format rules.

### Why?

The prior entry described changes in developer terms and buried usage details in the linked PRs. Per maintainer feedback, the changelog's audience is end users deciding whether a release affects them and what they now need to do differently, so features need concrete how/when and bugfixes need the problem they solved.

### Testing?

Documentation-only change (`CHANGELOG.md`, `CLAUDE.md`) — no code affected.

### Screenshots (if front end is affected)

N/A — no rendered output changes.

### Anything Else?

The deck-request URL points at `/decks/request/` (where a visitor starts a request); `/decks/request/new/` is the later creation step.

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_