### PR TITLE
Cover comments/models.py get_target_object, Document and clean_html gaps (93% → 99%)

### DIFF
--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -137,9 +137,11 @@ class CleanHTMLTests(TestCase):
         self.assertEqual(cleaned_text, expected_output)
 
     def test_clean_html__convert_newlines_false_keeps_newlines_unbroken(self):
-        """With convert_newlines=False, newlines in the text are not turned into <br> tags."""
+        """With convert_newlines=False, newlines in the text are preserved rather than turned into <br> tags."""
         text = "line one\nline two"
-        self.assertNotIn("<br>", clean_html(text, convert_newlines=False))
+        cleaned = clean_html(text, convert_newlines=False)
+        self.assertNotIn("<br>", cleaned)
+        self.assertIn("\n", cleaned)  # the newline is kept, not dropped or collapsed
 
 
 class CommentModelTest(ByteDeckTenantTestCase):

--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -1,12 +1,13 @@
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from model_bakery import baker
 from model_bakery.recipe import Recipe
 
-from comments.models import Comment, clean_html
+from comments.models import Comment, Document, clean_html
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 User = get_user_model()
@@ -135,6 +136,11 @@ class CleanHTMLTests(TestCase):
         cleaned_text = clean_html(text)
         self.assertEqual(cleaned_text, expected_output)
 
+    def test_clean_html__convert_newlines_false_keeps_newlines_unbroken(self):
+        """With convert_newlines=False, newlines in the text are not turned into <br> tags."""
+        text = "line one\nline two"
+        self.assertNotIn("<br>", clean_html(text, convert_newlines=False))
+
 
 class CommentModelTest(ByteDeckTenantTestCase):
 
@@ -240,3 +246,24 @@ class CommentModelTest(ByteDeckTenantTestCase):
         child2 = baker.make(Comment, parent=parent)
         children = parent.get_children()
         self.assertQuerySetEqual(children, [child, child2], ordered=False)
+
+    def test_get_target_object__returns_target_when_set(self):
+        """get_target_object() resolves the comment's generic target via its content type."""
+        target = baker.make('announcements.Announcement')
+        comment = Comment.objects.create_comment(user=self.student, text="hi", path="/some/path/", target=target)
+        self.assertEqual(comment.get_target_object(), target)
+
+    def test_get_target_object__returns_none_when_unset(self):
+        """get_target_object() returns None when the comment has no target object."""
+        comment = Comment.objects.create_comment(user=self.student, text="hi", path="/some/path/")
+        self.assertIsNone(comment.get_target_object())
+
+
+class DocumentModelTest(ByteDeckTenantTestCase):
+    """Tests for the Document model (a file attached to a comment)."""
+
+    def test_is_valid_portfolio_type__true_for_image_and_video_false_otherwise(self):
+        """is_valid_portfolio_type() accepts image/video attachments and rejects other file types."""
+        self.assertTrue(Document(docfile=SimpleUploadedFile("art.png", b"x")).is_valid_portfolio_type())
+        self.assertTrue(Document(docfile=SimpleUploadedFile("clip.mp4", b"x")).is_valid_portfolio_type())
+        self.assertFalse(Document(docfile=SimpleUploadedFile("notes.txt", b"x")).is_valid_portfolio_type())


### PR DESCRIPTION
### What?

Next gap-closing PR. Closes the untested lines in `comments/models.py`, taking it to **0 uncovered statements (99%)**.

### Why?

A few small model helpers were never exercised — resolving a comment's generic target, validating a document's file type for portfolios, and one `clean_html` branch. Comments are used across quests/announcements/badges, so worth locking down.

### How?

New tests in `comments/tests/test_models.py`:

- **`Comment.get_target_object`** — resolves the generic target object when set (via its content type), and returns `None` when unset.
- **`Document.is_valid_portfolio_type`** — accepts image/video attachments and rejects other file types (tested on unsaved `Document`s, so no `Comment` GFK fixtures needed).
- **`clean_html(convert_newlines=False)`** — the branch that leaves newlines as-is instead of converting them to `<br>` (the default `True` path was already covered).

### Testing?

- `python manage.py test comments` → **42 passing** (+4 new); `ruff` clean; `test_conventions` passes.
- Coverage of `comments/models.py` goes from 93% to **99% with 0 uncovered statements**. One partial branch remains — the defensive `elif ulgroup > 0` in the raw-`<li>` wrapping loop, only reachable in a malformed-parse state that normal input can't produce — left as-is rather than adding a contrived test.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Targets were picked from a fresh full-suite coverage run. The existing comments model tests were already clean (clear names + docstrings), so no test-quality tidy was warranted here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage for HTML cleaning behavior when newline conversion is disabled.
  * Added validation for comment target-object retrieval, including comments without a target.

* **Tests**
  * Expanded automated tests for file validation, newline preservation, and comment target handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->