### PR TITLE
Cover announcements/views.py toward 100% (Create/Update CBVs + paging)

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
@@ -434,3 +436,91 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     #     for announcement in announcements:
     #         announcement.refresh_from_db()
     #         self.assertTrue(announcement.archived)
+
+
+class AnnouncementCreateUpdateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+    """Covers the Create/Update CBV form_valid + success-message branches and EmptyPage paging."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a staff author and one existing published announcement to edit."""
+        cls.teacher = User.objects.create_user('cu_teacher', is_staff=True)
+        cls.announcement = baker.make(Announcement, draft=False)
+
+    def setUp(self):
+        """Set up a tenant test client for each test."""
+        self.client = TenantClient(self.tenant)
+
+    def _form_data(self, **overrides):
+        """Return valid AnnouncementForm POST data (title/content/release), with overrides applied."""
+        data = {
+            'title': 'Test Announcement',
+            'content': 'Some content',
+            'datetime_released': timezone.now().strftime('%Y-%m-%d %H:%M'),
+            'auto_publish': False,
+            'draft': False,
+            'sticky': False,
+            'archived': False,
+        }
+        data.update(overrides)
+        return data
+
+    @patch('announcements.views.send_notifications.apply_async')
+    def test_create__published_saves_sets_author_and_broadcasts(self, mock_send):
+        """Creating a non-draft announcement saves it, sets the author, and queues notifications."""
+        self.client.force_login(self.teacher)
+        response = self.client.post(reverse('announcements:create'), self._form_data(draft=False))
+
+        new = Announcement.objects.get(title='Test Announcement')
+        self.assertRedirects(response, new.get_absolute_url())
+        self.assertEqual(new.author, self.teacher)
+        self.assertFalse(new.draft)
+        mock_send.assert_called_once()
+        # Non-draft create shows the "published and broadcast" success message.
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(any('published and broadcast' in str(m) for m in messages))
+
+    @patch('announcements.views.send_notifications.apply_async')
+    def test_create__draft_does_not_broadcast(self, mock_send):
+        """Creating a draft announcement saves it but does not queue notifications."""
+        self.client.force_login(self.teacher)
+        response = self.client.post(reverse('announcements:create'), self._form_data(draft=True))
+
+        new = Announcement.objects.get(title='Test Announcement')
+        self.assertRedirects(response, new.get_absolute_url())
+        self.assertTrue(new.draft)
+        mock_send.assert_not_called()
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(any('Draft' in str(m) and 'created' in str(m) for m in messages))
+
+    def test_update__published_shows_not_rebroadcast_message(self):
+        """Editing a published announcement shows the 'updated but NOT (re-)broadcasted' message."""
+        self.client.force_login(self.teacher)
+        response = self.client.post(
+            reverse('announcements:update', args=[self.announcement.pk]),
+            self._form_data(draft=False, title='Edited Title'),
+        )
+
+        self.announcement.refresh_from_db()
+        self.assertRedirects(response, self.announcement.get_absolute_url())
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(any('NOT (re-)broadcasted' in str(m) for m in messages))
+
+    def test_update__draft_shows_draft_updated_message(self):
+        """Editing an announcement as a draft shows the 'Draft ... updated' message."""
+        self.client.force_login(self.teacher)
+        response = self.client.post(
+            reverse('announcements:update', args=[self.announcement.pk]),
+            self._form_data(draft=True, title='Edited Draft'),
+        )
+
+        self.announcement.refresh_from_db()
+        self.assertRedirects(response, self.announcement.get_absolute_url())
+        messages = list(get_messages(response.wsgi_request))
+        self.assertTrue(any('Draft' in str(m) and 'updated' in str(m) for m in messages))
+
+    def test_list__out_of_range_page_returns_last_page(self):
+        """Requesting a page past the end delivers the last page instead of erroring (EmptyPage)."""
+        self.client.force_login(self.teacher)
+        response = self.client.get(reverse('announcements:list'), {'page': 9999})
+        self.assertEqual(response.status_code, 200)

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -193,7 +193,8 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # self.add_error("auto_publish", forms.ValidationError('An Announcement that is archived cannot be auto published.'))
 
     def test_comment_on_announcement__by_student(self):
-        """A student's comment post requires the comment_button, returning 404 without it."""
+        """A student's comment post 404s without the comment_button, and succeeds
+        (redirect + comment saved) with it."""
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -203,22 +204,15 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.post(reverse('announcements:comment', args=[self.test_announcement.id]), form_data)
         self.assertEqual(response.status_code, 404)  # invalid submit button
 
-        # make sure it was submitted with the 'comment_button'
+        # With the comment_button present the post succeeds: it redirects back to the
+        # announcement and the comment is saved.
         form_data['comment_button'] = True
         response = self.client.post(
             reverse('announcements:comment', args=[self.test_announcement.id]),
             data=form_data
         )
-
-        # Empty comment strings should be replaced with blank string or we get an error
-        # WHY? THIS SEEMS SILLY! THE FORM SHOULDN'T VALIDATE IF THERE IS NO COMMENT!
-        # Old code not relevant any more?
-        # form_data['comment_text'] = None
-        # response = self.client.post(
-        #     reverse('announcements:comment', args=[self.test_announcement.id]),
-        #     data=form_data
-        # )
-        # self.assertRedirects(response, self.test_announcement.get_absolute_url())
+        self.assertRedirects(response, self.test_announcement.get_absolute_url())
+        self.assertTrue(Comment.objects.all_with_target_object(self.test_announcement).exists())
 
     def test_comment_on_announcement__escapes_html(self):
         """HTML entered in the announcement comment form is completely escaped when

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -520,7 +520,15 @@ class AnnouncementCreateUpdateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCa
         self.assertTrue(any('Draft' in str(m) and 'updated' in str(m) for m in messages))
 
     def test_list__out_of_range_page_returns_last_page(self):
-        """Requesting a page past the end delivers the last page instead of erroring (EmptyPage)."""
+        """Requesting a page past the end delivers the LAST page, not page 1 (EmptyPage fallback)."""
+        # The list paginates at 20/page; make enough active announcements for at least 2 pages
+        # (setUpTestData already created one), so serving page 1 vs the last page is distinguishable.
+        baker.make(Announcement, draft=False, datetime_released=timezone.now() - timedelta(days=1), _quantity=25)
         self.client.force_login(self.teacher)
+
         response = self.client.get(reverse('announcements:list'), {'page': 9999})
+
         self.assertEqual(response.status_code, 200)
+        page = response.context['object_list']
+        self.assertGreater(page.paginator.num_pages, 1)
+        self.assertEqual(page.number, page.paginator.num_pages)

--- a/src/announcements/views.py
+++ b/src/announcements/views.py
@@ -39,7 +39,9 @@ def comment(request, ann_id):
 
         if form.is_valid():
             comment_text = form.cleaned_data.get('comment_text')
-            if not comment_text:
+            # Defensive: CommentForm.comment_text is a required CharField, so a valid form
+            # always has non-empty text here; this fallback never fires. Excluded from coverage.
+            if not comment_text:  # pragma: no cover
                 comment_text = ""
             comment_new = Comment.objects.create_comment(
                 user=request.user,


### PR DESCRIPTION
### What?

Next gap-closing PR. Brings `announcements/views.py` from **87% → ~100% of intended** by testing the uncovered class-based-view branches and the out-of-range pagination path, and tidies one existing weak test in the same file.

### Why?

`announcements/views.py` was the next-biggest concentrated view gap. The uncovered code is the create/edit flow (author assignment, broadcast-on-publish, the draft vs published success messages) and the last-page pagination fallback — reachable, user-facing behaviour worth locking in.

### How?

New `AnnouncementCreateUpdateViewTests` in `announcements/tests/test_views.py`:
- **`Create.form_valid`** — a published (non-draft) announcement is saved, gets its `author` set, and queues `send_notifications` (patched so no Celery); a draft is saved but does **not** broadcast.
- **`Create` / `Update.get_success_message`** — the draft vs published/updated success messages for both create and edit.
- **`list()` `EmptyPage` handling** — an out-of-range `?page=` returns the **last** page (26 announcements → 2 pages, asserting `page.number == paginator.num_pages`, not just a 200).

One intended exclusion: the empty-comment fallback in `comment()` is unreachable — `CommentForm.comment_text` is a required `CharField`, so a valid form always has non-empty text — so it's marked `# pragma: no cover` with that rationale (per the coverage policy from #2065).

**Test-quality tidy (same file):** `test_comment_on_announcement__by_student` posted with the `comment_button` but asserted nothing on that valid path, and carried a block of commented-out dead code. It now asserts the successful post redirects to the announcement and that the comment is saved, and the dead block is removed.

### Testing?

- `python manage.py test announcements` → **34 passing** (+5 new); `ruff` clean; `test_conventions` passes.
- Verified via coverage that every targeted line is now covered or explicitly excluded; `views.py` rises from 87% to **99%** (0 missing statements — the 2 remaining partial branches are pre-existing in the `active_object` paging loop, out of scope here).

### Screenshots (if front end is affected)

N/A — test-only, plus one `# pragma: no cover`.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Going forward these coverage PRs also fold in trivial fixes to the existing tests in each app they touch (dead code, missing assertions, misleading docstrings).

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved reliable handling of empty comment submissions in the announcement commenting flow.
  * Improved resilience when viewing announcement list pages beyond the available results.
* **Tests**
  * Expanded coverage for create/update behavior of published vs draft announcements, including author assignment, notification broadcasting, user-facing success messages, comment posting, and out-of-range pagination fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->