### PR TITLE
Test-quality cleanup of earlier coverage-PR test files

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -458,13 +458,7 @@ class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # Now try adding them a second time, should not validate:
         response = self.client.post(add_course_url, data=self.valid_form_data)
 
-        # invalid form
         # GRADE field is depercated and no longer used within unique_together
-        # form = response.context['form']
-        # self.assertFalse(form.is_valid())
-        # self.assertEqual(response.status_code, 200)
-        # self.assertContains(response, 'Student Course with this User, Course and Grade already exists')
-        # self.assertEqual(self.test_student1.coursestudent_set.count(), 1)
 
         # Change the grade, still fails cus same block in same semester
         self.valid_form_data['grade_fk'] = baker.make('courses.grade').pk

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -154,7 +154,12 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn(scape.name, str(messages[0]))
 
 
-class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CourseViewTestData:
+    """Shared fixtures for the Course / CourseStudent view tests: a teacher, a student, the active
+    semester plus a block/course/grade, and valid registration form data.
+
+    A plain mixin (not a TestCase) so the test runner doesn't collect it as an empty test class.
+    """
 
     @classmethod
     def setUpTestData(cls):
@@ -179,6 +184,9 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
         """Set up a tenant client for each test."""
         self.client = TenantClient(self.tenant)
+
+
+class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def test_all_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to home page '''
@@ -388,31 +396,7 @@ class CourseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, dt_well_ptag)
 
 
-class CourseStudentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        """Create a teacher, student, block, course and grade plus valid registration form data."""
-        # need a teacher and a student so tests can log in as each with force_login()
-
-        # need a teacher before students can be created or the profile creation will fail when trying to notify
-        cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
-        cls.test_student1 = User.objects.create_user('test_student')
-
-        cls.sem = SiteConfig.get().active_semester
-        cls.block = baker.make('courses.block')
-        cls.course = baker.make('courses.course')
-        cls.grade = baker.make('courses.grade')
-
-        cls.valid_form_data = {
-            'semester': cls.sem.pk,
-            'block': cls.block.pk,
-            'course': cls.course.pk,
-        }
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
+class CourseStudentViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def test_CourseStudentUpdate_view__staff_can_update(self):
         """ Staff can update a student's course """

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -9,12 +9,10 @@ from django.test import SimpleTestCase
 
 from model_bakery import baker
 
-# from siteconfig.models import SiteConfig
 from djcytoscape.models import CytoElement, CytoScape, TempCampaign, TempCampaignNode, clean_JSON
 from prerequisites.models import Prereq
 from quest_manager.models import Quest, Category
 
-# from django_tenants.test.client import TenantClient
 from hackerspace_online.shell_utils import generate_quests
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -14,7 +14,12 @@ from psycopg2.errors import UndefinedTable
 User = get_user_model()
 
 
-class HasPrereqsMixinTest(ByteDeckTenantTestCase):
+class PrereqMixinTestData:
+    """Shared fixtures for the prereq mixin tests: a parent quest with an OR prereq and a plain prereq.
+
+    A plain mixin (not a TestCase) so the test runner doesn't collect it as an empty test class.
+    """
+
     @classmethod
     def setUpTestData(cls):
         """Create a parent quest with an OR prereq and a plain prereq."""
@@ -35,6 +40,8 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
             prereq_object=cls.quest_prereq2,
         )
 
+
+class HasPrereqsMixinTest(PrereqMixinTestData, ByteDeckTenantTestCase):
     def test_prereqs__returns_all_prereqs(self):
         """Returns the 2 prereqs created in setup"""
         prereqs = self.quest_parent.prereqs()
@@ -110,26 +117,7 @@ class HasPrereqsMixinTest(ByteDeckTenantTestCase):
         self.assertTrue(self.quest_parent.has_inverted_prereq())
 
 
-class IsAPrereqMixinTest(ByteDeckTenantTestCase):
-    @classmethod
-    def setUpTestData(cls):
-        """Create a parent quest with an OR prereq and a plain prereq."""
-        cls.quest_parent = baker.make('quest_manager.Quest', name="parent")
-        cls.quest_prereq = baker.make('quest_manager.Quest', name="prereq")
-        cls.quest_or_prereq = baker.make('quest_manager.Quest', name="or_prereq")
-
-        cls.prereq_with_or = Prereq.objects.create(
-            parent_object=cls.quest_parent,
-            prereq_object=cls.quest_prereq,
-            or_prereq_object=cls.quest_or_prereq
-        )
-
-        cls.quest_prereq2 = baker.make('quest_manager.Quest', name="prereq2")
-
-        cls.prereq_without_or = Prereq.objects.create(
-            parent_object=cls.quest_parent,
-            prereq_object=cls.quest_prereq2,
-        )
+class IsAPrereqMixinTest(PrereqMixinTestData, ByteDeckTenantTestCase):
 
     def test_is_used_prereq__true_when_used(self):
         """is_used_prereq is True for an object used as a prereq, False otherwise."""

--- a/src/prerequisites/tests/test_models.py
+++ b/src/prerequisites/tests/test_models.py
@@ -313,12 +313,6 @@ class PrereqModelTest(ByteDeckTenantTestCase):
         "returns the alternate prereq requirement"
         self.assertIsNone(self.prereq.get_or_prereq())
 
-    # Todo: need some massive mocking for this one
-    # @patch('prereq_object.condition_met_as_prerequisite', return_value=True)
-    # def test_conditions_met(self, condition_met_as_prerequisite):
-    #     print("Call count: ", condition_met_as_prerequisite.call_count)
-    #     self.assertTrue(self.prereq.condition_met(self.student))
-
     def test_add_simple_prereq__creates_reliance(self):
         """add_simple_prereq makes the parent reliant on the given prereq object."""
         quest3 = baker.make('quest_manager.Quest')

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -154,32 +154,36 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         # TODO fully test this with multiple blocks
 
     def test_teachers__empty_until_registered(self):
-        """teachers() is empty until the student has a course registration."""
+        """teachers() is empty before registration, yields a single None while the current
+        course's block has no teacher, and yields the teacher once one is assigned."""
         self.assertEqual(list(self.profile.teachers()), [])
         course_registration = self.create_active_course_registration()
-        # Still no teachers since no teacher assign to this course's block yet
-        # why is this a list of None instead of just empty? SQLite thing?
+        # Registered, but the course's block has no teacher yet, so teachers() -- which reads
+        # block__current_teacher -- yields a single None (one current course, no teacher).
         self.assertEqual(list(self.profile.teachers()), [None])
-
         self.assertTrue(self.profile.has_current_course)
-        course_registration.block = baker.make('courses.block', current_teacher=self.teacher)
 
-        # TODO should have teachers now... why not working? Should not be None...
-        # self.assertEqual(list(self.profile.teachers()), [None])
+        # Assign AND persist a block with a teacher (the DB query only sees a saved block);
+        # teachers() now lists that teacher.
+        course_registration.block = baker.make('courses.Block', current_teacher=self.teacher)
+        course_registration.save()
+        self.assertEqual(list(self.profile.teachers()), [self.teacher.id])
 
     def test_current_teachers__empty_until_teacher_assigned(self):
-        """current_teachers() stays empty until a teacher is assigned to the student's block."""
+        """current_teachers() stays empty until a teacher is assigned to the student's block,
+        then includes that teacher."""
         self.assertFalse(self.profile.current_teachers().exists())
 
         course_registration = self.create_active_course_registration()
 
-        # Still no teachers since no teacher assign to this course's block yet
+        # Still no teachers since no teacher is assigned to this course's block yet.
         self.assertFalse(self.profile.current_teachers().exists())
 
-        course_registration.block = baker.make('courses.block', current_teacher=self.teacher)
-
-        # print(course_registration)
-        # print(self.profile.current_teachers()) # why is this empty?!?!
+        # Assign AND persist a block with a teacher (an in-memory assignment isn't visible to the
+        # DB query behind current_teachers()); the teacher now shows up.
+        course_registration.block = baker.make('courses.Block', current_teacher=self.teacher)
+        course_registration.save()
+        self.assertIn(self.teacher, self.profile.current_teachers())
 
     def test_rank__default_for_new_user(self):
         """ By default a new user has a rank"""
@@ -237,6 +241,7 @@ class ProfileTestModel(ByteDeckTenantTestCase):
 
 
 class SmartListTests(SimpleTestCase):
+    """Covers the module-level smart_list value parser."""
 
     def test_smart_list__empty_inputs(self):
         """smart_list() returns an empty list for empty/None-like inputs."""
@@ -268,6 +273,24 @@ class SmartListTests(SimpleTestCase):
     def test_smart_list__single_int(self):
         """smart_list() wraps a single int in a list."""
         self.assertEqual(smart_list(1), [1])
+
+    def test_smart_list__parses_bracketed_delimited_string(self):
+        """A bracketed, comma-separated string is split and mapped by func."""
+        self.assertEqual(smart_list("[1, 2, 3]", func=int), [1, 2, 3])
+
+    def test_smart_list__empty_after_stripping_returns_empty_list(self):
+        """A bracket/whitespace-only string that strips to empty returns an empty list."""
+        self.assertEqual(smart_list("[   ]"), [])
+
+    def test_smart_list__raises_valueerror_for_unparseable_type(self):
+        """An unsupported value type raises ValueError."""
+        with self.assertRaises(ValueError):
+            smart_list(3.14)
+
+    def test_smart_list__raises_valueerror_when_func_fails_on_an_element(self):
+        """A per-element func that raises is re-raised as a ValueError."""
+        with self.assertRaises(ValueError):
+            smart_list("x,y", func=int)
 
 
 class UserDeletionTest(ByteDeckTenantTestCase):
@@ -417,27 +440,3 @@ class ProfileMiscMethodsTest(ByteDeckTenantTestCase):
         self.assertFalse(self.profile.chillax())
 
 
-class SmartListTest(SimpleTestCase):
-    """Covers the module-level smart_list value parser."""
-
-    def test_smart_list__parses_bracketed_delimited_string(self):
-        """A bracketed, comma-separated string is split and mapped by func."""
-        self.assertEqual(smart_list("[1, 2, 3]", func=int), [1, 2, 3])
-
-    def test_smart_list__empty_after_stripping_returns_empty_list(self):
-        """A bracket/whitespace-only string that strips to empty returns an empty list."""
-        self.assertEqual(smart_list("[   ]"), [])
-
-    def test_smart_list__wraps_a_bare_int_in_a_list(self):
-        """A bare int is wrapped in a single-element list."""
-        self.assertEqual(smart_list(7), [7])
-
-    def test_smart_list__raises_valueerror_for_unparseable_type(self):
-        """An unsupported value type raises ValueError."""
-        with self.assertRaises(ValueError):
-            smart_list(3.14)
-
-    def test_smart_list__raises_valueerror_when_func_fails_on_an_element(self):
-        """A per-element func that raises is re-raised as a ValueError."""
-        with self.assertRaises(ValueError):
-            smart_list("x,y", func=int)


### PR DESCRIPTION
### What?

Retroactive test-quality sweep of the test files touched by the earlier coverage PRs (#2071, #2072, #2078, #2088), applying the same tidying I've been folding inline into the more recent coverage PRs (#2091, #2093). Driven by an audit of those six files.

### Why?

The later coverage PRs started cleaning up trivial cruft in the tests they touched (dead code, weak assertions). These earlier ones predate that habit, so they still carried leftover dead code, two half-finished tests, and duplicated fixtures. This brings them in line.

### How?

**Dead-code deletions:**
- `prerequisites/tests/test_models.py` — drop the commented-out `test_conditions_met` stub ("need some massive mocking"); its `condition_met` branches are now fully tested by `PrereqStrAndConditionMetTest` (added in #2088).
- `djcytoscape/tests/test_models.py` — drop two commented-out unused imports (`SiteConfig`, `TenantClient`).
- `courses/tests/test_views.py` — drop the commented-out assertion block from the deprecated `GRADE` `unique_together` check (the current behaviour is already asserted live just below).

**Finished two half-written tests (real test bug, not a model bug):**
- `profile_manager` `test_teachers__empty_until_registered` and `test_current_teachers__empty_until_teacher_assigned` each assigned `course_registration.block = ...` **in memory but never saved it**, so the DB-backed `teachers()` / `current_teachers()` never saw it — exactly the *"why is this empty?!?"* their TODO comments puzzled over. Both now persist the block and assert the teacher actually appears.

**De-duplicated identical fixtures (hoisted into plain, non-collected mixins):**
- `prerequisites` — `HasPrereqsMixinTest` / `IsAPrereqMixinTest` shared `setUpTestData` → `PrereqMixinTestData`.
- `courses` — `CourseViewTests` / `CourseStudentViewTests` shared `setUpTestData` + `setUp` → `CourseViewTestData`.
- `profile_manager` — merged the two near-duplicate `smart_list` test classes (`SmartListTests` + `SmartListTest`) into one, keeping every distinct case.

### Testing?

- `profile_manager.tests.test_models`, `prerequisites.tests.test_models`, `courses.tests.test_views`, `djcytoscape.tests.test_models` + `test_conventions` all pass; `ruff` clean. No production code changed — test-only.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Two audit findings were left as-is by design (both are intentional patterns, not defects): the "no `NotImplementedError` raised" assertion style in `test_condition_met_as_prerequisite__is_implemented`, and the no-raise smoke check in `djcytoscape` `test_regenerate__no_error_on_good_map`.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)