### PR TITLE
Completion Statuses page: scope toggle, three-group breakdown, sortable date column, status filter (#1973)

### DIFF
--- a/src/quest_manager/templates/quest_manager/quest_user_status.html
+++ b/src/quest_manager/templates/quest_manager/quest_user_status.html
@@ -65,27 +65,63 @@
 
 
   <h5>Status Breakdown</h5>
-  <table class="table" style="width: 350px;">
-      {% for stat in status_stats %}
+  <table class="table table-hover" style="max-width: 520px;">
+    <thead>
       <tr>
-          <td>{{ stat.status }}:</td>
-          <td>{{ stat.count }} ({{ stat.percent }})</td>
+        <th>Status</th>
+        <th class="text-right">My blocks <small class="text-muted">({{ totals.my_blocks }})</small></th>
+        <th class="text-right">All enrolled <small class="text-muted">({{ totals.enrolled }})</small></th>
+        <th class="text-right">All active <small class="text-muted">({{ totals.active }})</small></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in status_breakdown %}
+      <tr>
+        <td>{{ row.status }}</td>
+        <td class="text-right">{{ row.my_blocks.count }} <small class="text-muted">({{ row.my_blocks.percent }})</small></td>
+        <td class="text-right">{{ row.enrolled.count }} <small class="text-muted">({{ row.enrolled.percent }})</small></td>
+        <td class="text-right">{{ row.active.count }} <small class="text-muted">({{ row.active.percent }})</small></td>
       </tr>
       {% endfor %}
+    </tbody>
   </table>
 
+  {# Which group of students the table below lists (issue #1973). #}
+  <div class="btn-group" role="group" aria-label="Which students to show" style="margin-bottom: 10px;">
+    <a href="?scope=my_blocks" role="button" class="btn btn-{% if scope == 'my_blocks' %}primary{% else %}default{% endif %}">My blocks</a>
+    <a href="?scope=enrolled" role="button" class="btn btn-{% if scope == 'enrolled' %}primary{% else %}default{% endif %}">All enrolled</a>
+    <a href="?scope=active" role="button" class="btn btn-{% if scope == 'active' %}primary{% else %}default{% endif %}">All active</a>
+  </div>
+
   {% if user_status_list %}
+    <div class="form-inline" style="margin-bottom: 8px;">
+      <label for="status-filter">Filter by status:</label>
+      <select id="status-filter" class="form-control input-sm">
+        <option value="">All</option>
+        <option value="Approved">Approved</option>
+        <option value="Returned">Returned</option>
+        <option value="Awaiting Approval">Awaiting Approval</option>
+        <option value="In Progress">In Progress</option>
+        <option value="Not Started">Not Started</option>
+      </select>
+    </div>
+
     {% include 'snippets/table_loading.html' %}
     <table id="user-status-table"
           class="user-status-table"
           data-toggle="table"
-          data-classes="table table-striped table-bordered table-hover"
+          data-classes="table table-striped table-hover"
           data-search="true"
           data-trim-on-search="false">
       <thead>
         <tr>
           <th data-field="user" data-sortable="true">User</th>
-          <th data-field="status">Status</th>
+          <th data-field="status" data-sortable="true">Status</th>
+          {# "Completed" sorts on the hidden ISO-8601 companion field so it orders by date, not text. #}
+          <th data-field="completed" data-sortable="true" data-sort-name="completed_sort">Completed</th>
+          <th data-field="completed_sort" data-visible="false" data-switchable="false"></th>
+          {# Plain-text status used by the filter dropdown (filterBy matches the field value). #}
+          <th data-field="status_text" data-visible="false" data-switchable="false"></th>
         </tr>
       </thead>
       <tbody>
@@ -101,11 +137,29 @@
               {{ entry.status }}
             {% endif %}
           </td>
+          <td>{% if entry.completed %}{{ entry.completed|date:"M j, Y" }}{% else %}&mdash;{% endif %}</td>
+          <td>{{ entry.completed|date:"c" }}</td>
+          <td>{{ entry.status }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   {% else %}
-    <p>No active students found.</p>
+    <p>No students found for this view.</p>
   {% endif %}
+{% endblock %}
+
+{% block js %}
+{{ block.super }}
+<script>
+  // #1973: filter the status table by the hidden plain-text `status_text` field (bootstrap-table's
+  // core filterBy, so it works regardless of the filter-control extension).
+  $(function () {
+    var $table = $('#user-status-table');
+    $('#status-filter').on('change', function () {
+      var value = $(this).val();
+      $table.bootstrapTable('filterBy', value ? { status_text: [value] } : {});
+    });
+  });
+</script>
 {% endblock %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1401,15 +1401,16 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(statuses[self.student2.username], 'Returned')
         self.assertEqual(statuses[self.student3.username], 'Awaiting Approval')
 
-        # Verify status_stats
-        status_stats = response.context['status_stats']
-        stats_dict = {stat['status']: stat for stat in status_stats}
-        self.assertEqual(stats_dict['Approved']['count'], 1)
-        self.assertEqual(stats_dict['Returned']['count'], 1)
-        self.assertEqual(stats_dict['Awaiting Approval']['count'], 1)
-        self.assertEqual(stats_dict['Approved']['percent'], "33%")
-        self.assertEqual(stats_dict['Returned']['percent'], "33%")
-        self.assertEqual(stats_dict['Awaiting Approval']['percent'], "33%")
+        # Verify the status breakdown (all three students are active and enrolled, none in a block
+        # this teacher teaches, so the counts land in the enrolled/active columns).
+        breakdown = {row['status']: row for row in response.context['status_breakdown']}
+        for group in ('enrolled', 'active'):
+            self.assertEqual(breakdown['Approved'][group]['count'], 1)
+            self.assertEqual(breakdown['Returned'][group]['count'], 1)
+            self.assertEqual(breakdown['Awaiting Approval'][group]['count'], 1)
+            self.assertEqual(breakdown['Approved'][group]['percent'], "33%")
+            self.assertEqual(breakdown['Returned'][group]['percent'], "33%")
+            self.assertEqual(breakdown['Awaiting Approval'][group]['percent'], "33%")
 
     def test_quest_user_status__users_with_no_submission_show_not_started(self):
         """Students without a submission are listed with the 'Not Started' status and no submission."""
@@ -1454,6 +1455,54 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         statuses = {entry['user'].username: entry['status'] for entry in response.context['user_status_list']}
         self.assertEqual(statuses[self.student1.username], 'Awaiting Approval')
+
+    def test_quest_user_status__default_scope_falls_back_to_active_when_no_blocks(self):
+        """The default scope is the teacher's own blocks, but falls back to all active students when
+        they teach none, so the page isn't empty (issue #1973)."""
+        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]))
+
+        self.assertEqual(response.context['scope'], 'active')
+        self.assertFalse(response.context['has_my_blocks'])
+        self.assertEqual(len(response.context['user_status_list']), 3)
+
+    def test_quest_user_status__scope_my_blocks_limits_to_taught_students(self):
+        """scope=my_blocks lists only students in a course block the logged-in teacher teaches (#1973)."""
+        block = baker.make('courses.Block', current_teacher=self.staff_user)
+        course_student = self.student1.coursestudent_set.get(semester=SiteConfig.get().active_semester)
+        course_student.block = block
+        course_student.save()
+
+        url = reverse('quests:quest_user_status', args=[self.quest.id]) + '?scope=my_blocks'
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['scope'], 'my_blocks')
+        self.assertTrue(response.context['has_my_blocks'])
+        usernames = [entry['user'].username for entry in response.context['user_status_list']]
+        self.assertEqual(usernames, [self.student1.username])
+
+    def test_quest_user_status__completed_date_and_breakdown_groups(self):
+        """Approved submissions expose a completion date, and the breakdown counts each of the three
+        student groups (my blocks / enrolled / active) — issue #1973."""
+        approved_time = timezone.now()
+        QuestSubmission.objects.create(
+            quest=self.quest, user=self.student1, is_approved=True, is_completed=True,
+            time_approved=approved_time, time_completed=approved_time, ordinal=1,
+            semester=SiteConfig.get().active_semester,
+        )
+
+        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]) + '?scope=active')
+
+        entries = {e['user'].username: e for e in response.context['user_status_list']}
+        self.assertEqual(entries[self.student1.username]['completed'], approved_time)
+        # a student without an approved submission has no completion date
+        self.assertIsNone(entries[self.student2.username]['completed'])
+
+        breakdown = {row['status']: row for row in response.context['status_breakdown']}
+        self.assertEqual(breakdown['Approved']['enrolled']['count'], 1)
+        self.assertEqual(breakdown['Approved']['active']['count'], 1)
+        # the teacher teaches no blocks in this test, so the my_blocks column is empty
+        self.assertEqual(breakdown['Approved']['my_blocks']['count'], 0)
 
 
 class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1504,6 +1504,26 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # the teacher teaches no blocks in this test, so the my_blocks column is empty
         self.assertEqual(breakdown['Approved']['my_blocks']['count'], 0)
 
+    def test_quest_user_status__started_but_not_submitted_shows_in_progress(self):
+        """A submission that has been started but not completed/returned/approved shows In Progress."""
+        QuestSubmission.objects.create(
+            quest=self.quest, user=self.student1, is_approved=False, is_completed=False,
+            ordinal=1, semester=SiteConfig.get().active_semester,
+        )
+
+        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]) + '?scope=active')
+
+        statuses = {entry['user'].username: entry['status'] for entry in response.context['user_status_list']}
+        self.assertEqual(statuses[self.student1.username], 'In Progress')
+
+    def test_quest_user_status__unknown_scope_falls_back(self):
+        """An unrecognised ?scope value is treated as the default (and then falls back to all active
+        students when the teacher teaches no blocks)."""
+        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]) + '?scope=bogus')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['scope'], 'active')
+
 
 class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """ Tests for:

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -25,7 +25,7 @@ from hackerspace_online.decorators import staff_member_required, xml_http_reques
 
 from badges.models import BadgeAssertion
 from comments.models import Comment, Document
-from courses.models import Block
+from courses.models import Block, CourseStudent
 from library.utils import from_library_schema_first
 from notifications.signals import notify
 from notifications.models import notify_rank_up
@@ -1031,66 +1031,101 @@ def quest_user_status(request, quest_id):
         HttpResponse: Rendered page showing the user status list for the quest.
     """
     quest = get_object_or_404(Quest.objects.all(), pk=quest_id)
+    active_semester = SiteConfig.get().active_semester
 
-    active_students = Profile.objects.all_active().students_only().select_related('user')
-    user_ids = active_students.values_list('user_id', flat=True)
+    # Three student groups the page can show, as sets of user ids (issue #1973):
+    #   active    — all active students (in a course or not); the superset
+    #   enrolled  — students enrolled in a course this active semester
+    #   my_blocks — students in a course block the current teacher teaches this semester
+    active_profiles = list(Profile.objects.all_active().students_only().select_related('user'))
+    active_ids = {profile.user_id for profile in active_profiles}
+    enrolled_ids = set(
+        CourseStudent.objects.all_users_for_active_semester(students_only=True).values_list('id', flat=True)
+    ) & active_ids
+    my_block_ids = set(
+        CourseStudent.objects.filter(
+            semester=active_semester, block__current_teacher=request.user
+        ).values_list('user_id', flat=True)
+    ) & active_ids
 
+    # Latest submission per user (over the active superset), newest attempt first.
     submissions = (
-        QuestSubmission.objects.filter(
-            quest=quest,
-            user_id__in=user_ids,
-        )
+        QuestSubmission.objects.filter(quest=quest, user_id__in=active_ids)
         .select_related('user')
-        # Latest attempt first per user
         .order_by('user_id', '-time_approved', '-id')
     )
-
-    # Map each user to their latest submission using the first occurrence in the ordered queryset.
     latest_sub_by_user = {}
     for sub in submissions:
-        if sub.user_id not in latest_sub_by_user:
-            latest_sub_by_user[sub.user_id] = sub
+        latest_sub_by_user.setdefault(sub.user_id, sub)
 
-    user_status_list = []
-    for profile in active_students:
-        sub = latest_sub_by_user.get(profile.user_id)
+    def status_of(sub):
+        """Map a user's latest submission (or None) to a display status."""
         if sub is None:
-            status = "Not Started"
-        elif sub.is_approved:
-            status = "Approved"
-        elif sub.is_returned():
-            status = "Returned"
-        elif sub.is_awaiting_approval():
-            status = "Awaiting Approval"
-        else:
-            status = "In Progress"
+            return "Not Started"
+        if sub.is_approved:
+            return "Approved"
+        if sub.is_returned():
+            return "Returned"
+        if sub.is_awaiting_approval():
+            return "Awaiting Approval"
+        return "In Progress"
 
-        user_status_list.append({"user": profile.user, "status": status, "submission": sub})
+    # One status entry per active student; a "completed" date only exists once approved.
+    entries_by_id = {}
+    for profile in active_profiles:
+        sub = latest_sub_by_user.get(profile.user_id)
+        entries_by_id[profile.user_id] = {
+            "user": profile.user,
+            "status": status_of(sub),
+            "submission": sub,
+            "completed": sub.time_approved if (sub and sub.is_approved) else None,
+        }
 
-    total_students = len(user_status_list)
-    status_counts = Counter(user['status'] for user in user_status_list)
     STATUS_ORDER = ["Approved", "Returned", "Awaiting Approval", "In Progress", "Not Started"]
-    status_stats = []
-
-    for status in STATUS_ORDER:
-        count = status_counts.get(status, 0)
-        percent = (count / total_students * 100) if total_students else 0
-        status_stats.append({
-            "status": status,
-            "count": count,
-            "percent": f"{percent:.0f}%"
-        })
-
     status_order_index = {status: i for i, status in enumerate(STATUS_ORDER)}
 
-    # sort user-status_list by the desired status order
-    user_status_list.sort(key=lambda x: status_order_index.get(x['status'], 99))
+    # Which group the table shows; default to the teacher's own blocks, falling back to all active
+    # students when they teach none so the page isn't empty.
+    scopes = {"my_blocks": my_block_ids, "enrolled": enrolled_ids, "active": active_ids}
+    scope = request.GET.get("scope", "my_blocks")
+    if scope not in scopes:
+        scope = "my_blocks"
+    if scope == "my_blocks" and not my_block_ids:
+        scope = "active"
+
+    user_status_list = [entries_by_id[uid] for uid in scopes[scope]]
+    user_status_list.sort(key=lambda e: (status_order_index.get(e["status"], 99), e["user"].username.lower()))
+
+    # Status breakdown across all three groups, side by side.
+    def counts_for(id_set):
+        counts = Counter(entries_by_id[uid]["status"] for uid in id_set)
+        total = len(id_set)
+        return {
+            status: {"count": counts.get(status, 0), "percent": f"{(counts.get(status, 0) / total * 100) if total else 0:.0f}%"}
+            for status in STATUS_ORDER
+        }
+
+    breakdown_my_blocks = counts_for(my_block_ids)
+    breakdown_enrolled = counts_for(enrolled_ids)
+    breakdown_active = counts_for(active_ids)
+    status_breakdown = [
+        {
+            "status": status,
+            "my_blocks": breakdown_my_blocks[status],
+            "enrolled": breakdown_enrolled[status],
+            "active": breakdown_active[status],
+        }
+        for status in STATUS_ORDER
+    ]
 
     context = {
         "q": quest,
         "maps": CytoScape.objects.get_related_maps(quest),
         "user_status_list": user_status_list,
-        "status_stats": status_stats,
+        "status_breakdown": status_breakdown,
+        "scope": scope,
+        "has_my_blocks": bool(my_block_ids),
+        "totals": {"my_blocks": len(my_block_ids), "enrolled": len(enrolled_ids), "active": len(active_ids)},
         "no_details": False,
         "is_library_view": False,
     }


### PR DESCRIPTION
### What?

The tweaks from #1973 to the quest "Completion Statuses" page (from #1934):

1. **Filter by status** — a dropdown above the table filters rows by status.
2. **Borderless table** — dropped `table-bordered` to match the app's other bootstrap-tables.
3. **"Completed" column** — shows the approval date and **sorts by date**, not alphabetically.
4. **Student-scope toggle** — **My blocks** (students in a course block *you* teach this semester) / **All enrolled** (students in a course this semester) / **All active** (all active students, in a course or not). Defaults to *My blocks*, falling back to *All active* when you teach no blocks (so the page isn't empty).
5. **Status breakdown** now shows all three groups side by side (count + percent).
6. The button already opened in the same tab — no `target="_blank"` to remove.

### How?

- **`views.py`** (`quest_user_status`): computes the three student-id groups (`my_blocks` via `block__current_teacher`, `enrolled` via `all_users_for_active_semester(students_only=True)`, `active` as the superset), the latest submission per student once over the superset, the selected scope for the table, a `completed` date (only when approved), and the three-group breakdown.
- **`quest_user_status.html`**: three-column breakdown; scope toggle (`?scope=`); status `<select>`; borderless table with a **Completed** column that sorts on a hidden ISO-8601 companion field (`data-sort-name`); a hidden plain-text `status_text` field the filter uses.
- **Filter mechanism**: bootstrap-table's core `filterBy` on the hidden `status_text` field — no dependency on the (currently unused) filter-control extension, so it works with the CDN bootstrap-table already loaded.

### Testing?

- Default scope falls back to *All active* when the teacher teaches no blocks; `scope=my_blocks` lists only students in a block they teach.
- Approved submissions expose a completion date (non-approved don't); the breakdown counts each of the three groups.
- Updated the existing test for the renamed `status_breakdown` context.

Verified the table behaviour headlessly (real bootstrap-table): the status dropdown filters via `filterBy`, and the hidden `completed_sort` field holds ISO dates so the Completed column sorts chronologically. `ruff check` passes.

### Screenshots (if front end is affected)

The reworked page — three-group breakdown, scope toggle, status filter, and the borderless table with the sortable **Completed** column:

![completion status page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1973/completion-status-page.png)

> Headless reproduction using the app's Slate theme + the real bootstrap-table (live app unavailable here); markup and copy are the real ones.

### Anything Else?

"My blocks" reads the current teacher from each course block's `current_teacher`. The completion date only exists for approved submissions (other statuses show "—").

### Review request
@tylerecouture

- Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_