### PR TITLE
Warn before leaving a form with unsaved changes (#192)

### DIFF
--- a/src/announcements/templates/announcements/form.html
+++ b/src/announcements/templates/announcements/form.html
@@ -11,7 +11,7 @@
 {% block heading_inner %} {{ heading }}{% endblock %}
 
 {% block content %}
-<form action="" enctype="multipart/form-data" method="post">{% csrf_token %}
+<form action="" enctype="multipart/form-data" method="post" data-warn-unsaved>{% csrf_token %}
   <div class="announcement-action-btns">
     <a href="{% url 'announcements:list' %}" role="button" class="btn btn-danger">Cancel</a>
     <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success" />

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -36,6 +36,15 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """Set up a tenant test client for each test."""
         self.client = TenantClient(self.tenant)
 
+    def test_announcement_form__has_unsaved_changes_guard(self):
+        """The announcement create and edit forms opt into the unsaved-changes warning, and the guard script is loaded (#192)."""
+        self.client.force_login(self.test_teacher)
+
+        for url in (reverse('announcements:create'), reverse('announcements:update', args=[self.ann_pk])):
+            response = self.client.get(url)
+            self.assertContains(response, 'data-warn-unsaved')
+            self.assertContains(response, 'warn-unsaved-changes.js')
+
     def test_all_announcement_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to login page '''
 

--- a/src/quest_manager/templates/quest_manager/quest_form.html
+++ b/src/quest_manager/templates/quest_manager/quest_form.html
@@ -11,7 +11,7 @@
 {% block heading_inner %} {{ heading }}{% endblock %}
 
 {% block content %}
-<form action="" enctype="multipart/form-data" method="post"> {% csrf_token %}
+<form action="" enctype="multipart/form-data" method="post" data-warn-unsaved> {% csrf_token %}
   {% crispy form %}
 </form>
 {% endblock %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1668,6 +1668,16 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn('id_tags', content)
         self.assertGreater(content.index('id_quick_reply'), content.index('id_tags'))
 
+    def test_quest_form__has_unsaved_changes_guard(self):
+        """The quest create and edit forms opt into the unsaved-changes warning, and the guard script is loaded (#192)."""
+        self.client.force_login(self.test_teacher)
+        quest = Quest.objects.create(**self.minimal_valid_form_data)
+
+        for url in (reverse('quests:quest_create'), reverse('quests:quest_update', args=[quest.pk])):
+            response = self.client.get(url)
+            self.assertContains(response, 'data-warn-unsaved')
+            self.assertContains(response, 'warn-unsaved-changes.js')
+
     def test_quest_create__teacher_can_create_and_delete(self):
         """Teachers can create quests and delete both live and archived quests."""
         # simulate a logged in teacher

--- a/src/static/js/warn-unsaved-changes.js
+++ b/src/static/js/warn-unsaved-changes.js
@@ -1,0 +1,53 @@
+/*
+  Unsaved-changes protection (issue #192).
+
+  Opt a form in by adding the `data-warn-unsaved` attribute to its <form> tag.
+  If the user edits any field and then tries to leave the page (close the tab,
+  hit back, refresh, or follow a link) without submitting, the browser shows its
+  native "Leave site? Changes you made may not be saved." confirmation.
+
+  Submitting the form is a deliberate save, so it clears the guard and never warns.
+*/
+(function () {
+  "use strict";
+
+  function guardForm(form) {
+    var dirty = false;
+    var submitting = false;
+
+    function markDirty() {
+      dirty = true;
+    }
+
+    // Native controls: text inputs, textareas, selects, checkboxes, radios, etc.
+    form.addEventListener("input", markDirty);
+    form.addEventListener("change", markDirty);
+
+    // Summernote WYSIWYG editors (used for quest/announcement content) sync to a
+    // hidden textarea and emit a bubbling `summernote.change` jQuery event — catch
+    // those edits too, since they don't fire a native input/change on the form.
+    if (window.jQuery) {
+      window.jQuery(form).on("summernote.change", markDirty);
+    }
+
+    // A submit is an intentional save — don't warn about it.
+    form.addEventListener("submit", function () {
+      submitting = true;
+    });
+
+    window.addEventListener("beforeunload", function (e) {
+      if (dirty && !submitting) {
+        // Setting returnValue is what triggers the native confirmation dialog;
+        // modern browsers ignore any custom message and show their own text.
+        e.preventDefault();
+        e.returnValue = "";
+        return "";
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var forms = document.querySelectorAll("form[data-warn-unsaved]");
+    Array.prototype.forEach.call(forms, guardForm);
+  });
+})();

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -31,6 +31,9 @@
         if (window.jQuery && $.fn.popover) { $.fn.popover.Constructor.DEFAULTS.sanitize = false; }
     </script>
 
+    <!-- Warn before leaving a form with unsaved changes (issue #192); opt in via `data-warn-unsaved` on a <form>. -->
+    <script src="{% static 'js/warn-unsaved-changes.js' %}"></script>
+
 
     <!-- ** head block ** -->
     {% block head %}{% endblock %}


### PR DESCRIPTION
### What?

Closes #192. If you edit a content form (a quest or an announcement) and then try to leave the page — close the tab, hit back/refresh, or follow a link — without saving, the browser now asks you to confirm first, so you don't lose unsaved work. Submitting the form saves normally and never warns.

### Why?

These edit forms are long (Summernote WYSIWYG bodies, prerequisites, tags…). It's easy to click away or hit back and silently lose everything you typed. #192 asks for *"a confirmation before leaving unsaved changes."*

### How?

- **`static/js/warn-unsaved-changes.js`** — a small reusable guard. Opt a form in by adding **`data-warn-unsaved`** to its `<form>` tag. The script marks the form "dirty" on any field edit — native inputs/selects/checkboxes (`input`/`change`) **and** Summernote WYSIWYG edits (its bubbling `summernote.change` event) — and, while dirty, cancels `beforeunload` so the browser shows its native *"Leave site? Changes you made may not be saved."* dialog. A `submit` stands the guard down, because saving is intentional.
- Loaded globally (in `templates/base.html`), and the **quest** create/edit form (`quest_form.html`) and **announcement** create/edit form (`announcements/form.html`) opt in via `data-warn-unsaved`. Because it's opt-in, any other content-edit form (badges, campaigns, …) can adopt it later by adding the one attribute.

The confirmation is the **browser's own** dialog (the modern, cross-browser way to guard tab-close/refresh/back as well as in-app link clicks); browsers ignore custom message text and show their own.

### Testing?

- `quest_manager/tests/test_views.py` — the quest **create and edit** pages include `data-warn-unsaved` on the form and load the guard script (`test_quest_form__has_unsaved_changes_guard`).
- `announcements/tests/test_views.py` — same for the announcement **create and edit** pages (`test_announcement_form__has_unsaved_changes_guard`).

Both fail without the template wiring. There's no server-side logic to cover (pure front-end behaviour).

**Behavioural verification** (Playwright against the running `hackerspace` deck, dispatching a real `beforeunload` on the quest edit form and checking whether the guard cancels it):

| State | Leave confirmation shown? |
| --- | --- |
| Form untouched | **No** |
| After editing a field | **Yes** |
| After editing, then submitting | **No** |

### Screenshots (if front end is affected)

The confirmation itself is the browser-native "Leave site?" dialog (browser chrome — it can't be rendered/screenshotted in a headless capture, hence the behavioural table above). For context, here's the **Update Quest** form the guard now protects, from the real running app (seeded `hackerspace` deck, dark theme):

![quest edit form](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/192/quest-edit-form.png)

### Anything Else?

- Opt-in by design: only forms tagged `data-warn-unsaved` are guarded, so search/filter forms and other quick forms are unaffected.
- No new dependencies — plain JS using the already-loaded jQuery only to hook Summernote's change event.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_