### PR TITLE
Cover courses/views.py mark-calculation and semester-delete gaps

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -989,6 +989,17 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('courses:semester_list'))
         self.assertFalse(Semester.objects.filter(pk=semester.pk).exists())
 
+    def test_SemesterDelete_view__lists_registrations_in_context(self):
+        """The delete confirmation page lists the students registered in the semester."""
+        self.client.force_login(self.test_teacher)
+        semester = baker.make(Semester)
+        registration = baker.make(CourseStudent, user=baker.make(User), course=baker.make(Course), semester=semester)
+
+        response = self.client.get(reverse('courses:semester_delete', args=[semester.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(registration, response.context['registrations'])
+
 
 class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
@@ -1553,6 +1564,25 @@ class MarkCalculationsViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         siteconfig = SiteConfig.get()
         siteconfig.display_marks_calculation = True
         siteconfig.save()
+
+    def test_mark_calculations__deactivated_shows_staff_the_deactivated_notice(self):
+        """When mark-calculation display is turned off, staff get the 'deactivated' notice page
+        (students get a 404 instead, since they shouldn't reach this URL)."""
+        siteconfig = SiteConfig.get()
+        siteconfig.display_marks_calculation = False
+        siteconfig.save()
+
+        self.client.force_login(baker.make(User, is_staff=True))
+        response = self.client.get(reverse('courses:my_marks'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'courses/mark_calculations_deactivated.html')
+
+    def test_mark_calculations__staff_can_view_another_students_marks(self):
+        """Staff can view a specific student's mark page via the user_id URL."""
+        self.client.force_login(baker.make(User, is_staff=True))
+        response = self.client.get(reverse('courses:marks', args=[self.student.pk]))
+        self.assertEqual(response.status_code, 200)
 
     @patch('courses.models.Semester.fraction_complete')
     def test_current_mark_ranges_by_xp__correct_values(self, mock_sem_fraction_complete):


### PR DESCRIPTION
### What?

Next gap-closing PR. Closes the genuinely-uncovered lines in `courses/views.py` — the staff paths of the mark-calculations view and the semester-delete confirmation context.

### Why?

A few staff-facing branches were never exercised: the "marks deactivated" notice, viewing another student's marks, and the delete-confirmation page's registration list. These are teacher tools, so worth locking down.

> **Note on the numbers:** targets came from a fresh **full-suite** coverage run. An app-scoped `courses` run over-reports (e.g. line 66 and a few partial branches show as missing there but are exercised by other apps in the full suite), so the lines below are the ones genuinely uncovered across the whole suite.

### How?

New tests in `courses/tests/test_views.py`:

- **`mark_calculations` — deactivated notice for staff**: with `display_marks_calculation` off, staff get the `mark_calculations_deactivated.html` page (students already 404, which was covered).
- **`mark_calculations` — staff viewing another student**: staff can load a specific student's mark page via the `user_id` URL (`courses:marks`).
- **`SemesterDelete.get_context_data`**: the delete-confirmation page lists the students registered in the semester (`context['registrations']`).

### Testing?

- `python manage.py test courses` → passing (+3 new); `ruff` clean; `test_conventions` passes.
- Verified via the full-suite coverage run that all targeted lines (the staff mark-calc branches and the semester-delete context) are now covered.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. The existing courses view tests were already clean (clear names + docstrings), so no test-quality tidy was warranted here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_