### PR TITLE
HOTFIX: Don't duplicate the admin deck-stats freshness notice on action POSTs

### DIFF
--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -241,9 +241,17 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         The cached deck stats (current-student counts, owner info, quest counts) refresh via the
         nightly deck-status task, not on page load, so tell the admin how old the
         numbers they're looking at are.
+
+        GET only: an action POST runs through this view too and then redirects (or
+        re-renders), so a notice queued during the POST would survive into the next
+        render and show as a duplicate beside the one the follow-up GET queues
+        (production find after running the refresh action).
         """
         from django.db.models import Max
         from django.utils.timesince import timesince
+
+        if request.method != 'GET':
+            return super().changelist_view(request, extra_context)
 
         latest = self.model.objects.aggregate(latest=Max('cached_fields_updated_on'))['latest']
         if latest:

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -164,6 +164,19 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "have not been refreshed yet")
 
+    def test_changelist_view__freshness_notice_not_duplicated_by_action_posts(self):
+        """The freshness notice is queued on GET only: an action POST also passes
+        through changelist_view before redirecting, and a notice queued during the
+        POST survives into the redirected page, rendering as a duplicate beside the
+        GET's own copy (production find after running the refresh action)."""
+        url = reverse("admin:{}_{}_changelist".format("tenant", "tenant"))
+        self.client.get(url)  # move client to public schema
+        self.client.force_login(self.superuser)
+
+        action_data = {"action": "refresh_cached_fields", ACTION_CHECKBOX_NAME: [self.tenant.pk]}
+        response = self.client.post(url, action_data, follow=True)
+        self.assertContains(response, "were last refreshed", count=1)
+
     def test_refresh_cached_fields_action__refreshes_selected_decks(self):
         """The "Refresh deck stats" changelist action refreshes the selected decks'
         cached stats on demand -- the admin-UI alternative to the management command."""


### PR DESCRIPTION
### What?
The tenant changelist's "Deck stats … were last refreshed X ago" notice now queues on **GET requests only**, fixing the duplicate copies that appeared after running an action (maintainer-reported after "Refresh deck stats" on staging).

### Why?
Admin action POSTs also pass through `changelist_view` before redirecting, so the notice queued during the POST was never rendered there — it survived into the redirected page and showed as a duplicate beside the copy the follow-up GET queued. Extra confusing: the POST-queued copy carried the **pre-refresh** age, so the two duplicates disagreed ("3 hours, 50 minutes ago" next to "0 minutes ago" — visible in the before screenshot).

### How?
Early-return in `TenantAdmin.changelist_view` for non-GET requests before queueing the message; everything else is unchanged. Each GET queues exactly one notice and renders exactly one.

### Testing?
* New regression test `test_changelist_view__freshness_notice_not_duplicated_by_action_posts`: POSTs the refresh action with `follow=True` and asserts the notice renders exactly once — verified to fail (count=2) on the unfixed code.
* Full serial suite on this branch (based on `staging`): **1528 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
Real dev admin (`localhost:8000/admin/`), running "Refresh deck stats" on a deck.

**Before** — the notice appears twice, with contradictory ages, around the action's success message:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/admin-freshness-dedupe/before.png)

**After** — one success message, one (fresh) notice:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/admin-freshness-dedupe/after.png)

### Anything Else?
Hotfix to `staging`; flows back to `develop` with the next staging sync. Sibling hotfixes from this testing round: #2137 (one-line trial banner with live count, open) and the upcoming message-icons + expired-banner PR.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_