### PR TITLE
Cover notifications/tasks.py all-tenants delete and non-enrolled email gaps (90% → 100%)

### DIFF
--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMultiAlternatives
 from django.utils import timezone
+from django_tenants.utils import get_tenant_model
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from notifications import tasks
@@ -176,8 +177,15 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         self.assertIn(str(notification), html_content)  # Links to notifications
 
     def test_generate_notification_email__non_enrolled_student_returns_none(self):
-        """A non-staff student not enrolled in a current course gets no notification email at all."""
-        non_enrolled_student = baker.make(User)  # not staff, no course
+        """A non-staff student not enrolled in a current course gets no notification email, even
+        when they have unread notifications that would otherwise generate one."""
+        non_enrolled_student = baker.make(User, is_staff=False)  # not staff, no course
+        # an unread notification, so the None result must come from the enrollment guard
+        # rather than the "no content to send" branch
+        baker.make(
+            Notification, recipient=non_enrolled_student,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
         self.assertIsNone(generate_notification_email(non_enrolled_student, 'https://test.com'))
 
     def test_get_notification_emails__skips_inactive_students(self):
@@ -240,7 +248,8 @@ class DeleteOldNotificationsTestCase(ByteDeckTenantTestCase):
         """The all-tenants task schedules a per-schema delete for each non-public tenant."""
         result = tasks.delete_old_notifications_for_all_tenants()
 
-        # at least the (non-public) test tenant is scheduled
-        self.assertTrue(mock_apply_async.called)
-        mock_apply_async.assert_called_with(queue='default')
+        # one scheduled delete per non-public tenant, each on the default queue
+        expected_tenants = get_tenant_model().objects.exclude(schema_name='public')
+        self.assertEqual(mock_apply_async.call_count, expected_tenants.count())
+        self.assertTrue(all(call.kwargs == {'queue': 'default'} for call in mock_apply_async.call_args_list))
         self.assertEqual(result, "Scheduled notifications.tasks.delete_old_notifications for all schemas/tenants")

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -175,6 +175,11 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         self.assertIn("Unread notifications:", html_content)
         self.assertIn(str(notification), html_content)  # Links to notifications
 
+    def test_generate_notification_email__non_enrolled_student_returns_none(self):
+        """A non-staff student not enrolled in a current course gets no notification email at all."""
+        non_enrolled_student = baker.make(User)  # not staff, no course
+        self.assertIsNone(generate_notification_email(non_enrolled_student, 'https://test.com'))
+
     def test_get_notification_emails__skips_inactive_students(self):
         """A student not enrolled in any course gets no email even with notifications enabled."""
         root_url = 'https://test.com'
@@ -229,3 +234,13 @@ class DeleteOldNotificationsTestCase(ByteDeckTenantTestCase):
         """Ensure the task can be scheduled via Celery."""
         delete_old_notifications.delay()
         mock_task.assert_called_once()
+
+    @patch('notifications.tasks.delete_old_notifications.apply_async')
+    def test_delete_old_notifications_for_all_tenants__schedules_per_tenant(self, mock_apply_async):
+        """The all-tenants task schedules a per-schema delete for each non-public tenant."""
+        result = tasks.delete_old_notifications_for_all_tenants()
+
+        # at least the (non-public) test tenant is scheduled
+        self.assertTrue(mock_apply_async.called)
+        mock_apply_async.assert_called_with(queue='default')
+        self.assertEqual(result, "Scheduled notifications.tasks.delete_old_notifications for all schemas/tenants")


### PR DESCRIPTION
### What?

Next gap-closing PR. Closes the untested lines in `notifications/tasks.py`, taking it from **90% → 100%**.

### Why?

Two paths in the notification background tasks were never exercised — the cross-tenant fan-out that schedules old-notification cleanup, and the "skip non-enrolled students" guard when building notification emails.

### How?

New tests in `notifications/tests/test_tasks.py`:

- **`delete_old_notifications_for_all_tenants`** — schedules a `delete_old_notifications` task for each non-public schema and returns its summary (verified by mocking `apply_async` and asserting it's called for the non-public test tenant, plus the return string).
- **`generate_notification_email`** — returns `None` for a non-staff student who isn't enrolled in a current course (the enrollment guard).

### Testing?

- `python manage.py test notifications` → passing (+2 new, 10 in `test_tasks`); `ruff` clean; `test_conventions` passes.
- Verified via coverage that `notifications/tasks.py` reaches **100%** (0 missing statements, 0 partial branches).

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Targets were picked from a fresh full-suite coverage run and confirmed with a scoped run (the file isn't cross-exercised, so scoped == genuine). The existing notifications task tests were already clean (clear names + docstrings), so no test-quality tidy was warranted here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming notification emails are not generated for non-enrolled students.
  * Added coverage confirming old notifications are scheduled for deletion separately across tenants using the default queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->