### PR TITLE
Make campaign map_order work for connected campaigns, compactly (#1977)

### DIFF
--- a/src/djcytoscape/static/djcytoscape/js/maps.js
+++ b/src/djcytoscape/static/djcytoscape/js/maps.js
@@ -179,73 +179,51 @@ addedCampaignLayoutEdges.remove();
 /***************************************
  * #1977: order the campaign columns left-to-right by Category.map_order.
  *
- * dagre decides the order of same-rank nodes with a crossing-minimization heuristic and ignores
- * the order elements were fed in, so the campaign order can't be set before layout — it has to be
- * imposed on the finished layout. Each campaign (a compound node + its member quests) and each
- * connected clump of campaign-less quests is one connected "column"; we sort the columns by their
- * campaign map_order (ties, and campaign-less columns, fall back to the smallest node id — the
- * deterministic #2012 order) and repack them left-to-right, shifting each column horizontally as a
- * rigid block so its internal shape and every node's vertical position are untouched.
+ * dagre decides the order of same-rank nodes with a crossing-minimization heuristic and ignores the
+ * order the elements were fed in, so campaign order has to be imposed on the finished layout.
+ *
+ * Rather than repack every column left-to-right (which spreads the map out whenever campaign-less
+ * "bridge" nodes — e.g. a shared badge, or the intro quest — sit between campaigns, and which merged
+ * two campaigns into one un-orderable column when one branches off the other), we PERMUTE the
+ * campaigns among the x-slots dagre already gave them: sort the campaigns by (map_order, smallest
+ * quest id) and drop the i-th into the i-th slot from the left. The set of x positions is unchanged,
+ * so the map stays exactly as compact as dagre made it and campaign-less nodes don't move — only the
+ * campaigns swap places. Each campaign's quests shift together as a rigid block, so their internal
+ * shape and every node's vertical position (the #1787 vertical stacking) are untouched. Because both
+ * the sorted slots and the desired order are deterministic, the result no longer toggles between
+ * generations even though dagre's raw order does (the original #1977 complaint).
  ***************************************/
 (function orderCampaignColumns() {
-    // A node's "root" is its campaign compound parent, or itself when it isn't in a campaign.
-    function rootOf(node) { return node.isChild() ? node.parent() : node; }
+    // Only campaigns (compound parents) are reordered; campaign-less quests stay where dagre put them.
+    var campaigns = cy.nodes().filter(function (n) { return n.isParent(); });
+    if (campaigns.length < 2) { return; }
 
-    // Union-find over roots, joined by every (real) edge between two different roots, so a campaign
-    // and any campaign-less quest-chain each collapse to a single column.
-    var parent = {};
-    function find(x) {
-        while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
-        return x;
-    }
-    function union(a, b) { parent[find(a)] = find(b); }
-
-    cy.nodes().forEach(function (node) {
-        var r = rootOf(node).id();
-        if (parent[r] === undefined) { parent[r] = r; }
-    });
-    cy.edges().forEach(function (edge) {
-        var a = rootOf(edge.source()).id();
-        var b = rootOf(edge.target()).id();
-        if (parent[a] === undefined) { parent[a] = a; }
-        if (parent[b] === undefined) { parent[b] = b; }
-        if (a !== b) { union(a, b); }
-    });
-
-    // Bucket every node into its column, tracking each column's order key and smallest node id.
-    var columns = {};
-    cy.nodes().forEach(function (node) {
-        var key = find(rootOf(node).id());
-        var col = columns[key] || (columns[key] = { nodes: cy.collection(), order: Infinity, minId: Infinity });
-        col.nodes = col.nodes.union(node);
-        var order = node.data('campaignOrder');
+    var info = campaigns.map(function (camp) {
+        var kids = camp.children();
+        var order = camp.data('campaignOrder');
         if (order === undefined || order === null) { order = 0; }
-        if (order < col.order) { col.order = order; }
-        var idNum = parseInt(node.id(), 10);
-        if (!isNaN(idNum) && idNum < col.minId) { col.minId = idNum; }
+        var minId = Infinity;
+        kids.forEach(function (k) {
+            var idNum = parseInt(k.id(), 10);
+            if (!isNaN(idNum) && idNum < minId) { minId = idNum; }
+        });
+        // A campaign's column x is its compound node's centre (which follows its children).
+        return { kids: kids, x: camp.position('x'), order: order, minId: minId };
     });
 
-    var cols = Object.keys(columns).map(function (key) { return columns[key]; });
-    if (cols.length > 1) {
-        // Left-to-right by campaign map_order, then smallest node id (the deterministic #2012 order).
-        cols.sort(function (a, b) { return (a.order - b.order) || (a.minId - b.minId); });
+    // The x-slots the campaigns currently occupy, left to right.
+    var slots = info.map(function (i) { return i.x; }).sort(function (a, b) { return a - b; });
 
-        var GAP = 45;  // horizontal gap between columns, matching dagre's nodeSep above
-        var cursorX = null;
-        cols.forEach(function (col) {
-            // Shift only the leaf nodes — moving a compound (campaign) parent in cytoscape drags its
-            // children too, so shifting the whole collection would move them twice. The parent's box
-            // re-wraps its children automatically once they move.
-            var leaves = col.nodes.filter(function (n) { return !n.isParent(); });
-            // Measure by node extents only (not labels) so columns pack as tightly as dagre spaced
-            // them — the node labels are drawn offset to the left and would otherwise inflate the gap.
-            var bb = leaves.boundingBox({ includeLabels: false });
-            if (cursorX === null) { cursorX = bb.x1; }  // anchor at the current leftmost column
-            var dx = cursorX - bb.x1;
-            if (dx !== 0) { leaves.shift({ x: dx, y: 0 }); }
-            cursorX += bb.w + GAP;
-        });
-    }
+    // Desired left-to-right order: campaign map_order, then smallest quest id (the deterministic
+    // #2012 order) so ties — and every campaign at the default map_order 0 — stay stable.
+    var desired = info.slice().sort(function (a, b) { return (a.order - b.order) || (a.minId - b.minId); });
+
+    // Drop the i-th campaign (desired order) into the i-th slot, shifting its quests horizontally as
+    // a rigid block. Positions were all read before any shift, so swaps don't interfere.
+    desired.forEach(function (item, idx) {
+        var dx = slots[idx] - item.x;
+        if (dx !== 0) { item.kids.shift({ x: dx, y: 0 }); }
+    });
 })();
 
 /***************************************

--- a/src/djcytoscape/static/djcytoscape/js/maps.js
+++ b/src/djcytoscape/static/djcytoscape/js/maps.js
@@ -220,10 +220,29 @@ addedCampaignLayoutEdges.remove();
 
     // Drop the i-th campaign (desired order) into the i-th slot, shifting its quests horizontally as
     // a rigid block. Positions were all read before any shift, so swaps don't interfere.
+    var moved = false;
     desired.forEach(function (item, idx) {
         var dx = slots[idx] - item.x;
-        if (dx !== 0) { item.kids.shift({ x: dx, y: 0 }); }
+        if (dx !== 0) { item.kids.shift({ x: dx, y: 0 }); moved = true; }
     });
+
+    // Reordering a campaign can strand a campaign-less "connector" node — the intro quest that leads
+    // into a campaign, a shared badge, etc. — over the campaign's OLD position (e.g. an intro quest
+    // left sitting above where a campaign used to be instead of above the one it points to). Re-centre
+    // each campaign-less node over the mean x of its neighbours so it follows the campaign(s) it
+    // connects to. Skip this entirely when nothing moved (every campaign at the default map_order) so
+    // those maps stay byte-for-byte unchanged; read all neighbour positions before moving anything.
+    if (!moved) { return; }
+    var recentre = [];
+    cy.nodes().forEach(function (node) {
+        if (node.isParent() || node.isChild()) { return; }  // campaigns and their quests already placed
+        var neighbours = node.neighborhood('node');
+        if (neighbours.empty()) { return; }
+        var sum = 0;
+        neighbours.forEach(function (m) { sum += m.position('x'); });
+        recentre.push({ node: node, x: sum / neighbours.length });
+    });
+    recentre.forEach(function (r) { r.node.position('x', r.x); });
 })();
 
 /***************************************

--- a/src/djcytoscape/tests/test_map_order_render.py
+++ b/src/djcytoscape/tests/test_map_order_render.py
@@ -79,7 +79,7 @@ var elements = {{
   ],
   edges: [
     {{ data: {{ id: '101', source: '11', target: '12' }} }},
-    {{ data: {{ id: '102', source: '21', target: '22' }} }}
+    {{ data: {{ id: '102', source: '21', target: '22' }} }}{extra_edges}
   ]
 }};
 var cy = cytoscape({{ container: document.getElementById('cy'), elements: elements, style: [] }});
@@ -110,10 +110,18 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
         cls._pw.stop()
         super().tearDownClass()
 
-    def _campaign_mean_x(self, order_a, order_b):
-        """Render the two-campaign map with the given map_orders; return (meanX_A, meanX_B)."""
+    def _campaign_mean_x(self, order_a, order_b, connected=False):
+        """Render the two-campaign map with the given map_orders; return (meanX_A, meanX_B).
+
+        When ``connected`` is True, add a cross-campaign prerequisite edge from A's first quest to
+        B's first quest, so campaign B branches off the side of campaign A (A1 continues to A2 AND
+        to B1) — the case that used to merge the two campaigns into a single un-orderable column
+        (issue #1977).
+        """
+        extra_edges = ",\n    { data: { id: '201', source: '11', target: '21' } }" if connected else ""
         html = _PAGE_TEMPLATE.format(
             jquery_stub=_JQUERY_STUB, js_dir=self.js_dir, order_a=order_a, order_b=order_b,
+            extra_edges=extra_edges,
         )
         # Load from a real file so the browser will fetch the file:// asset <script>s (it refuses
         # to load file:// sub-resources for an in-memory set_content document).
@@ -149,3 +157,14 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
         """
         ax, bx = self._campaign_mean_x(order_a=0, order_b=0)
         self.assertLess(ax, bx, "with equal map_order, smaller-id campaign A should be left")
+
+    def test_map_order__connected_campaigns_still_ordered_by_map_order(self):
+        """A campaign that branches off another must still obey map_order (reopened #1977).
+
+        When B's first quest is a prerequisite continuation of A (a cross-campaign edge), the
+        previous connected-component grouping merged A and B into one column, so map_order between
+        them did nothing. B has the lower map_order here and must render to the left of A even
+        though it hangs off A.
+        """
+        ax, bx = self._campaign_mean_x(order_a=1000, order_b=0, connected=True)
+        self.assertLess(bx, ax, "connected campaign B (lower map_order) should still be left of A")

--- a/src/djcytoscape/tests/test_map_order_render.py
+++ b/src/djcytoscape/tests/test_map_order_render.py
@@ -75,7 +75,7 @@ var elements = {{
     {{ data: {{ id: '11', parent: '10', label: 'A1', campaignOrder: {order_a} }} }},
     {{ data: {{ id: '12', parent: '10', label: 'A2', campaignOrder: {order_a} }} }},
     {{ data: {{ id: '21', parent: '20', label: 'B1', campaignOrder: {order_b} }} }},
-    {{ data: {{ id: '22', parent: '20', label: 'B2', campaignOrder: {order_b} }} }}
+    {{ data: {{ id: '22', parent: '20', label: 'B2', campaignOrder: {order_b} }} }}{extra_nodes}
   ],
   edges: [
     {{ data: {{ id: '101', source: '11', target: '12' }} }},
@@ -110,18 +110,25 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
         cls._pw.stop()
         super().tearDownClass()
 
-    def _campaign_mean_x(self, order_a, order_b, connected=False):
-        """Render the two-campaign map with the given map_orders; return (meanX_A, meanX_B).
+    def _positions(self, order_a, order_b, connected=False, intro=False):
+        """Render the two-campaign map and return ``{'a': meanX_A, 'b': meanX_B, 'intro': x|None}``.
 
-        When ``connected`` is True, add a cross-campaign prerequisite edge from A's first quest to
-        B's first quest, so campaign B branches off the side of campaign A (A1 continues to A2 AND
-        to B1) — the case that used to merge the two campaigns into a single un-orderable column
-        (issue #1977).
+        ``connected`` adds a cross-campaign prerequisite edge from A's first quest to B's first quest,
+        so campaign B branches off the side of campaign A (A1 continues to A2 AND to B1) — the case
+        that used to merge the two campaigns into a single un-orderable column (issue #1977).
+
+        ``intro`` adds a campaign-less node that leads into campaign A (intro -> A1); its rendered x is
+        returned so a test can check the intro node follows campaign A when the columns are reordered.
         """
-        extra_edges = ",\n    { data: { id: '201', source: '11', target: '21' } }" if connected else ""
+        extra_nodes = ",\n    { data: { id: '1', label: 'Intro' } }" if intro else ""
+        extra_edges = ""
+        if connected:
+            extra_edges += ",\n    { data: { id: '201', source: '11', target: '21' } }"
+        if intro:
+            extra_edges += ",\n    { data: { id: '301', source: '1', target: '11' } }"
         html = _PAGE_TEMPLATE.format(
             jquery_stub=_JQUERY_STUB, js_dir=self.js_dir, order_a=order_a, order_b=order_b,
-            extra_edges=extra_edges,
+            extra_nodes=extra_nodes, extra_edges=extra_edges,
         )
         # Load from a real file so the browser will fetch the file:// asset <script>s (it refuses
         # to load file:// sub-resources for an in-memory set_content document).
@@ -134,12 +141,20 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
             # maps.js repositions synchronously right after layout.run(); give the page a beat to settle.
             page.wait_for_timeout(300)
             mean_x = "(ids) => ids.reduce((s, id) => s + cy.getElementById(id).position('x'), 0) / ids.length"
-            ax = page.evaluate(mean_x, ["11", "12"])
-            bx = page.evaluate(mean_x, ["21", "22"])
+            result = {
+                "a": page.evaluate(mean_x, ["11", "12"]),
+                "b": page.evaluate(mean_x, ["21", "22"]),
+                "intro": page.evaluate(mean_x, ["1"]) if intro else None,
+            }
         finally:
             page.close()
             os.unlink(html_path)
-        return ax, bx
+        return result
+
+    def _campaign_mean_x(self, order_a, order_b, connected=False):
+        """Render the two-campaign map with the given map_orders; return (meanX_A, meanX_B)."""
+        p = self._positions(order_a, order_b, connected=connected)
+        return p["a"], p["b"]
 
     def test_map_order__lower_map_order_campaign_renders_on_the_left(self):
         """Campaign B (larger id) with a lower map_order than A must render to the left of A."""
@@ -173,3 +188,22 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
         # for the connected case either.
         ax, bx = self._campaign_mean_x(order_a=0, order_b=1000, connected=True)
         self.assertLess(ax, bx, "connected campaign A (lower map_order) should be left of B")
+
+    def test_map_order__intro_node_follows_its_reordered_campaign(self):
+        """A campaign-less intro node that leads into a campaign follows that campaign after the
+        columns are reordered, instead of being stranded over the campaign's old slot (#1977).
+
+        The intro leads into campaign A; B has the lower map_order (so B goes left, A right). The
+        intro must sit over A's column, not stay stranded on the left where A used to be. Checked
+        both ways so it isn't direction-dependent.
+        """
+        p = self._positions(order_a=1000, order_b=0, connected=True, intro=True)
+        self.assertLess(
+            abs(p["intro"] - p["a"]), abs(p["intro"] - p["b"]),
+            "intro node should sit over campaign A (which it leads into), not the reordered-away B",
+        )
+        p = self._positions(order_a=0, order_b=1000, connected=True, intro=True)
+        self.assertLess(
+            abs(p["intro"] - p["a"]), abs(p["intro"] - p["b"]),
+            "intro node should still sit over campaign A after swapping the order",
+        )

--- a/src/djcytoscape/tests/test_map_order_render.py
+++ b/src/djcytoscape/tests/test_map_order_render.py
@@ -168,3 +168,8 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
         """
         ax, bx = self._campaign_mean_x(order_a=1000, order_b=0, connected=True)
         self.assertLess(bx, ax, "connected campaign B (lower map_order) should still be left of A")
+
+        # Mirror it — swapping the values swaps the columns, so the fix isn't direction-dependent
+        # for the connected case either.
+        ax, bx = self._campaign_mean_x(order_a=0, order_b=1000, connected=True)
+        self.assertLess(ax, bx, "connected campaign A (lower map_order) should be left of B")


### PR DESCRIPTION
### What?

Reopened #1977: setting a campaign's **map_order** had no effect when one campaign branches off another — e.g. a *Blender Donut* campaign whose first quest continues from a *Blender Basics* quest. No matter the value, Donut stayed on the right. This fixes that, does it **without spreading the map out**, and keeps campaign-less "connector" nodes (the intro quest, a shared badge) sitting where they belong after a reorder.

### Why?

The left-to-right campaign ordering grouped map nodes into columns with a **union-find over connected components**. A cross-campaign prerequisite edge (Donut branching off Blender Basics) joined the two campaigns into a **single column**, so map_order could never separate them — setting one lower did nothing.

My first attempt (each campaign its own column, repacked left-to-right) fixed the ordering but **spread complex maps out**: campaign-less "bridge" nodes — like the shared *ByteDeck Proficiency* badge on the default map — each became their own column, widening every deck's main map.

### How?

Instead of repacking, **permute the campaigns among the x-slots dagre already produced**:

- Sort campaigns by `(map_order, smallest quest id)` and drop the i-th into the i-th slot from the left.
- The **set of x positions is unchanged**, so the map stays exactly as compact as dagre made it, and only the campaigns swap places.
- Each campaign's quests shift together as a rigid block, so vertical stacking (#1787) is preserved.
- Sorted slots + a deterministic order key also stop the layout **toggling between generations** (the original #1977 complaint).

Then **re-center campaign-less connector nodes**: moving a campaign can strand a campaign-less node — the intro quest that leads into a campaign, a shared badge — over the campaign's *old* slot (e.g. the "Start Here" intro quest left sitting above where a campaign used to be). After the permutation, each campaign-less node is re-centered over the mean x of its neighbours so it follows the campaign it connects to. **Both steps are skipped when nothing moved** (every campaign at the default map_order), so those maps render **byte-for-byte as before**.

### Testing?

`djcytoscape/tests/test_map_order_render.py` — the existing headless render test (real vendored cytoscape/dagre + real `maps.js` in Chromium) now covers, in addition to the three prior cases (lower→left, swap, equal→id-tiebreak):

- **Connected campaigns** — B branches off the side of A, B has the lower map_order, and must render left of A (checked both directions). Fails on the old grouping; passes now.
- **Intro node follows its campaign** — a campaign-less intro node that leads into a campaign must sit over that campaign after a reorder, not be stranded over the reordered-away one (checked both directions). Fails without the re-centering; passes with it.

Full `djcytoscape` suite (81 tests) green; `ruff` clean. I also verified on the running `hackerspace` deck that the **default 6-campaign map is positioned identically** to before this change (same campaign x-coordinates, no overlaps).

### Screenshots (if front end is affected)

Two connected campaigns on the real running app: *Blender Donut* (map_order **0**) branches off *Blender Basics* (map_order **10**), so Donut should be on the left.

| Before (map_order ignored — Donut stuck right) | After (Donut ordered left, same compact spacing) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1977/blender-before-order-ignored.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1977/blender-after-order-respected-compact.png) |

And the connector-node re-centering, on a campaign with an internal branch-and-rejoin plus an intro quest — the "Start Here" intro sits centered above the quest it leads into, the spine stays straight, and the two branch quests spread symmetrically and rejoin:

![diamond](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1977/diamond-intro-centered.png)

### Anything Else?

- The other half of the reopened report — *Blender Basics not vertically straight (a bend where Donut branches off)* — I could **not** reproduce on `develop`, including with the internal branch-and-rejoin shown above: the spine stays straight (the #1787 / #2023 straightening). That screenshot was taken on **staging**, which likely hasn't merged those fixes yet, so it should resolve once staging catches up.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)