### PR TITLE
Show repeatable quests in cooldown as "available again soon" with a countdown (#57)

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -551,6 +551,28 @@ class QuestManager(models.Manager):
         qs = self.get_active().get_conditions_met(user).available_without_course()
         return qs.not_in_progress_completed_or_cooldown(user)
 
+    def get_in_cooldown(self, user):
+        """Repeatable quests the user completed this semester that are still within cooldown (issue #57).
+
+        These would be available to repeat except that their per-quest cooldown
+        (``hours_between_repeats``) hasn't elapsed since the last completion, so the Available tab
+        shows them as "available again soon" (with a countdown) instead of letting them be started.
+        Quests already at their repeat cap are excluded — they won't come back. Uses the same active /
+        prerequisite / not-in-progress / not-hidden filters as ``get_available`` so the two lists are
+        consistent and disjoint (``get_available`` excludes exactly these via its cooldown condition).
+        """
+        now = timezone.now()
+        qs = self.get_active().select_related('campaign').get_conditions_met(user).not_in_progress(user)
+        completed_quest_ids = QuestSubmission.objects.all_completed(user=user).values_list('quest_id', flat=True)
+        qs = qs.filter(pk__in=completed_quest_ids).exclude_hidden(user)
+
+        cooldown_ids = []
+        for quest in qs:
+            next_available = quest.next_repeat_available(user)
+            if next_available is not None and next_available > now:
+                cooldown_ids.append(quest.pk)
+        return qs.filter(pk__in=cooldown_ids)
+
     def all_drafts(self, user):
         """
         Return a queryset of draft quests (not published)
@@ -708,6 +730,36 @@ class Quest(IsAPrereqMixin, HasPrereqsMixin, TagsModelMixin, XPItem):
             return True
         else:
             return False
+
+    def next_repeat_available(self, user):
+        """When this repeatable quest will next be available to `user` to repeat, or None (issue #57).
+
+        Returns a datetime — the last completion time plus ``hours_between_repeats`` — when the user
+        has completed this repeatable quest but has not yet reached its repeat cap. Returns None when
+        the quest is not repeatable, has never been completed by the user, or has already reached its
+        repeat cap (so it will not become available again). The datetime may be in the past if the
+        cooldown has already elapsed (i.e. the quest is available to repeat right now). Mirrors the
+        cap/timing logic of ``is_repeat_available``.
+        """
+        if self.max_repeats == 0 and not self.repeat_per_semester:
+            return None  # not repeatable
+
+        submissions = QuestSubmission.objects.all_for_user_quest(user, self, False)
+        if not submissions.exists():
+            return None
+
+        latest_sub = submissions.latest('first_time_completed')
+        if not latest_sub.first_time_completed:
+            return None  # the latest attempt is still in progress, not completed
+
+        # already at the repeat cap → it won't come back
+        if self.repeat_per_semester:
+            if QuestSubmission.objects.all_completed(user=user).filter(quest=self).count() > self.max_repeats:
+                return None
+        elif self.max_repeats != -1 and latest_sub.ordinal > self.max_repeats:
+            return None
+
+        return latest_sub.first_time_completed + timezone.timedelta(hours=self.hours_between_repeats)
 
     def condition_met_as_prerequisite(self, user, num_required=1):
         """

--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -110,6 +110,28 @@ back to its original look.
         {% endif %}
       {% endif %}
       {% include 'quest_manager/tab_quests_available.html' %}
+
+      {% comment %} Repeatable quests you've completed that are waiting out their cooldown (#57) {% endcomment %}
+      {% if cooldown_quests %}
+        <div class="panel panel-default" style="margin-top: 1em;">
+          <div class="panel-heading">
+            <i class="fa fa-fw fa-history"></i> Available again soon
+            <small class="text-muted">&mdash; repeatable quests you've done, back after a cooldown</small>
+          </div>
+          <ul class="list-group">
+            {% for q in cooldown_quests %}
+              <li class="list-group-item">
+                <img class="img-rounded" src="{{ q.get_icon_url }}" alt="icon"
+                     style="width:1.6em; height:1.6em; vertical-align:middle; margin-right:0.4em;">
+                <a href="{% url 'quests:quest_detail' q.id %}">{{ q.name }}</a>
+                <span class="pull-right text-muted">
+                  <i class="fa fa-fw fa-clock-o"></i> Available in {{ q.cooldown_available_at|timeuntil }}
+                </span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
     </div>
     <div role="tabpanel"
          class="tab-pane fade {% if view_type == VIEW_TYPES.IN_PROGRESS %}in active{% endif %}" id="inprogress">

--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -109,11 +109,11 @@ back to its original look.
           <p>There are currently no new quest available to you!</p>
         {% endif %}
       {% endif %}
-      {% include 'quest_manager/tab_quests_available.html' %}
 
-      {% comment %} Repeatable quests you've completed that are waiting out their cooldown (#57) {% endcomment %}
+      {% comment %} Repeatable quests you've completed that are waiting out their cooldown (#57).
+         Shown above the available-quests list so it's the first thing a student sees. {% endcomment %}
       {% if cooldown_quests %}
-        <div class="panel panel-default" style="margin-top: 1em;">
+        <div class="panel panel-default" style="margin-bottom: 1em;">
           <div class="panel-heading">
             <i class="fa fa-fw fa-history"></i> Available again soon
             <small class="text-muted">&mdash; repeatable quests you've done, back after a cooldown</small>
@@ -132,6 +132,8 @@ back to its original look.
           </ul>
         </div>
       {% endif %}
+
+      {% include 'quest_manager/tab_quests_available.html' %}
     </div>
     <div role="tabpanel"
          class="tab-pane fade {% if view_type == VIEW_TYPES.IN_PROGRESS %}in active{% endif %}" id="inprogress">

--- a/src/quest_manager/tests/test_cooldown.py
+++ b/src/quest_manager/tests/test_cooldown.py
@@ -108,8 +108,16 @@ class GetInCooldownManagerTests(CooldownTestMixin, ByteDeckTenantTestCase):
         self.assertIn(self.quest, Quest.objects.get_available(self.test_student))
 
     def test_get_in_cooldown__excludes_in_progress_quest(self):
-        """A quest with an in-progress (uncompleted) attempt is not shown as in cooldown."""
+        """A quest with an in-progress (uncompleted / just-started) attempt is not shown as in cooldown."""
         QuestSubmission.objects.create_submission(self.test_student, self.quest)  # started, not completed
+        self.assertNotIn(self.quest, Quest.objects.get_in_cooldown(self.test_student))
+
+    def test_get_in_cooldown__excludes_quest_with_returned_attempt(self):
+        """A quest whose latest attempt was returned (still in progress) is not shown as in cooldown."""
+        self._complete()  # attempt 1 completed → would otherwise be in cooldown
+        returned = QuestSubmission.objects.create_submission(self.test_student, self.quest)  # attempt 2
+        returned.mark_completed()
+        returned.mark_returned()  # teacher returns it → is_completed=False (an active, in-progress submission)
         self.assertNotIn(self.quest, Quest.objects.get_in_cooldown(self.test_student))
 
     def test_get_in_cooldown__excludes_non_repeatable_quest(self):

--- a/src/quest_manager/tests/test_cooldown.py
+++ b/src/quest_manager/tests/test_cooldown.py
@@ -1,0 +1,145 @@
+"""Tests for the repeatable-quest cooldown "available again soon" surface (issue #57)."""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from django_tenants.test.client import TenantClient
+from freezegun import freeze_time
+from model_bakery import baker
+
+from courses.models import CourseStudent
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from quest_manager.models import Quest, QuestSubmission
+from siteconfig.models import SiteConfig
+
+User = get_user_model()
+
+
+class CooldownTestMixin:
+    """Shared setup: a student enrolled this semester with a completed repeatable (24h cooldown) quest."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a teacher, an enrolled student, and a repeatable quest the student just completed."""
+        cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.test_student = User.objects.create_user('test_student')
+        cls.semester = SiteConfig.get().active_semester
+        baker.make(CourseStudent, user=cls.test_student, semester=cls.semester)
+
+        # unlimited repeats, 24h cooldown between them
+        cls.quest = baker.make(Quest, name="Daily Quest", max_repeats=-1, hours_between_repeats=24)
+
+    def setUp(self):
+        """Set up a tenant-aware test client."""
+        self.client = TenantClient(self.tenant)
+
+    def _complete(self, quest=None):
+        """Create and complete a submission of `quest` (defaults to self.quest) for the student."""
+        quest = quest or self.quest
+        sub = QuestSubmission.objects.create_submission(self.test_student, quest)
+        sub.mark_completed()
+        return sub
+
+
+class NextRepeatAvailableModelTests(CooldownTestMixin, ByteDeckTenantTestCase):
+
+    def test_next_repeat_available__none_when_not_repeatable(self):
+        """A non-repeatable quest never has a next-repeat time."""
+        one_off = baker.make(Quest, max_repeats=0, repeat_per_semester=False)
+        QuestSubmission.objects.create_submission(self.test_student, one_off).mark_completed()
+        self.assertIsNone(one_off.next_repeat_available(self.test_student))
+
+    def test_next_repeat_available__none_when_never_completed(self):
+        """A repeatable quest the student hasn't completed has no next-repeat time."""
+        self.assertIsNone(self.quest.next_repeat_available(self.test_student))
+
+    def test_next_repeat_available__future_while_in_cooldown(self):
+        """Right after completion, the next-repeat time is the cooldown window into the future."""
+        self._complete()
+        next_at = self.quest.next_repeat_available(self.test_student)
+        self.assertIsNotNone(next_at)
+        # ~24h from now (allow a little slack for execution time)
+        self.assertGreater(next_at, timezone.now() + timedelta(hours=23))
+        self.assertLess(next_at, timezone.now() + timedelta(hours=25))
+
+    def test_next_repeat_available__in_past_once_cooldown_elapsed(self):
+        """Once the cooldown has elapsed, the next-repeat time is in the past (available now)."""
+        with freeze_time(timezone.now() - timedelta(hours=25)):
+            self._complete()
+        next_at = self.quest.next_repeat_available(self.test_student)
+        self.assertIsNotNone(next_at)
+        self.assertLess(next_at, timezone.now())
+
+    def test_next_repeat_available__none_when_repeat_cap_reached(self):
+        """A quest at its repeat cap won't come back, so it has no next-repeat time."""
+        capped = baker.make(Quest, max_repeats=1, hours_between_repeats=24)
+        self._complete(capped)  # ordinal 1
+        self._complete(capped)  # ordinal 2 > max_repeats=1 → capped out
+        self.assertIsNone(capped.next_repeat_available(self.test_student))
+
+    def test_next_repeat_available__none_when_per_semester_cap_reached(self):
+        """A once-per-semester quest already done this semester won't come back until next semester."""
+        per_sem = baker.make(Quest, max_repeats=0, repeat_per_semester=True, hours_between_repeats=24)
+        self._complete(per_sem)  # one completion this semester == the per-semester cap
+        self.assertIsNone(per_sem.next_repeat_available(self.test_student))
+
+    def test_next_repeat_available__none_when_latest_attempt_in_progress(self):
+        """With only an in-progress (never-completed) attempt, there's no next-repeat time."""
+        QuestSubmission.objects.create_submission(self.test_student, self.quest)  # started, not completed
+        self.assertIsNone(self.quest.next_repeat_available(self.test_student))
+
+
+class GetInCooldownManagerTests(CooldownTestMixin, ByteDeckTenantTestCase):
+
+    def test_get_in_cooldown__includes_quest_while_in_cooldown(self):
+        """A just-completed repeatable quest appears in the cooldown list (and not in available)."""
+        self._complete()
+        self.assertIn(self.quest, Quest.objects.get_in_cooldown(self.test_student))
+        self.assertNotIn(self.quest, Quest.objects.get_available(self.test_student))
+
+    def test_get_in_cooldown__empty_once_cooldown_elapsed(self):
+        """After the cooldown passes the quest leaves the cooldown list (it's available again)."""
+        with freeze_time(timezone.now() - timedelta(hours=25)):
+            self._complete()
+        self.assertNotIn(self.quest, Quest.objects.get_in_cooldown(self.test_student))
+        self.assertIn(self.quest, Quest.objects.get_available(self.test_student))
+
+    def test_get_in_cooldown__excludes_in_progress_quest(self):
+        """A quest with an in-progress (uncompleted) attempt is not shown as in cooldown."""
+        QuestSubmission.objects.create_submission(self.test_student, self.quest)  # started, not completed
+        self.assertNotIn(self.quest, Quest.objects.get_in_cooldown(self.test_student))
+
+    def test_get_in_cooldown__excludes_non_repeatable_quest(self):
+        """A completed non-repeatable quest is never in the cooldown list."""
+        one_off = baker.make(Quest, name="One Off", max_repeats=0, repeat_per_semester=False)
+        self._complete(one_off)
+        self.assertNotIn(one_off, Quest.objects.get_in_cooldown(self.test_student))
+
+
+class CooldownViewTests(CooldownTestMixin, ViewTestUtilsMixin, ByteDeckTenantTestCase):
+
+    def test_quest_list__available_tab_lists_cooldown_quest(self):
+        """The Available tab shows a completed-in-cooldown quest with its countdown."""
+        self._complete()
+        self.client.force_login(self.test_student)
+        response = self.client.get(reverse('quests:available'))
+        self.assertIn(self.quest, response.context['cooldown_quests'])
+        self.assertContains(response, "Available again soon")
+
+    def test_quest_list__no_cooldown_section_without_cooldown_quests(self):
+        """With nothing in cooldown, the Available tab omits the cooldown section."""
+        self.client.force_login(self.test_student)
+        response = self.client.get(reverse('quests:available'))
+        self.assertEqual(list(response.context['cooldown_quests']), [])
+        self.assertNotContains(response, "Available again soon")
+
+    def test_start__already_in_progress_shows_message(self):
+        """Starting a quest that's already in progress redirects to it with an explanatory message."""
+        sub = QuestSubmission.objects.create_submission(self.test_student, self.quest)
+        self.client.force_login(self.test_student)
+        response = self.client.get(reverse('quests:start', args=[self.quest.id]), follow=True)
+        self.assertRedirects(response, sub.get_absolute_url())
+        self.assertContains(response, "already have")

--- a/src/quest_manager/tests/test_cooldown.py
+++ b/src/quest_manager/tests/test_cooldown.py
@@ -86,6 +86,14 @@ class NextRepeatAvailableModelTests(CooldownTestMixin, ByteDeckTenantTestCase):
         self._complete(per_sem)  # one completion this semester == the per-semester cap
         self.assertIsNone(per_sem.next_repeat_available(self.test_student))
 
+    def test_next_repeat_available__future_for_per_semester_quest_under_cap(self):
+        """A per-semester quest still under its per-semester cap returns a future next-repeat time."""
+        per_sem = baker.make(Quest, max_repeats=2, repeat_per_semester=True, hours_between_repeats=24)
+        self._complete(per_sem)  # 1 completion, still under the per-semester allowance
+        next_at = per_sem.next_repeat_available(self.test_student)
+        self.assertIsNotNone(next_at)
+        self.assertGreater(next_at, timezone.now())
+
     def test_next_repeat_available__none_when_latest_attempt_in_progress(self):
         """With only an in-progress (never-completed) attempt, there's no next-repeat time."""
         QuestSubmission.objects.create_submission(self.test_student, self.quest)  # started, not completed

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -810,6 +810,14 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
         else:
             available_quests = Quest.objects.get_available_without_course(request.user)
 
+    # Repeatable quests the student completed that are still within their cooldown window: shown in
+    # the Available tab as "available again soon" with a countdown, rather than being hidden (#57).
+    cooldown_quests = []
+    if not request.user.is_staff:
+        cooldown_quests = list(Quest.objects.get_in_cooldown(request.user))
+        for quest in cooldown_quests:
+            quest.cooldown_available_at = quest.next_repeat_available(request.user)
+
     in_progress_submissions = QuestSubmission.objects.all_not_completed(
         request.user, blocking=True
     )
@@ -870,6 +878,7 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
         "past_submissions": past_submissions,
         "num_past": past_submissions_count,
         "num_completed": completed_submissions_count,
+        "cooldown_quests": cooldown_quests,
         "active_q_id": active_quest_id,
         "VIEW_TYPES": QuestListViewTabTypes,
         "view_type": view_type,
@@ -1852,8 +1861,13 @@ def start(request, quest_id):
             # could happen if they manually enter a different quest.id in the start url
             raise Http404
         else:
-            # We found an in-progress/not completed submission for the quest,
-            # so send them to it instead of starting a new one
+            # We found an in-progress/not completed submission for the quest, so send them to it
+            # instead of starting a new one, and let them know why (issue #57).
+            messages.info(
+                request,
+                f"You already have <strong>{quest.name}</strong> in progress — "
+                "finish this one before starting it again.",
+            )
             return redirect(sub)
     else:
         new_sub = QuestSubmission.objects.create_submission(request.user, quest)


### PR DESCRIPTION
### What?

Closes #57. When a student completes a **repeatable** quest, it now shows in an **"Available again soon"** section at the top of the Available tab with a **countdown** ("Available in 19 hours, 53 minutes"), instead of silently disappearing until its cooldown lapses. Also: starting a quest you already have in progress now tells you so.

### Why?

Today a repeatable quest with a cooldown (`hours_between_repeats`) is **hidden** from the Available tab the moment it's completed, and only reappears once the cooldown passes — with no indication it's coming back or when. #57 asks for these to "appear immediately… with the time left until available," and to note when a student already has the quest in progress so they finish that one first.

### How?

Rather than change *when* quests become startable (which would mean relaxing the core availability engine, gating start/complete, and rewriting its well-tested contract), this surfaces cooldown quests as a **separate, read-only "coming back" list** — the availability engine is untouched, and the two lists are disjoint.

- **`Quest.next_repeat_available(user)`** — the datetime a completed repeatable quest becomes available again (last completion + `hours_between_repeats`), or `None` when it isn't repeatable, hasn't been completed, or has hit its repeat cap (so it won't return). Mirrors the cap/timing logic of `is_repeat_available`.
- **`QuestManager.get_in_cooldown(user)`** — the student's completed repeatable quests currently within cooldown. Uses the same active / prerequisite / **not-in-progress** / not-hidden filters as `get_available`, so it's exactly the set `get_available` excludes via its cooldown condition — no overlap, no double-listing. Because it reuses `not_in_progress`, a quest with any active submission — **started or returned** — is excluded (it belongs in the In Progress tab, not here).
- **`quest_list`** passes `cooldown_quests` (each annotated with its next-available datetime) to the Available tab; the template renders it as a panel **above** the available-quests list, with the countdown via Django's `|timeuntil`.
- **`start`** view now adds a `messages.info(...)` when it redirects a student to a quest they already have in progress ("finish this one before starting it again") — previously it redirected silently.

### Testing?

`quest_manager/tests/test_cooldown.py` — 16 tests, all passing locally (Django 5.2 / py3.12 / postgres), and the existing `quest_manager` manager/model availability suites still pass (no change to the availability engine or its contract):

- **`next_repeat_available`**: `None` for non-repeatable / never-completed / repeat-cap-reached (both all-time and per-semester) / in-progress-latest; a future datetime while in cooldown (incl. a per-semester quest still under its cap); a past datetime once the cooldown has elapsed (`freeze_time`).
- **`get_in_cooldown`**: includes a just-completed quest (and it's *not* in `get_available`); becomes empty once the cooldown elapses (and the quest *is* then in `get_available`); excludes a **started** in-progress quest, a **returned** in-progress quest, and non-repeatable quests.
- **View**: the Available tab lists the cooldown quest with the "Available again soon" heading; no section when nothing's in cooldown; `start` shows the "already have … in progress" message.

New lines are fully covered; `ruff` and `makemigrations --check` clean (no model changes → no migration).

### Screenshots (if front end is affected)

Captured from the actual running app — a seeded `hackerspace` dev deck, logged in as a student (dark theme), with two repeatable quests completed and one in progress.

**In context, with the available-quests list rendered** — the "Available again soon" panel sits at the top of the Available tab, above the normal available-quests table:

![available tab with quests](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/57/available-tab-with-quests-real.png)

> (The lone "Loading content…" between the two is the available-quests accordion's own loading placeholder — it can't fully clear in this sandbox because bootstrap-table's JS is CDN-hosted and egress-blocked; I force-revealed the table rows so the two sections can be compared. In a real deck it clears on its own.)

**Close-up of the panel** (live `|timeuntil` countdowns):

![cooldown panel](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/57/cooldown-panel-real.png)

**The "already in progress" message** when starting a quest that's already on the go:

![start already-in-progress message](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/57/start-in-progress-real.png)

### Anything Else?

- **These entries don't expand.** Unlike the available-quests accordion rows (click to expand the preview), each "Available again soon" entry is just a **link to that quest's detail page** with its countdown — they're read-only "coming back" notices, not startable quests, so there's intentionally no Start button or accordion.
- **In-progress quests are never listed here.** A quest you've **started** (or one that was **returned** to you — still `is_completed=False`) is excluded via `not_in_progress`; it lives in the In Progress tab. "Available again soon" only lists quests with no active submission that are purely waiting out their hourly cooldown.
- **Deliberately does not make cooldown quests startable/completable early** — the issue's "not completable until the time has lapsed" is preserved by simply not offering a Start button in this read-only section; the countdown communicates when it returns.
- **Scope: hourly cooldown only, not semester resets.** This surfaces quests coming back within the current semester via `hours_between_repeats` (which has a concrete countdown). A `repeat_per_semester` quest whose per-semester allowance is *used up* is **not** shown here — it returns only when a teacher opens a new semester, and there's no fixed date to count down to, so a `|timeuntil` would be meaningless. (A per-semester quest that still has repeats *left* this semester **does** appear during its hourly cooldown.) Happy to add a separate countdown-less "Available again next semester" note if you'd like that surfaced too.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi