### PR TITLE
HOTFIX: Trial banner: time remaining and seats-used copy with Subscription details link

### DIFF
--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -40,8 +40,14 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
         {% elif current_deck.is_on_trial %}
             <div class="alert alert-info" id="deck-status-banner">
                 <strong>Trial Mode:</strong> this deck is on a free trial until {{ current_deck.trial_end_date }}
-                (max {{ current_deck.effective_max_active_users }} current students).
-                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> for more.
+                ({{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }} remaining).
+                {{ current_deck.active_user_count }} current student seat{{ current_deck.active_user_count|pluralize }} used
+                {% if current_deck.effective_max_active_users == -1 %}
+                    (no seat limit).
+                {% else %}
+                    out of a maximum of {{ current_deck.effective_max_active_users }}.
+                {% endif %}
+                See your <a href="{{ deck_subscribe_url }}" class="alert-link">Subscription details</a> page for more info.
             </div>
         {% endif %}
     {% endif %}

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -561,6 +561,34 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Trial Mode')
         self.assertContains(response, reverse('decks:subscription'))
 
+    def test_banner__trial_mode_shows_days_remaining_and_seat_usage(self):
+        """The trial banner spells out the time remaining after the end date and the
+        seats used out of the cap, pointing at the Subscription details page
+        (maintainer request from staging v1.19 testing)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=localdate() + timedelta(days=52), active_user_count=3, max_active_users=5)
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, '52 days remaining')
+        self.assertContains(response, '3 current student seats used')
+        self.assertContains(response, 'out of a maximum of 5')
+        self.assertContains(response, 'Subscription details')
+
+    def test_banner__trial_mode_unlimited_deck_shows_no_seat_limit(self):
+        """A trial deck with the -1 unlimited cap says "no seat limit" instead of
+        "a maximum of -1"."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=localdate() + timedelta(days=52), active_user_count=1, max_active_users=-1)
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, '1 current student seat used')
+        self.assertContains(response, 'no seat limit')
+        self.assertNotContains(response, 'maximum of -1')
+
     def test_banner__not_shown_to_students_on_trial_deck(self):
         """Students never see the trial banner (it's staff-facing nagware)."""
         response = self.get_quests_page(self.student)


### PR DESCRIPTION
### What?
Maintainer-requested copy tweaks to the staff **Trial Mode** banner (from staging v1.19 live testing):

* The end date now carries the time remaining: "…on a free trial until Sept. 13, 2026 **(52 days remaining)**."
* "(max 5 current students)" is replaced with "**1 current student seat used out of a maximum of 5.** See your **Subscription details** page for more info." — the link lands on the staff Subscription details page (which carries the subscribe button and full seat breakdown).
* Unlimited (`-1`) decks say "(no seat limit)" instead of "a maximum of -1".

### Why?
The old banner told owners the cap but not how much of it they'd used or how long the trial had left — the two numbers that actually drive the subscribe decision — and its "Subscribe" link duplicated what the Subscription details page already does better.

### How?
Template-only change in `deck_status_banner.html`. The seats-used figure is the cached `active_user_count` — consistent with the banner's other counts (the over-limit branch), refreshed nightly and by the admin action; the Subscription details page remains the live-count source of truth.

### Testing?
* Two new tests: `test_banner__trial_mode_shows_days_remaining_and_seat_usage` and `test_banner__trial_mode_unlimited_deck_shows_no_seat_limit`.
* Full serial suite on this branch (based on `staging`): **1524 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
Captured from the real dev deck (`hackerspace.localhost:8000`, staff login, light theme; deck on trial until Sept. 13 with 1 current student, cap 5).

**Before**:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/trial-banner-copy/before.png)

**After**:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/trial-banner-copy/after.png)

### Anything Else?
Hotfix to `staging` per maintainer request; flows back to `develop` with the next staging sync. Sibling hotfixes from the same testing round: #2133 (banner styling), #2134 (subscription-page seats/date rows). The three touch different lines, so they merge independently in any order.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_