### PR TITLE
HOTFIX: Subscription banner: level icons, danger styling when expired, concrete grace copy

### DIFF
--- a/src/hackerspace_online/context_processors.py
+++ b/src/hackerspace_online/context_processors.py
@@ -38,9 +38,16 @@ def deck_status(request):
     """
     from django.urls import reverse
 
+    from tenant.models import TRIAL_MAX_ACTIVE_USERS
     from tenant.utils import get_current_deck
 
     deck = get_current_deck()
     if deck is None:
         return {"current_deck": None}
-    return {"current_deck": deck, "deck_subscribe_url": reverse('decks:subscription')}
+    return {
+        "current_deck": deck,
+        "deck_subscribe_url": reverse('decks:subscription'),
+        # what a lapsed deck reverts to -- the grace banner can't derive this from
+        # the deck's effective cap, which is still the paid cap during grace
+        "trial_cap": TRIAL_MAX_ACTIVE_USERS,
+    }

--- a/src/hackerspace_online/tests/test_views.py
+++ b/src/hackerspace_online/tests/test_views.py
@@ -139,8 +139,9 @@ class GoogleSigninViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
 
 class MessagesSnippetIconTest(ByteDeckTenantTestCase):
-    """Rendering tests for the level icons on django messages (messages-snippet.html,
-    maintainer request from staging live testing)."""
+    """Rendering tests pinning django messages (messages-snippet.html) icon-free:
+    the level-icon request from staging live testing was scoped to the
+    subscription-status banner only (#2140 review)."""
 
     class FakeMessage:
         """Stand-in for a django.contrib.messages Message: the snippet only reads
@@ -158,18 +159,12 @@ class MessagesSnippetIconTest(ByteDeckTenantTestCase):
         from django.template.loader import render_to_string
         return render_to_string('messages-snippet.html', {'messages': [self.FakeMessage(tags, 'the message text')]})
 
-    def test_messages_snippet__renders_level_icon_left_of_text(self):
-        """Each message level renders its FontAwesome icon before the text: ban for
-        error/danger, exclamation-triangle for warning, info-circle for info."""
-        for tags, icon in (('error', 'fa-ban'), ('warning', 'fa-exclamation-triangle'), ('info', 'fa-info-circle')):
+    def test_messages_snippet__messages_have_no_level_icon(self):
+        """Django messages render icon-free at every level: the maintainer scoped the
+        icon request to the subscription-status banner only, so no fa- icon may leak
+        into the shared messages snippet."""
+        for tags in ('error', 'warning', 'info', 'success'):
             html = self.render_messages(tags)
-            self.assertIn(icon, html)
-            self.assertLess(html.index(icon), html.index('the message text'))  # icon sits left of the text
-
-    def test_messages_snippet__success_messages_have_no_icon(self):
-        """Success messages keep their icon-free look (only info/warning/error were
-        requested); no stray fa- icon renders."""
-        html = self.render_messages('success')
-        self.assertNotIn('fa-ban', html)
-        self.assertNotIn('fa-exclamation-triangle', html)
-        self.assertNotIn('fa-info-circle', html)
+            self.assertNotIn('fa-ban', html)
+            self.assertNotIn('fa-exclamation-triangle', html)
+            self.assertNotIn('fa-info-circle', html)

--- a/src/hackerspace_online/tests/test_views.py
+++ b/src/hackerspace_online/tests/test_views.py
@@ -136,3 +136,40 @@ class GoogleSigninViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         response = self.client.get(reverse('account_signup'))
         self.assertIn("btn_google_signin_dark_normal_web", response.content.decode('utf-8'))
+
+
+class MessagesSnippetIconTest(ByteDeckTenantTestCase):
+    """Rendering tests for the level icons on django messages (messages-snippet.html,
+    maintainer request from staging live testing)."""
+
+    class FakeMessage:
+        """Stand-in for a django.contrib.messages Message: the snippet only reads
+        .tags and renders str(message)."""
+
+        def __init__(self, tags, text):
+            self.tags = tags
+            self.text = text
+
+        def __str__(self):
+            return self.text
+
+    def render_messages(self, tags):
+        """Render the snippet with one fake message of the given tags."""
+        from django.template.loader import render_to_string
+        return render_to_string('messages-snippet.html', {'messages': [self.FakeMessage(tags, 'the message text')]})
+
+    def test_messages_snippet__renders_level_icon_left_of_text(self):
+        """Each message level renders its FontAwesome icon before the text: ban for
+        error/danger, exclamation-triangle for warning, info-circle for info."""
+        for tags, icon in (('error', 'fa-ban'), ('warning', 'fa-exclamation-triangle'), ('info', 'fa-info-circle')):
+            html = self.render_messages(tags)
+            self.assertIn(icon, html)
+            self.assertLess(html.index(icon), html.index('the message text'))  # icon sits left of the text
+
+    def test_messages_snippet__success_messages_have_no_icon(self):
+        """Success messages keep their icon-free look (only info/warning/error were
+        requested); no stray fa- icon renders."""
+        html = self.render_messages('success')
+        self.assertNotIn('fa-ban', html)
+        self.assertNotIn('fa-exclamation-triangle', html)
+        self.assertNotIn('fa-info-circle', html)

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -24,10 +24,12 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
                 or <a href="{{ deck_subscribe_url }}" class="alert-link">upgrade your subscription</a>.
             </div>
         {% elif current_deck.is_expiring_soon %}
-            <div class="alert alert-warning" id="deck-status-banner">
+            {# expired-into-grace escalates to danger styling; the approaching-deadline variants stay warnings #}
+            <div class="alert {% if current_deck.days_until_expiry < 0 %}alert-danger{% else %}alert-warning{% endif %}" id="deck-status-banner">
                 {% if current_deck.days_until_expiry < 0 %}
-                    <strong>Subscription expired</strong> &mdash; this deck is in its grace
-                    period and will revert to trial limits soon.
+                    <strong>Subscription expired</strong> &mdash; this deck is in its grace period, which ends in
+                    {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
+                    it will then revert to trial limits (max {{ trial_cap }} current students).
                 {% elif current_deck.is_on_trial %}
                     <strong>Trial ending soon:</strong> this deck's free trial ends in
                     {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -7,6 +7,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
 {% if current_deck %}
     {% if current_deck.is_suspended %}
         <div class="alert alert-danger" id="deck-status-banner">
+            <i class="fa fa-fw fa-ban"></i>
             {% if request.user.is_staff %}
                 <strong>This deck is suspended</strong> &mdash; its trial or subscription has ended, and it has
                 reverted to trial limits (max {{ current_deck.effective_max_active_users }} current students).
@@ -18,6 +19,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
     {% elif request.user.is_staff %}
         {% if current_deck.is_over_user_limit %}
             <div class="alert alert-warning" id="deck-status-banner">
+                <i class="fa fa-fw fa-exclamation-triangle"></i>
                 <strong>Current-student limit exceeded:</strong> this deck has {{ current_deck.active_user_count }}
                 current students of {{ current_deck.effective_max_active_users }} allowed.
                 <a href="{% url 'courses:archive_students_help' %}" class="alert-link">Archive past students</a>,
@@ -26,6 +28,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
         {% elif current_deck.is_expiring_soon %}
             {# expired-into-grace escalates to danger styling; the approaching-deadline variants stay warnings #}
             <div class="alert {% if current_deck.days_until_expiry < 0 %}alert-danger{% else %}alert-warning{% endif %}" id="deck-status-banner">
+                <i class="fa fa-fw fa-exclamation-triangle"></i>
                 {% if current_deck.days_until_expiry < 0 %}
                     <strong>Subscription expired</strong> &mdash; this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
@@ -41,6 +44,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
             </div>
         {% elif current_deck.is_on_trial %}
             <div class="alert alert-info" id="deck-status-banner">
+                <i class="fa fa-fw fa-info-circle"></i>
                 <strong>Trial Mode:</strong> this deck is on a free trial until {{ current_deck.trial_end_date }}
                 ({{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }} remaining).
                 {{ current_deck.active_user_count }} current student seat{{ current_deck.active_user_count|pluralize }} used

--- a/src/templates/messages-snippet.html
+++ b/src/templates/messages-snippet.html
@@ -23,6 +23,11 @@
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>
     </button>
+    {# level icon left of the text (inherits the alert variant's text color); success stays icon-free #}
+    {% if 'error' in message.tags %}<i class="fa fa-fw fa-ban"></i>
+    {% elif 'warning' in message.tags %}<i class="fa fa-fw fa-exclamation-triangle"></i>
+    {% elif 'info' in message.tags %}<i class="fa fa-fw fa-info-circle"></i>
+    {% endif %}
     {% if 'safe' in message.tags %}
     {{ message|safe }}
     {% else %}

--- a/src/templates/messages-snippet.html
+++ b/src/templates/messages-snippet.html
@@ -23,11 +23,6 @@
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>
     </button>
-    {# level icon left of the text (inherits the alert variant's text color); success stays icon-free #}
-    {% if 'error' in message.tags %}<i class="fa fa-fw fa-ban"></i>
-    {% elif 'warning' in message.tags %}<i class="fa fa-fw fa-exclamation-triangle"></i>
-    {% elif 'info' in message.tags %}<i class="fa fa-fw fa-info-circle"></i>
-    {% endif %}
     {% if 'safe' in message.tags %}
     {{ message|safe }}
     {% else %}

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -194,6 +194,19 @@ class Tenant(TenantMixin):
         return self.subscription_active and localdate() > self.paid_until
 
     @property
+    def grace_days_remaining(self):
+        """Days of paid grace left after `paid_until`; None when not in the grace
+        period. 0 on the final day (the grace period ends today). Drives the
+        expired banner's "grace period ends in N days" copy.
+
+        days_until_expiry is negative throughout the grace window, so the days
+        left until suspension are GRACE_PERIOD_DAYS + days_until_expiry.
+        """
+        if not self.in_grace_period:
+            return None
+        return GRACE_PERIOD_DAYS + self.days_until_expiry
+
+    @property
     def is_on_trial(self):
         """Whether the deck is in trial mode: no active subscription, and a trial
         clock that hasn't run out."""

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -163,6 +163,20 @@ class TenantBillingStatusTest(SimpleTestCase):
         """A deck with no paid_until has no subscription, regardless of its trial date."""
         self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=30)).subscription_active)
 
+    def test_grace_days_remaining__counts_down_through_the_grace_window(self):
+        """Days of grace left after paid_until: GRACE_PERIOD_DAYS minus the days
+        elapsed, 0 on the final grace day, and None for any deck not in grace
+        (still paid, on trial, suspended, or unmanaged)."""
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=10)).grace_days_remaining, GRACE_PERIOD_DAYS - 10)
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS)).grace_days_remaining, 0)
+        self.assertIsNone(self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=90)).grace_days_remaining)  # still paid
+        self.assertIsNone(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=30)).grace_days_remaining)  # trial
+        self.assertIsNone(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).grace_days_remaining)  # suspended
+        self.assertIsNone(self.make_tenant().grace_days_remaining)  # unmanaged
+
     def test_in_grace_period__only_between_paid_until_and_grace_end(self):
         """in_grace_period is True strictly after paid_until and only while subscription_active."""
         self.assertFalse(self.make_tenant(paid_until=FROZEN_TODAY).in_grace_period)

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -642,6 +642,31 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'Subscription expiring')
 
+    def test_banner__expired_grace_deck_gets_danger_styling_and_grace_copy(self):
+        """A deck past paid_until (in grace) gets the DANGER (red) banner -- not the
+        approaching-deadline warning style -- and the copy states when the grace
+        period ends and that the deck then reverts to the trial cap (maintainer
+        requests from staging live testing)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        from tenant.models import TRIAL_MAX_ACTIVE_USERS
+
+        self.set_deck(trial_end_date=None, paid_until=localdate() - timedelta(days=10))
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'Subscription expired')
+        self.assertContains(response, 'alert-danger')
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('which ends in 20 days', text)
+        self.assertIn(f'revert to trial limits (max {TRIAL_MAX_ACTIVE_USERS} current students)', text)
+        # the approaching-deadline variants keep the warning style
+        self.set_deck(paid_until=localdate() + timedelta(days=3))
+        self.assertContains(self.get_quests_page(self.staff), 'alert-warning')
+        # self.tenant is shared across the class in memory and set_deck saves the
+        # whole object, so clear the paid date or it leaks into later tests
+        self.set_deck(paid_until=None)
+
 
 class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """Access and rendering tests for the staff-facing Subscription details page

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -570,6 +570,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         subscription page (PR 6; previously the public subscribe flatpage)."""
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'Trial Mode')
+        self.assertContains(response, 'fa-info-circle')  # banner level icon (review request)
         self.assertContains(response, reverse('decks:subscription'))
 
     def test_banner__trial_mode_shows_days_remaining_and_seat_usage(self):
@@ -618,6 +619,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
 
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'This deck is suspended')
+        self.assertContains(response, 'fa-ban')  # danger-level banner icon
         self.assertContains(response, reverse('decks:subscription'))
 
     def test_banner__over_limit_warns_staff(self):
@@ -626,6 +628,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
 
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'Current-student limit exceeded')
+        self.assertContains(response, 'fa-exclamation-triangle')  # warning-level banner icon
 
     def test_banner__expiring_soon_warns_staff(self):
         """Staff see the expiring-soon warning inside the two-week window, for both
@@ -657,6 +660,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'Subscription expired')
         self.assertContains(response, 'alert-danger')
+        self.assertContains(response, 'fa-exclamation-triangle')  # banner level icon (review request)
         text = ' '.join(response.content.decode().split())
         self.assertIn('which ends in 20 days', text)
         self.assertIn(f'revert to trial limits (max {TRIAL_MAX_ACTIVE_USERS} current students)', text)


### PR DESCRIPTION
### What?
Maintainer requests from staging live testing, all on the deck status (subscription) banner:

* **Each banner variant leads with a FontAwesome level icon**: `fa-exclamation-triangle` on the expired/grace, trial-ending, subscription-expiring, and over-limit variants; `fa-info-circle` on the Trial Mode banner; `fa-ban` on the suspended banner. Icons inherit each alert variant's text color, so they're automatically red/yellow/blue.
* **The "Subscription expired" (grace) banner escalates to danger (red) styling** — the approaching-deadline variants stay yellow warnings.
* **Its copy now answers "when and what happens?"**: "…this deck is in its grace period, which ends in **20 days**; it will then revert to trial limits (**max 5 current students**)."

Per review, the icons are **scoped to the subscription banner only** — an earlier revision also added level icons to all django messages site-wide, and that has been reverted (messages render exactly as before; a test now pins them icon-free).

### Why?
The banner variants were only distinguishable by background color; the expired banner used the same styling as mild pre-deadline warnings and said only that the deck "will revert to trial limits soon" — no date, no consequence.

### How?
* `deck_status_banner.html`: a leading level icon in each of the six banner variants; conditional `alert-danger`/`alert-warning` class on the expiring-soon banner; new grace sentence.
* New `Tenant.grace_days_remaining` property (`GRACE_PERIOD_DAYS + days_until_expiry`, negative through the grace window; `None` outside it, `0` on the final day) and `trial_cap` added to the `deck_status` context processor — during grace the deck's *effective* cap is still the paid cap, so the banner can't derive the revert-to value from the deck itself.
* `messages-snippet.html` is untouched relative to `staging` (the site-wide icons were reverted per review).

### Testing?
* `test_grace_days_remaining__counts_down_through_the_grace_window` (pure-date `SimpleTestCase`).
* `test_banner__expired_grace_deck_gets_danger_styling_and_grace_copy` (danger class + triangle icon + "ends in 20 days" + trial-cap consequence); banner icons pinned across the suspended, over-limit, and trial tests too.
* `MessagesSnippetIconTest` now pins django messages **icon-free at every level**, so the banner-only scoping can't regress.
* Full serial suite on this branch (current with `staging`, incl. #2142): **OK**; `ruff` clean.

### Screenshots (if front end is affected)
All captured from real flows on the dev deck (staff login). The dev proxy blocks the FontAwesome CDN, so the captures serve the identical npm-packaged FA 4.7.0 assets locally — same files the CDN delivers in production.

**After — expired/grace**: red danger styling, triangle icon, concrete grace copy; the django messages below it are back to icon-free:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/messages-icons/after.png)

**After — Trial Mode**: `fa-info-circle` leads the banner; messages below unchanged:
![trial](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/messages-icons/trial.png)

**Before** — the old yellow expired banner, no icon, vague copy:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/messages-icons/before.png)

### Anything Else?
Hotfix to `staging`; flows back to `develop` with the next staging sync. Branch is merged up to current `staging` (including #2142's live-count banner copy). The suspended (`fa-ban`) and over-limit (`fa-exclamation-triangle`) variants are icon-consistent too and pinned in tests. Note: four inline review comments on this PR sit in a **pending review** — once it's submitted I can reply/resolve them on-thread (all four are implemented).

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)