### PR TITLE
Deck status banner: trial, expiring, over-limit, and suspended variants (#1729 PR 3)

### DIFF
--- a/src/hackerspace_online/context_processors.py
+++ b/src/hackerspace_online/context_processors.py
@@ -18,3 +18,22 @@ def config(request):
     if connection.schema_name != get_public_schema_name():
         return {"config": SiteConfig.get()}
     return {"config": None}
+
+
+def deck_status(request):
+    """Expose the current deck's Tenant row and public subscribe URL to templates.
+
+    Powers the deck status banner in base.html (trial / expiring / over-limit /
+    suspended, epic #1729). `current_deck` is None on the public and shared-library
+    schemas, which also suppresses the banner entirely.
+        TEMPLATE_CONTEXT_PROCESSORS = (
+            # ...
+            'hackerspace_online.context_processors.deck_status',
+        )
+    """
+    from tenant.utils import get_current_deck, get_public_subscribe_url
+
+    deck = get_current_deck()
+    if deck is None:
+        return {"current_deck": None}
+    return {"current_deck": deck, "deck_subscribe_url": get_public_subscribe_url()}

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -399,6 +399,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
 
                 'hackerspace_online.context_processors.config',
+                'hackerspace_online.context_processors.deck_status',
             ],
             # 'string_if_invalid': 'DEBUG WARNING: undefined template variable [%s] not found',
         },

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -46,6 +46,7 @@
 <!-- ** end  content_first block ** -->
 {% include 'navbar-fixed.html' %}
 <div class="container-fluid" id="main-container">
+    {% include 'deck_status_banner.html' %}
     <div id="messages-container">
         {% include 'messages-snippet.html' %}
     </div>

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -1,0 +1,47 @@
+{% comment %}
+Deck billing-status banner (epic #1729): rendered on every tenant page via base.html.
+`current_deck` and `deck_subscribe_url` come from the deck_status context processor;
+current_deck is None on the public/library schemas, which hides the banner entirely.
+Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > trial (staff).
+{% endcomment %}
+{% if current_deck %}
+    {% if current_deck.is_suspended %}
+        <div class="alert alert-danger" id="deck-status-banner">
+            {% if request.user.is_staff %}
+                <strong>This deck is suspended</strong> &mdash; its trial or subscription has ended, and it has
+                reverted to trial limits (max {{ current_deck.effective_max_active_users }} active students).
+                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore full access.
+            {% else %}
+                <strong>This deck is suspended.</strong> Please let your teacher know.
+            {% endif %}
+        </div>
+    {% elif request.user.is_staff %}
+        {% if current_deck.is_over_user_limit %}
+            <div class="alert alert-warning" id="deck-status-banner">
+                <strong>Active-student limit exceeded:</strong> this deck has {{ current_deck.active_user_count }}
+                active students of {{ current_deck.effective_max_active_users }} allowed.
+                Archive past students, or <a href="{{ deck_subscribe_url }}" class="alert-link">upgrade your subscription</a>.
+            </div>
+        {% elif current_deck.is_expiring_soon %}
+            <div class="alert alert-warning" id="deck-status-banner">
+                {% if current_deck.days_until_expiry < 0 %}
+                    <strong>Subscription expired</strong> &mdash; this deck is in its grace
+                    period and will revert to trial limits soon.
+                {% elif current_deck.is_on_trial %}
+                    <strong>Trial ending soon:</strong> this deck's free trial ends in
+                    {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.
+                {% else %}
+                    <strong>Subscription expiring:</strong> this deck's subscription ends in
+                    {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.
+                {% endif %}
+                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to keep full access.
+            </div>
+        {% elif current_deck.is_on_trial %}
+            <div class="alert alert-info" id="deck-status-banner">
+                <strong>Trial Mode:</strong> this deck is on a free trial until {{ current_deck.trial_end_date }}
+                (max {{ current_deck.effective_max_active_users }} active students).
+                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> for more.
+            </div>
+        {% endif %}
+    {% endif %}
+{% endif %}

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -49,6 +49,10 @@ TRIAL_MAX_ACTIVE_USERS = 5
 # for recently expired decks (#1494).
 GRACE_PERIOD_DAYS = 30
 
+# The status banner starts warning staff when the governing deadline (trial end or
+# paid_until) is this many days away or closer (#1733's "2 week notice").
+EXPIRY_WARNING_DAYS = 14
+
 
 class Tenant(TenantMixin):
     # for reference: https://django-tenants.readthedocs.io/en/stable/use.html#deleting-a-tenant
@@ -230,6 +234,32 @@ class Tenant(TenantMixin):
         if deadline is None:
             return None
         return (deadline - localdate()).days
+
+    @property
+    def is_over_user_limit(self):
+        """Whether the deck's cached active-student count exceeds its effective cap.
+
+        Advisory (banner/notification) check against the nightly-refreshed cached
+        count -- enforcement at the registration choke points recounts live.
+        Always False for unlimited (-1) decks.
+        """
+        if self.effective_max_active_users == -1:
+            return False
+        return self.active_user_count > self.effective_max_active_users
+
+    @property
+    def is_expiring_soon(self):
+        """Whether the governing deadline is within EXPIRY_WARNING_DAYS (or already
+        past, while still in the paid grace window) -- i.e. the status banner should
+        escalate from "info" to "warning".
+
+        False for suspended decks (they get the suspension banner instead) and for
+        unmanaged/comped decks (no deadline at all).
+        """
+        if self.is_suspended:
+            return False
+        days = self.days_until_expiry
+        return days is not None and days <= EXPIRY_WARNING_DAYS
 
     # END BILLING / LIFECYCLE STATUS ##################################
 

--- a/src/tenant/signals.py
+++ b/src/tenant/signals.py
@@ -23,7 +23,12 @@ def initialize_tenant_with_data(sender, tenant, **kwargs):
 
 
 def tenant_save_callback(sender, instance, **kwargs):
-    """ Create one tenant domain """
+    """ Create one tenant domain; invalidate the schema's cached deck row """
+    from .utils import invalidate_current_deck_cache
+
+    # any Tenant save (admin edit, cached-field refresh, future Stripe sync) must
+    # invalidate the cached row the status banner reads, so changes show promptly
+    invalidate_current_deck_cache(instance.schema_name)
 
     # Already have a domain so no further action required
     if instance.domains.exists():

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -11,7 +11,9 @@ from hackerspace_online import settings
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
 
-from tenant.models import GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS, Tenant, check_tenant_name, default_trial_end_date
+from tenant.models import (
+    EXPIRY_WARNING_DAYS, GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS, Tenant, check_tenant_name, default_trial_end_date,
+)
 
 User = get_user_model()
 
@@ -317,3 +319,44 @@ class DefaultTrialEndDateTest(SimpleTestCase):
         # Field defaults are applied at instantiation, so no save() (and no DB) is needed.
         tenant = Tenant(schema_name="demo", name="demo")
         self.assertEqual(tenant.trial_end_date, date(2024, 2, 29) + timedelta(days=60))
+
+
+@freeze_time(FROZEN_NOW)
+class TenantBannerStatusTest(SimpleTestCase):
+    """Tests for the banner-support properties is_over_user_limit and is_expiring_soon
+    (epic #1729 PR 3), on unsaved in-memory instances with today frozen at FROZEN_TODAY."""
+
+    def make_tenant(self, trial_end_date=None, paid_until=None, max_active_users=5, active_user_count=0):
+        """Build an unsaved Tenant with the given billing dates and cached count."""
+        return Tenant(
+            name='bannertest', trial_end_date=trial_end_date, paid_until=paid_until,
+            max_active_users=max_active_users, active_user_count=active_user_count,
+        )
+
+    def test_is_over_user_limit__compares_cached_count_to_effective_cap(self):
+        """Over-limit only when the cached count exceeds the effective cap; unlimited (-1) is never over."""
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=30), active_user_count=6).is_over_user_limit)
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=30), active_user_count=5).is_over_user_limit)
+        # subscribed deck uses its own (tier) cap, not the trial cap
+        self.assertFalse(
+            self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=30), max_active_users=40, active_user_count=39).is_over_user_limit
+        )
+        self.assertTrue(
+            self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=30), max_active_users=40, active_user_count=41).is_over_user_limit
+        )
+        self.assertFalse(self.make_tenant(max_active_users=-1, active_user_count=999).is_over_user_limit)
+
+    def test_is_expiring_soon__within_warning_window_or_grace(self):
+        """Warns within EXPIRY_WARNING_DAYS of the governing deadline, and through the
+        paid grace window (negative days); quiet before the window."""
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=EXPIRY_WARNING_DAYS)).is_expiring_soon)
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=EXPIRY_WARNING_DAYS + 1)).is_expiring_soon)
+        self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=3)).is_expiring_soon)
+        # in the paid grace window: expired but still subscription_active
+        self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=5)).is_expiring_soon)
+
+    def test_is_expiring_soon__false_for_suspended_and_unmanaged_decks(self):
+        """Suspended decks get the suspension banner instead, and dateless (comped)
+        decks have no deadline to warn about."""
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).is_expiring_soon)
+        self.assertFalse(self.make_tenant().is_expiring_soon)

--- a/src/tenant/tests/test_utils.py
+++ b/src/tenant/tests/test_utils.py
@@ -33,10 +33,21 @@ class GetCurrentDeckTest(ByteDeckTenantTestCase):
         with patch('library.utils.get_library_schema_name', return_value=self.tenant.schema_name):
             self.assertIsNone(get_current_deck())
 
+    def test_get_current_deck__none_when_schema_has_no_tenant_row(self):
+        """A schema with no matching Tenant row (e.g. an orphaned schema left by a
+        deleted deck) yields None, and nothing gets cached for it."""
+        with schema_context('orphanschema'):
+            self.assertIsNone(get_current_deck())
+        self.assertIsNone(cache.get(deck_cache_key('orphanschema')))
+
     def test_get_current_deck__caches_and_invalidates_on_save(self):
         """The row is served from cache until a Tenant save invalidates it."""
         get_current_deck()  # prime the cache
         self.assertIsNotNone(cache.get(deck_cache_key(self.tenant.schema_name)))
+
+        # a warm cache serves the row without touching the database
+        with self.assertNumQueries(0):
+            self.assertEqual(get_current_deck().schema_name, self.tenant.schema_name)
 
         # a change persisted via save() (signal fires) becomes visible immediately
         self.tenant.max_active_users = 42

--- a/src/tenant/tests/test_utils.py
+++ b/src/tenant/tests/test_utils.py
@@ -1,0 +1,87 @@
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+
+from django_tenants.utils import get_public_schema_name, schema_context
+
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from tenant.utils import deck_cache_key, get_current_deck, get_public_subscribe_url
+
+
+class GetCurrentDeckTest(ByteDeckTenantTestCase):
+    """Tests for the cached per-schema Tenant accessor behind the status banner (epic #1729 PR 3)."""
+
+    def setUp(self):
+        """Clear this schema's deck cache -- the cache backend outlives the per-test transaction."""
+        cache.delete(deck_cache_key(self.tenant.schema_name))
+
+    def test_get_current_deck__returns_this_schemas_tenant(self):
+        """Inside a deck's schema, the accessor returns that deck's Tenant row."""
+        deck = get_current_deck()
+        self.assertIsNotNone(deck)
+        self.assertEqual(deck.schema_name, self.tenant.schema_name)
+
+    def test_get_current_deck__none_on_public_schema(self):
+        """The public schema is not a deck, so the accessor returns None there."""
+        with schema_context(get_public_schema_name()):
+            self.assertIsNone(get_current_deck())
+
+    def test_get_current_deck__none_on_library_schema(self):
+        """The shared-library schema is not a billable deck, so the accessor returns None
+        there without touching the cache or database."""
+        from unittest.mock import patch
+
+        with patch('library.utils.get_library_schema_name', return_value=self.tenant.schema_name):
+            self.assertIsNone(get_current_deck())
+
+    def test_get_current_deck__caches_and_invalidates_on_save(self):
+        """The row is served from cache until a Tenant save invalidates it."""
+        get_current_deck()  # prime the cache
+        self.assertIsNotNone(cache.get(deck_cache_key(self.tenant.schema_name)))
+
+        # a change persisted via save() (signal fires) becomes visible immediately
+        self.tenant.max_active_users = 42
+        self.tenant.save()
+        self.assertIsNone(cache.get(deck_cache_key(self.tenant.schema_name)))
+        self.assertEqual(get_current_deck().max_active_users, 42)
+
+    # The test settings replace the cache with a plain LocMem one, dropping the
+    # schema-prefixing KEY_FUNCTION that production uses -- restore it here or
+    # this test cannot reproduce the cross-schema invalidation bug it pins.
+    @override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'tenant-prefixed-test',
+            'KEY_FUNCTION': 'django_tenants.cache.make_key',
+            'REVERSE_KEY_FUNCTION': 'django_tenants.cache.reverse_key',
+        }
+    })
+    def test_get_current_deck__invalidated_by_save_from_public_schema(self):
+        """A Tenant save from the PUBLIC schema (admin edits, future Stripe syncs)
+        must invalidate the deck's cached row despite the schema-prefixed cache
+        keys (django_tenants KEY_FUNCTION) -- fails without the schema_context
+        wrap in invalidate_current_deck_cache."""
+        get_current_deck()  # prime the cache from inside the tenant schema
+
+        with schema_context(get_public_schema_name()):
+            self.tenant.max_active_users = 77
+            self.tenant.save()
+
+        self.assertEqual(get_current_deck().max_active_users, 77)
+
+
+class GetPublicSubscribeUrlTest(SimpleTestCase):
+    """Tests for the absolute public subscribe URL used by the status banner.
+
+    Flatpages are per-schema, so the banner must never link a schema-relative
+    /pages/subscribe/ (it would 404 on deck subdomains).
+    """
+
+    @override_settings(ROOT_DOMAIN='localhost')
+    def test_get_public_subscribe_url__development(self):
+        """On a localhost deployment the URL uses http and the dev port."""
+        self.assertEqual(get_public_subscribe_url(), 'http://localhost:8000/pages/subscribe/')
+
+    @override_settings(ROOT_DOMAIN='bytedeck.com')
+    def test_get_public_subscribe_url__production(self):
+        """On a real domain the URL uses https with no port."""
+        self.assertEqual(get_public_subscribe_url(), 'https://bytedeck.com/pages/subscribe/')

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -522,3 +522,83 @@ class EmailVerificationRequiredMixinTest(TestCase):
         request = make_request(stale_ts)
         response = self.view(request)
         self.assertEqual(response.status_code, 403)
+
+
+class DeckStatusBannerTest(ByteDeckTenantTestCase):
+    """Rendering tests for the deck status banner in base.html (epic #1729 PR 3;
+    closes the Trial Mode banner checkbox of #1730)."""
+
+    def setUp(self):
+        """Log in per-role users and clear the cached deck row (the cache backend
+        outlives each test's transaction)."""
+        from django.core.cache import cache
+        from model_bakery import baker
+
+        from tenant.utils import deck_cache_key
+
+        cache.delete(deck_cache_key(self.tenant.schema_name))
+        self.client = TenantClient(self.tenant)
+        self.staff = baker.make(User, is_staff=True)
+        self.student = baker.make(User)
+
+    def set_deck(self, **fields):
+        """Persist billing fields on this deck via save() so the cache invalidates."""
+        for name, value in fields.items():
+            setattr(self.tenant, name, value)
+        self.tenant.save()
+
+    def get_quests_page(self, user):
+        """Return the quest-list page (which extends base.html) as the given user."""
+        self.client.force_login(user)
+        response = self.client.get(reverse('quests:quests'))
+        self.assertEqual(response.status_code, 200)
+        return response
+
+    def test_banner__trial_mode_shown_to_staff_with_subscribe_link(self):
+        """Staff on a trial deck see the Trial Mode banner with an absolute subscribe
+        link to the public host."""
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'Trial Mode')
+        self.assertContains(response, '/pages/subscribe/')
+
+    def test_banner__not_shown_to_students_on_trial_deck(self):
+        """Students never see the trial banner (it's staff-facing nagware)."""
+        response = self.get_quests_page(self.student)
+        self.assertNotContains(response, 'deck-status-banner')
+
+    def test_banner__suspended_deck_warns_everyone(self):
+        """On a suspended deck, staff get the subscribe call-to-action and students
+        get the 'let your teacher know' variant."""
+        from datetime import date
+
+        self.set_deck(trial_end_date=date(2020, 1, 1), paid_until=None)
+
+        response = self.get_quests_page(self.student)
+        self.assertContains(response, 'This deck is suspended')
+        self.assertContains(response, 'let your teacher know')
+
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'This deck is suspended')
+        self.assertContains(response, '/pages/subscribe/')
+
+    def test_banner__over_limit_warns_staff(self):
+        """Staff see the over-limit warning when the cached count exceeds the cap."""
+        self.set_deck(active_user_count=99)
+
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'Active-student limit exceeded')
+
+    def test_banner__expiring_soon_warns_staff(self):
+        """Staff see the expiring-soon warning inside the two-week window, for both
+        trial and subscribed decks."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=localdate() + timedelta(days=3))
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'Trial ending soon')
+
+        self.set_deck(trial_end_date=None, paid_until=localdate() + timedelta(days=3))
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'Subscription expiring')

--- a/src/tenant/utils.py
+++ b/src/tenant/utils.py
@@ -226,3 +226,64 @@ class DeckRequestService:
             args=[subject, message, [user.email]],
             queue="default",
         )
+
+
+def deck_cache_key(schema_name):
+    """Cache key for the per-schema cached Tenant row used by get_current_deck."""
+    return f'{schema_name}-deck'
+
+
+def invalidate_current_deck_cache(schema_name):
+    """Drop the cached Tenant row for a schema (called on every Tenant save).
+
+    The cache's KEY_FUNCTION (django_tenants.cache.make_key) prefixes every key
+    with the CURRENT connection's schema, and Tenant saves usually happen from
+    the public schema (admin edits; later, Stripe webhooks). Deleting inside
+    schema_context(schema_name) makes the prefix match the one the banner's
+    get_current_deck() used when it cached the row -- without it, the delete
+    silently targets a different key and the banner stays stale for up to an hour.
+    """
+    from django_tenants.utils import schema_context
+
+    with schema_context(schema_name):
+        cache.delete(deck_cache_key(schema_name))
+
+
+def get_current_deck():
+    """Return the current schema's Tenant row for status/banner display, or None.
+
+    None on the public schema and the shared-library schema (not billable decks).
+    The row is cached per schema for an hour -- mirroring the SiteConfig.get()
+    pattern, since the status banner reads it on every page -- and invalidated by
+    the Tenant post_save signal so admin edits (and later, Stripe syncs) show
+    promptly.
+    """
+    from django.db import connection
+    from django_tenants.utils import get_public_schema_name
+    from library.utils import get_library_schema_name
+
+    schema_name = connection.schema_name
+    if schema_name in (get_public_schema_name(), get_library_schema_name()):
+        return None
+
+    cache_key = deck_cache_key(schema_name)
+    deck = cache.get(cache_key)
+    if deck is None:
+        deck = Tenant.objects.filter(schema_name=schema_name).first()
+        if deck is not None:
+            cache.set(cache_key, deck, 60 * 60)
+    return deck
+
+
+def get_public_subscribe_url():
+    """Absolute URL of the public tenant's subscribe page.
+
+    Flatpages are per-schema, so a schema-relative "/pages/subscribe/" link 404s on
+    every deck subdomain -- the banner must link to the public host explicitly.
+    Mirrors Tenant.get_root_url()'s dev/production scheme handling.
+    """
+    from django.conf import settings
+
+    if 'localhost' in settings.ROOT_DOMAIN:  # Development
+        return f"http://{settings.ROOT_DOMAIN}:8000/pages/subscribe/"
+    return f"https://{settings.ROOT_DOMAIN}/pages/subscribe/"


### PR DESCRIPTION
### What?
Step 3 of the #1729 epic — the per-deck status banner in `base.html`, closing the **last open checkbox of #1730** ("Deck displays a Trial Mode banner with link to subscribe"):

* New `Tenant` properties `is_over_user_limit` and `is_expiring_soon` (with `EXPIRY_WARNING_DAYS = 14`, per #1733's two-week notice) — pure derivations, no migration.
* `tenant.utils.get_current_deck()`: a per-schema cached `Tenant` accessor (mirroring the `SiteConfig.get()` pattern; `None` on the public and shared-library schemas), invalidated on every `Tenant` save.
* `deck_status` context processor exposing the deck plus an **absolute** public subscribe URL — flatpages are per-schema, so a relative `/pages/subscribe/` would 404 on deck subdomains.
* `deck_status_banner.html`, rendered by priority: **suspended** (all users; staff get a subscribe link, students get "let your teacher know") → **over-limit** (staff) → **expiring/grace** (staff) → **Trial Mode** info bar (staff).

### Why?
Deck owners currently get no in-app signal about their trial, subscription, or user-count status — the epic's reminder emails (#1733, plan PR 5) need a persistent in-app counterpart, and #1730 explicitly asks for the trial banner. Everything renders from the already-cached local row: zero extra queries per page after the first (cached 1 h), no Stripe dependency.

### How?
One noteworthy fix baked in: the cache uses `django_tenants.cache.make_key`, which prefixes keys with the **current connection's schema** — so an admin editing a deck's dates from the public-schema admin would invalidate the wrong key and leave the banner stale for up to an hour. `invalidate_current_deck_cache()` therefore deletes inside `schema_context(schema_name)`. The regression test restores the production `KEY_FUNCTION` (the default test cache is un-prefixed LocMem, which hides the bug) and fails without the fix.

### Testing?
* 13 new tests: property boundaries (over-limit incl. unlimited passthrough; expiring incl. the grace window), `get_current_deck` caching/exclusions/invalidation (incl. the cross-schema regression above), and every banner variant rendered through real page loads as staff and student.
* Full serial suite: **1263 tests, OK**; `ruff` and `makemigrations --check --dry-run` clean (no model field changes).

### Screenshots (if front end is affected)
Captured from the running app (dev server, dark theme). **Before** — staff quest page, no banner:

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1730/before-staff-quests.png)

**After** — staff view of a trial deck (info banner with subscribe link):

![after trial](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1730/after-staff-trial.png)

**After** — student view of a suspended deck:

![after suspended](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1730/after-student-suspended.png)

### Anything Else?
* With this merged, **#1730 can be closed** once the cap-enforcement piece (plan PR 4, next) lands — the banner checkbox was its last UI item.
* The subscribe link points at the public `/pages/subscribe/` flatpage until the in-app checkout (`decks:subscribe`, plan PR 6) exists, then it swaps.
* Next per the plan's phasing (auto-starting on merge, per maintainer instruction): PR 4 — active-user cap enforcement at the course-registration choke points.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_