### PR TITLE
Pin Claude Code reasoning effort to xhigh (Max) for the project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "effortLevel": "xhigh",
   "permissions": {
     "allow": [
       "mcp__Claude_Code_Remote__send_later",


### PR DESCRIPTION
### What?
Add `"effortLevel": "xhigh"` to the committed `.claude/settings.json` so Claude Code sessions on this repo default to **Max** reasoning effort.

### Why?
The effort level chosen in the in-session selector is **session-scoped** — it resets to the model's default (High, for Opus) on every new session, resume, or compaction, so it kept "reverting to High." Writing it into project settings persists it, so sessions consistently run at Max without anyone re-selecting it each time.

### How?
One top-level key in `.claude/settings.json` (alongside the existing `permissions`/`hooks`):
```json
"effortLevel": "xhigh"
```
`xhigh` is the maximum persistable effort level and is what the in-session selector labels **Max**. Because Claude Code reads `effortLevel` from settings live, this applies to already-running sessions too, not just new ones. Committed (not `settings.local.json`) so it's the team-wide default for the repo.

### Testing?
Config-only. Validated `.claude/settings.json` parses as JSON with `effortLevel == "xhigh"`; no application code touched.

### Screenshots (if front end is affected)
N/A — editor/agent configuration only.

### Anything Else?
Precedence is user → project → local, so any individual who wants a different effort locally can still override this in their own `.claude/settings.local.json`.

### Review request
@tylerecouture

- Claude Code (Bytedeck - integrations and automations)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_