### PR TITLE
Isolate PortfolioViewTests uploads in a throwaway MEDIA_ROOT (fixes rerun-only failure)

### DIFF
--- a/src/portfolios/tests/test_views.py
+++ b/src/portfolios/tests/test_views.py
@@ -53,6 +53,29 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """
 
     @classmethod
+    def setUpClass(cls):
+        """Isolate MEDIA_ROOT in a per-run temp dir before any uploads happen.
+
+        The uploads these tests make (e.g. clip.mp4) otherwise land in the
+        project's real _media_uploads and stay there: on the NEXT run Django's
+        storage dedupes the repeat filename to clip_XXXX.mp4, so the view titles
+        the Artwork "clip_XXXX" and the get(title="clip") assertions error --
+        the suite passes once, then fails on every rerun in the same workspace.
+        A throwaway MEDIA_ROOT keeps runs deterministic and the repo clean.
+        """
+        import shutil
+        import tempfile
+
+        from django.test import override_settings
+
+        cls._temp_media = tempfile.mkdtemp(prefix='test-media-portfolios-')
+        cls._media_override = override_settings(MEDIA_ROOT=cls._temp_media)
+        cls._media_override.enable()
+        cls.addClassCleanup(cls._media_override.disable)
+        cls.addClassCleanup(shutil.rmtree, cls._temp_media, ignore_errors=True)
+        super().setUpClass()
+
+    @classmethod
     def setUpTestData(cls):
         """Create a student with a portfolio, one artwork, and a commented document."""
         cls.test_student = baker.make(User)


### PR DESCRIPTION
### What?
`PortfolioViewTests` now runs with an isolated per-run temp `MEDIA_ROOT` (enabled in `setUpClass` before any uploads, torn down via `addClassCleanup`).

### Why?
`test_art_add__video_document_creates_video_artwork` (from #2130) **passes once and then fails on every rerun in the same workspace**: its uploaded `clip.mp4` lands in the project's real `_media_uploads` and stays there, so the next run's upload is deduped by Django's storage to `clip_XXXX.mp4`, the `art_add` view titles the Artwork `clip_XXXX`, and `Artwork.objects.get(title="clip")` raises `DoesNotExist`. CI never sees it (fresh workspace every run); any persistent checkout — a dev machine, a long-lived agent workspace — hits it deterministically on the second run. It cost me two full-suite gate failures today while working on unrelated branches before I traced it.

### How?
A `tempfile.mkdtemp()` `MEDIA_ROOT` per class run: reruns are deterministic (the storage never needs to dedupe), and the repo's `_media_uploads` stops accumulating test files. No test logic or assertions changed.

### Testing?
* This is itself a test fix; the "failing test" is the second consecutive run: `python src/manage.py test src/portfolios` twice in a row now passes both times (before: first OK, second `DoesNotExist`), and `_media_uploads` gains no files.
* Full serial suite: **1553 tests, OK**; `ruff` clean.

### Screenshots (if front end is affected)
N/A — test-only change, nothing user-visible.

### Anything Else?
Other test classes that upload files may deserve the same treatment eventually; this PR fixes the one that actively breaks reruns.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_