### PR TITLE
Quick-reply tooltip improvements + move the field below Tags (#2114)

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -142,12 +142,12 @@ class QuestForm(forms.ModelForm):
                 'instructions',
                 'submission_details',
                 'instructor_notes',
-                'quick_reply',
                 'campaign',
                 'common_data',
                 'max_repeats',
                 'hours_between_repeats',
                 'tags',
+                'quick_reply',
                 Accordion(
                     AccordionGroup(
                         "Basic Prerequisites",

--- a/src/quest_manager/templates/quest_manager/quest_approval.html
+++ b/src/quest_manager/templates/quest_manager/quest_approval.html
@@ -73,9 +73,10 @@ $( document ).ready(function() {
     // Quest-specific quick reply (#161): the text lives in the button's data-quick-reply attribute.
     // Read with .attr() (not .data(), which would type-coerce values like "true"/"null"/numbers).
     $(document).on('click', '[id^=btn_quest_quick_text]', function () {
-        var msg = ' ' + $(this).attr('data-quick-reply') + ' ';
+        var raw = $(this).attr('data-quick-reply');
+        if (!raw) return;  // no quest-specific text set (#2114): the button still shows, but pastes nothing
         var textarea = $($(this).data('target')).find('textarea');
-        textarea.val(textarea.val() + msg);
+        textarea.val(textarea.val() + ' ' + raw + ' ');
     });
 
     $('[data-toggle="tooltip"]').tooltip();

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -144,6 +144,7 @@
             // Read with .attr() (not .data(), which would type-coerce values like "true"/"null"/numbers).
             $('[id^=btn_quest_quick_text]').on('click', function () {
                 var raw = $(this).attr('data-quick-reply');
+                if (!raw) return;  // no quest-specific text set (#2114): the button still shows, but pastes nothing
                 // Escape first (injection-safe), then turn newlines into <br> so multi-line text survives in the HTML editor.
                 var escaped = $('<div>').text(raw).html().replace(/\r\n|\r|\n/g, '<br>');
                 var msg = '<p>' + escaped + '<br></p>';

--- a/src/quest_manager/templates/quest_manager/submission_buttons_form.html
+++ b/src/quest_manager/templates/quest_manager/submission_buttons_form.html
@@ -20,18 +20,18 @@
     {% endif %}
 
     <button type="button" class="btn btn-warning" data-target="#quick_reply{{s.id}}" id="btn_quick_text{{s.id}}"
-       title='ADD TEXT: "{{ quick_reply_text }}"' aria-label="Insert the site-wide quick reply text into your response">
+       title='ADD TEXT: "{{ quick_reply_text }}" (This text can be customized in your Site Configuration.)'
+       aria-label="Insert the site-wide quick reply text into your response">
        <i class="fa fa-fw fa-commenting-o fa-flip-horizontal"></i>
     </button>
 
-    {% comment %} Quest-specific quick reply (#161): only shown when this quest has its own quick
-       reply text set. Carries the text in a data attribute so the shared handler can insert it. {% endcomment %}
-    {% if s.quest.quick_reply %}
-      <button type="button" class="btn btn-warning" data-target="#quick_reply{{s.id}}" id="btn_quest_quick_text{{s.id}}"
-         data-quick-reply="{{ s.quest.quick_reply }}"
-         title='ADD QUEST-SPECIFIC TEXT: "{{ s.quest.quick_reply }}"'
-         aria-label="Insert this quest's quick reply text into your response">
-         <i class="fa fa-fw fa-commenting fa-flip-horizontal"></i>
-      </button>
-    {% endif %}
+    {% comment %} Quest-specific quick reply (#161, #2114): always shown so teachers discover it.
+       Carries this quest's text in a data attribute (empty when unset); the handler no-ops on empty,
+       and the tooltip then explains how to set it on the quest form. {% endcomment %}
+    <button type="button" class="btn btn-warning" data-target="#quick_reply{{s.id}}" id="btn_quest_quick_text{{s.id}}"
+       data-quick-reply="{{ s.quest.quick_reply }}"
+       {% if s.quest.quick_reply %}title='ADD QUEST-SPECIFIC TEXT: "{{ s.quest.quick_reply }}"'{% else %}title='ADD TEXT: (Add quest-specific quick-reply text by changing the "Quick Reply Text" field when editing the quest)'{% endif %}
+       aria-label="Insert this quest's quick reply text into your response">
+       <i class="fa fa-fw fa-commenting fa-flip-horizontal"></i>
+    </button>
   </div>

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -464,14 +464,22 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertContains(response, f'btn_quest_quick_text{self.sub1.id}')
         self.assertContains(response, "Reminder: attach a screenshot of your working code.")
 
-    def test_submission_view__no_quest_quick_reply_button_when_unset(self):
-        """A quest without quick_reply text shows no quest-specific quick-reply button (#161)."""
+    def test_submission_view__quest_quick_reply_button_shown_even_when_unset(self):
+        """The quest-specific quick-reply button always shows; when unset its tooltip explains how to set it (#2114)."""
         self.quest1.quick_reply = ""
         self.quest1.save()
         self.client.force_login(self.test_teacher)
 
         response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
-        self.assertNotContains(response, f'btn_quest_quick_text{self.sub1.id}')
+        self.assertContains(response, f'btn_quest_quick_text{self.sub1.id}')
+        self.assertContains(response, "Add quest-specific quick-reply text by changing")
+
+    def test_submission_view__site_wide_quick_reply_tooltip_mentions_config(self):
+        """The site-wide quick-reply button tooltip notes the text is customizable in Site Configuration (#2114)."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
+        self.assertContains(response, "This text can be customized in your Site Configuration.")
 
     def test_submission_view__ta_sees_copy_quest_button(self):
         """A TA viewing the full submission page gets a 'copy quest' link (#141), targeting the submission's quest."""
@@ -1589,6 +1597,14 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
         """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
+
+    def test_quest_form__quick_reply_field_below_tags(self):
+        """The Quick Reply Text field renders below the Tags field on the quest form (#2114)."""
+        self.client.force_login(self.test_teacher)
+        content = self.client.get(reverse('quests:quest_create')).content.decode()
+        self.assertIn('id_quick_reply', content)
+        self.assertIn('id_tags', content)
+        self.assertGreater(content.index('id_quick_reply'), content.index('id_tags'))
 
     def test_quest_create__teacher_can_create_and_delete(self):
         """Teachers can create quests and delete both live and archived quests."""


### PR DESCRIPTION
### What?

Closes #2114. Three small quick-reply refinements (follow-up to #161):

1. **Site-wide** quick-reply button tooltip now ends with *"(This text can be customized in your Site Configuration.)"*.
2. The **quest-specific** quick-reply button now **always shows** (so teachers discover the feature). When the quest has no quick-reply text set, clicking it pastes nothing and its tooltip reads: *"ADD TEXT: (Add quest-specific quick-reply text by changing the "Quick Reply Text" field when editing the quest)"*.
3. Moved the quest **"Quick Reply Text"** field to sit **below Tags** on the quest form.

### How?

- `submission_buttons_form.html` — appended the Site-Configuration note to the site-wide button's tooltip; dropped the `{% if s.quest.quick_reply %}` guard on the quest-specific button so it always renders, with a conditional tooltip (the guidance text when unset).
- `submission.html` + `quest_approval.html` — the two quest-specific quick-reply JS handlers now no-op when `data-quick-reply` is empty, so the always-visible button pastes nothing until text is set.
- `forms.py` — moved `'quick_reply'` in the `QuestForm` layout from below Instructor Notes to just below `'tags'`.

### Testing?

`quest_manager/tests/test_views.py`:
- `test_submission_view__quest_quick_reply_button_shown_even_when_unset` — button present + guidance tooltip when unset (replaces the old "not shown when unset" test).
- `test_submission_view__site_wide_quick_reply_tooltip_mentions_config` — the Site-Configuration note is present.
- `test_quest_form__quick_reply_field_below_tags` — the `quick_reply` field renders after `tags` on the quest form.

All pass; `ruff` clean.

### Screenshots (if front end is affected)

Real app (seeded `hackerspace` deck, deck owner). The two quick-reply button tooltips are native `title` attributes (like the app's other action-button tooltips), so their text isn't capturable in a headless screenshot — it's quoted above and asserted in tests. What is shown:

**Quest form — "Quick Reply Text" now sits below Tags:**

![field below tags](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2114/field-below-tags.png)

**Submission review — both quick-reply buttons now show even when the quest has no text set** (the two orange speech-bubble buttons: outline = site-wide, solid = quest-specific):

![buttons always shown](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2114/buttons-always-shown.png)

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_