### PR TITLE
Serve the select2-bootstrap theme locally, not from cdnjs

### DIFF
--- a/src/badges/templates/badges/assertion_form.html
+++ b/src/badges/templates/badges/assertion_form.html
@@ -4,7 +4,7 @@
 
 {% block head %}
     {{ form.media.css }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'css/select2-bootstrap.min.css' %}">
 {% endblock %}
 
 {% block heading_inner %} {{ heading }}{% endblock %}

--- a/src/djcytoscape/templates/djcytoscape/cytoscape_form.html
+++ b/src/djcytoscape/templates/djcytoscape/cytoscape_form.html
@@ -1,10 +1,11 @@
 {% extends "djcytoscape/base.html" %}
+{% load static %}
 {% load crispy_forms_tags %}
 {% block heading_inner %}Update Quest Map{% endblock%}
 
 {% block head %}
     {{ form.media.css }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'css/select2-bootstrap.min.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/src/djcytoscape/templates/djcytoscape/generate_new_form.html
+++ b/src/djcytoscape/templates/djcytoscape/generate_new_form.html
@@ -1,10 +1,11 @@
 {% extends "djcytoscape/base.html" %}
+{% load static %}
 {% load crispy_forms_tags %}
 {% block heading_inner %}Generate a New Quest Map{% endblock%}
 
 {% block head %}
   {{ form.media }}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+  <link rel="stylesheet" href="{% static 'css/select2-bootstrap.min.css' %}">
 {% endblock %}
 
 {% block content %}

--- a/src/prerequisites/templates/prerequisites/advanced_prereqs_form.html
+++ b/src/prerequisites/templates/prerequisites/advanced_prereqs_form.html
@@ -4,7 +4,7 @@
 
 {% block head %}
   {{ form.media.css }}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+  <link rel="stylesheet" href="{% static 'css/select2-bootstrap.min.css' %}">
 {% endblock %}
 
 {% block heading_inner %}Advanced Prerequisites Form{% endblock %}

--- a/src/quest_manager/templates/quest_manager/quest_form.html
+++ b/src/quest_manager/templates/quest_manager/quest_form.html
@@ -5,7 +5,7 @@
 {% block head %}
   {{ form.media.css }}
   <script src="{% static 'js/bootstrap-datetimepicker.js' %}"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+  <link rel="stylesheet" href="{% static 'css/select2-bootstrap.min.css' %}">
 {% endblock %}
 
 {% block heading_inner %} {{ heading }}{% endblock %}

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -1,9 +1,10 @@
 {% extends "quest_manager/base.html" %}
+{% load static %}
 {% load crispy_forms_tags %}
 
 {% block head %}
     {{ submission_form.media }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'css/select2-bootstrap.min.css' %}">
 {% endblock %}
 
 {% block head_css %}


### PR DESCRIPTION
### What?

Third step of the Bootstrap cleanup series (follows #2095, #2105). Six form templates loaded the **select2-bootstrap-theme** CSS from `cdnjs` (`0.1.0-beta.10`), while a **byte-identical copy already sat unused** at `src/static/css/select2-bootstrap.min.css`. This points them at the local file and drops the cdnjs `<link>`.

### Why?

- **Consistency + no CDN dependency** (same rationale as the earlier cleanup PRs — the cdnjs copy doesn't load in CI/offline dev).
- The local file is **already there and already the right version** — the cdnjs `<link>` was a redundant external dependency on a file we ship.

### How?

- Repointed the theme `<link>` in all six templates to `{% static 'css/select2-bootstrap.min.css' %}`:
  - `badges/assertion_form.html`
  - `quest_manager/submission.html`
  - `quest_manager/quest_form.html`
  - `prerequisites/advanced_prereqs_form.html`
  - `djcytoscape/generate_new_form.html`
  - `djcytoscape/cytoscape_form.html`
- Added `{% load static %}` to the three that didn't already have it (`submission`, `generate_new_form`, `cytoscape_form`).
- **No change to the CSS file itself** — I confirmed the existing local `select2-bootstrap.min.css` is **byte-for-byte identical** to the cdnjs `0.1.0-beta.10` build (both 16,792 bytes, `diff` clean), so there's no version or visual change.

### Testing?

- `python src/manage.py check` — clean; `ruff check src` — clean; `badges` + `djcytoscape` view tests (110) — OK. Full suite in CI.
- **Verified on a running `hackerspace` deck**: the quest create form's select2 fields (Campaign, Common Quest Info, Tags) render with the bootstrap theme — the Tags dropdown opens with the themed blue-highlighted option — the local `select2-bootstrap.min.css` loads (HTTP 200), and there are **no console errors**.

### Screenshots (if front end is affected)

No visual change (byte-identical file) — this confirms the local theme renders the select2 dropdowns correctly:

![quest form select2](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/select2-theme-dedupe/quest-form-select2.png)

(Dark panel on the right is the dev-only django-debug-toolbar.)

### Anything Else?

Last in the cleanup series: **PR4** deletes the dead files (`bootstrap_theme_examples.html`, `bootstrap-theme.min.css`, the dead `bootstrap-table-filter-control.js`). After that, the LMS BS3 → BS5 migration. Public tenant stays on Bootstrap 5 (intended).

### Review request
@tylerecouture

- Claude Code (Bytedeck - dependancies upgrades)

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form and submission pages to load Select2 styling from local application assets.
  * Improved reliability and consistency of page styling when external CDN resources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->