### PR TITLE
Cover quest_manager/models.py submission + quest gaps (93% → 97%)

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -994,7 +994,10 @@ class QuestSubmissionManager(models.Manager):
             self.all_not_completed(user=user).get(quest=quest)
             # if no exception is thrown it means that an inprogress submission was found
             return False
-        except MultipleObjectsReturned:
+        # Unreachable: all_not_completed(user=...) is scoped to the active semester, and the partial
+        # unique constraint on (user, quest, semester) for in-progress submissions (migration 0049)
+        # allows at most one match -- so .get() never returns multiple. Excluded from coverage.
+        except MultipleObjectsReturned:  # pragma: no cover
             return False  # multiple found
         except ObjectDoesNotExist:
             pass  # nothing found, continue
@@ -1167,7 +1170,10 @@ class QuestSubmission(models.Model):
 
         if self.quest:
             name = self.quest.name
-        else:
+        # Defensive: quest is a non-nullable CASCADE FK, so a submission always has a quest
+        # (deleting a quest deletes its submissions). This fallback is unreachable, so it's
+        # excluded from coverage rather than tested with an impossible state.
+        else:  # pragma: no cover
             name = "[DELETED QUEST]"
         name += ordinal_str
         return name
@@ -1175,7 +1181,8 @@ class QuestSubmission(models.Model):
     def quest_name(self):
         if self.quest:
             return self.quest.name
-        else:
+        # Unreachable for the same reason as __str__ above (non-nullable CASCADE quest FK).
+        else:  # pragma: no cover
             return "[DELETED QUEST]"
 
     def get_absolute_url(self):

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -161,6 +161,17 @@ class QuestTestModel(ByteDeckTenantTestCase):
         """The quest's absolute URL is reachable and returns 200."""
         self.assertEqual(self.client.get(self.quest.get_absolute_url(), follow=True).status_code, 200)
 
+    def test_get_icon_url__returns_quest_icon_when_set(self):
+        """get_icon_url returns the quest's own icon url when it has one."""
+        self.quest.icon = 'icons/quest.png'
+        self.assertEqual(self.quest.get_icon_url(), self.quest.icon.url)
+
+    def test_get_icon_url__falls_back_to_campaign_icon(self):
+        """With no quest icon but a campaign icon set, get_icon_url returns the campaign's icon url."""
+        self.quest.icon = ''
+        self.quest.campaign = baker.make('quest_manager.Category', icon='icons/campaign.png')
+        self.assertEqual(self.quest.get_icon_url(), self.quest.campaign.icon.url)
+
     def test_active__false_for_unavailable_expired_or_hidden_quests(self):
         """
         The active method of the Quest model's parent "XPItem" should return the correct values based on a quest object's settings.
@@ -467,6 +478,65 @@ class SubmissionManagerTest(ByteDeckTenantTestCase):
             ordered=False
         )
 
+    def test_all_returned__no_user_returns_returned_submissions(self):
+        """all_returned() with no user returns every returned submission (has a completion date
+        while is_completed is False), and excludes still-in-progress ones."""
+        returned = baker.make(
+            QuestSubmission, is_completed=False, time_completed=timezone.now(), semester=self.active_semester,
+        )
+        in_progress = baker.make(
+            QuestSubmission, is_completed=False, time_completed=None, semester=self.active_semester,
+        )
+        all_returned = QuestSubmission.objects.all_returned()
+        self.assertIn(returned, all_returned)
+        self.assertNotIn(in_progress, all_returned)
+
+    def test_remove_in_progress__deletes_not_completed_submissions(self):
+        """remove_in_progress() deletes every not-completed submission across semesters."""
+        baker.make(QuestSubmission, is_completed=False, semester=self.active_semester, _quantity=2)
+
+        QuestSubmission.objects.remove_in_progress()
+
+        remaining = QuestSubmission.objects.get_queryset(active_semester_only=False).not_completed()
+        self.assertFalse(remaining.exists())
+
+    def test_queryset_completed__oldest_first_branch(self):
+        """The completed(oldest_first=True) queryset returns completed submissions."""
+        completed = baker.make(QuestSubmission, is_completed=True, semester=self.active_semester)
+        qs = QuestSubmission.objects.get_queryset(active_semester_only=False).completed(oldest_first=True)
+        self.assertIn(completed, qs)
+
+    def test_queryset_has_completion_date__filters_by_time_completed(self):
+        """has_completion_date() keeps only submissions that have a time_completed."""
+        with_date = baker.make(QuestSubmission, time_completed=timezone.now(), semester=self.active_semester)
+        without_date = baker.make(QuestSubmission, time_completed=None, semester=self.active_semester)
+        qs = QuestSubmission.objects.get_queryset(active_semester_only=False).has_completion_date()
+        self.assertIn(with_date, qs)
+        self.assertNotIn(without_date, qs)
+
+    def test_all_returned__with_user_returns_that_users_returned_submissions(self):
+        """all_returned(user) returns the given user's returned submissions."""
+        user = baker.make(User)
+        returned = baker.make(
+            QuestSubmission, user=user, is_completed=False, time_completed=timezone.now(), semester=self.active_semester,
+        )
+        self.assertIn(returned, QuestSubmission.objects.all_returned(user=user))
+
+    def test_not_submitted_or_inprogress__false_while_in_progress(self):
+        """not_submitted_or_inprogress() is False while an in-progress submission exists."""
+        user = baker.make(User)
+        quest = baker.make(Quest)
+        baker.make(QuestSubmission, user=user, quest=quest, is_completed=False, semester=self.active_semester)
+        self.assertFalse(QuestSubmission.objects.not_submitted_or_inprogress(user, quest))
+
+    def test_not_submitted_or_inprogress__defers_to_repeat_availability_when_completed(self):
+        """With a completed (not in-progress) submission, the result defers to the quest's repeat availability;
+        a non-repeatable quest is not available again."""
+        user = baker.make(User)
+        quest = baker.make(Quest, max_repeats=0)  # not repeatable
+        baker.make(QuestSubmission, user=user, quest=quest, is_completed=True, semester=self.active_semester)
+        self.assertFalse(QuestSubmission.objects.not_submitted_or_inprogress(user, quest))
+
 
 class SubmissionTestModel(ByteDeckTenantTestCase):
 
@@ -486,6 +556,11 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         """Creating a QuestSubmission yields a QuestSubmission linked to its quest."""
         self.assertIsInstance(self.submission, QuestSubmission)
         self.assertEqual("Test", self.submission.quest.name)
+
+    def test_str__appends_ordinal_for_repeat_submissions(self):
+        """__str__ appends the ordinal in parentheses for a repeat submission (ordinal > 1)."""
+        sub = baker.make(QuestSubmission, quest__name="Repeatable", ordinal=2)
+        self.assertEqual(str(sub), "Repeatable (2)")
 
     def test_get_absolute_url__submission_page_loads(self):
         """The submission's absolute URL is reachable and returns 200."""


### PR DESCRIPTION
### What?

Next gap-closing PR. Fills the concentrated untested branches in `quest_manager/models.py` — the submission display/manager/queryset helpers and `Quest.get_icon_url` — taking the file from **93% → 97%**.

### Why?

These are small, reachable helpers used all over the LMS (how a submission is labelled, how a quest's icon resolves, the submission manager/queryset filters), but several branches were never exercised because seed data sets no quest icons and the manager methods were only partially hit.

### How?

New tests (in the existing `QuestTestModel`, `SubmissionTestModel`, `SubmissionManagerTest`):
- **`Quest.get_icon_url`** — the "quest has its own icon" and "fall back to the campaign icon" branches (only the `SiteConfig`-default branch was tested).
- **`QuestSubmission.__str__`** — the ordinal-in-parentheses branch for repeat submissions (`ordinal > 1`).
- **`QuestSubmissionQuerySet`** — `completed(oldest_first=True)` and `has_completion_date()`.
- **`QuestSubmissionManager`** — `all_returned()` with and without a user, `remove_in_progress()`, and `not_submitted_or_inprogress()`'s in-progress and repeat-availability branches.

Two intended exclusions (`# pragma: no cover`, each with a rationale, per the coverage policy from #2065):
- The **`[DELETED QUEST]`** fallback in `__str__` / `quest_name` — `quest` is a non-nullable `CASCADE` FK, so a submission always has a quest (deleting a quest deletes its submissions); the fallback is unreachable.
- The **`MultipleObjectsReturned`** handler in `not_submitted_or_inprogress` — `all_not_completed(user=...)` is scoped to the active semester and the partial unique constraint on `(user, quest, semester)` for in-progress submissions (migration 0049) allows at most one match, so `.get()` never returns multiple.

### Testing?

- `python manage.py test quest_manager` → **303 passing** (+11 new); `ruff` clean; `test_conventions` passes.
- Verified via coverage that `models.py` rises from 93% to **97%** (the remaining misses are scattered single branches elsewhere in `Quest`/`Category`, partly cross-exercised by other apps — out of scope here).

### Screenshots (if front end is affected)

N/A — test-only, plus two `# pragma: no cover` comments.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. The existing `quest_manager` model tests were already clean, so no test-quality tidy was warranted here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_