### PR TITLE
Cover notifications/views.py to 100% (list paging + read view)

### DIFF
--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -215,7 +215,10 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """Reading one's own notification marks it read (unread=False, time_read set) and
         redirects to the list when no ?next is given."""
         self.client.force_login(self.test_student1)
-        note = baker.make(Notification, recipient=self.test_student1, unread=True, time_read=None)
+        note = baker.make(
+            Notification, recipient=self.test_student1, unread=True, time_read=None,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
 
         response = self.client.get(reverse('notifications:read', args=[note.id]))
 
@@ -227,7 +230,10 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def test_read__redirects_to_next_when_provided(self):
         """Reading one's own notification with ?next= redirects to that url."""
         self.client.force_login(self.test_student1)
-        note = baker.make(Notification, recipient=self.test_student1, unread=True)
+        note = baker.make(
+            Notification, recipient=self.test_student1, unread=True,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
 
         response = self.client.get(reverse('notifications:read', args=[note.id]), {'next': '/quests/available/'})
 
@@ -236,7 +242,10 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def test_read__other_users_notification_raises_404(self):
         """Reading a notification that belongs to another user is a 404 (not readable)."""
         self.client.force_login(self.test_student1)
-        note = baker.make(Notification, recipient=self.test_student2, unread=True)
+        note = baker.make(
+            Notification, recipient=self.test_student2, unread=True,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
 
         response = self.client.get(reverse('notifications:read', args=[note.id]))
 

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -115,6 +115,10 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+        # the notification is actually marked read, not just a 200 response
+        notification.refresh_from_db()
+        self.assertFalse(notification.unread)
+
     def test_ajax__returns_200_for_logged_in_student(self):
         """A logged-in student's ajax POST to the notifications endpoint returns 200."""
         # log in student1
@@ -180,3 +184,60 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(Notification.objects.all_unread(self.test_student1).count(), 0)
         for note in Notification.objects.filter(recipient=self.test_student1):
             self.assertIsNotNone(note.time_read)
+
+    def test_list__non_integer_page_returns_first_page(self):
+        """A non-integer ?page= falls back to the first page (PageNotAnInteger)."""
+        self.client.force_login(self.test_student1)
+        response = self.client.get(reverse('notifications:list'), {'page': 'notanumber'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['notifications'].number, 1)
+
+    def test_list__out_of_range_page_returns_last_page(self):
+        """An out-of-range ?page= falls back to the last page (EmptyPage)."""
+        # The list paginates at 15/page; send >15 notifications with a real target
+        # (so the list template can render them) to produce a distinguishable 2nd page.
+        target = baker.make('quest_manager.Quest')
+        for _ in range(16):
+            notify.send(
+                self.test_teacher, target=target, recipient=self.test_student1,
+                affected_users=[self.test_student1], verb="did",
+            )
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('notifications:list'), {'page': 9999})
+
+        self.assertEqual(response.status_code, 200)
+        page = response.context['notifications']
+        self.assertGreater(page.paginator.num_pages, 1)
+        self.assertEqual(page.number, page.paginator.num_pages)
+
+    def test_read__marks_own_notification_read_and_redirects_to_list(self):
+        """Reading one's own notification marks it read (unread=False, time_read set) and
+        redirects to the list when no ?next is given."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(Notification, recipient=self.test_student1, unread=True, time_read=None)
+
+        response = self.client.get(reverse('notifications:read', args=[note.id]))
+
+        self.assertRedirects(response, reverse('notifications:list'), fetch_redirect_response=False)
+        note.refresh_from_db()
+        self.assertFalse(note.unread)
+        self.assertIsNotNone(note.time_read)
+
+    def test_read__redirects_to_next_when_provided(self):
+        """Reading one's own notification with ?next= redirects to that url."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(Notification, recipient=self.test_student1, unread=True)
+
+        response = self.client.get(reverse('notifications:read', args=[note.id]), {'next': '/quests/available/'})
+
+        self.assertRedirects(response, '/quests/available/', fetch_redirect_response=False)
+
+    def test_read__other_users_notification_raises_404(self):
+        """Reading a notification that belongs to another user is a 404 (not readable)."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(Notification, recipient=self.test_student2, unread=True)
+
+        response = self.client.get(reverse('notifications:read', args=[note.id]))
+
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
### What?

Next gap-closing PR. Brings `notifications/views.py` from **82% → 100%** by testing the uncovered `list()` pagination fallbacks and the `read()` view's own-notification branch, and tidies one existing weak test in the same file.

### Why?

`notifications/views.py` was the lowest-coverage view module. The uncovered code is the out-of-range/non-integer pagination handling and the whole "mark a notification read and redirect" flow (including the 404 for another user's notification) — reachable, user-facing behaviour worth locking in.

### How?

New tests in `notifications/tests/test_views.py`:
- **`list()` pagination** — a non-integer `?page=` falls back to the first page (`PageNotAnInteger`); an out-of-range `?page=` falls back to the **last** page (`EmptyPage`, asserted specifically as the last page, using real `notify.send` notifications so the list template renders).
- **`read()`** — reading one's own notification marks it read (`unread=False`, `time_read` set) and redirects to the list; redirects to `?next=` when provided; and raises **404** when the notification belongs to another user.

**Test-quality tidy (same file):** `test_ajax_mark_read__marks_notification_read` asserted only `status_code == 200` and never checked the notification was actually marked read — which is the entire point of the test. It now refreshes from the DB and asserts `unread` is `False`.

### Testing?

- `python manage.py test notifications` → **45 passing** (+5 new); `ruff` clean; `test_conventions` passes.
- Verified via coverage that `views.py` reaches **100%** (0 missing statements, 0 partial branches).

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test; these coverage PRs also fold in trivial fixes to the existing tests in each app they touch.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification handling to ensure notifications are correctly marked as read and saved.
  * Reading another user’s notification now returns an appropriate not-found response.
  * Notification list pagination now handles invalid or out-of-range page numbers gracefully.

* **Improvements**
  * Reading notifications now records the read time and supports redirecting to a specified destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->