### PR TITLE
Add dedicated coverage for the oauth_merge_account view

### DIFF
--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -1,12 +1,15 @@
 import re
 from unittest.mock import patch
-from allauth.account.models import EmailConfirmationHMAC
+from allauth.account.models import EmailAddress, EmailConfirmationHMAC
+from allauth.socialaccount.models import SocialAccount, SocialApp, SocialLogin
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.cache import cache
 from django.urls import reverse
 
 from django_tenants.test.client import TenantClient
+from django_tenants.utils import get_public_schema_name, schema_context
 from model_bakery import baker
 
 from courses.models import Block, CourseStudent
@@ -733,4 +736,109 @@ class ProfileDeleteTests(ByteDeckTenantTestCase):
         non_existent_url = reverse("profiles:profile_delete", kwargs={"pk": 99999})
         response = self.client.post(non_existent_url)
 
+        self.assertEqual(response.status_code, 404)
+
+
+class OAuthMergeAccountViewTests(ByteDeckTenantTestCase):
+    """Dedicated, isolated tests for the ``oauth_merge_account`` view.
+
+    The view lets a user whose Google-login email matches an existing (but unverified)
+    local account decide whether to link the Google account to that local account
+    (``submit=yes``) or decline and sign up separately (``submit=no``). The full Google
+    callback flow that lands a user here is covered end-to-end in
+    ``hackerspace_online.tests.test_forms``; these tests instead drive the view directly
+    by seeding the session the OAuth adapter would have populated
+    (``merge_with_user_id`` + a serialized ``socialaccount_sociallogin``), so the view has
+    intentional coverage independent of that larger signup flow.
+    """
+
+    def setUp(self):
+        """Create a teacher (required before other users, as profile creation notifies staff),
+        a local user with an unverified email, the Google SocialApp, and a tenant client."""
+        self.client = TenantClient(self.tenant)
+        self.User = get_user_model()
+        self.teacher = self.User.objects.create_user('test_teacher', is_staff=True)
+        self.user = self.User.objects.create_user('existing_student', email='student@example.com')
+        self._setup_social_app()
+
+    def tearDown(self):
+        """Clear the cache after each test."""
+        cache.clear()
+
+    def _setup_social_app(self):
+        """Create the Google SocialApp in the public schema and propagate the provider so
+        ``SocialLogin.serialize()``/``deserialize()`` work (mirrors test_forms setup)."""
+        with schema_context(get_public_schema_name()):
+            app = SocialApp.objects.create(
+                provider='google',
+                name='Test Google App',
+                client_id='test_client_id',
+                secret='test_secret',
+            )
+            app.sites.add(Site.objects.get_current())
+        SiteConfig.get()._propagate_google_provider()
+
+    def _social_login(self, email):
+        """Build a SocialLogin the way the Google provider would for the given email."""
+        provider = SocialApp.objects.filter(provider='google').first().get_provider(request=None)
+        return SocialLogin(
+            provider=provider,  # required by serialize() since django-allauth 65
+            user=self.User(email=email, first_name='Given', last_name='Family'),
+            account=SocialAccount(provider='google', extra_data={'email': email}),
+            email_addresses=[EmailAddress(email=email, verified=True, primary=True)],
+        )
+
+    def _seed_merge_session(self, email=None):
+        """Populate the session as the adapter does before redirecting to the merge page."""
+        email = email or self.user.email
+        session = self.client.session
+        session['merge_with_user_id'] = self.user.pk
+        session['socialaccount_sociallogin'] = self._social_login(email).serialize()
+        session.save()
+
+    def test_oauth_merge_account__get_renders_merge_page(self):
+        """GET shows the merge confirmation page with the matched account's username and email."""
+        self._seed_merge_session()
+        response = self.client.get(reverse('profiles:oauth_merge_account'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['other_account_username'], self.user.username)
+        self.assertEqual(response.context['email_address'], self.user.email)
+
+    def test_oauth_merge_account__post_yes_links_account_verifies_email_and_logs_in(self):
+        """Clicking Yes links the Google account to the local user, marks their email
+        verified+primary, clears the merge session keys, and logs them in."""
+        self._seed_merge_session()
+        self.assertFalse(SocialAccount.objects.filter(user=self.user, provider='google').exists())
+
+        response = self.client.post(reverse('profiles:oauth_merge_account'), data={'submit': 'yes'})
+
+        # The Google account is now linked to the local user...
+        self.assertTrue(SocialAccount.objects.filter(user=self.user, provider='google').exists())
+        # ...their email is verified and primary...
+        self.assertTrue(
+            EmailAddress.objects.filter(user=self.user, email=self.user.email, verified=True, primary=True).exists()
+        )
+        # ...they are logged in...
+        self.assertEqual(int(self.client.session['_auth_user_id']), self.user.pk)
+        # ...and the merge session data has been popped so it doesn't leak.
+        self.assertNotIn('merge_with_user_id', self.client.session)
+        self.assertNotIn('socialaccount_sociallogin', self.client.session)
+        self.assertEqual(response.status_code, 302)
+
+    def test_oauth_merge_account__post_no_clears_email_and_redirects_to_signup(self):
+        """Clicking No removes the conflicting email from the local user and sends them to the
+        social signup page to create a separate account."""
+        self._seed_merge_session()
+        response = self.client.post(reverse('profiles:oauth_merge_account'), data={'submit': 'no'})
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, '')
+        self.assertFalse(self.user.emailaddress_set.filter(email='student@example.com').exists())
+        self.assertRedirects(response, reverse('socialaccount_signup'), fetch_redirect_response=False)
+
+    def test_oauth_merge_account__missing_session_user_returns_404(self):
+        """With no ``merge_with_user_id`` in the session, ``get_object_or_404`` short-circuits to a
+        404 before any POST handling — which is why the view's own ``if not merge_with_user_id``
+        guard can never be reached."""
+        response = self.client.get(reverse('profiles:oauth_merge_account'))
         self.assertEqual(response.status_code, 404)

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -429,9 +429,11 @@ def oauth_merge_account(request):
 
         merge_account = request.POST.get('submit') == 'yes'
 
-        # The socialaccount_sociallogin must've been removed from the session
-        # or there is no user to merge with so we don't have anything else to do...
-        if not merge_with_user_id:
+        # Unreachable guard: get_object_or_404(User, id=merge_with_user_id) above already
+        # 404s when merge_with_user_id is missing/falsy, so this can never be True here.
+        # Kept as a defensive no-op; excluded from coverage (see
+        # OAuthMergeAccountViewTests.test_oauth_merge_account__missing_session_user_returns_404).
+        if not merge_with_user_id:  # pragma: no cover
             return redirect('account_login')
 
         if merge_account:


### PR DESCRIPTION
### What?

Adds a dedicated `OAuthMergeAccountViewTests` class for `profile_manager.views.oauth_merge_account`, and marks one genuinely-unreachable line in that view as excluded from coverage (with a reason). Follow-up to **#2100** (the "add tests and mocking PR for 2" ask).

### Why?

While covering `profile_manager/views.py` in #2100 I flagged `oauth_merge_account` as untested. On closer inspection it turned out to be **already exercised — but only incidentally.** The end-to-end Google signup-flow tests in `hackerspace_online.tests.test_forms` (`..._merge_yes` / `..._merge_no`) drive a real Google callback that happens to land on this view, so it was covered as a *side effect* of testing a different flow, in a different app.

That's fragile: a refactor of the signup flow could silently drop this view's coverage, and there was no test that states this view's own contract. This PR gives it intentional, self-contained coverage.

(Concretely: with `test_views` + `test_forms` together, `profile_manager/views.py` was already at 98%; the only `oauth_merge_account` line missing was the unreachable guard addressed below.)

### How?

`OAuthMergeAccountViewTests` drives the view **directly** by seeding the session the OAuth adapter would have populated (`merge_with_user_id` + a serialized `socialaccount_sociallogin`), instead of going through the whole Google callback. The `SocialApp`/`SocialLogin` setup mirrors the existing pattern in `test_forms`. Cases:

- **GET** renders the merge confirmation page with the matched account's username + email.
- **`submit=yes`** links the Google account to the local user, marks their email verified + primary, pops the merge session keys, and logs them in.
- **`submit=no`** clears the conflicting email off the local user and redirects to the social signup page.
- **Missing `merge_with_user_id`** in the session → **404**.

That last case documents a small dead-code finding: the view's `if not merge_with_user_id: return redirect('account_login')` guard is **unreachable**, because `get_object_or_404(User, id=merge_with_user_id)` earlier in the function already 404s on a missing/falsy id. I've left the guard in place as a defensive no-op and excluded just those two lines from coverage with a `# pragma: no cover` explaining why (rather than reorder the function, which would change the missing-session response from a 404 to a login redirect — a behaviour question for a maintainer, not a coverage fix). Happy to open a tracking issue for that if you'd prefer it addressed.

### Testing?

- `python manage.py test profile_manager` → **101 passing** (+4 new).
- New tests verified to cover the full `oauth_merge_account` body (425–473) on their own; the pragma'd guard is the only excluded line.
- `ruff check` clean; `test_conventions` passes.

### Screenshots (if front end is affected)

N/A — test-only, plus a comment/pragma on one unreachable branch.

### Anything Else?

- This is **suggestion 2** from #2100. Suggestion 1 (the `ProfileDelete.delete()` dead code + stray `print`) is tracked separately in **#2101**.
- No production behaviour changes here — the guard is kept, only annotated.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_