### PR TITLE
Offset custom-page ToC anchors below the fixed navbar (#821)

### DIFF
--- a/src/utilities/templates/flatpages/default.html
+++ b/src/utilities/templates/flatpages/default.html
@@ -35,6 +35,10 @@
         var $el = $(this);
         var title = $el.text();
         $el.attr("id", title);
+        // Give each heading the `.anchor` class so its `scroll-margin-top` (custom_common.css)
+        // offsets the fixed navbar; without it a ToC jump lands with the heading hidden behind
+        // the navbar (issue #821).
+        $el.addClass("anchor");
 
         var tocEntry =
             "<li>" +


### PR DESCRIPTION
### What?

Closes #821. On a custom page (`/pages/…`) with an auto-generated Table of Contents, clicking a ToC entry scrolled the target heading **up under the fixed navbar**, hiding it — you landed on the text *below* the heading instead of the heading.

### Why?

The site already has the fix mechanism: `.anchor { scroll-margin-top: 60px }` in `custom_common.css`, which offsets anchor targets so they clear the fixed navbar (used by comment anchors, etc.). But the ToC script in `flatpages/default.html` gave each `<h3>` an `id` **without** the `.anchor` class, so `scroll-margin-top` never applied and the jump landed behind the navbar.

Measured on the running app (clicking a ToC entry): the target heading's top was at `0px` while the navbar's bottom was at `52px` — i.e. hidden behind it.

### How?

- **`utilities/templates/flatpages/default.html`** — add `$el.addClass("anchor")` to each ToC heading as its `id` is assigned, so it reuses the existing `scroll-margin-top` offset. **No new CSS.** As a bonus, the existing `.anchor:target` highlight now flashes the heading you jumped to.

### Testing?

This is a client-side scroll-behaviour fix (the offset happens in the browser when following the anchor), so there's no meaningful server-side unit test — verified against the real running app with Playwright (below). After the fix the same heading lands at `60px` (below the navbar's `52px` bottom) with the `.anchor` class applied. The `utilities` test suite (60 tests) still passes.

### Screenshots (if front end is affected)

Custom page with an auto-generated ToC on the real `hackerspace` deck (dark theme), after clicking the "Section Two Bravo" ToC entry. **Before**: the heading is scrolled up under the navbar (you see the filler text below it). **After**: the heading sits just below the navbar, fully visible (and highlighted).

| Before (heading hidden behind navbar) | After (heading below navbar) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/821/before-hidden-behind-navbar.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/821/after-below-navbar.png) |

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Table of Contents navigation so heading links account for the fixed navigation bar.
  * Prevented linked headings from being obscured beneath the navbar when scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->