### PR TITLE
HOTFIX: Match the deck status banner styling to django messages (#2132)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -53,8 +53,9 @@
 <!-- ** end  content_first block ** -->
 {% include 'navbar-fixed.html' %}
 <div class="container-fluid" id="main-container">
-    {% include 'deck_status_banner.html' %}
     <div id="messages-container">
+        {# inside the messages container so the banner gets the exact same alert styling as django messages (#2132) #}
+        {% include 'deck_status_banner.html' %}
         {% include 'messages-snippet.html' %}
     </div>
 

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -554,6 +554,17 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         return response
 
+    def test_banner__renders_inside_messages_container(self):
+        """The banner renders INSIDE #messages-container so it inherits the exact
+        same alert styling (margins) as django messages -- outside it, the
+        container-scoped rules in custom_common.css don't apply and the banner
+        sits flush against the navbar with a mismatched gap below (#2132)."""
+        response = self.get_quests_page(self.staff)
+        content = response.content.decode()
+        # before the fix the banner rendered above (before) the container, so the
+        # container's opening tag appearing first is exactly what the fix changes
+        self.assertLess(content.index('id="messages-container"'), content.index('id="deck-status-banner"'))
+
     def test_banner__trial_mode_shown_to_staff_with_subscribe_link(self):
         """Staff on a trial deck see the Trial Mode banner linking to the deck's own
         subscription page (PR 6; previously the public subscribe flatpage)."""


### PR DESCRIPTION
### What?
The deck status banner (Trial Mode / expiring / over-limit / suspended) now renders **inside `#messages-container`** in `base.html`, so it picks up the exact same alert styling as the django messages below it. Closes #2132.

### Why?
The banner sat *outside* the messages container, so the container-scoped rules in `custom_common.css` (10px top margin on the first alert, 8px bottom margins) didn't apply to it — it rendered flush against the navbar with Bootstrap's default 20px gap below, visibly mismatched with the messages right under it (reported by @tylerecouture while live-testing staging v1.19).

### How?
Moved the `deck_status_banner.html` include into `#messages-container`, above the messages snippet — one template change, no new/duplicated CSS: the banner now inherits whatever the messages' styling is, today and in the future. The banner stays non-dismissible (it's persistent status, not a one-off message).

### Testing?
* New regression test `test_banner__renders_inside_messages_container` asserts the banner renders inside the container (fails on the old template, where the banner preceded it).
* Full serial suite on this branch (based on `staging`): **1523 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
Captured from the real dev deck (`hackerspace.localhost:8000`, staff login, light theme), same trial state as the report.

**Before** — banner flush to the navbar, oversized gap below:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2132/before.png)

**After** — same margins as the django messages:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2132/after.png)

### Anything Else?
Hotfix to `staging` per maintainer request; it will flow back to `develop` with the next staging sync. Two sibling hotfix PRs (subscription-page seats table, trial-banner copy) follow separately.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_