### PR TITLE
HOTFIX: Trial banner: one-line copy with LIVE student count

### DIFF
--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -18,7 +18,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
     {% elif request.user.is_staff %}
         {% if current_deck.is_over_user_limit %}
             <div class="alert alert-warning" id="deck-status-banner">
-                <strong>Current-student limit exceeded:</strong> this deck has {{ current_deck.active_user_count }}
+                <strong>Current-student limit exceeded:</strong> this deck has {{ current_deck.get_active_user_count }}
                 current students of {{ current_deck.effective_max_active_users }} allowed.
                 <a href="{% url 'courses:archive_students_help' %}" class="alert-link">Archive past students</a>,
                 or <a href="{{ deck_subscribe_url }}" class="alert-link">upgrade your subscription</a>.
@@ -39,15 +39,14 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
             </div>
         {% elif current_deck.is_on_trial %}
             <div class="alert alert-info" id="deck-status-banner">
-                <strong>Trial Mode:</strong> this deck is on a free trial until {{ current_deck.trial_end_date }}
-                ({{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }} remaining).
-                {{ current_deck.active_user_count }} current student seat{{ current_deck.active_user_count|pluralize }} used
-                {% if current_deck.effective_max_active_users == -1 %}
-                    (no seat limit).
-                {% else %}
-                    out of a maximum of {{ current_deck.effective_max_active_users }}.
-                {% endif %}
-                See your <a href="{{ deck_subscribe_url }}" class="alert-link">Subscription details</a> page for more info.
+                {# always plural here: this branch only renders when days_until_expiry > EXPIRY_WARNING_DAYS (the warning banner covers the final days) #}
+                <strong>Trial Mode:</strong> this deck is on a free trial until {{ current_deck.trial_end_date|date:"j M Y" }}
+                ({{ current_deck.days_until_expiry }} days remain).
+                {# the count is LIVE (get_active_user_count), not the nightly-cached field: the cached figure reads as a bug beside live student lists #}
+                You are using {{ current_deck.get_active_user_count }} out of
+                {% if current_deck.effective_max_active_users == -1 %}unlimited{% else %}max {{ current_deck.effective_max_active_users }}{% endif %}
+                current students.
+                See your <a href="{{ deck_subscribe_url }}" class="alert-link">Subscription details</a> for more info.
             </div>
         {% endif %}
     {% endif %}

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -259,15 +259,19 @@ class Tenant(TenantMixin):
 
     @property
     def is_over_user_limit(self):
-        """Whether the deck's cached current-student count exceeds its effective cap.
+        """Whether the deck's LIVE current-student count exceeds its effective cap.
 
-        Advisory (banner/notification) check against the nightly-refreshed cached
-        count -- enforcement at the registration choke points recounts live.
-        Always False for unlimited (-1) decks.
+        Recounts live (like the registration choke points) rather than reading the
+        nightly-cached ``active_user_count``: the banner this drives renders next
+        to pages that list current students live, so a stale cached count reads as
+        a bug (production find: banner claimed 0 seats used beside a student list
+        showing 1). Only the banner uses this property, and only for staff, so the
+        extra COUNT per staff page load is acceptable. Always False for unlimited
+        (-1) decks. Must be evaluated inside the deck's schema.
         """
         if self.effective_max_active_users == -1:
             return False
-        return self.active_user_count > self.effective_max_active_users
+        return self.get_active_user_count() > self.effective_max_active_users
 
     @property
     def is_expiring_soon(self):

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -312,6 +312,29 @@ class TenantCountingAndCachingTest(ByteDeckTenantTestCase):
         stale.update_cached_fields()
         self.tenant.refresh_from_db()
         self.assertEqual(self.tenant.paid_until, date(2030, 1, 1))
+
+    def test_is_over_user_limit__compares_live_count_to_effective_cap(self):
+        """Over-limit only when the LIVE current-student count exceeds the effective
+        cap -- the nightly-cached field is ignored (production find: a stale cached
+        count made the banner disagree with the live student list)."""
+        from django.utils.timezone import localdate
+
+        baseline = self.tenant.get_active_user_count()
+        for _ in range(2):
+            baker.make('courses.CourseStudent', user=baker.make(User), active=True,
+                       semester=SiteConfig.get().active_semester)
+        live = baseline + 2
+
+        # cached count deliberately left stale at 0 in every case: it must not matter
+        def deck(**fields):
+            Tenant.objects.filter(pk=self.tenant.pk).update(active_user_count=0, **fields)
+            return Tenant.objects.get(pk=self.tenant.pk)
+
+        self.assertTrue(deck(trial_end_date=localdate(), max_active_users=live - 1).is_over_user_limit)
+        self.assertFalse(deck(max_active_users=live).is_over_user_limit)  # at the cap is not over it
+        # subscribed deck uses its own (tier) cap, not the trial cap
+        self.assertFalse(deck(paid_until=localdate(), max_active_users=40).is_over_user_limit)
+        self.assertTrue(deck(paid_until=localdate(), max_active_users=live - 1).is_over_user_limit)
 class DefaultTrialEndDateTest(SimpleTestCase):
     """Tests for the default demo/trial expiry date on new tenants (Issue #1146).
 
@@ -344,17 +367,10 @@ class TenantBannerStatusTest(SimpleTestCase):
             max_active_users=max_active_users, active_user_count=active_user_count,
         )
 
-    def test_is_over_user_limit__compares_cached_count_to_effective_cap(self):
-        """Over-limit only when the cached count exceeds the effective cap; unlimited (-1) is never over."""
-        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=30), active_user_count=6).is_over_user_limit)
-        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=30), active_user_count=5).is_over_user_limit)
-        # subscribed deck uses its own (tier) cap, not the trial cap
-        self.assertFalse(
-            self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=30), max_active_users=40, active_user_count=39).is_over_user_limit
-        )
-        self.assertTrue(
-            self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=30), max_active_users=40, active_user_count=41).is_over_user_limit
-        )
+    def test_is_over_user_limit__unlimited_short_circuits_without_querying(self):
+        """An unlimited (-1) deck is never over its limit -- and the check must not
+        touch the database at all (this SimpleTestCase would raise on any query),
+        since the live recount is skipped entirely by the -1 short-circuit."""
         self.assertFalse(self.make_tenant(max_active_users=-1, active_user_count=999).is_over_user_limit)
 
     def test_is_expiring_soon__within_warning_window_or_grace(self):

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -572,33 +572,45 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Trial Mode')
         self.assertContains(response, reverse('decks:subscription'))
 
-    def test_banner__trial_mode_shows_days_remaining_and_seat_usage(self):
-        """The trial banner spells out the time remaining after the end date and the
-        seats used out of the cap, pointing at the Subscription details page
-        (maintainer request from staging v1.19 testing)."""
+    def test_banner__trial_mode_shows_days_remaining_and_live_seat_usage(self):
+        """The trial banner's one-line copy shows the short date, the time remaining,
+        and the LIVE seats-used count -- a student registered moments ago counts even
+        though the nightly-cached field still says 0 (production find: banner claimed
+        0 seats used beside a student list showing 1)."""
         from datetime import timedelta
 
+        from django.template.defaultfilters import date as date_filter
         from django.utils.timezone import localdate
 
-        self.set_deck(trial_end_date=localdate() + timedelta(days=52), active_user_count=3, max_active_users=5)
+        from model_bakery import baker
+
+        from siteconfig.models import SiteConfig
+
+        end = localdate() + timedelta(days=52)
+        # cached count deliberately left at 0: the live count must win
+        self.set_deck(trial_end_date=end, active_user_count=0, max_active_users=5)
+        baker.make('courses.CourseStudent', user=baker.make(User), active=True,
+                   semester=SiteConfig.get().active_semester)
         response = self.get_quests_page(self.staff)
-        self.assertContains(response, '52 days remaining')
-        self.assertContains(response, '3 current student seats used')
-        self.assertContains(response, 'out of a maximum of 5')
+        self.assertContains(response, f'until {date_filter(end, "j M Y")}')
+        self.assertContains(response, '52 days remain')
+        # template whitespace collapses in HTML; normalize before asserting the sentence
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('You are using 1 out of max 5 current students.', text)
         self.assertContains(response, 'Subscription details')
 
     def test_banner__trial_mode_unlimited_deck_shows_no_seat_limit(self):
-        """A trial deck with the -1 unlimited cap says "no seat limit" instead of
-        "a maximum of -1"."""
+        """A trial deck with the -1 unlimited cap says "unlimited" instead of
+        "max -1"."""
         from datetime import timedelta
 
         from django.utils.timezone import localdate
 
-        self.set_deck(trial_end_date=localdate() + timedelta(days=52), active_user_count=1, max_active_users=-1)
+        self.set_deck(trial_end_date=localdate() + timedelta(days=52), max_active_users=-1)
         response = self.get_quests_page(self.staff)
-        self.assertContains(response, '1 current student seat used')
-        self.assertContains(response, 'no seat limit')
-        self.assertNotContains(response, 'maximum of -1')
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('You are using 0 out of unlimited current students.', text)
+        self.assertNotIn('max -1', text)
 
     def test_banner__not_shown_to_students_on_trial_deck(self):
         """Students never see the trial banner (it's staff-facing nagware)."""
@@ -620,12 +632,22 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'This deck is suspended')
         self.assertContains(response, reverse('decks:subscription'))
 
-    def test_banner__over_limit_warns_staff(self):
-        """Staff see the over-limit warning when the cached count exceeds the cap."""
-        self.set_deck(active_user_count=99)
+    def test_banner__over_limit_warns_staff_from_live_count(self):
+        """Staff see the over-limit warning from the LIVE current-student count --
+        a stale cached count (still 0 here) neither hides a real overage nor keeps
+        the warning up after students were archived."""
+        from model_bakery import baker
+
+        from siteconfig.models import SiteConfig
+
+        self.set_deck(active_user_count=0, max_active_users=1)
+        for _ in range(2):
+            baker.make('courses.CourseStudent', user=baker.make(User), active=True,
+                       semester=SiteConfig.get().active_semester)
 
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'Current-student limit exceeded')
+        self.assertContains(response, 'this deck has 2')
 
     def test_banner__expiring_soon_warns_staff(self):
         """Staff see the expiring-soon warning inside the two-week window, for both


### PR DESCRIPTION
### What?
Two maintainer requests from staging live testing, both landing in the same banner sentence:

* **One-line copy** (exact requested wording): "**Trial Mode:** this deck is on a free trial until 13 Sep 2026 (52 days remain). You are using 1 out of max 5 current students. See your **Subscription details** for more info." — short date (`j M Y`), tighter phrasing, and the link rides the sentence. Unlimited (`-1`) decks read "…out of unlimited current students."
* **The seats-used figure is now LIVE** — this is the "banner says 0 when there is 1 current student" bug. The banner read the *nightly-cached* `active_user_count` (refreshed at 06:00 or by the admin action), so a student who registered after the last refresh wasn't counted while the Students page (live query) showed them. `is_over_user_limit` now recounts live too, so the over-limit banner appears/disappears as students register or get archived instead of lagging a day.

### Why?
The cached count made the banner disagree with the student list sitting right under it — a trust-destroying mismatch for the number that drives the subscribe decision. (To answer "how did this pass tests": the tests *pinned* the cached-count design from PR 3 — they set the cached field and asserted the copy. The design was the bug, not a missed test; the new tests pin the live behavior instead: a stale cached 0 with a real registered student must render 1.)

### How?
* Template: trial branch rewritten to the requested copy using `get_active_user_count` (live); over-limit branch's displayed count is live as well.
* `Tenant.is_over_user_limit` recounts live, mirroring the registration choke points. It's used only by the banner, and only staff see the counting branches, so the cost is one extra COUNT per staff page load. The `-1` short-circuit still skips the query entirely (pinned by a `SimpleTestCase` that would raise on any DB access).
* The "(N days remain)" figure needs no singular form: this branch only renders when more than `EXPIRY_WARNING_DAYS` (14) days remain — the final days show the warning banner instead (commented in the template).

### Testing?
* `test_banner__trial_mode_shows_days_remaining_and_live_seat_usage` — cached count forced stale at 0 with 1 real current student: the banner must say "You are using 1 out of max 5 current students." (fails on the old cached-count template), plus the short-date and days-remain copy.
* `test_banner__over_limit_warns_staff_from_live_count` — over-limit triggers from live rows with the cached field still 0.
* `test_is_over_user_limit__compares_live_count_to_effective_cap` (DB-backed) and the `SimpleTestCase` no-query pin for `-1`; unlimited copy test updated.
* Full serial suite on this branch (based on `staging`): **1528 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
Real dev deck, staff login, light theme — deck has **1 live current student with the cached count deliberately stale at 0**, reproducing the report.

**Before** — two lines, and the stale "0 current student seats used":
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/trial-banner-one-line/before.png)

**After** — one line, live count:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/trial-banner-one-line/after.png)

### Anything Else?
Hotfix to `staging` per maintainer request; flows back to `develop` with the next staging sync. Two more hotfixes from this testing round follow separately: the duplicated admin freshness message, and FontAwesome icons on django messages.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_