### PR TITLE
HOTFIX: Subscription page: relative time on every Dates row

### DIFF
--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -36,10 +36,10 @@
 {# one governing deadline row, not both: a paid date (even lapsed) supersedes the trial date #}
 <table class="table" style="max-width: 30em;">
   {% if deck.paid_until %}
-    <tr><th>Paid until</th><td>{{ deck.paid_until }}</td></tr>
-    <tr><th>Grace period</th><td>{{ grace_days }} days after <em>paid until</em></td></tr>
+    <tr><th>Paid until</th><td>{{ deck.paid_until }} ({{ paid_until_phrase }})</td></tr>
+    <tr><th>Grace period</th><td>extends {{ grace_days }} days after your subscription ends ({{ grace_end_phrase }})</td></tr>
   {% elif deck.trial_end_date %}
-    <tr><th>Trial ends</th><td>{{ deck.trial_end_date }}</td></tr>
+    <tr><th>Trial ends</th><td>{{ deck.trial_end_date }} ({{ trial_end_phrase }})</td></tr>
   {% else %}
     <tr><th>Expires</th><td>Never &mdash; this deck is managed manually</td></tr>
   {% endif %}

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -12,16 +12,16 @@
     This deck's trial and/or subscription period has ended, so it has reverted to trial limits
     (max {{ trial_cap }} current student{{ trial_cap|pluralize }}). Existing students keep their access and
     nothing has been deleted, but no new students can register in a course beyond the trial limit.</p>
+{% elif deck.in_grace_period %}
+  {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
+  <p><span class="label label-danger">Grace period</span>
+    The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
+    {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise it will revert to
+    trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
 {% elif deck.subscription_active %}
   <p><span class="label label-success">Subscribed</span>
-    {% if deck.days_until_expiry >= 0 %}
-      Paid through <strong>{{ deck.paid_until }}</strong>
-      ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining).
-    {% else %}
-      The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
-      {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise it will revert to
-      trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).
-    {% endif %}</p>
+    Paid through <strong>{{ deck.paid_until }}</strong>
+    ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining).</p>
 {% elif deck.is_on_trial %}
   <p><span class="label label-info">Free trial</span>
     Ends <strong>{{ deck.trial_end_date }}</strong>

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -807,14 +807,18 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIsNone(self.get_page().context['remaining_seats'])
 
     def test_page__grace_period_states_trial_cap(self):
-        """A deck in its paid grace window explains the grace period and the trial
-        cap it will revert to (5), not its current paid cap."""
+        """A deck in its paid grace window gets its own DANGER "Grace period" label --
+        never the green "Subscribed" badge (maintainer review find) -- and explains
+        the trial cap it will revert to (5), not its current paid cap."""
         from datetime import timedelta
 
         from django.utils.timezone import localdate
 
         self.set_deck(paid_until=localdate() - timedelta(days=5))
         response = self.get_page()
+        self.assertContains(response, 'Grace period</span>')
+        self.assertContains(response, 'label-danger')
+        self.assertNotContains(response, 'Subscribed')
         self.assertContains(response, 'grace period')
         self.assertContains(response, 'max 5 current students')
 

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -723,6 +723,45 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'Remaining students')
         self.assertContains(response, '30')
 
+    def test_page__dates_show_relative_time_in_every_state(self):
+        """Every Dates row carries a relative phrase: time remaining while the date
+        is ahead, or how long ago it passed -- for Paid until, the grace period's
+        end, and Trial ends alike (maintainer request from staging live testing)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        # subscribed: paid_until ahead, grace end further ahead
+        text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn('(100 days remaining)', text)
+        self.assertIn('extends 30 days after your subscription ends (ends in 130 days)', text)
+
+        # in grace: paid_until behind, grace end still ahead
+        self.set_deck(paid_until=localdate() - timedelta(days=10))
+        text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn('(expired 10 days ago)', text)
+        self.assertIn('(ends in 20 days)', text)
+
+        # suspended: both behind (the maintainer's "ended 24 days ago" example)
+        self.set_deck(paid_until=localdate() - timedelta(days=54))
+        text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn('(expired 54 days ago)', text)
+        self.assertIn('(ended 24 days ago)', text)
+
+        # trial deck: the Trial ends row gets the same treatment, both directions
+        self.set_deck(paid_until=None, trial_end_date=localdate() + timedelta(days=10))
+        self.assertIn('(10 days remaining)', ' '.join(self.get_page().content.decode().split()))
+        self.set_deck(trial_end_date=localdate() - timedelta(days=3))
+        self.assertIn('(expired 3 days ago)', ' '.join(self.get_page().content.decode().split()))
+
+        # boundary days read "today", singular day is "1 day"
+        self.set_deck(trial_end_date=localdate())
+        self.assertIn('(expires today)', ' '.join(self.get_page().content.decode().split()))
+        self.set_deck(trial_end_date=localdate() + timedelta(days=1))
+        self.assertIn('(1 day remaining)', ' '.join(self.get_page().content.decode().split()))
+        self.set_deck(trial_end_date=None, paid_until=localdate() - timedelta(days=30))  # final grace day
+        self.assertIn('(ends today)', ' '.join(self.get_page().content.decode().split()))
+
     def test_page__dates_show_only_the_governing_deadline(self):
         """The Dates table shows ONE deadline row -- Paid until when a paid date
         exists (it supersedes the trial date, even while lapsed), Trial ends on a

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -383,6 +383,31 @@ class RequestNewDeckSubmitted(PublicOnlyViewMixin, TemplateView):
         return context
 
 
+def _relative_date_phrase(target, style):
+    """Human phrase locating `target` relative to today, for the Dates table on the
+    subscription page (maintainer request: every date shows the time remaining, or
+    how long ago it passed).
+
+    Args:
+        target (date): The date to describe.
+        style (str): 'remaining' for deadline rows ("N days remaining" /
+            "expires today" / "expired N days ago"), 'ends' for the grace-period
+            row ("ends in N days" / "ends today" / "ended N days ago").
+
+    Returns:
+        str: The phrase, ready to drop into the row's parenthetical.
+    """
+    days = (target - timezone.localdate()).days
+    plural = 's' if abs(days) != 1 else ''
+    if style == 'remaining':
+        if days > 0:
+            return f"{days} day{plural} remaining"
+        return "expires today" if days == 0 else f"expired {-days} day{plural} ago"
+    if days > 0:
+        return f"ends in {days} day{plural}"
+    return "ends today" if days == 0 else f"ended {-days} day{plural} ago"
+
+
 class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
     """Staff-facing "Subscription details" page for the current deck (epic #1729 PR 6).
 
@@ -408,6 +433,8 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             effective cap, the billing constants the copy references, whether
             Stripe billing is configured, and the public-subscribe fallback URL.
         """
+        from datetime import timedelta
+
         from .billing import billing_configured
         from .models import GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS
         from .utils import get_public_subscribe_url
@@ -416,6 +443,16 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         deck = self.request.tenant
         current_student_count = deck.get_active_user_count()  # live, not cached
         cap = deck.effective_max_active_users
+        context.update({
+            # relative phrases for the Dates rows ("(100 days remaining)" /
+            # "(expired 24 days ago)"); None when the corresponding date is unset
+            'paid_until_phrase': _relative_date_phrase(deck.paid_until, 'remaining') if deck.paid_until else None,
+            'trial_end_phrase': _relative_date_phrase(deck.trial_end_date, 'remaining') if deck.trial_end_date else None,
+            'grace_end_phrase': (
+                _relative_date_phrase(deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS), 'ends')
+                if deck.paid_until else None
+            ),
+        })
         context.update({
             'deck': deck,
             'current_student_count': current_student_count,


### PR DESCRIPTION
### What?
Two changes to the Subscription details page's status/dates area (maintainer requests + review find from staging live testing):

**1. Relative time on every Dates row**, in every page state:

* **Paid until**: `July 13, 2026 (expired 10 days ago)` — or `(100 days remaining)` / `(expires today)`.
* **Grace period**: `extends 30 days after your subscription ends (ends in 20 days)` — or `(ends today)` / `(ended 24 days ago)` once it has lapsed.
* **Trial ends** (trial decks): same treatment — `(10 days remaining)` / `(expired 3 days ago)`.

**2. The grace period gets its own red `Grace period` status label** (review find on the first screenshot): `subscription_active` includes the grace window, so grace decks wore the green "Subscribed" badge next to copy saying their paid period had ended. The green badge is now reserved for decks actually inside their paid period.

### Why?
The table showed bare dates (and a static "30 days after paid until" for grace), leaving the owner to do the calendar math that actually matters; and the green badge on an expired deck read as a bug.

### How?
* New module-level `_relative_date_phrase(target, style)` helper in `tenant/views.py` (`'remaining'` style for deadline rows, `'ends'` style for the grace end at `paid_until + GRACE_PERIOD_DAYS`), with one pre-built phrase per visible row passed through the view context — templates can't do date arithmetic.
* Status section: a dedicated `in_grace_period` branch (checked before `subscription_active`, since grace is a subset of it) with `label-danger`, matching the danger styling the expired *banner* adopts in #2140.

### Testing?
* `test_page__dates_show_relative_time_in_every_state` covers subscribed (remaining), in-grace (expired + ends-in), suspended (both past — including the requested "ended 24 days ago" example), trial future/past, and the today/singular boundaries of both phrase styles.
* `test_page__grace_period_states_trial_cap` now pins the grace label: `Grace period` + `label-danger` present, `Subscribed` absent.
* Full serial suite on this branch (based on `staging`): **1530 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
Real dev deck, staff login, light theme; deck 10 days past `paid_until` (in grace).

**Before** — bare dates, green "Subscribed" badge while expired:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-dates/before.png)

**After** — every row locates itself in time, and grace wears its own red label:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-dates/after.png)

### Anything Else?
Hotfix to `staging`; flows back to `develop` with the next sync. The yellow expired *banner* visible up top in both shots is #2140's territory (it turns red with concrete grace copy there); the two PRs touch different files and merge independently.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)