### PR TITLE
Show qualifying students as a bulleted list on the grant-badge page (#2117)

### DIFF
--- a/src/badges/templates/badges/badge_grant_qualifying_confirm.html
+++ b/src/badges/templates/badges/badge_grant_qualifying_confirm.html
@@ -14,6 +14,15 @@
 
   <hr>
 
+  <div class="alert alert-info">
+    <strong>When is this {{ config.custom_name_for_badge|lower }} granted automatically?</strong>
+    Students earn it on their own the next time one of their quest submissions is approved, or when
+    their profile page loads &mdash; that's when the system re-checks which
+    {{ config.custom_name_for_badge|lower }}s they've qualified for. Use this page to grant it to
+    everyone who <em>already</em> qualifies right now (for example, right after you change its
+    prerequisites), instead of waiting for each student's next quest.
+  </div>
+
   <h3>Students who qualify for this {{ config.custom_name_for_badge|lower }}</h3>
 
   {% if qualifying_students %}

--- a/src/badges/templates/badges/badge_grant_qualifying_confirm.html
+++ b/src/badges/templates/badges/badge_grant_qualifying_confirm.html
@@ -34,7 +34,7 @@
       </p>
 
       <div class="well">
-        <ul class="list-unstyled">
+        <ul>
           {% for student in qualifying_students %}
             <li><a href="{{ student.profile.get_absolute_url }}">{{ student.profile }}</a></li>
           {% endfor %}

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -283,6 +283,20 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, f'{self.test_badge.xp} XP')
         # the qualifying students render as a bulleted list, not the previous unstyled list (#2117)
         self.assertNotContains(response, 'list-unstyled')
+        # a note explains that badges are granted automatically on quest approval / profile view (#2117)
+        self.assertContains(response, 'granted automatically')
+        self.assertContains(response, 'the next time one of their quest submissions is approved')
+
+    def test_badge_grant_qualifying__auto_grant_note_shown_when_no_qualifiers(self):
+        """The auto-grant explanation note is shown even when no current student qualifies, so a
+        teacher always sees when the badge grants on its own (#2117)."""
+        self.client.force_login(self.test_teacher)
+        # test_badge has no prereqs / no qualifying students in this fresh state
+        response = self.client.get(reverse('badges:grant_qualifying', args=[self.test_badge.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context['qualifying_students']), [])
+        self.assertContains(response, 'granted automatically')
 
     @patch('badges.views.grant_badge_assertions_for_badge.apply_async')
     def test_badge_grant_qualifying__POST_queues_task_and_redirects(self, task):

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -281,6 +281,8 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # heading and the XP that granting will award are both shown (issue #2061)
         self.assertContains(response, 'Students who qualify for this')
         self.assertContains(response, f'{self.test_badge.xp} XP')
+        # the qualifying students render as a bulleted list, not the previous unstyled list (#2117)
+        self.assertNotContains(response, 'list-unstyled')
 
     @patch('badges.views.grant_badge_assertions_for_badge.apply_async')
     def test_badge_grant_qualifying__POST_queues_task_and_redirects(self, task):


### PR DESCRIPTION
### What?

Closes #2117. Two changes to the "grant this badge to everyone who qualifies" confirmation page:

1. The list of qualifying students now renders as a proper **bulleted list** instead of a flat, marker-less list.
2. Added a note explaining **when the badge is granted automatically** if you don't use this page (requested in review).

### How?

- The list used `<ul class="list-unstyled">`, which strips the bullets. Dropped `list-unstyled` in `badge_grant_qualifying_confirm.html` so it renders as a normal bulleted `<ul>`.
- Added an info-alert note. Badges are granted automatically by `BadgeAssertion.check_for_new_assertions()`, which runs when a student's quest submission is approved (`QuestSubmission.mark_approved`) and when their profile page loads. So the note explains this page's role is to grant the badge to everyone who *already* qualifies right now (e.g. right after changing its prerequisites), instead of waiting for each student's next quest. The note shows whether or not there are current qualifiers.

### Testing?

`badges/tests/test_views.py`:
- `test_badge_grant_qualifying__GET_lists_qualifying_students` asserts the page no longer uses `list-unstyled` (students render bulleted) and that the auto-grant note is present.
- `test_badge_grant_qualifying__auto_grant_note_shown_when_no_qualifiers` asserts the note still shows when no current student qualifies.

### Screenshots (if front end is affected)

Real app (seeded `hackerspace` deck, deck owner) — the grant page with the auto-grant note above six qualifying students shown as a bulleted list:

![grant-qualifying page with the auto-grant note and bulleted list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2117/grant-qualifying-with-note.png)

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi