### PR TITLE
Cover portfolios/views.py artwork update/delete/add gaps (93% → 100%)

### DIFF
--- a/src/portfolios/tests/test_views.py
+++ b/src/portfolios/tests/test_views.py
@@ -2,13 +2,14 @@ from django.utils import timezone
 from io import BytesIO
 from django.urls import reverse
 from django_tenants.test.client import TenantClient
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedFile
 from django.contrib.auth import get_user_model
 
 from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
-from portfolios.models import Portfolio
+from portfolios.models import Artwork, Portfolio
+from portfolios.views import is_acceptable_vid_type
 
 User = get_user_model()
 
@@ -212,3 +213,61 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse('portfolios:edit', args=[self.portfolio.pk]))
+
+    def test_ArtworkUpdateView__post(self):
+        """A valid ArtworkUpdate POST saves and redirects to the owner's portfolio edit page."""
+        self.client.force_login(self.test_student)
+        form_data = {
+            'title': "Updated Title",
+            'portfolio': self.portfolio,
+            'date': timezone.now().date(),
+            'video_url': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        }
+        response = self.client.post(reverse('portfolios:art_update', args=[self.art.pk]), data=form_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('portfolios:edit', args=[self.portfolio.pk]))
+        self.art.refresh_from_db()
+        self.assertEqual(self.art.title, "Updated Title")
+
+    def test_ArtworkDeleteView__post(self):
+        """An ArtworkDelete POST removes the art and redirects to the owner's portfolio edit page."""
+        self.client.force_login(self.test_student)
+        response = self.client.post(reverse('portfolios:art_delete', args=[self.art.pk]))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('portfolios:edit', args=[self.portfolio.pk]))
+        self.assertFalse(Artwork.objects.filter(pk=self.art.pk).exists())
+
+    def test_is_acceptable_vid_type__accepts_video_extensions_only(self):
+        """is_acceptable_vid_type recognises video file extensions and rejects others."""
+        self.assertTrue(is_acceptable_vid_type("clip.mp4"))
+        self.assertTrue(is_acceptable_vid_type("clip.webm"))
+        self.assertFalse(is_acceptable_vid_type("picture.png"))
+
+    def test_art_add__video_document_creates_video_artwork(self):
+        """Adding art from a video-file comment document creates an Artwork with a video (not image)."""
+        self.client.force_login(self.test_student)
+        video_doc = baker.make(
+            'comments.Document',
+            docfile=SimpleUploadedFile("clip.mp4", b"fake-video-bytes", content_type="video/mp4"),
+            comment=baker.make('comments.Comment', user=self.test_student),
+        )
+
+        response = self.client.get(reverse('portfolios:art_add', args=[video_doc.pk]))
+
+        self.assertEqual(response.status_code, 302)
+        artwork = Artwork.objects.get(title="clip")
+        self.assertTrue(artwork.video_file)
+        self.assertFalse(artwork.image_file)
+
+    def test_art_add__unsupported_format_returns_404(self):
+        """Adding art from a comment document that is neither an image nor a video is rejected (404)."""
+        self.client.force_login(self.test_student)
+        text_doc = baker.make(
+            'comments.Document',
+            docfile=SimpleUploadedFile("notes.txt", b"not media", content_type="text/plain"),
+            comment=baker.make('comments.Comment', user=self.test_student),
+        )
+
+        self.assert404('portfolios:art_add', args=[text_doc.pk])


### PR DESCRIPTION
### What?

Next gap-closing PR. Fills the untested branches in `portfolios/views.py`, taking it from **93% → 100%**.

### Why?

A few artwork-management paths were never exercised — the update/delete redirects, the video-file helper, and `art_add`'s non-image branches. Portfolios are how students show their work, so worth locking down.

### How?

New tests in `portfolios/tests/test_views.py`:

- **`ArtworkUpdate` / `ArtworkDelete`** POST tests — a valid update saves and a delete removes the art, each redirecting to the owner's portfolio edit page (`get_success_url`).
- **`is_acceptable_vid_type`** — recognises video extensions and rejects non-video files.
- **`art_add` from a video document** — creates an `Artwork` with a video file (not an image), exercising the branch the existing image-only test skipped.
- **`art_add` with an unsupported format** — a comment document that is neither an image nor a video is rejected with a 404.

### Testing?

- `python manage.py test portfolios` → **32 passing** (+5 new); `ruff` clean; `test_conventions` passes.
- Verified via coverage that `portfolios/views.py` reaches **100%** (0 missing statements, 0 partial branches).

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Targets were picked from a fresh full-suite coverage run. The existing portfolios view tests were already clean (clear names + docstrings), so no test-quality tidy was warranted here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_