### PR TITLE
Hotfix (staging): comped decks must keep their admin-set student cap

### DIFF
--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -217,12 +217,21 @@ class Tenant(TenantMixin):
 
     @property
     def effective_max_active_users(self):
-        """The active-user cap that should be enforced right now: `max_active_users`
-        while a subscription is active, otherwise the trial cap ("back to trial mode",
-        #1734). -1 (unlimited, admin-set) is passed through unchanged."""
+        """The current-student cap that should be enforced right now.
+
+        -1 (unlimited, admin-set) passes through unchanged. A SUSPENDED deck
+        reverts to the trial cap ("back to trial mode", #1734). Every other deck
+        -- subscribed, on trial, or managed manually (no dates) -- uses its
+        admin-set ``max_active_users``: new decks are created with the trial
+        default (5), so the trial cap is the default, not an override, and an
+        admin who deliberately raises a trial or comped deck's cap is honored.
+        (Production bug find, 2026-07-22: the old subscription_active-based rule
+        capped comped/managed-manually decks at 5, contradicting their admin-set
+        cap on the banner and subscription page.)
+        """
         if self.max_active_users == -1:
             return -1
-        return self.max_active_users if self.subscription_active else TRIAL_MAX_ACTIVE_USERS
+        return TRIAL_MAX_ACTIVE_USERS if self.is_suspended else self.max_active_users
 
     @property
     def days_until_expiry(self):

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -201,16 +201,23 @@ class TenantBillingStatusTest(SimpleTestCase):
         """An actively subscribed deck's cap is its max_active_users field."""
         self.assertEqual(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=80).effective_max_active_users, 80)
 
-    def test_effective_max_active_users__trial_and_suspended_use_trial_cap(self):
-        """Trial and suspended decks are capped at TRIAL_MAX_ACTIVE_USERS regardless of the field ("back to trial mode")."""
-        self.assertEqual(
-            self.make_tenant(trial_end_date=FROZEN_TODAY, max_active_users=80).effective_max_active_users,
-            TRIAL_MAX_ACTIVE_USERS,
-        )
+    def test_effective_max_active_users__only_suspended_reverts_to_trial_cap(self):
+        """Only a SUSPENDED deck reverts to TRIAL_MAX_ACTIVE_USERS ("back to trial
+        mode"); trial and managed-manually (comped, no dates) decks keep their
+        admin-set cap -- new decks default to the trial cap anyway, so a raised cap
+        is a deliberate admin grant. (Production find: the old rule capped a comped
+        deck with an admin-set cap of 40 at 5.)"""
+        # suspended (trial lapsed, no subscription): reverts to the trial cap
         self.assertEqual(
             self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=80).effective_max_active_users,
             TRIAL_MAX_ACTIVE_USERS,
         )
+        # on trial with an admin-raised cap: the admin grant is honored
+        self.assertEqual(
+            self.make_tenant(trial_end_date=FROZEN_TODAY, max_active_users=80).effective_max_active_users, 80,
+        )
+        # managed manually (no dates at all): the admin-set cap is honored
+        self.assertEqual(self.make_tenant(max_active_users=40).effective_max_active_users, 40)
 
     def test_effective_max_active_users__unlimited_passthrough(self):
         """The admin-set unlimited sentinel (-1) is honored in every state."""


### PR DESCRIPTION
### What?
Hotfix for the cap bug found during live testing (2026-07-22), extracted from #2110 at the maintainer's request so it can land on **staging** immediately.

`effective_max_active_users` capped every non-subscribed deck at the trial limit (5) — including **"managed manually" decks** (both billing dates blank), whose admin-set cap it ignored. On the live hackerspace deck (cap 40, comped) this produced the "**14 of 5 students allowed**" banner and "Maximum allowed: 5" on the subscription page, and would refuse course registrations past 5.

Now only a **suspended** deck reverts to the trial cap ("back to trial mode", #1734); subscribed, trial, and managed-manually decks use their admin-set `max_active_users`. This is safe for trial decks because new decks are *created* with the trial default (5) — the trial cap was the default, not an override, so an admin-raised cap is a deliberate grant. `-1` unlimited passthrough unchanged.

One property fixes all four surfaces at once: the status banner, the subscription details page, course-registration enforcement, and the limit-warning emails.

### Why?
The maintainer is live-testing PR 6 on staging/production; any comped deck with more than 5 current students is currently mis-warned and would be refusing course registrations.

### How?
Two-file change: the property in `tenant/models.py` (suspended → trial cap; everything else → admin-set cap) and the regression test, including the exact production case (comped deck, admin cap 40 → effective cap 40).

### Testing?
* Regression test `test_effective_max_active_users__only_suspended_reverts_to_trial_cap` covers suspended (reverts to 5), trial-with-raised-cap (honored), and comped (honored — the production case).
* Full `tenant` + `courses` suites pass on this branch (the enforcement choke points live in `courses`); `ruff` clean. The identical change passed the full 1409-test serial suite on the #2110 branch.

### Screenshots (if front end is affected)
No template changes — the same page/banner simply render the correct number. (Live production evidence of the bug is in the session discussion: banner "14 of 5" vs admin cap 40.)

### Anything Else?
* #2110 carries this same fix for `develop` — when both are merged, the next staging↔develop sync will see identical code (no conflict: same hunks).
* After deploying to staging: reload the hackerspace deck's subscription page — "Maximum allowed" should now read 40.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_