### PR TITLE
Cache-bust map scripts so the campaign name-wrap fix reaches users (#1289)

### DIFF
--- a/src/djcytoscape/templates/djcytoscape/quest_map.html
+++ b/src/djcytoscape/templates/djcytoscape/quest_map.html
@@ -85,10 +85,17 @@
 
 </script>
 
-<script src="{% static 'djcytoscape/js/maps.js' %}"></script>
+{% comment %}
+  Cache-bust the map scripts with a ?v= query (same convention as the versioned CSS in
+  head_css.html and other JS like jquery-double-submission.js). maps.js has no hashed
+  filename, so without this a browser keeps serving a stale copy — which is why the campaign
+  name-wrap fix (#1289 / PR #1937) never reached users who had already cached the old maps.js.
+  Bump this version whenever maps.js / maps-dark.js changes.
+{% endcomment %}
+<script src="{% static 'djcytoscape/js/maps.js' %}?v=1.1"></script>
 
 {% if request.user.profile.dark_theme %}
- <script src="{% static 'djcytoscape/js/maps-dark.js' %}"></script>
+ <script src="{% static 'djcytoscape/js/maps-dark.js' %}?v=1.1"></script>
 {% endif %}
 
 

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -107,6 +107,19 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # self.assert200('djcytoscape:regenerate', args=[self.map.id])
         # self.assert200('djcytoscape:regenerate_all')
 
+    def test_quest_map__map_scripts_are_cache_busted(self):
+        """maps.js (and maps-dark.js) are served with a ?v= cache-buster so browsers don't keep
+        serving a stale copy that misses map fixes like the campaign name-wrap fix (#1289 / #1937)."""
+        self.client.force_login(self.test_student1)
+        response = self.client.get(reverse('djcytoscape:quest_map', args=[self.map.id]))
+        self.assertContains(response, 'js/maps.js?v=')
+
+        # dark-theme users load an extra script that must be cache-busted too
+        self.test_student1.profile.dark_theme = True
+        self.test_student1.profile.save()
+        response = self.client.get(reverse('djcytoscape:quest_map', args=[self.map.id]))
+        self.assertContains(response, 'js/maps-dark.js?v=')
+
     def test_ScapeGenerateMap__POST(self):
         """ Assert a teacher can generate a map using ScapeGenerateMapView """
         from djcytoscape.forms import GenerateQuestMapForm


### PR DESCRIPTION
### What?

Closes #1289. Long campaign names still appear to wrap onto stacked lines down the side of a campaign column on the quest map — even though #1937 already fixed this. The fix is correct and on `develop`; it just **wasn't reaching browsers**. This PR delivers it by cache-busting the map scripts.

### Why? (root cause)

#1937 fixed the wrapping by setting `text-wrap: none` on the compound campaign label in `maps.js`. But `maps.js` is served with a **plain, unhashed filename and no `?v=` query**:

```
<script src="{% static 'djcytoscape/js/maps.js' %}"></script>
```

So a browser that had already cached the pre-#1937 `maps.js` keeps serving the **old** file — which still has `text-wrap: wrap` and breaks long campaign names onto stacked lines. That's why #1289 looked unsolved even after #1937 merged: the deployed code is right, but the cached JS is stale. (The project already cache-busts other changed assets this way — `jquery-double-submission.js?v=1.1`, `custom_common.css?v=1.7` — `maps.js` was just missing it.)

I verified there is **no remaining rendering bug** on current `develop`: the only campaign node that appears on a real map is the compound parent (`classes="campaign"`), and its label already renders single-line with `text-wrap: none`. (A campaign can't be a downstream/reliant node — `Category` is `IsAPrereqMixin` but not `HasPrereqsMixin` — so no other campaign-name node type exists to wrap.) The wrapping only reproduces with the **old** `maps.js`, i.e. from cache.

### How?

- **`djcytoscape/templates/djcytoscape/quest_map.html`** — add a `?v=1.1` cache-buster to the `maps.js` and `maps-dark.js` includes (with a `{% comment %}` noting to bump it whenever those files change), matching the existing `?v=` convention for changed JS/CSS. A browser holding the old `maps.js` now fetches the new one, which carries the #1937 fix.

### Testing?

- `djcytoscape/tests/test_views.py::ViewTests::test_quest_map__map_scripts_are_cache_busted` — asserts the map page serves `maps.js?v=` (and `maps-dark.js?v=` for dark-theme users). Fails before this change, passes after. Full `djcytoscape` view suite green; `ruff` clean.

### Screenshots (if front end is affected)

Same real map on the running `hackerspace` deck (dark theme), campaign renamed to a long multi-word name to force the break. **Before** = what a browser with the stale cached `maps.js` renders (old `text-wrap: wrap`); **After** = current / cache-busted `maps.js` (`text-wrap: none`).

| Before (stale cached maps.js — wraps) | After (cache-busted — single line) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1289/before-cached-wrap.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1289/after-cachebusted.png) |

### Anything Else?

- If you (or a user) still see wrapping after this ships, a one-time hard refresh (Ctrl+Shift+R) on the map page clears the stale `maps.js`; the `?v=` bump makes that automatic going forward.
- Longer term, hashed static filenames (a manifest static storage) would cache-bust everything automatically and remove the need to bump `?v=` by hand — out of scope here, flagging as a follow-up option.

### Review request
@tylerecouture — heads up, this turned out to be a caching-delivery issue rather than a new CSS bug; the before/after above shows the stale-cache wrapping vs. the fixed render. If your screenshot was something other than a compound campaign column wrapping, point me at the specific campaign and I'll dig further.

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_