### PR TITLE
Sanitize comment HTML instead of escaping it all (#2113)

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -214,10 +214,10 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, self.test_announcement.get_absolute_url())
         self.assertTrue(Comment.objects.all_with_target_object(self.test_announcement).exists())
 
-    def test_comment_on_announcement__escapes_html(self):
-        """HTML entered in the announcement comment form is completely escaped when
-        the comment is saved, so scripts can't execute when the comment is rendered.
-        Regression test for issue #1343.
+    def test_comment_on_announcement__sanitizes_html(self):
+        """HTML entered in the announcement comment form is sanitized when the comment
+        is saved: scripts and event handlers are stripped so nothing executes when the
+        comment is rendered. Regression test for issue #1343.
         """
         self.client.force_login(self.test_student1)
 
@@ -230,9 +230,29 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         comment = Comment.objects.all_with_target_object(self.test_announcement).first()
         self.assertIsNotNone(comment)
+        # the <script> tag is neutralized (escaped, not a live tag) and the onerror
+        # event handler is stripped, so no JavaScript can run
         self.assertNotIn('<script', comment.text)
-        self.assertNotIn('<img', comment.text)
         self.assertIn('&lt;script&gt;', comment.text)
+        self.assertNotIn('onerror', comment.text)
+
+    def test_comment_on_announcement__preserves_formatting(self):
+        """Legitimate formatting HTML entered in an announcement comment survives so it
+        renders instead of showing its literal tags. Regression test for issue #2113.
+        """
+        self.client.force_login(self.test_student1)
+
+        payload = '<p>hello <b>bold</b> <a href="http://example.com">link</a></p>'
+        response = self.client.post(
+            reverse('announcements:comment', args=[self.test_announcement.id]),
+            data={'comment_text': payload, 'comment_button': True}
+        )
+        self.assertRedirects(response, self.test_announcement.get_absolute_url())
+
+        comment = Comment.objects.all_with_target_object(self.test_announcement).first()
+        self.assertIsNotNone(comment)
+        self.assertIn('<b>bold</b>', comment.text)
+        self.assertIn('href="http://example.com"', comment.text)
 
     def test_copy_announcement__creates_new_announcement(self):
         """Copying an announcement via POST creates a new announcement and redirects to it."""

--- a/src/comments/forms.py
+++ b/src/comments/forms.py
@@ -1,7 +1,7 @@
 from django import forms
-from django.utils.html import escape
 
 from bytedeck_summernote.widgets import ByteDeckSummernoteSafeInplaceWidget
+from comments.sanitize import sanitize_comment_html
 
 
 # class CommentForm(forms.ModelForm):
@@ -29,9 +29,10 @@ class CommentForm(forms.Form):
     def clean_comment_text(self):
         text = self.cleaned_data.get('comment_text', '')
         if not self.wysiwyg:
-            # The plain-text (non-wysiwyg) comment field is accessible to all users,
-            # so no HTML at all is allowed in it, otherwise scripts can be injected
-            # and will execute when the comment is rendered (see issue #1343).
+            # The plain-text (non-wysiwyg) comment field is accessible to all users
+            # and rendered with |safe, so it must be sanitized to prevent scripts from
+            # executing (issue #1343). We sanitize with an allow-list rather than escape
+            # everything, so legitimate formatting still renders (issue #2113).
             # The wysiwyg variant is sanitized by the safe summernote widget instead.
-            text = escape(text)
+            text = sanitize_comment_html(text)
         return text

--- a/src/comments/forms.py
+++ b/src/comments/forms.py
@@ -27,6 +27,8 @@ class CommentForm(forms.Form):
     comment_text = forms.CharField()
 
     def clean_comment_text(self):
+        """Return the submitted comment text, sanitized to safe HTML for the plain-text
+        (non-wysiwyg) variant; the wysiwyg variant is left for the summernote widget."""
         text = self.cleaned_data.get('comment_text', '')
         if not self.wysiwyg:
             # The plain-text (non-wysiwyg) comment field is accessible to all users

--- a/src/comments/sanitize.py
+++ b/src/comments/sanitize.py
@@ -1,0 +1,55 @@
+"""Shared sanitization for user-entered comment HTML.
+
+Comment bodies are rendered with Django's ``|safe`` filter, so whatever is
+stored is emitted as-is into the page. The plain-text / quick-reply comment
+forms are reachable by every user (including students), and in practice they
+receive rich HTML from the Summernote editor rather than literal plain text.
+
+Issue #1343 originally locked these fields down by ``escape()``-ing *all* HTML,
+but that also escaped legitimate formatting, so a normal comment like
+``<p>hello</p>`` rendered as the literal text ``<p>hello</p>`` (issue #2113).
+
+The fix is to sanitize with an allow-list instead of escaping everything:
+legitimate formatting tags are kept (so comments render), while ``<script>``,
+inline event-handler attributes (``onclick``/``onerror``/...), and
+``javascript:`` URLs are stripped, so a crafted comment still can't run script.
+This reuses the same tag/style allow-list as the "safe" Summernote widget, but
+with a stricter attribute policy that drops event handlers (the Summernote
+widget currently allows all attributes).
+"""
+
+import bleach
+
+from bytedeck_summernote.css_sanitizer import CSSSanitizer
+from bytedeck_summernote.settings import ALLOWED_TAGS, STYLES
+
+# Attributes that must never survive sanitization regardless of tag: inline
+# event handlers (any ``on*``) and a few attributes that can smuggle script or
+# hijack forms.
+_DISALLOWED_ATTRIBUTES = {"srcdoc", "formaction", "form", "xlink:href"}
+
+
+def _allow_attribute(tag, name, value):
+    """bleach attribute filter: allow anything except event handlers and a small
+    deny-list of dangerous attributes, so sanitized comment HTML can't carry
+    inline JavaScript."""
+    name = name.lower()
+    if name.startswith("on"):
+        return False
+    return name not in _DISALLOWED_ATTRIBUTES
+
+
+def sanitize_comment_html(text):
+    """Return ``text`` with dangerous HTML removed but safe formatting preserved.
+
+    Keeps the Summernote allow-list of formatting tags/styles so rich comments
+    render (issue #2113), while stripping ``<script>``, ``on*`` event-handler
+    attributes, and ``javascript:`` URLs so a crafted comment can't execute when
+    displayed with ``|safe`` (issue #1343).
+    """
+    return bleach.clean(
+        text or "",
+        tags=ALLOWED_TAGS,
+        attributes=_allow_attribute,
+        css_sanitizer=CSSSanitizer(allowed_css_properties=STYLES),
+    )

--- a/src/comments/tests/test_forms.py
+++ b/src/comments/tests/test_forms.py
@@ -3,20 +3,33 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 
 class CommentFormTest(ByteDeckTenantTestCase):
-    """The plain-text (non-wysiwyg) comment form is accessible to all users, so
-    all HTML entered in it must be completely escaped. Regression tests for
-    issue #1343 where scripts entered in plain-text comment fields would execute.
+    """The plain-text (non-wysiwyg) comment form is accessible to all users and
+    rendered with |safe, so its HTML is sanitized with an allow-list on cleaning:
+    legitimate formatting is preserved (issue #2113) while scripts and event
+    handlers are stripped so they can't execute (regression tests for issue #1343).
     """
 
     xss_payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
-    escaped_payload = ('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
-                       '&lt;img src=x onerror=alert(1)&gt;')
+    formatting_payload = '<p>hello <b>bold</b> <a href="http://example.com">link</a></p>'
 
-    def test_comment_form__escapes_html_when_not_wysiwyg(self):
-        """All HTML in the plain-text (default) comment form is escaped on cleaning."""
+    def test_comment_form__strips_scripts_and_event_handlers_when_not_wysiwyg(self):
+        """Scripts and event handlers are removed from the plain-text (default) comment
+        form so injected JavaScript can't execute (issue #1343)."""
         form = CommentForm(data={'comment_text': self.xss_payload})
         self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+        cleaned = form.cleaned_data['comment_text']
+        self.assertNotIn('<script>', cleaned)
+        self.assertIn('&lt;script&gt;', cleaned)
+        self.assertNotIn('onerror', cleaned)
+
+    def test_comment_form__preserves_formatting_when_not_wysiwyg(self):
+        """Legitimate formatting HTML survives sanitizing so comments render instead
+        of showing their literal tags (issue #2113)."""
+        form = CommentForm(data={'comment_text': self.formatting_payload})
+        self.assertTrue(form.is_valid())
+        cleaned = form.cleaned_data['comment_text']
+        self.assertIn('<b>bold</b>', cleaned)
+        self.assertIn('<a href="http://example.com">link</a>', cleaned)
 
     def test_comment_form__wysiwyg_html_untouched_by_form(self):
         """The wysiwyg variant leaves HTML alone at the form level: its content is

--- a/src/comments/tests/test_sanitize.py
+++ b/src/comments/tests/test_sanitize.py
@@ -6,7 +6,7 @@ from comments.sanitize import sanitize_comment_html
 class SanitizeCommentHTMLTest(SimpleTestCase):
     """Unit tests for the shared comment-HTML sanitizer (issues #1343 / #2113)."""
 
-    def test_preserves_legitimate_formatting(self):
+    def test_sanitize_comment_html__preserves_legitimate_formatting(self):
         """Ordinary formatting tags survive so rich comments render (issue #2113)."""
         html = '<p>hi <b>bold</b> <a href="http://example.com">link</a></p><ul><li>a</li></ul>'
         cleaned = sanitize_comment_html(html)
@@ -14,29 +14,29 @@ class SanitizeCommentHTMLTest(SimpleTestCase):
         self.assertIn('<a href="http://example.com">link</a>', cleaned)
         self.assertIn('<li>a</li>', cleaned)
 
-    def test_strips_script_tag(self):
+    def test_sanitize_comment_html__strips_script_tag(self):
         """<script> is neutralized so it can't execute (issue #1343)."""
         cleaned = sanitize_comment_html('<script>alert(1)</script>')
         self.assertNotIn('<script>', cleaned)
         self.assertIn('&lt;script&gt;', cleaned)
 
-    def test_strips_event_handler_attributes(self):
+    def test_sanitize_comment_html__strips_event_handler_attributes(self):
         """Inline event handlers (on*) are removed from otherwise-allowed tags."""
         cleaned = sanitize_comment_html('<img src=x onerror=alert(1)>')
         self.assertNotIn('onerror', cleaned)
         self.assertIn('<img', cleaned)  # the tag itself is allowed, only the handler is dropped
 
-    def test_strips_denylisted_attributes(self):
+    def test_sanitize_comment_html__strips_denylisted_attributes(self):
         """Explicitly denied attributes (e.g. srcdoc) are stripped even on allowed tags."""
         cleaned = sanitize_comment_html('<iframe srcdoc="<script>alert(1)</script>"></iframe>')
         self.assertNotIn('srcdoc', cleaned)
 
-    def test_strips_javascript_url(self):
+    def test_sanitize_comment_html__strips_javascript_url(self):
         """javascript: URLs are removed from links."""
         cleaned = sanitize_comment_html('<a href="javascript:alert(1)">x</a>')
         self.assertNotIn('javascript:', cleaned)
 
-    def test_none_and_empty_are_safe(self):
+    def test_sanitize_comment_html__none_and_empty_are_safe(self):
         """None / empty input sanitize to an empty string without error."""
         self.assertEqual(sanitize_comment_html(None), '')
         self.assertEqual(sanitize_comment_html(''), '')

--- a/src/comments/tests/test_sanitize.py
+++ b/src/comments/tests/test_sanitize.py
@@ -1,0 +1,42 @@
+from django.test import SimpleTestCase
+
+from comments.sanitize import sanitize_comment_html
+
+
+class SanitizeCommentHTMLTest(SimpleTestCase):
+    """Unit tests for the shared comment-HTML sanitizer (issues #1343 / #2113)."""
+
+    def test_preserves_legitimate_formatting(self):
+        """Ordinary formatting tags survive so rich comments render (issue #2113)."""
+        html = '<p>hi <b>bold</b> <a href="http://example.com">link</a></p><ul><li>a</li></ul>'
+        cleaned = sanitize_comment_html(html)
+        self.assertIn('<b>bold</b>', cleaned)
+        self.assertIn('<a href="http://example.com">link</a>', cleaned)
+        self.assertIn('<li>a</li>', cleaned)
+
+    def test_strips_script_tag(self):
+        """<script> is neutralized so it can't execute (issue #1343)."""
+        cleaned = sanitize_comment_html('<script>alert(1)</script>')
+        self.assertNotIn('<script>', cleaned)
+        self.assertIn('&lt;script&gt;', cleaned)
+
+    def test_strips_event_handler_attributes(self):
+        """Inline event handlers (on*) are removed from otherwise-allowed tags."""
+        cleaned = sanitize_comment_html('<img src=x onerror=alert(1)>')
+        self.assertNotIn('onerror', cleaned)
+        self.assertIn('<img', cleaned)  # the tag itself is allowed, only the handler is dropped
+
+    def test_strips_denylisted_attributes(self):
+        """Explicitly denied attributes (e.g. srcdoc) are stripped even on allowed tags."""
+        cleaned = sanitize_comment_html('<iframe srcdoc="<script>alert(1)</script>"></iframe>')
+        self.assertNotIn('srcdoc', cleaned)
+
+    def test_strips_javascript_url(self):
+        """javascript: URLs are removed from links."""
+        cleaned = sanitize_comment_html('<a href="javascript:alert(1)">x</a>')
+        self.assertNotIn('javascript:', cleaned)
+
+    def test_none_and_empty_are_safe(self):
+        """None / empty input sanitize to an empty string without error."""
+        self.assertEqual(sanitize_comment_html(None), '')
+        self.assertEqual(sanitize_comment_html(''), '')

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.html import escape
 
 from bootstrap_datepicker_plus.widgets import DatePickerInput, TimePickerInput
 from crispy_forms.bootstrap import Accordion, AccordionGroup
@@ -10,6 +9,7 @@ from django_select2.forms import ModelSelect2MultipleWidget, ModelSelect2Widget
 
 from badges.models import Badge
 from bytedeck_summernote.widgets import ByteDeckSummernoteSafeInplaceWidget, ByteDeckSummernoteAdvancedInplaceWidget
+from comments.sanitize import sanitize_comment_html
 from utilities.fields import RestrictedMultiFileFormField
 from tags.forms import BootstrapTaggitSelect2Widget
 
@@ -276,19 +276,22 @@ class SubmissionFormStaff(SubmissionForm):
         )
 
 
-class EscapeCommentTextMixin:
-    """Completely escapes HTML entered in a form's `comment_text` field.
+class SanitizeCommentTextMixin:
+    """Sanitizes HTML entered in a form's `comment_text` field.
 
-    Plain-text (non-wysiwyg) comment fields are accessible to all users, so no
-    HTML at all is allowed in them, otherwise scripts can be injected and will
-    execute when the comment is rendered (see issue #1343).
+    These plain-text (non-wysiwyg) comment fields are accessible to all users and
+    rendered with |safe, so they must be sanitized to stop injected scripts from
+    executing (issue #1343). In practice they carry rich HTML from the Summernote
+    editor, so we sanitize with an allow-list rather than escaping everything,
+    keeping legitimate formatting while stripping scripts and event handlers
+    (issue #2113).
     """
 
     def clean_comment_text(self):
-        return escape(self.cleaned_data.get('comment_text', ''))
+        return sanitize_comment_html(self.cleaned_data.get('comment_text', ''))
 
 
-class SubmissionReplyForm(EscapeCommentTextMixin, forms.Form):
+class SubmissionReplyForm(SanitizeCommentTextMixin, forms.Form):
     comment_text = forms.CharField(label='Reply', widget=forms.Textarea(attrs={'rows': 2}))
 
 
@@ -296,7 +299,7 @@ class BadgeModelChoiceField(BadgeLabel, forms.ModelChoiceField):
     pass
 
 
-class SubmissionQuickReplyForm(EscapeCommentTextMixin, forms.Form):
+class SubmissionQuickReplyForm(SanitizeCommentTextMixin, forms.Form):
     comment_text = forms.CharField(label='', required=False, widget=forms.Textarea(attrs={'rows': 2}))
     # Queryset needs to be set on creation in __init__(), otherwise bad stuff happens upon initial migration
     award = BadgeModelChoiceField(queryset=None, label='Grant an Award', required=False)
@@ -306,7 +309,7 @@ class SubmissionQuickReplyForm(EscapeCommentTextMixin, forms.Form):
         self.fields['award'].queryset = Badge.objects.all_manually_granted()
 
 
-class SubmissionQuickReplyFormStudent(EscapeCommentTextMixin, forms.Form):
+class SubmissionQuickReplyFormStudent(SanitizeCommentTextMixin, forms.Form):
     comment_text = forms.CharField(label='', required=False, widget=forms.Textarea(attrs={'rows': 2}))
 
 

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -288,6 +288,7 @@ class SanitizeCommentTextMixin:
     """
 
     def clean_comment_text(self):
+        """Return the submitted ``comment_text`` sanitized to safe HTML for storage/display."""
         return sanitize_comment_html(self.cleaned_data.get('comment_text', ''))
 
 

--- a/src/quest_manager/tests/test_forms.py
+++ b/src/quest_manager/tests/test_forms.py
@@ -94,30 +94,45 @@ class QuestFormTest(ByteDeckTenantTestCase):
         self.assertTrue(form.is_valid())
 
 
-class QuickReplyFormsEscapeHTMLTest(ByteDeckTenantTestCase):
-    """The plain-text (non-wysiwyg) reply forms are accessible to all users, so
-    all HTML entered in them must be completely escaped. Regression tests for
-    issue #1343 where scripts entered in the quick reply form would execute.
+class QuickReplyFormsSanitizeHTMLTest(ByteDeckTenantTestCase):
+    """The plain-text (non-wysiwyg) reply forms are accessible to all users and
+    rendered with |safe. They carry rich HTML from the Summernote editor, so their
+    `comment_text` is sanitized with an allow-list on cleaning: legitimate
+    formatting is preserved (issue #2113) while scripts and event handlers are
+    stripped so they can't execute (regression tests for issue #1343).
     """
 
     xss_payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
-    escaped_payload = ('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
-                       '&lt;img src=x onerror=alert(1)&gt;')
+    formatting_payload = '<p>hello <b>bold</b> <a href="http://example.com">link</a></p>'
 
-    def test_SubmissionQuickReplyFormStudent__escapes_html(self):
-        """All HTML in the student quick reply form is escaped on cleaning."""
-        form = SubmissionQuickReplyFormStudent(data={'comment_text': self.xss_payload})
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+    forms_under_test = (
+        ('student quick reply', SubmissionQuickReplyFormStudent),
+        ('staff quick reply', SubmissionQuickReplyForm),
+        ('reply', SubmissionReplyForm),
+    )
 
-    def test_SubmissionQuickReplyForm__escapes_html(self):
-        """All HTML in the staff quick reply form is escaped on cleaning."""
-        form = SubmissionQuickReplyForm(data={'comment_text': self.xss_payload})
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+    def test_reply_forms__strip_scripts_and_event_handlers(self):
+        """Scripts and inline event handlers are removed from every reply form so a
+        crafted comment can't run JavaScript when rendered (issue #1343)."""
+        for label, form_class in self.forms_under_test:
+            with self.subTest(form=label):
+                form = form_class(data={'comment_text': self.xss_payload})
+                self.assertTrue(form.is_valid())
+                cleaned = form.cleaned_data['comment_text']
+                # the <script> tag is neutralized (escaped, not a live tag)...
+                self.assertNotIn('<script>', cleaned)
+                self.assertIn('&lt;script&gt;', cleaned)
+                # ...and the onerror event handler is stripped off the surviving <img>
+                self.assertNotIn('onerror', cleaned)
 
-    def test_SubmissionReplyForm__escapes_html(self):
-        """All HTML in the reply form is escaped on cleaning."""
-        form = SubmissionReplyForm(data={'comment_text': self.xss_payload})
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['comment_text'], self.escaped_payload)
+    def test_reply_forms__preserve_legitimate_formatting(self):
+        """Ordinary formatting HTML survives sanitizing so rich comments render
+        instead of showing their literal tags (issue #2113)."""
+        for label, form_class in self.forms_under_test:
+            with self.subTest(form=label):
+                form = form_class(data={'comment_text': self.formatting_payload})
+                self.assertTrue(form.is_valid())
+                cleaned = form.cleaned_data['comment_text']
+                self.assertIn('<b>bold</b>', cleaned)
+                self.assertIn('<a href="http://example.com">link</a>', cleaned)
+                self.assertIn('<p>', cleaned)

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -791,10 +791,10 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments[0].text, f'<p>{comment}</p>')
 
-    def test_complete_quick_reply_form__escapes_html(self):
-        """HTML entered in the quick reply form is completely escaped when the comment
-        is saved, so scripts can't execute when the comment is rendered. Regression
-        test for issue #1343.
+    def test_complete_quick_reply_form__sanitizes_html(self):
+        """HTML entered in the quick reply form is sanitized when the comment is saved:
+        scripts and event handlers are stripped so nothing executes when the comment is
+        rendered. Regression test for issue #1343.
         """
         payload = '<script>alert("xss")</script><img src=x onerror=alert(1)>'
         response = self.post_complete(submission_comment=payload)
@@ -803,8 +803,23 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         comments = self.sub.get_comments()
         self.assertEqual(comments.count(), 1)
         self.assertNotIn('<script', comments[0].text)
-        self.assertNotIn('<img', comments[0].text)
         self.assertIn('&lt;script&gt;', comments[0].text)
+        self.assertNotIn('onerror', comments[0].text)
+
+    def test_complete_quick_reply_form__preserves_formatting(self):
+        """Legitimate formatting HTML from the submission editor is preserved (not
+        escaped) when the comment is saved, so it renders instead of showing its literal
+        tags. Regression test for issue #2113.
+        """
+        response = self.post_complete(submission_comment='<p>giggity <b>bold</b></p>')
+        self.assertRedirects(response, expected_url=reverse('quests:quests'))
+
+        comments = self.sub.get_comments()
+        self.assertEqual(comments.count(), 1)
+        # the formatting tags survive as real HTML, not escaped literal text
+        self.assertIn('<b>bold</b>', comments[0].text)
+        self.assertNotIn('&lt;b&gt;', comments[0].text)
+        self.assertNotIn('&lt;p&gt;', comments[0].text)
 
     def test_complete__no_verification(self):
         """ Checks if a student completing a submission that causes their XP to go over


### PR DESCRIPTION
## What

Comments were showing their **literal HTML tags** as text (e.g. a comment displaying `<p>giggity</p>` instead of the paragraph) — issue #2113. This fixes the regression by **sanitizing** comment HTML with an allow-list instead of escaping all of it, so legitimate formatting renders while scripts are still stripped.

## Why

The stored-XSS fix for #1343 added a blanket `escape()` on the `comment_text` field of the plain-text / quick-reply comment forms. In practice those fields don't receive plain text — they carry **rich HTML from the Summernote editor** (a student's submission comment posts `<p>…</p>`, `<b>`, lists, links, etc.). Escaping all of it turned that legitimate formatting into literal text on the page.

The forms are still rendered with `|safe`, so we can't simply stop sanitizing — that would reopen the #1343 XSS hole. The correct fix is an **allow-list sanitizer**: keep safe formatting, strip anything that can execute.

## How

- New `comments/sanitize.py` → `sanitize_comment_html()`. It runs `bleach.clean()` with the **same tag/style allow-list as the "safe" Summernote widget** (`bytedeck_summernote.settings.ALLOWED_TAGS` / `STYLES`), but with a **stricter attribute policy** that drops inline event handlers (`on*`) and a small deny-list (`srcdoc`, `formaction`, …). Result:
  - kept: `<p>`, `<b>`, `<a href="http…">`, `<ul>/<li>`, styles, etc. → comments render
  - stripped: `<script>` (escaped), `onerror`/`onclick`/… handlers, `javascript:` URLs → nothing can execute
  - This is actually **stricter than the current Summernote box**, which keeps `on*` attributes.
- `comments/forms.py` (`CommentForm`, non-wysiwyg branch) and `quest_manager/forms.py` (renamed `EscapeCommentTextMixin` → `SanitizeCommentTextMixin`, used by the reply / quick-reply forms) now call `sanitize_comment_html()` instead of `escape()`.

Sanitizing at the form level covers every save path, including the student draft path that writes `Comment.text` directly (bypassing `clean_html()`).

## Testing

- The #1343 regression tests (in `comments`, `quest_manager`, `announcements`) are updated to assert **sanitization** — `<script>` neutralized, `onerror` stripped — rather than full escaping.
- New tests assert **legitimate formatting survives** (`<b>bold</b>`, links preserved; not escaped) across all the reply/comment forms and through the full submission-complete save path.
- `python manage.py test comments quest_manager.tests.test_forms quest_manager.tests.test_views.SubmissionCompleteViewTest announcements.tests.test_views.AnnouncementViewTests` — all pass. `ruff` clean.

## Screenshots

Captured from a real `hackerspace` dev deck. Same comment content (a paragraph with bold text, a link, and a bulleted list) on a real quest submission, rendered by the real template:

**Before** (the bug — tags shown as literal text):

![Before: comment shows literal HTML tags](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2113/before.png)

**After** (this PR — formatting renders):

![After: comment renders formatting](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2113/after.png)

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved comment and reply protection by removing scripts, JavaScript URLs, and inline event handlers.
* **Formatting**
  * Preserved safe HTML formatting, including bold text, paragraphs, and links, in comments and replies.
* **Bug Fixes**
  * Updated comment rendering and submission flows to safely support legitimate rich-text formatting without exposing users to malicious content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->