### PR TITLE
Move returned submissions to the active semester (#1231)

### DIFF
--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -1223,6 +1223,12 @@ class QuestSubmission(models.Model):
         self.is_approved = False
         self.do_not_grant_xp = False
         self.time_returned = timezone.now()
+        # Re-attach the submission to the current semester (issue #1231). A quest completed in a past
+        # (now closed) semester and returned for a redo would otherwise stay linked to the old semester,
+        # so it never appeared in the student's current in-progress list and, once re-approved, granted
+        # its XP in the closed semester. Returning always happens "now", so the redo belongs to the
+        # active semester. When the submission is already in the active semester this is a no-op.
+        self.semester = SiteConfig.get().active_semester
         self.save()
         self.user.profile.xp_invalidate_cache()  # recalculate XP
 

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -670,6 +670,49 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         self.assertFalse(self.submission.is_completed, False)
         self.assertIsNone(self.submission.get_minutes_to_complete())
 
+    def test_mark_returned__moves_submission_to_active_semester(self):
+        """A submission returned in a later semester is re-attached to the current semester (issue #1231).
+
+        A quest completed in a past (now closed) semester and returned for a redo in a new semester used
+        to stay linked to the old semester, so it never showed up in the student's current in-progress
+        list and, once re-approved, granted its XP in the closed semester. Returning it now moves it to
+        the active semester so the redo behaves like any other current submission.
+        """
+        past_semester = baker.make(
+            Semester, name="Past", first_day=datetime.date(2020, 1, 1),
+            last_day=datetime.date(2020, 6, 1), closed=True,
+        )
+        active_semester = SiteConfig.get().active_semester
+        self.assertNotEqual(past_semester, active_semester)
+
+        # A quest completed and approved back in the past (closed) semester.
+        sub = baker.make(
+            QuestSubmission, user=self.student, semester=past_semester,
+            is_completed=True, is_approved=True,
+        )
+        self.assertEqual(sub.semester, past_semester)
+
+        # Teacher returns it in the current semester -- it should move to the active semester.
+        sub.mark_returned()
+        sub.refresh_from_db()
+        self.assertEqual(sub.semester, active_semester)
+
+    def test_mark_returned__keeps_active_semester_submission_on_active_semester(self):
+        """Returning a submission already in the active semester leaves it there (issue #1231).
+
+        The common case -- a teacher returning a submission for revision in the same semester it was
+        made -- must not be disturbed by the re-attachment above.
+        """
+        active_semester = SiteConfig.get().active_semester
+        sub = baker.make(
+            QuestSubmission, user=self.student, semester=active_semester,
+            is_completed=True, is_approved=True,
+        )
+
+        sub.mark_returned()
+        sub.refresh_from_db()
+        self.assertEqual(sub.semester, active_semester)
+
 
 class QuestExpiredAnnotationTest(ByteDeckTenantTestCase):
     """Quest.expired() is called for every quest rendered in list templates, so


### PR DESCRIPTION
### What?

When a teacher **returns** a quest submission that was completed in a **past (now closed) semester**, the submission now moves to the **current active semester**. Previously it stayed linked to the old semester.

### Why?

Reported in #1231: a student completes a quest in one semester; in a later semester the teacher returns it (e.g. so the student can redo it as review for XP). The returned submission stayed attached to the **old** semester, which caused two problems:

- It never appeared in the student's **current** "In Progress" list (it only showed up yellow under *Past Quests*).
- When re-approved, its **XP was granted in the closed semester**, not the current one.

The maintainer's diagnosis in the issue was exactly this: *"the submission's semester is changed to the current semester (← this will probably fix everything)."*

### How?

`QuestSubmission.mark_returned()` now re-attaches the submission to `SiteConfig.get().active_semester`:

```python
self.time_returned = timezone.now()
# Re-attach to the current semester (#1231) ...
self.semester = SiteConfig.get().active_semester
self.save()
```

- Returning always happens "now", so the redo belongs to the active semester.
- When the submission is **already** in the active semester — the common case of a teacher returning a submission for revision in the same semester — this is a **no-op**.
- The submission's `ordinal` and `first_time_completed` are untouched, so repeatable-quest counting is unaffected, and the partial unique in-progress constraint (`unique_inprogress_submission_per_quest_semester`, which only applies when `first_time_completed IS NULL`) can't be violated because a returned submission always has `first_time_completed` set.

No schema change (logic only); `makemigrations --check` is clean.

### Testing?

Two new tests in `quest_manager/tests/test_models.py::SubmissionTestModel` (test-driven — the first fails without the fix):

- `test_mark_returned__moves_submission_to_active_semester` — a submission in a past closed semester is moved to the active semester on return.
- `test_mark_returned__keeps_active_semester_submission_on_active_semester` — the same-semester return-for-revision case stays put (no-op).

Full `quest_manager` suite (321 tests) green; `ruff` clean.

### Screenshots (if front end is affected)

N/A — this is a backend data-flow fix. No template, CSS, or JS changed; the "In Progress" and profile views render unchanged. The visible effect (a returned past-semester quest appearing in the current in-progress list and granting XP in the current semester) is a direct consequence of the semester reassignment and is covered by the unit tests above.

### Anything Else?

The issue lists several downstream symptoms (profile in-progress display, teacher approvals tab, XP granted in current semester). These all flow from the submission's semester, so this single fix addresses them, matching the maintainer's "this will probably fix everything" note.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_