### PR TITLE
Reveal bootstrap-tables atomically with their spinner so they don't jump (reopened #1981)

### DIFF
--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -1127,17 +1127,18 @@ div.btn-group.action-btn-group {
    A "Loading content..." spinner (.bt-loading) is server-rendered right before each such
    table (snippets/table_loading.html), so it's on screen from the very first paint — a
    JS-inserted spinner would arrive too late, after the raw table has already been parsed.
-   This <head> CSS hides the raw table until bootstrap-table formats it, and hides the spinner
-   the moment its table is ready. */
+   This <head> CSS hides the raw table until custom.js reveals it. */
 table[data-toggle="table"] {
     /* Out of flow while hidden so a big table reserves no tall blank gap under the spinner. */
     position: absolute;
     visibility: hidden;
 }
-/* Once bootstrap-table wraps the table in .bootstrap-table it is fully formatted — put it
-   back in flow and show it. The .bt-reveal fallback (custom.js) covers any table
-   bootstrap-table never initializes, so data is never left hidden. */
-.bootstrap-table table[data-toggle="table"],
+/* The table is revealed ONLY by the .bt-reveal class, which custom.js adds in the same step that
+   it hides the spinner. Revealing it automatically as soon as bootstrap-table wrapped it (via a
+   `.bootstrap-table table` rule) let the table appear a frame before the spinner was hidden, so the
+   table then jumped up when the spinner vanished (issue #1981). One JS-driven reveal keeps the
+   swap atomic. .bt-reveal also covers tables bootstrap-table never initializes (6s fallback), so
+   data is never left hidden. */
 table[data-toggle="table"].bt-reveal {
     position: static;
     visibility: visible;
@@ -1151,12 +1152,6 @@ table[data-toggle="table"].bt-reveal {
     justify-content: center;
     min-height: 120px;
     color: #999;
-}
-/* Hide the spinner the moment its table is formatted (wrapped in .bootstrap-table) or
-   force-revealed (.bt-reveal). custom.js also hides it, covering browsers without :has(). */
-.bt-loading:has(+ .bootstrap-table),
-.bt-loading:has(+ table[data-toggle="table"].bt-reveal) {
-    display: none;
 }
 
 

--- a/src/static/js/custom.js
+++ b/src/static/js/custom.js
@@ -36,32 +36,38 @@ $(document).ready(function() {
        window.location.href = $(this).attr("href");
      });
 
-    // #1981: bootstrap-table reformats server-rendered tables on load. A "Loading content..."
-    // spinner (.bt-loading) is server-rendered right before each data-toggle="table", so it's
-    // visible from the first paint; the head CSS (custom_common.css) hides the raw table until
-    // bootstrap-table formats it. Here we hide each spinner once its table is wrapped in
-    // .bootstrap-table — and, if bootstrap-table never initializes a table, reveal the raw
-    // table after a timeout so its data is never left hidden behind the spinner.
-    $('.bt-loading').each(function() {
-        var $spinner = $(this);
+    // #1981: bootstrap-table reformats server-rendered tables on load. The head CSS
+    // (custom_common.css) hides each data-toggle="table" until this code adds .bt-reveal, and a
+    // "Loading content..." spinner (.bt-loading) is server-rendered right before the table so
+    // something is on screen from the first paint. For each table we reveal it (add .bt-reveal)
+    // and hide its spinner in ONE synchronous step, so the browser paints both together: the table
+    // never appears while the spinner is still on screen (which made the table jump up when the
+    // spinner then vanished). We iterate the tables themselves — not the spinners — so a table
+    // without a spinner is still revealed. If bootstrap-table never initializes a table, a timeout
+    // reveals it anyway so data is never left hidden.
+    $('table[data-toggle="table"]').each(function() {
+        var table = this;
 
-        // The table this spinner covers is the next sibling — still the raw <table>, or, if
-        // bootstrap-table already ran, the .bootstrap-table wrapper it was replaced with.
-        function findTable() {
-            var $next = $spinner.next();
-            return $next.is('table[data-toggle="table"]') ? $next : $next.find('table[data-toggle="table"]').first();
+        // The spinner, if present, sits right before the table — or before the .bootstrap-table
+        // wrapper once bootstrap-table has moved the table inside it.
+        function findSpinner() {
+            var $wrap = $(table).closest('.bootstrap-table');
+            var $prev = ($wrap.length ? $wrap : $(table)).prev();
+            return $prev.hasClass('bt-loading') ? $prev : $();
+        }
+
+        // Reveal the table and hide its spinner atomically (same synchronous tick → same paint).
+        function revealTable() {
+            $(table).addClass('bt-reveal');
+            findSpinner().hide();
         }
 
         var start = Date.now();
         var poll = setInterval(function() {
-            var $table = findTable();
-            var wrapped = $table.length && $table.closest('.bootstrap-table').length;
+            var wrapped = $(table).closest('.bootstrap-table').length;
             if (wrapped || Date.now() - start > 6000) {
                 clearInterval(poll);
-                if (!wrapped && $table.length) {
-                    $table.addClass('bt-reveal');
-                }
-                $spinner.hide();
+                revealTable();
             }
         }, 50);
     });


### PR DESCRIPTION
### What?

Fixes the remaining jump reported on #1981: *"the table loads and becomes visible before the spinner disappears, so the table appears, then the spinner disappears, causing the table to jump up."*

### Why?

The previous approach had **two independent triggers**:
- the table was revealed by a CSS rule (`.bootstrap-table table[data-toggle]`) the instant bootstrap-table wrapped it, and
- the spinner was hidden separately — by a `:has()` rule and/or the JS poll.

Because those are different mechanisms, the browser could paint them a frame apart: the table shows while the spinner is still up, then the spinner is removed and the table jumps up into its place.

### How?

Make the reveal and the spinner-hide a **single atomic step**:
- `custom_common.css`: the table is hidden until it gets a `.bt-reveal` class — and *only* that class reveals it (removed the `.bootstrap-table table` auto-reveal and the `:has()` spinner-hide).
- `custom.js`: for each `table[data-toggle="table"]`, once bootstrap-table has wrapped it (or after a 6s fallback), add `.bt-reveal` **and** hide its spinner in the same synchronous function, so the browser paints both together. The table can no longer appear before the spinner is gone.

It iterates the **tables** (not the spinners) so a `data-toggle="table"` that has no spinner is still revealed — otherwise, with the CSS auto-reveal removed, such a table would have stayed hidden.

### Testing?

This is a transition-timing fix, so it's verified by driving the **real** bootstrap-table + `custom.js` + `custom_common.css` in headless Chromium (Playwright) and frame-sampling the load: across the whole load the table is **never** visible while the spinner is, and it ends visible with the spinner hidden — confirmed both with a spinner present and without one:

```
with spinner       everBoth=False  finalTableVisible=True  spinnerHidden=True
without spinner    everBoth=False  finalTableVisible=True  spinnerHidden=True
```

### Screenshots (if front end is affected)

The change is to the *timing* of the loading→table transition, which a still can't capture. Here's the loading ("holding") state that stays in place until the atomic swap:

![loading state](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1981/loading-state.png)

Happy to record a short screen capture of the smooth swap for you to attach to the issue if useful (raw-URL videos don't play inline on GitHub).

### Anything Else?

No behaviour change for the non-table content or for tables that bootstrap-table never initializes (the 6s fallback still reveals them). All 6 current `data-toggle="table"` tables ship the spinner include; the table-iterating reveal just future-proofs any that don't.

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unstyled Bootstrap tables from briefly appearing before they are fully initialized.
  * Improved table loading transitions to reveal tables smoothly and hide loading indicators at the same time.
  * Ensured server-rendered tables are revealed even when table initialization does not occur as expected.
  * Removed unreliable spinner-hiding behavior that could leave loading indicators visible or cause visual flicker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->