### PR TITLE
Fix hollow first-level bullets in comment lists (#1388)

### DIFF
--- a/src/comments/templates/comments/comments.html
+++ b/src/comments/templates/comments/comments.html
@@ -45,7 +45,7 @@
         </h3>
         <div class="comment-heading-divider"></div>
 
-        <div class="comment-content">{{comment.text|safe}}</div>
+        <div class="comment-content user-content">{{comment.text|safe}}</div>
         {% with comment.document_set.all as docs %}{% if docs %}
         <hr class="tighter">
         <p>Attached files:</p>

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -108,6 +108,24 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, path)
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
 
+    def test_comment_content_has_user_content_class(self):
+        """Rendered comment bodies carry the `user-content` class (#1388).
+
+        Comments live inside a Bootstrap `.list-group`, which is itself a `<ul>`, so a
+        bullet/number list typed into a comment would otherwise be treated as a *nested*
+        list and marked with the hollow level-2 style. The `.user-content` class re-establishes
+        depth-correct markers (solid disc at the first level) via custom_common.css.
+        """
+        Comment.objects.create_comment(
+            user=self.teacher,
+            text="<ul><li>a bullet</li></ul>",
+            path=self.announcement.get_absolute_url(),
+            target=self.announcement,
+        )
+        self.client.force_login(self.teacher)
+        response = self.client.get(reverse('announcements:list'))
+        self.assertContains(response, 'comment-content user-content')
+
     def test_delete_comment__cancel_button_path(self):
         ''' Test if the 'Cancel' button in src/comments/templates/comments/confirm_delete.html
         correctly contains the `comment.path` as its href attribute.

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -108,7 +108,7 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, path)
         self.assertFalse(Comment.objects.filter(id=self.comment.id).exists())
 
-    def test_comment_content_has_user_content_class(self):
+    def test_comment_content__has_user_content_class(self):
         """Rendered comment bodies carry the `user-content` class (#1388).
 
         Comments live inside a Bootstrap `.list-group`, which is itself a `<ul>`, so a


### PR DESCRIPTION
### What?

Closes #1388. A bullet (or numbered) list typed into a **comment** renders with the wrong marker levels: the first level shows a **hollow circle** (the level-2 style) instead of a solid disc, and each deeper level is off by one too. This fix restores depth-correct markers.

### Why?

Comments are rendered inside a Bootstrap `.list-group`, which is itself a `<ul>`. So a list inside a comment is technically a *nested* `<ul>`, and the browser's user-agent stylesheet (`ul ul { list-style-type: circle }`) marks its top level as level‑2 (hollow).

This was already reported and fixed once as #811, which added depth-correct list rules **scoped to a `.user-content` container** (`custom_common.css`). But that fix only reached the templates that were given the `.user-content` class (announcements, submission previews). The **comment body** (`comments/comments.html`) never got the class, so comment lists kept rendering wrong — which is exactly what #1388 is about.

### How?

- **`comments/templates/comments/comments.html`** — add the existing `user-content` class to the `.comment-content` div. That's it: comments now reuse the same depth-correct list CSS from #811. **No new CSS** — the `.user-content ul / ul ul / ul ul ul` rules already exist.

### Testing?

- `comments/tests/test_views.py::CommentViewTests::test_comment_content_has_user_content_class` — renders a comment on the announcements page and asserts the comment body carries `comment-content user-content`. Fails before this change, passes after. Full `comments` suite (43 tests) green; `ruff` clean.

### Screenshots (if front end is affected)

A comment containing a two-level bullet list, on the real running `hackerspace` deck (dark theme). **Before**: first level is a hollow circle (looks like a sub-list); second level is a square. **After**: first level is a solid disc, second level is a hollow circle — proper nesting.

| Before (hollow first-level bullets) | After (solid first-level bullets) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1388/before-hollow-bullets.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1388/after-solid-bullets.png) |

### Anything Else?

- This is the same class of bug as #811; #1388 was the remaining un-wrapped surface (comments). If any other spot renders user rich-text directly inside a `.list-group` without `.user-content`, the same one-line class addition fixes it.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_