### PR TITLE
Add session-hygiene hooks: re-read CLAUDE.md on change; prompt for session name

### DIFF
--- a/.claude/hooks/reload-claude-md.sh
+++ b/.claude/hooks/reload-claude-md.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# UserPromptSubmit hook: keep long-running Claude Code sessions from acting on a
+# STALE copy of CLAUDE.md.
+#
+# CLAUDE.md is read into a session's context once, at session start, and is NOT
+# re-read when the file changes on disk. So a session that's been open across a
+# CLAUDE.md edit keeps following the old version. This hook re-injects the file's
+# current contents (as extra context for the turn) the first time it notices the
+# file changed since this particular session last saw it.
+#
+# Design notes:
+#   - Per session: state is keyed by session_id, so two concurrent sessions each
+#     get the update (a single shared marker would let the first session swallow
+#     it for the others).
+#   - mtime-gated: on the common case (file unchanged) it does a couple of stats
+#     and emits nothing -- negligible cost per prompt.
+#   - Fail-open: any error exits 0 with no output, so a broken hook can never
+#     block you from submitting a prompt.
+#
+# stdout on exit 0 from a UserPromptSubmit hook is added to the model's context
+# for that turn; that's how the refreshed CLAUDE.md reaches the assistant.
+
+# --- fail open no matter what ------------------------------------------------
+fail_open() { exit 0; }
+trap fail_open EXIT
+
+payload="$(cat 2>/dev/null || true)"          # hook receives JSON on stdin
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+md="$proj/CLAUDE.md"
+[ -f "$md" ] || exit 0
+
+# session_id from the payload; bail quietly if we can't get it (need python3).
+command -v python3 >/dev/null 2>&1 || exit 0
+sid="$(printf '%s' "$payload" | python3 -c 'import sys, json
+try:
+    print(json.load(sys.stdin).get("session_id", ""))
+except Exception:
+    pass' 2>/dev/null || true)"
+sid="$(printf '%s' "$sid" | tr -cd 'A-Za-z0-9_-')"   # sanitize for a filename
+[ -n "$sid" ] || exit 0
+
+cache_dir="$proj/.claude/.cache"
+mkdir -p "$cache_dir" 2>/dev/null || exit 0
+state="$cache_dir/claude_md_mtime.$sid"
+
+# Current mtime (GNU stat, then BSD stat, then give up).
+cur="$(stat -c %Y "$md" 2>/dev/null || stat -f %m "$md" 2>/dev/null || echo '')"
+[ -n "$cur" ] || exit 0
+prev="$(cat "$state" 2>/dev/null || echo '')"
+printf '%s' "$cur" > "$state" 2>/dev/null || true
+
+# First time this session runs the hook: the session already loaded CLAUDE.md at
+# startup, so just record the mtime and inject nothing.
+[ -n "$prev" ] || exit 0
+
+# Unchanged since we last checked: nothing to do.
+[ "$cur" = "$prev" ] && exit 0
+
+# Changed: re-inject the current contents.
+printf 'NOTE: CLAUDE.md was edited on disk after this session started, so the copy loaded into your context is stale. Its current contents are below and supersede any earlier copy — follow this version for the rest of the session.\n\n===== BEGIN CURRENT CLAUDE.md =====\n'
+cat "$md" 2>/dev/null || true
+printf '\n===== END CURRENT CLAUDE.md =====\n'
+exit 0

--- a/.claude/hooks/session-name-prompt.sh
+++ b/.claude/hooks/session-name-prompt.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook: a Claude Code session cannot read its own human-readable
+# name (only the opaque session_... id is in context). CLAUDE.md asks sessions to
+# sign GitHub posts with that readable name, so this hook injects an instruction
+# telling the session to ask the user for its name.
+#
+# It's phrased conditionally ("if you don't already know it"), so on resume /
+# compaction -- where the name is already in the conversation history -- the
+# assistant simply won't re-ask.
+#
+# stdout on exit 0 from a SessionStart hook is added to the session's context.
+
+trap 'exit 0' EXIT   # fail open: never disrupt session startup
+
+cat <<'EOF'
+SESSION NAME: This session does not automatically know its own human-readable
+name (only its session_... id). Per CLAUDE.md, GitHub posts are signed with the
+readable session name. So, unless the user has already told you this session's
+name in this conversation, ask them once near the start -- e.g. "What should I
+use as this session's name when I sign GitHub posts?" -- and use their answer in
+sign-offs for the rest of the session.
+EOF
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,5 +28,27 @@
       "mcp__github__search_issues",
       "mcp__github__issue_write"
     ]
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/reload-claude-md.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-name-prompt.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Claude Code hook runtime state (per-session mtime cache)
+.claude/.cache/


### PR DESCRIPTION
### What?
Two Claude Code hooks (wired in `.claude/settings.json`) so long-running sessions stop acting on a **stale CLAUDE.md**, and so a session can figure out its **human-readable name** for sign-offs.

### Why?
- CLAUDE.md is read into a session's context **once, at startup**, and is *not* re-read when the file changes on disk. A session open across a CLAUDE.md edit keeps following the old version. (This is the staleness you flagged — and a CLAUDE.md instruction can't fix it, because a stale session never sees the new instruction; it needs a harness-level hook.)
- A session **can't read its own name** (only the opaque `session_…` id is in context), yet CLAUDE.md now asks posts to be signed with the readable name.

### How?
- **`UserPromptSubmit` → `.claude/hooks/reload-claude-md.sh`** — on each prompt, if CLAUDE.md changed since *this* session last checked, re-inject its current contents as context (that's how a UserPromptSubmit hook's stdout reaches the model). It's:
  - **per-session** (state keyed by `session_id`, so concurrent sessions each get the refresh — a single shared marker would let the first session swallow it for the others),
  - **mtime-gated** (unchanged file → a couple of `stat`s and no output; negligible per-prompt cost),
  - **fail-open** (any error → no output, exit 0; a broken hook can never block you from submitting a prompt).
- **`SessionStart` → `.claude/hooks/session-name-prompt.sh`** — injects an instruction telling the session to ask you for its name near the start, *unless it already knows it* (so resume/compaction don't re-ask).
- Runtime state lives in `.claude/.cache/` (gitignored).

### Testing?
Drove `reload-claude-md.sh` directly with fake payloads: first sighting → silent (records mtime); unchanged → silent; after `touch CLAUDE.md` → injects the NOTE + full current file; a second `session_id` gets its own independent state; malformed stdin → fail-open exit 0. `session-name-prompt.sh` emits the ask. `.claude/settings.json` validated as JSON; scripts committed executable (100755).

### Screenshots (if front end is affected)
N/A — tooling/config only.

### Anything Else?
- These are committed to **`.claude/settings.json`**, so they apply to **every** contributor's Claude Code sessions in this repo (that's what "all sessions" needs). If you'd rather they be personal-only, move both blocks to `.claude/settings.local.json` — happy to switch.
- Since Claude Code reloads `hooks`/`permissions` from settings live, this takes effect for already-running sessions too, not just new ones.
- Honest caveat on the name hook: it makes the session *ask* for its name; it can't discover it automatically. If Claude Code ever exposes the session name to hooks, the SessionStart hook could inject the name directly instead of asking.

### Review request
@tylerecouture

- Claude Code (bytedeck - integrations and automations)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_