### PR TITLE
Fix leaked template comment on the badge detail page (#2116)

### DIFF
--- a/src/badges/templates/badges/detail.html
+++ b/src/badges/templates/badges/detail.html
@@ -24,9 +24,9 @@
 
         {% if request.user.is_staff %}
         <div class="col-xs-12 col-sm-5 text-right">
-          {# One btn-group keeps every action button the same height and connected (like the
+          {% comment %} One btn-group keeps every action button the same height and connected (like the
              Current/All Active toggle below); fa-fw gives the icons a uniform width. The column is
-             col-sm-5 so the six icon buttons fit on one row without wrapping and breaking apart. #}
+             col-sm-5 so the six icon buttons fit on one row without wrapping and breaking apart. {% endcomment %}
           <div class="btn-group pull-right" role="group" aria-label="{{ config.custom_name_for_badge }} actions">
             <a class="btn btn-warning" title="Edit" href="{% url 'badges:badge_update' badge.id %}">
               <i class="fa fa-fw fa-edit"></i>

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -114,6 +114,12 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('badges:badge_prereqs_update', args=[b_pk])
         self.assert200('badges:grant_qualifying', args=[b_pk])
 
+    def test_badge_detail__action_button_comment_not_rendered(self):
+        """The explanatory comment above the action buttons must not render as visible text (#2116)."""
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('badges:badge_detail', args=[self.test_badge.pk]))
+        self.assertNotContains(response, 'One btn-group keeps every action button')
+
     def test_badge_create__creates_badge(self):
         """Posting valid data to the create view creates a new badge and redirects to the list."""
         # log in a teacher


### PR DESCRIPTION
### What?

Closes #2116. An explanatory developer comment was rendering as visible text at the top of the **badge detail** page (above the action buttons).

### Why?

The comment used a **multi-line `{# … #}`**. Django's `{# #}` comments are **single-line only** — a comment that spans lines isn't recognized, so its text renders verbatim. (Added in #2066.)

### How?

Switched it to a `{% comment %}…{% endcomment %}` block, which is the correct tag for multi-line comments.

### Testing?

`badges/tests/test_views.py` — `test_badge_detail__action_button_comment_not_rendered` asserts the comment text does **not** appear on the badge detail page. It fails against the old template (the text leaks) and passes with the fix.

### Screenshots (if front end is affected)

Real app (seeded `hackerspace` deck, deck owner), badge detail page top card.

**Before** — the comment text leaks next to the action buttons:

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2116/before.png)

**After** — clean:

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2116/after.png)

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_