### PR TITLE
Cover profile_manager/views.py helper views (recalc XP, tour, edit-own)

### DIFF
--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -122,6 +122,40 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
+    def test_recalculate_current_xp__invalidates_active_semester_profiles(self):
+        """recalculate_current_xp iterates the active-semester profiles and invalidates their XP cache."""
+        # a student registered in the active semester so all_for_active_semester() is non-empty
+        # and the loop body actually runs
+        baker.make(
+            'courses.CourseStudent', user=self.test_student1,
+            semester=self.active_sem, course=baker.make('courses.Course'),
+        )
+        self.assertTrue(Profile.objects.all_for_active_semester().exists())
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('profiles:recalculate_xp_current'))
+        self.assertEqual(response.status_code, 302)
+
+    def test_tour_complete__marks_completed_and_redirects_to_quests(self):
+        """tour_complete sets the profile's intro_tour_completed flag and redirects to the quests page."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('profiles:tour_complete'))
+
+        self.assertRedirects(response, reverse('quests:quests'))
+        self.test_student1.profile.refresh_from_db()
+        self.assertTrue(self.test_student1.profile.intro_tour_completed)
+
+    def test_profile_edit_own__resolves_to_logged_in_users_own_profile(self):
+        """profile_edit_own (ProfileUpdateOwn.get_object) loads the logged-in user's own profile form."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('profiles:profile_edit_own'))
+
+        # A 200 means get_object() resolved the user's own profile and the update form rendered.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['form'].instance, self.test_student1.profile)
+
     def test_profile_detail__courses_correct_displayed_text(self):
         """
             Admins in their course tab should only see: 'Not applicable to staff users.'

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -123,7 +123,7 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
     def test_recalculate_current_xp__invalidates_active_semester_profiles(self):
-        """recalculate_current_xp iterates the active-semester profiles and invalidates their XP cache."""
+        """recalculate_current_xp invalidates the XP cache of each active-semester profile."""
         # a student registered in the active semester so all_for_active_semester() is non-empty
         # and the loop body actually runs
         baker.make(
@@ -133,8 +133,12 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertTrue(Profile.objects.all_for_active_semester().exists())
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('profiles:recalculate_xp_current'))
+        with patch.object(Profile, 'xp_invalidate_cache') as mock_invalidate:
+            response = self.client.get(reverse('profiles:recalculate_xp_current'))
+
         self.assertEqual(response.status_code, 302)
+        # the view actually invalidated the XP cache (would still pass on a bare redirect otherwise)
+        self.assertTrue(mock_invalidate.called)
 
     def test_tour_complete__marks_completed_and_redirects_to_quests(self):
         """tour_complete sets the profile's intro_tour_completed flag and redirects to the quests page."""
@@ -153,8 +157,9 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('profiles:profile_edit_own'))
 
         # A 200 means get_object() resolved the user's own profile and the update form rendered.
+        # ProfileUpdate exposes its forms as context['forms'] (the profile form is first).
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['form'].instance, self.test_student1.profile)
+        self.assertEqual(response.context['forms'][0].instance, self.test_student1.profile)
 
     def test_profile_detail__courses_correct_displayed_text(self):
         """

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -487,10 +487,6 @@ def tour_complete(request):
     profile = request.user.profile
     profile.intro_tour_completed = True
     profile.save()
-    # print("*********TOUR COMPLETED**********")
-    # print("*********TOUR COMPLETED**********")
-    # print("*********TOUR COMPLETED**********")
-    # print("*********TOUR COMPLETED**********")
     return redirect('quests:quests')
 
 


### PR DESCRIPTION
### What?

Next gap-closing PR. Fills the cleanly-coverable gaps in `profile_manager/views.py` (85% → 89%) and removes some dead debug prints.

### Why?

A few small staff/user helper views were untested — the XP-recalc loop only ran against an empty queryset, and `tour_complete` / `ProfileUpdateOwn` had no direct coverage.

### How?

New tests in `ProfileViewTests`:
- **`recalculate_current_xp`** — with a student registered in the active semester so `Profile.objects.all_for_active_semester()` is non-empty and the loop body actually runs (the existing status-code test hit an empty queryset).
- **`tour_complete`** — sets `intro_tour_completed` and redirects to the quests page.
- **`ProfileUpdateOwn.get_object`** — `profile_edit_own` loads the logged-in user's own profile form.

Also drops four dead commented-out debug prints from `tour_complete`.

### Testing?

- `python manage.py test profile_manager` → passing (+3 new); `ruff` clean; `test_conventions` passes.
- Verified via coverage that the targeted lines (337, 479-482, 487-494) are now covered.

### Screenshots (if front end is affected)

N/A — test-only, plus a dead-comment removal.

### Anything Else? — two follow-ups I want to flag

Two blocks in this file are deliberately left uncovered here because they aren't a clean coverage add:

1. **`ProfileDelete.delete()` (lines 248-261) is dead code under Django 5.2.** `DeleteView` stopped routing POST through `delete()` in Django 4.0 — it now goes through `form_valid`. So this override never runs: the user *is* still deleted (the default flow deletes the `Profile`, which cascades to the `User`), but its **custom success message ("The user … has been successfully deleted") never shows**, and its explicit `user.delete()` is dead. There's also a stray live `print(approved_submission_qs)` in `get_context_data` (line 244) that spams stdout on every delete-confirm page load. Fixing this (migrate `delete()` → `form_valid()`, drop the print) is a small production behaviour change, so I've left it out of this test-only PR pending a decision.
2. **`oauth_merge_account` (lines 425-473)** — the social-account merge flow — needs `socialaccount` session/login mocking to exercise; a larger, separate effort.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completing the introductory tour now redirects to the quests page cleanly, with no extraneous debug output.

* **Tests**
  * Added authenticated test coverage for XP recalculation, introductory tour completion (profile flag update + redirect), and editing the logged-in user’s profile (correct form shown + successful response).
  * Confirmed expected redirects, profile updates, form rendering, and HTTP status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->