### PR TITLE
HOTFIX: Subscription page: remaining-seats row and single governing date row

### DIFF
--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -615,6 +615,17 @@ form > div.alert.alert-block.alert-danger {
   margin-top: 8px;
 }
 
+/************TABLES *************************/
+
+/* Summary row at the bottom of a facts table (e.g. "Remaining students" on the
+   subscription page): set off from the rows above by a heavier rule, matching the
+   2px weight Bootstrap uses under a thead. Width-only override, so each theme
+   keeps its own table border color. */
+.table > tbody > tr.total-row > th,
+.table > tbody > tr.total-row > td {
+    border-top-width: 2px;
+}
+
 /******* Accordian ***********************/
 
 .panel-heading-tall {

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -31,7 +31,7 @@
 {% else %}
 <link href="{{ STATIC_PREFIX }}css/custom.css?v=1.6" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=1.7" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=1.8" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -33,21 +33,31 @@
 {% endif %}
 
 <h3>Dates</h3>
+{# one governing deadline row, not both: a paid date (even lapsed) supersedes the trial date #}
 <table class="table" style="max-width: 30em;">
-  <tr><th>Trial ends</th><td>{{ deck.trial_end_date|default:"&mdash;" }}</td></tr>
-  <tr><th>Paid until</th><td>{{ deck.paid_until|default:"&mdash;" }}</td></tr>
-  <tr><th>Grace period</th><td>{{ grace_days }} days after <em>paid until</em></td></tr>
+  {% if deck.paid_until %}
+    <tr><th>Paid until</th><td>{{ deck.paid_until }}</td></tr>
+    <tr><th>Grace period</th><td>{{ grace_days }} days after <em>paid until</em></td></tr>
+  {% elif deck.trial_end_date %}
+    <tr><th>Trial ends</th><td>{{ deck.trial_end_date }}</td></tr>
+  {% else %}
+    <tr><th>Expires</th><td>Never &mdash; this deck is managed manually</td></tr>
+  {% endif %}
 </table>
 
 <h3>Student seats</h3>
 <table class="table" style="max-width: 30em;">
   <tr>
+    <th>Maximum allowed</th>
+    <td>{% if cap == -1 %}Unlimited{% else %}{{ cap }}{% endif %}</td>
+  </tr>
+  <tr>
     <th>Current students</th>
     <td>{{ current_student_count }}</td>
   </tr>
-  <tr>
-    <th>Maximum allowed</th>
-    <td>{% if cap == -1 %}Unlimited{% else %}{{ cap }}{% endif %}</td>
+  <tr class="total-row">
+    <th>Remaining students</th>
+    <td>{% if cap == -1 %}Unlimited{% else %}{{ remaining_seats }}{% endif %}</td>
   </tr>
 </table>
 {% if cap != -1 and current_student_count >= cap %}

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -651,15 +651,60 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.get_page()
 
     def test_page__shows_dates_seats_and_status(self):
-        """A subscribed deck shows its status, both dates, days remaining, and seat usage."""
+        """A subscribed deck shows its status, the governing date, days remaining,
+        and the three seat rows (maximum / current / remaining)."""
         response = self.get_page()
         self.assertContains(response, 'Subscribed')
         self.assertContains(response, '100 days remaining')
         self.assertContains(response, 'Paid until')
-        self.assertContains(response, 'Trial ends')
         self.assertContains(response, 'Current students')
         self.assertContains(response, 'Maximum allowed')
+        self.assertContains(response, 'Remaining students')
         self.assertContains(response, '30')
+
+    def test_page__dates_show_only_the_governing_deadline(self):
+        """The Dates table shows ONE deadline row -- Paid until when a paid date
+        exists (it supersedes the trial date, even while lapsed), Trial ends on a
+        trial-only deck, and a never-expires row on a managed-manually deck."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        # subscribed decks keep their old trial date; only the paid row shows
+        self.set_deck(trial_end_date=localdate() - timedelta(days=300))
+        response = self.get_page()
+        self.assertContains(response, 'Paid until')
+        self.assertNotContains(response, 'Trial ends')
+
+        self.set_deck(trial_end_date=localdate() + timedelta(days=10), paid_until=None)
+        response = self.get_page()
+        self.assertContains(response, 'Trial ends')
+        self.assertNotContains(response, 'Paid until')
+
+        self.set_deck(trial_end_date=None, paid_until=None)
+        response = self.get_page()
+        self.assertContains(response, 'Never')
+        self.assertNotContains(response, 'Trial ends')
+        self.assertNotContains(response, 'Paid until')
+
+    def test_page__remaining_seats_counts_down_and_clamps_at_zero(self):
+        """Remaining students = cap minus the LIVE current-student count, clamped
+        at 0 when over the limit; None (rendered "Unlimited") on unlimited decks."""
+        from model_bakery import baker
+
+        from siteconfig.models import SiteConfig
+
+        self.assertEqual(self.get_page().context['remaining_seats'], 30)
+
+        for _ in range(2):  # two current students on a cap of 1: clamped, not -1
+            baker.make('courses.CourseStudent', user=baker.make(User), active=True,
+                       semester=SiteConfig.get().active_semester)
+        self.set_deck(max_active_users=1)
+        response = self.get_page()
+        self.assertEqual(response.context['remaining_seats'], 0)
+
+        self.set_deck(max_active_users=-1)
+        self.assertIsNone(self.get_page().context['remaining_seats'])
 
     def test_page__grace_period_states_trial_cap(self):
         """A deck in its paid grace window explains the grace period and the trial

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -414,10 +414,15 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
 
         context = super().get_context_data(**kwargs)
         deck = self.request.tenant
+        current_student_count = deck.get_active_user_count()  # live, not cached
+        cap = deck.effective_max_active_users
         context.update({
             'deck': deck,
-            'current_student_count': deck.get_active_user_count(),  # live, not cached
-            'cap': deck.effective_max_active_users,
+            'current_student_count': current_student_count,
+            'cap': cap,
+            # None for unlimited decks; clamped at 0 when over the limit (the
+            # template's at-limit warning covers the overage)
+            'remaining_seats': None if cap == -1 else max(0, cap - current_student_count),
             'trial_cap': TRIAL_MAX_ACTIVE_USERS,
             'grace_days': GRACE_PERIOD_DAYS,
             'stripe_configured': billing_configured(),


### PR DESCRIPTION
### What?
Two maintainer-requested tweaks to the staff Subscription details page (from staging v1.19 live testing):

* **Student seats reads as a subtraction**: Maximum allowed on top, Current students below it, then a **Remaining students** summary row set off by a heavier rule. Remaining is clamped at 0 when over the limit (the existing red at-limit warning covers the overage) and shows Unlimited on `-1` decks.
* **One date row, not both**: the Dates table shows only the governing deadline — **Paid until** (plus the grace-period row) when a paid date exists (a paid date supersedes the old trial date, even while lapsed), else **Trial ends**, else a "Never — managed manually" row.

### Why?
The old table always showed both Trial ends and Paid until (one of them a dash), and listed the seat rows in an order that didn't answer the owner's actual question — "how many more students can I add?"

### How?
* `remaining_seats` added to the view context (`None` for unlimited, `max(0, cap - live count)` otherwise).
* New reusable `.total-row` rule in `custom_common.css` (theme-agnostic: only the border *width* changes, so each theme keeps its own table border color, matching the 2px weight Bootstrap uses under a `thead`); `?v=` cache-buster bumped.
* Grace-period row now renders only alongside Paid until — it was meaningless next to a trial date.

### Testing?
* Updated `test_page__shows_dates_seats_and_status` plus two new tests: `test_page__dates_show_only_the_governing_deadline` (paid supersedes trial / trial-only / managed-manually) and `test_page__remaining_seats_counts_down_and_clamps_at_zero` (count-down, over-limit clamp, unlimited → None).
* Full serial suite on this branch (based on `staging`): **1524 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
Captured from the real dev deck (`hackerspace.localhost:8000`, staff login, light theme).

**Before** — both date rows, no remaining count:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-seats/before.png)

**After (trial deck)** — single Trial ends row; Maximum → Current → Remaining with the heavier rule:
![after trial](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-seats/after_trial.png)

**After (subscribed deck)** — single Paid until row with the grace row:
![after subscribed](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-seats/after_subscribed.png)

### Anything Else?
Hotfix to `staging` per maintainer request; flows back to `develop` with the next staging sync. Sibling hotfixes: #2133 (banner styling), and the trial-banner copy PR that follows.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_