### PR TITLE
Actually honour campaign map_order on quest maps (reopened #1977)

### DIFF
--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -594,12 +594,16 @@ class CytoScape(models.Model):
     def elements_dict(self):
         """Serialize this scape's nodes and edges into the dict cytoscape/dagre consumes.
 
-        Elements are ordered so the rendered layout is both deterministic (issue #1977) and
-        honours the user's campaign order: dagre places same-rank nodes by their input order, so
-        emitting campaign nodes, their member quests, and the edges into them in Category.map_order
-        nudges campaigns left-to-right into that order. Ties (including every campaign at the
-        default map_order 0) fall back to the node id — i.e. the deterministic node ordering from
-        issue #1977 — so maps where nobody has set an order are unchanged.
+        Every node carries a ``campaignOrder`` in its data — its campaign's ``Category.map_order``
+        (a quest inherits its parent campaign's; campaign-less nodes default to 0). The client
+        (``maps.js``) uses it to order the campaign columns left-to-right *after* dagre has run:
+        dagre decides same-rank order by crossing-minimization and ignores input order, so the
+        order can't be imposed here — it's applied by repositioning the laid-out columns. Ties
+        (and every campaign at the default map_order 0) fall back to the node id, preserving the
+        deterministic layout from issue #2012, so maps where nobody set an order are unchanged.
+
+        Nodes are still emitted parents-before-children because cytoscape requires a compound
+        parent to be defined before any child that references it.
         """
         nodes = list(self.elements().filter(group=CytoElement.NODES))
         edges = list(self.elements().filter(group=CytoElement.EDGES))
@@ -614,20 +618,18 @@ class CytoScape(models.Model):
                 return map_orders[node.id]
             return map_orders.get(node.data_parent_id, 0)
 
-        # Keep every top-level node (compound campaign parents included) before any child node —
-        # cytoscape requires a parent to be defined before the child that references it — then order
-        # by campaign map_order, then node id (the deterministic #1977 fallback).
-        nodes.sort(key=lambda n: (n.data_parent_id is not None, node_campaign_order(n), n.id))
+        # Parents (compound campaign nodes) before children, then deterministic node-id order (#2012).
+        nodes.sort(key=lambda n: (n.data_parent_id is not None, n.id))
+        edges.sort(key=lambda e: e.id)
 
-        nodes_by_id = {node.id: node for node in nodes}
-
-        # Order an edge by the campaign of the node it points at, so the edges feeding a campaign's
-        # quests arrive in the same left-to-right order as the campaigns themselves. Every edge
-        # targets a node in this scape, so the lookup always resolves.
-        edges.sort(key=lambda e: (node_campaign_order(nodes_by_id[e.data_target_id]), e.id))
+        node_dicts = []
+        for node in nodes:
+            node_dict = node.json_dict()
+            node_dict['data']['campaignOrder'] = node_campaign_order(node)
+            node_dicts.append(node_dict)
 
         return {
-            'nodes': [node.json_dict() for node in nodes],
+            'nodes': node_dicts,
             'edges': [edge.json_dict() for edge in edges],
         }
 

--- a/src/djcytoscape/static/djcytoscape/js/maps.js
+++ b/src/djcytoscape/static/djcytoscape/js/maps.js
@@ -177,6 +177,78 @@ layout.run()
 addedCampaignLayoutEdges.remove();
 
 /***************************************
+ * #1977: order the campaign columns left-to-right by Category.map_order.
+ *
+ * dagre decides the order of same-rank nodes with a crossing-minimization heuristic and ignores
+ * the order elements were fed in, so the campaign order can't be set before layout — it has to be
+ * imposed on the finished layout. Each campaign (a compound node + its member quests) and each
+ * connected clump of campaign-less quests is one connected "column"; we sort the columns by their
+ * campaign map_order (ties, and campaign-less columns, fall back to the smallest node id — the
+ * deterministic #2012 order) and repack them left-to-right, shifting each column horizontally as a
+ * rigid block so its internal shape and every node's vertical position are untouched.
+ ***************************************/
+(function orderCampaignColumns() {
+    // A node's "root" is its campaign compound parent, or itself when it isn't in a campaign.
+    function rootOf(node) { return node.isChild() ? node.parent() : node; }
+
+    // Union-find over roots, joined by every (real) edge between two different roots, so a campaign
+    // and any campaign-less quest-chain each collapse to a single column.
+    var parent = {};
+    function find(x) {
+        while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+        return x;
+    }
+    function union(a, b) { parent[find(a)] = find(b); }
+
+    cy.nodes().forEach(function (node) {
+        var r = rootOf(node).id();
+        if (parent[r] === undefined) { parent[r] = r; }
+    });
+    cy.edges().forEach(function (edge) {
+        var a = rootOf(edge.source()).id();
+        var b = rootOf(edge.target()).id();
+        if (parent[a] === undefined) { parent[a] = a; }
+        if (parent[b] === undefined) { parent[b] = b; }
+        if (a !== b) { union(a, b); }
+    });
+
+    // Bucket every node into its column, tracking each column's order key and smallest node id.
+    var columns = {};
+    cy.nodes().forEach(function (node) {
+        var key = find(rootOf(node).id());
+        var col = columns[key] || (columns[key] = { nodes: cy.collection(), order: Infinity, minId: Infinity });
+        col.nodes = col.nodes.union(node);
+        var order = node.data('campaignOrder');
+        if (order === undefined || order === null) { order = 0; }
+        if (order < col.order) { col.order = order; }
+        var idNum = parseInt(node.id(), 10);
+        if (!isNaN(idNum) && idNum < col.minId) { col.minId = idNum; }
+    });
+
+    var cols = Object.keys(columns).map(function (key) { return columns[key]; });
+    if (cols.length > 1) {
+        // Left-to-right by campaign map_order, then smallest node id (the deterministic #2012 order).
+        cols.sort(function (a, b) { return (a.order - b.order) || (a.minId - b.minId); });
+
+        var GAP = 45;  // horizontal gap between columns, matching dagre's nodeSep above
+        var cursorX = null;
+        cols.forEach(function (col) {
+            // Shift only the leaf nodes — moving a compound (campaign) parent in cytoscape drags its
+            // children too, so shifting the whole collection would move them twice. The parent's box
+            // re-wraps its children automatically once they move.
+            var leaves = col.nodes.filter(function (n) { return !n.isParent(); });
+            // Measure by node extents only (not labels) so columns pack as tightly as dagre spaced
+            // them — the node labels are drawn offset to the left and would otherwise inflate the gap.
+            var bb = leaves.boundingBox({ includeLabels: false });
+            if (cursorX === null) { cursorX = bb.x1; }  // anchor at the current leftmost column
+            var dx = cursorX - bb.x1;
+            if (dx !== 0) { leaves.shift({ x: dx, y: 0 }); }
+            cursorX += bb.w + GAP;
+        });
+    }
+})();
+
+/***************************************
  *
  * BEHAVIOUR/INTERACTIVE OPTIONS
  *

--- a/src/djcytoscape/tests/test_map_order_render.py
+++ b/src/djcytoscape/tests/test_map_order_render.py
@@ -1,0 +1,151 @@
+"""Headless render test for issue #1977 — campaign map_order actually reorders the columns.
+
+The bug this guards against: PR #2016 tried to order campaigns by re-sorting the elements JSON,
+assuming dagre honours input order. It doesn't (dagre orders same-rank nodes by crossing
+minimization), so setting a campaign's map_order had no visible effect. The real fix repositions
+the campaign columns in ``maps.js`` after dagre runs. That behaviour lives entirely in the
+browser, so this test drives the *real* vendored cytoscape/dagre assets and the *real* maps.js in
+headless Chromium and asserts the rendered left-to-right order follows map_order.
+
+It is hermetic — no Django server, no DB, no tenant routing — and skips cleanly unless Playwright
+and a Chromium build are both available, so a normal suite run (or CI without a browser) is
+unaffected. Runs for real once a Chromium build is present (see the front-end-testing setup in
+#2053/#503).
+"""
+
+import glob
+import os
+import tempfile
+from unittest import skipUnless
+
+from django.apps import apps
+from django.test import SimpleTestCase
+
+try:
+    from playwright.sync_api import sync_playwright
+    HAS_PLAYWRIGHT = True
+except ImportError:
+    HAS_PLAYWRIGHT = False
+
+
+def _find_chromium():
+    """Return the path to a pre-installed Chromium/headless-shell binary, or None if there is none.
+
+    Playwright pins an exact build directory, so rather than let it download one (disabled in this
+    environment) we resolve whatever build is already on disk under PLAYWRIGHT_BROWSERS_PATH.
+    """
+    root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "/opt/pw-browsers")
+    for pattern in ("chromium-*/chrome-linux/chrome", "chromium_headless_shell-*/chrome-linux/headless_shell"):
+        hits = sorted(glob.glob(os.path.join(root, pattern)))
+        if hits:
+            return hits[-1]
+    return None
+
+
+_CHROMIUM = _find_chromium() if HAS_PLAYWRIGHT else None
+
+# A minimal jQuery stand-in so maps.js (which only uses $ for document-ready, resize, and a few
+# .css()/.click() calls that never fire in a headless load) runs to completion. Ready callbacks are
+# deferred like real jQuery so maps.js's later `var updateBounds` exists by the time they run.
+_JQUERY_STUB = """
+window.$ = window.jQuery = function () {
+    var api = {
+        ready: function (fn) { setTimeout(fn, 0); return api; },
+        resize: function () { return api; },
+        click: function () { return api; },
+        css: function () { return api; },
+        toggleClass: function () { return api; },
+    };
+    return api;
+};
+"""
+
+_PAGE_TEMPLATE = """<!doctype html><html><head>
+<style>#cy {{ width: 1200px; height: 800px; position: absolute; top: 0; left: 0; }}</style>
+</head><body><div id="cy"></div>
+<script>{jquery_stub}</script>
+<script src="file://{js_dir}/cytoscape.min.js"></script>
+<script src="file://{js_dir}/dagre.min.js"></script>
+<script src="file://{js_dir}/cytoscape-dagre.js"></script>
+<script>
+var elements = {{
+  nodes: [
+    {{ data: {{ id: '10', label: 'Campaign A', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '20', label: 'Campaign B', campaignOrder: {order_b} }} }},
+    {{ data: {{ id: '11', parent: '10', label: 'A1', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '12', parent: '10', label: 'A2', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '21', parent: '20', label: 'B1', campaignOrder: {order_b} }} }},
+    {{ data: {{ id: '22', parent: '20', label: 'B2', campaignOrder: {order_b} }} }}
+  ],
+  edges: [
+    {{ data: {{ id: '101', source: '11', target: '12' }} }},
+    {{ data: {{ id: '102', source: '21', target: '22' }} }}
+  ]
+}};
+var cy = cytoscape({{ container: document.getElementById('cy'), elements: elements, style: [] }});
+</script>
+<script src="file://{js_dir}/maps.js"></script>
+</body></html>"""
+
+
+@skipUnless(HAS_PLAYWRIGHT and _CHROMIUM, "Playwright and a Chromium build are required")
+class CampaignMapOrderRenderTest(SimpleTestCase):
+    """Drive the real maps.js in headless Chromium and check map_order controls campaign order.
+
+    Campaign A always has the smaller node id (10 < 20), so if the layout were ordered by id (the
+    pre-fix behaviour) A would always be on the left. Driving the order via campaignOrder proves the
+    fix: the campaign with the lower map_order wins regardless of id.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.js_dir = os.path.join(apps.get_app_config("djcytoscape").path, "static", "djcytoscape", "js")
+        cls._pw = sync_playwright().start()
+        cls._browser = cls._pw.chromium.launch(executable_path=_CHROMIUM)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._browser.close()
+        cls._pw.stop()
+        super().tearDownClass()
+
+    def _campaign_mean_x(self, order_a, order_b):
+        """Render the two-campaign map with the given map_orders; return (meanX_A, meanX_B)."""
+        html = _PAGE_TEMPLATE.format(
+            jquery_stub=_JQUERY_STUB, js_dir=self.js_dir, order_a=order_a, order_b=order_b,
+        )
+        # Load from a real file so the browser will fetch the file:// asset <script>s (it refuses
+        # to load file:// sub-resources for an in-memory set_content document).
+        with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as fh:
+            fh.write(html)
+            html_path = fh.name
+        page = self._browser.new_page()
+        try:
+            page.goto("file://" + html_path)
+            # maps.js repositions synchronously right after layout.run(); give the page a beat to settle.
+            page.wait_for_timeout(300)
+            mean_x = "(ids) => ids.reduce((s, id) => s + cy.getElementById(id).position('x'), 0) / ids.length"
+            ax = page.evaluate(mean_x, ["11", "12"])
+            bx = page.evaluate(mean_x, ["21", "22"])
+        finally:
+            page.close()
+            os.unlink(html_path)
+        return ax, bx
+
+    def test_map_order__lower_map_order_campaign_renders_on_the_left(self):
+        """Campaign B (larger id) with a lower map_order than A must render to the left of A."""
+        ax, bx = self._campaign_mean_x(order_a=1000, order_b=0)
+        self.assertLess(bx, ax, "campaign B (lower map_order) should be left of A")
+
+    def test_map_order__swapping_map_order_swaps_the_columns(self):
+        """Giving A the lower map_order flips it back to the left — the order tracks the value."""
+        ax, bx = self._campaign_mean_x(order_a=0, order_b=1000)
+        self.assertLess(ax, bx, "campaign A (lower map_order) should be left of B")
+
+    def test_map_order__equal_map_order_falls_back_to_node_id(self):
+        """With equal map_order, the smaller-id campaign (A) stays left — the deterministic #2012
+        tie-break, so maps where nobody set an order look exactly as before.
+        """
+        ax, bx = self._campaign_mean_x(order_a=0, order_b=0)
+        self.assertLess(ax, bx, "with equal map_order, smaller-id campaign A should be left")

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -586,9 +586,12 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
 
 class CampaignMapOrderTest(ByteDeckTenantTestCase):
     """Campaigns are placed left-to-right on the quest map in Category.map_order (issue #1977,
-    the ordering half). dagre lays out same-rank nodes by their input order, so emitting a
-    campaign's node, its member quest, and the edge into that quest earlier moves the campaign
-    left. Two campaigns branch off a common Start quest so they render as siblings.
+    the ordering half). dagre orders same-rank nodes by crossing-minimization and ignores input
+    order, so the order can't be imposed in the emitted JSON — instead every node carries a
+    ``campaignOrder`` (its campaign's map_order) and maps.js repositions the campaign columns to
+    match after layout. These tests cover the server side of that contract: that the right
+    ``campaignOrder`` is emitted on every node. Two campaigns branch off a common Start quest so
+    they render as siblings.
     """
 
     @classmethod
@@ -616,9 +619,14 @@ class CampaignMapOrderTest(ByteDeckTenantTestCase):
         return next(i for i, n in enumerate(nodes) if n['data'].get('Category') == category_id)
 
     @staticmethod
-    def _index_by_quest(nodes, quest_id):
-        """Position of a quest's node in the emitted node list."""
-        return next(i for i, n in enumerate(nodes) if n['data'].get('Quest') == quest_id)
+    def _campaign_order(nodes, *, category_id=None, quest_id=None):
+        """The campaignOrder emitted on a campaign's compound node or on a quest's node."""
+        for n in nodes:
+            if category_id is not None and n['data'].get('Category') == category_id:
+                return n['data']['campaignOrder']
+            if quest_id is not None and n['data'].get('Quest') == quest_id:
+                return n['data']['campaignOrder']
+        raise AssertionError("node not found")
 
     def test_add_to_campaign__campaign_node_links_back_to_its_category(self):
         """The compound campaign node carries selector_id 'Category: <pk>' so the map can look up
@@ -628,9 +636,10 @@ class CampaignMapOrderTest(ByteDeckTenantTestCase):
         node = scape.cytoelement_set.get(classes='campaign', label__startswith='AAA')
         self.assertEqual(node.selector_id, f'Category: {self.camp_a.id}')
 
-    def test_elements_dict__default_map_order_keeps_creation_order(self):
-        """With map_order left at its default 0, campaigns keep their deterministic creation
-        order (A before B), so the feature is backwards compatible with existing maps.
+    def test_elements_dict__default_map_order_keeps_deterministic_node_order(self):
+        """With map_order left at its default 0, nodes are emitted in ascending-id order (A's
+        campaign node before B's), preserving the deterministic layout from issue #2012 so maps
+        where nobody set an order are unchanged.
         """
         nodes = self._emit()['nodes']
         self.assertLess(
@@ -638,36 +647,26 @@ class CampaignMapOrderTest(ByteDeckTenantTestCase):
             self._index_by_category(nodes, self.camp_b.id),
         )
 
-    def test_elements_dict__map_order_reorders_campaigns_left_to_right(self):
-        """Giving B a lower map_order than A emits campaign B first — its compound node, its
-        member quest, and the edge feeding that quest all precede A's — which dagre renders to
-        the left. This flips the default A-before-B order.
+    def test_elements_dict__emits_campaign_order_on_every_node(self):
+        """Every node carries `campaignOrder` = its campaign's map_order; member quests inherit
+        their campaign's, and campaign-less nodes (the shared Start quest) default to 0. This is
+        the value maps.js reads to order the campaign columns left-to-right — the array position
+        no longer encodes the order (dagre would ignore it), so the data attribute must.
         """
-        self.camp_a.map_order = 2
+        self.camp_a.map_order = 5
         self.camp_a.full_clean()
         self.camp_a.save()
         self.camp_b.map_order = 1
         self.camp_b.full_clean()
         self.camp_b.save()
 
-        elements = self._emit()
-        nodes = elements['nodes']
+        nodes = self._emit()['nodes']
 
-        # campaign B's compound node now precedes campaign A's
-        self.assertLess(
-            self._index_by_category(nodes, self.camp_b.id),
-            self._index_by_category(nodes, self.camp_a.id),
-        )
-        # and B's member quest precedes A's
-        self.assertLess(
-            self._index_by_quest(nodes, self.qb.id),
-            self._index_by_quest(nodes, self.qa.id),
-        )
-
-        # the edge feeding B's quest is emitted before the edge feeding A's quest
-        node_id_by_quest = {n['data']['Quest']: n['data']['id'] for n in nodes if 'Quest' in n['data']}
-        edge_targets = [e['data']['target'] for e in elements['edges']]
-        self.assertLess(
-            edge_targets.index(node_id_by_quest[self.qb.id]),
-            edge_targets.index(node_id_by_quest[self.qa.id]),
-        )
+        # campaign compound nodes carry their own map_order
+        self.assertEqual(self._campaign_order(nodes, category_id=self.camp_a.id), 5)
+        self.assertEqual(self._campaign_order(nodes, category_id=self.camp_b.id), 1)
+        # member quests inherit their campaign's map_order
+        self.assertEqual(self._campaign_order(nodes, quest_id=self.qa.id), 5)
+        self.assertEqual(self._campaign_order(nodes, quest_id=self.qb.id), 1)
+        # the campaign-less Start quest defaults to 0
+        self.assertEqual(self._campaign_order(nodes, quest_id=self.start.id), 0)


### PR DESCRIPTION
### What?

Makes a campaign's **Map order** field actually reorder the campaigns left-to-right on the quest map. Reopens/fixes #1977 — the field, migration and edit-form UI from #2016 were all fine, but the value had no effect on the rendered layout.

### Why?

#2016 tried to impose the order by re-sorting the elements JSON, on the assumption (in a code comment) that *"dagre places same-rank nodes by their input order."* That assumption is wrong: the map uses the **dagre** layout, which orders same-rank nodes with a **crossing-minimization heuristic** driven by the graph's edges and ignores input order (it's a weak tiebreak at best). So re-sorting the array did nothing, exactly as reported ("I set … 1000 … the other is at 0 … they still ignore it").

### How?

Impose the order where it's actually decided — **after** layout, in the browser:

- **`djcytoscape/models.py`**: emit each node's `campaignOrder` (its campaign's `map_order`; quests inherit their campaign's, campaign-less nodes default to 0) into its data, and drop the disproven input-array reordering (nodes are now just parents-first then ascending id, preserving the deterministic order from #2012).
- **`maps.js`**: after `layout.run()`, group nodes into connected **columns** (a campaign compound node + its quests, or a connected clump of campaign-less quests), sort the columns by `(map_order, smallest node id)`, and repack them left-to-right — shifting each column's leaf nodes as a rigid block so its internal shape and every vertical position are untouched. Ties (and unordered maps) fall back to node id, so existing maps look exactly as they do today.

### Testing?

- **Server side** (`test_models.py`, runs in CI): asserts `campaignOrder` is emitted on every node — on campaign compound nodes, inherited by their member quests, and `0` for the campaign-less Start quest — and that the default (unordered) case keeps the deterministic node order.
- **Rendered layout** (`test_map_order_render.py`, new): drives the **real** vendored cytoscape/dagre + `maps.js` in headless Chromium and asserts the lower-`map_order` campaign renders left, swapping the values swaps the columns, and equal `map_order` falls back to node id. It skips cleanly unless a Chromium build is present (so the normal suite / current CI is unaffected; it runs once browser support lands, per #2053/#503). Verified passing locally.

Ties into the existing determinism guarantee from #2012 — verified those tests still hold under the new sort key.

### Screenshots (if front end is affected)

The reported scenario: two campaigns where the **left** one ("Blender Basics 1") has the *higher* map_order (1000) and the right one ("…Donut…") has map_order 0. Before, the value is ignored (Basics stays left); after, the columns order by map_order (Donut/0 left, Basics/1000 right):

**Before** (map_order ignored — Basics/1000 on the left):
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1977/map-order-before.png)

**After** (ordered by map_order — Donut/0 left, Basics/1000 right):
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1977/map-order-after.png)

(Rendered from the real `maps.js` + cytoscape/dagre in headless Chromium — a faithful reproduction of the map, not a mockup.)

### Anything Else?

The repack shifts only leaf nodes because moving a cytoscape compound (campaign) parent drags its children too — shifting the whole collection moved them twice (caught while verifying the screenshots). Column widths are measured without labels so columns pack as tightly as dagre spaced them.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_