### PR TITLE
Let TAs copy a quest from its submission preview (#141)

### DIFF
--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -100,7 +100,7 @@
         {% endif %}
 
         {% if request.user.profile.is_TA %}
-          <a title="Create a new quest using this one as a template. By default this quest will be a prerequisite for the new one."
+          <a title="Copy Quest &mdash; available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
              class="btn btn-default" role="button" href="{% url 'quests:quest_copy' q.id %}" >
             <i class="fa fa-copy"></i>
           </a>

--- a/src/quest_manager/templates/quest_manager/preview_content_submissions.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_submissions.html
@@ -41,7 +41,7 @@
        The copy view (quests:quest_copy) already allows TAs; this exposes it from the submission tabs,
        where a started quest lives once it leaves the Available list. {% endcomment %}
     {% if request.user.profile.is_TA %}
-      <a title="Create a new quest using this one as a template. By default this quest will be a prerequisite for the new one."
+      <a title="Copy Quest &mdash; available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
          class="btn btn-default" role="button" href="{% url 'quests:quest_copy' s.quest.id %}">
         <i class="fa fa-fw fa-copy"></i>
       </a>

--- a/src/quest_manager/templates/quest_manager/preview_content_submissions.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_submissions.html
@@ -36,6 +36,16 @@
           <i class="fa fa-fw fa-info-circle"></i><span class="visible-lg-inline-block icon-text">View Details</span>
       </a>
     {% endif %}
+
+    {% comment %} TAs can copy the quest a submission is for, even after it's been started (#141).
+       The copy view (quests:quest_copy) already allows TAs; this exposes it from the submission tabs,
+       where a started quest lives once it leaves the Available list. {% endcomment %}
+    {% if request.user.profile.is_TA %}
+      <a title="Create a new quest using this one as a template. By default this quest will be a prerequisite for the new one."
+         class="btn btn-default" role="button" href="{% url 'quests:quest_copy' s.quest.id %}">
+        <i class="fa fa-fw fa-copy"></i>
+      </a>
+    {% endif %}
   </div>
   <div class="user-content">{{s.quest.submission_details|safe}}</div>
 </li>

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -105,7 +105,7 @@
              In Progress/Completed tab preview (#141). Shown regardless of the quest's published
              state so a TA can always template off a quest they've started. {% endcomment %}
           {% if request.user.profile.is_TA %}
-            <a title="Create a new quest using this one as a template. By default this quest will be a prerequisite for the new one."
+            <a title="Copy Quest &mdash; available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
                class="btn btn-default" role="button" href="{% url 'quests:quest_copy' submission.quest.id %}">
               <i class="fa fa-fw fa-copy"></i> Copy Quest
             </a>

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -101,6 +101,15 @@
               <a class="btn btn-danger" href="{% url 'quests:drop' submission.id %}" role="button">Drop Quest</a>
             {% endif %}
           {% endif %}
+          {% comment %} TAs can copy the quest from the full submission view too, not just the
+             In Progress/Completed tab preview (#141). Shown regardless of the quest's published
+             state so a TA can always template off a quest they've started. {% endcomment %}
+          {% if request.user.profile.is_TA %}
+            <a title="Create a new quest using this one as a template. By default this quest will be a prerequisite for the new one."
+               class="btn btn-default" role="button" href="{% url 'quests:quest_copy' submission.quest.id %}">
+              <i class="fa fa-fw fa-copy"></i> Copy Quest
+            </a>
+          {% endif %}
         {% endif %}
         </div>
       </form>

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3105,6 +3105,33 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(response.context['completed'])
         self.assertTrue(response.context['past'])
 
+    def test_ajax_submission_info__ta_sees_copy_quest_button(self):
+        """A TA viewing a submission preview gets a 'copy quest' link so they can copy a started quest (#141)."""
+        ta = User.objects.create_user('test_ta')
+        ta.profile.is_TA = True
+        ta.profile.save()
+        self.client.force_login(ta)
+
+        response = self.client.post(
+            reverse('quests:ajax_info_in_progress', args=[self.submission.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+        # The copy link targets the submission's underlying quest.
+        self.assertContains(response, reverse('quests:quest_copy', args=[self.submission.quest.id]))
+
+    def test_ajax_submission_info__non_ta_student_has_no_copy_button(self):
+        """A regular (non-TA) student viewing a submission preview does not get the copy-quest link (#141)."""
+        # setUp logs in the non-TA test_student
+        response = self.client.post(
+            reverse('quests:ajax_info_in_progress', args=[self.submission.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, reverse('quests:quest_copy', args=[self.submission.quest.id]))
+
 
 class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """ Tests for:

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -454,6 +454,22 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
         self.assertNotContains(response, status_url)
 
+    def test_submission_view__ta_sees_copy_quest_button(self):
+        """A TA viewing the full submission page gets a 'copy quest' link (#141), targeting the submission's quest."""
+        self.test_student1.profile.is_TA = True
+        self.test_student1.profile.save()
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
+        self.assertContains(response, reverse('quests:quest_copy', args=[self.sub1.quest.id]))
+
+    def test_submission_view__non_ta_student_has_no_copy_button(self):
+        """A regular (non-TA) student viewing the full submission page does not get the copy-quest link (#141)."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
+        self.assertNotContains(response, reverse('quests:quest_copy', args=[self.sub1.quest.id]))
+
     def test_drop__student_can_drop_completed_submission_when_hidden(self):
         """
         Make sure student can drop a submission from a quest when an admin decides


### PR DESCRIPTION
### What?

Closes #141. Adds the TA **"copy quest"** button to **both** places a TA views a started quest — the **submission preview** (In Progress / Completed / Past Courses tab accordion) **and the full submission detail page** (`quests:submission`) — so a TA can copy a quest even after it's been started.

### Why?

TAs (`profile.is_TA`) can already copy a quest as a template for a new one — but the copy button (in `quest_manager/buttons.html`) only shows on the **Available** quests list. As the issue notes: *"Currently they can only copy available quests, but once they are started and become submissions, can't copy them."* Once a TA starts a quest it becomes a submission and leaves the Available list, so the only handle for copying it disappears. This surfaces the same copy action from the submission views.

### How?

The copy view already permits TAs — `QuestCopy` extends `QuestCreate`, whose `test_func` is `is_staff_or_TA(...)` — so no view/permission change was needed. The gap was purely UI: the button wasn't rendered on the submission surfaces.

- **`preview_content_submissions.html`** (the AJAX-loaded accordion preview for a `QuestSubmission`): copy button gated on `request.user.profile.is_TA`, linking to `quests:quest_copy` for the submission's underlying quest (`s.quest.id`), alongside Drop / Continue / View Details.
- **`submission.html`** (the full submission detail page): copy button in the non-staff button row next to Save Draft / Submit / Drop (gated on `is_TA`), shown regardless of the quest's published/approved state. *(Added in response to review — the first commit only covered the preview.)*
- **Verbose hover text**: the copy button's `title` tooltip now fully describes the action and notes it's available because the user is a TA — *"Copy Quest — available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."* Applied consistently to all three TA copy buttons (available list, preview, full submission view).

Regular students never see the button.

### Testing?

`quest_manager/tests/test_views.py` — 4 new tests, plus the existing submission-preview and `QuestCopyViewTest` suites still pass:

- `AjaxSubmissionInfoTest.test_ajax_submission_info__ta_sees_copy_quest_button` / `__non_ta_student_has_no_copy_button` — the **preview**.
- `SubmissionViewTests.test_submission_view__ta_sees_copy_quest_button` / `__non_ta_student_has_no_copy_button` — the **full submission page**.

Each TA test fails without its template change. New lines fully covered; `ruff` clean; no model change → no migration.

### Screenshots (if front end is affected)

Captured from the actual running app — a seeded `hackerspace` dev deck, logged in as a **TA** (`is_TA`, dark theme).

**Submission preview (In Progress tab accordion) — before / after:**

Before — only Drop / Continue:

![preview before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/141/before-closeup.png)

After — Drop / Continue / **Copy**:

![preview after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/141/after-closeup.png)

**Full submission detail page — after (button row + full page):**

![submission view copy button](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/141/submission-view-closeup.png)

![submission view full page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/141/submission-view-fullpage.png)

*(The hover tooltip is a native `title` attribute — the same mechanism as the app's other button tooltips — so it renders as the browser's own hover text and isn't capturable in a headless screenshot; its wording is quoted under "How?" above.)*

### Anything Else?

- All three copy buttons share the same icon and verbose "you're a TA / templates a new draft quest" tooltip, for consistency.
- Because the copy view already restricts creation to staff/TAs, this is purely additive UI — no new permissions surface, and non-TA students see no change.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi