### PR TITLE
Show a notice instead of an empty form for unavailable-quest submissions (#798)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -42,6 +42,23 @@
   {% endwith %}
   {% endif %}
 
+  {% comment %} A quest can be unpublished (drafted) or archived after a student has already
+     submitted it. The student keeps access to review their past work, but the submission form
+     below is useless and confusing (a form with no submit button), so hide it and explain why
+     with a notice, matching the red "Quest Preview" panel shown for not-yet-available quests
+     (issue #798). Staff still see the form so they can manage the submission. {% endcomment %}
+  {% if quest_no_longer_available and not request.user.is_staff %}
+    <div id="quest-unavailable-{{ submission.quest.id }}" class="panel panel-danger panel-top">
+      <div class="panel-heading">
+        <h3 class="panel-title"><i class="fa fa-warning"></i> Quest No Longer Available</h3>
+      </div>
+      <div class="panel-body">
+        <p>This quest is no longer available, so it can't be submitted or commented on.
+           You can still view your past work below.</p>
+      </div>
+    </div>
+  {% endif %}
+
   {% with submission.quest as quest %}
     {% include "quest_manager/quest_detail_content.html" %}
   {% endwith %}
@@ -67,6 +84,9 @@
     </ul>
   </div>
 
+  {% comment %} Hide the whole submission form from students when the quest is no longer available
+     (see the notice above, issue #798); staff keep it to manage the submission. {% endcomment %}
+  {% if not quest_no_longer_available or request.user.is_staff %}
   <div id='submission-form-{{submission.quest.id}}' class="panel panel-primary">
     <div class="panel-heading">
       <h3 class="panel-title">Quest Submission Form</h3>
@@ -119,6 +139,7 @@
       </form>
     </div>
   </div>
+  {% endif %}{# submission form hidden when quest no longer available (#798) #}
 
 {% endblock %}
 {% block js %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -549,6 +549,42 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[s4_pk]))
         self.assertNotContains(response, 'Submit Quest for Approval')
 
+    def test_submission__unavailable_quest_shows_notice_and_hides_form_for_student(self):
+        """A student viewing a submission of an unpublished quest gets a "no longer available"
+        notice and the (empty, useless) submission form is hidden entirely (issue #798).
+
+        quest3/sub4 is unpublished, so the submission form has no submit button; rather than
+        leave the confusing empty form, the student sees a red notice and no form panel.
+        """
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('quests:submission', args=[self.sub4.pk]))
+        self.assertContains(response, 'Quest No Longer Available')
+        self.assertNotContains(response, 'Quest Submission Form')
+
+    def test_submission__available_quest_shows_form_without_notice(self):
+        """A published, non-archived quest still shows the submission form and no notice (issue #798)."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
+        self.assertContains(response, 'Quest Submission Form')
+        self.assertNotContains(response, 'Quest No Longer Available')
+
+    def test_submission__archived_quest_submission_is_not_viewable(self):
+        """A submission of an archived quest is already not viewable (404), which matches the
+        "no longer viewable" fallback the issue accepts for the archived case (issue #798).
+
+        The QuestSubmission manager excludes archived quests from this view, so there is no empty
+        form to worry about -- the page simply isn't served.
+        """
+        self.client.force_login(self.test_student1)
+
+        self.quest3.archived = True
+        self.quest3.save()
+
+        response = self.client.get(reverse('quests:submission', args=[self.sub4.pk]))
+        self.assertEqual(response.status_code, 404)
+
     def test_submission__drop_button_hidden_when_approved(self):
         """
         Make sure drop button is not visible when quest submission is already approved

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2067,6 +2067,14 @@ def submission(request, submission_id=None, quest_id=None):
         "submission_form": main_comment_form,
         # "reply_comment_form": reply_comment_form,
         "quick_reply_text": SiteConfig.get().submission_quick_text,
+        # A quest can become unpublished (drafted) after a student has already submitted it.
+        # The student can still open the submission to review their past work, but the submission
+        # form is useless (it has no submit button) and confusing (issue #798), so the template
+        # hides the form and shows a "no longer available" notice instead. Staff keep the form so
+        # they can still manage the submission. (Archived quests are already unreachable here -- the
+        # QuestSubmission manager excludes them from this view entirely, so they 404, which matches
+        # the "no longer viewable" fallback the issue accepts for the archived case.)
+        "quest_no_longer_available": not sub.quest.published,
     }
     return render(request, "quest_manager/submission.html", context)
 


### PR DESCRIPTION
### What?

When a student opens a submission of a quest that has since been **unpublished** (drafted), the page no longer shows a broken, empty submission form. It shows a red **"Quest No Longer Available"** notice instead and hides the form.

### Why?

Reported in #798: a student can still view an approved/completed submission after the quest becomes unavailable (which is intended — they should be able to review their past work), but the page rendered the full **Quest Submission Form** — summernote editor + "Attach files" picker — **with no submit button**. The buttons were already hidden (the template gates them on `quest.published`), but the empty, non-functional form was left behind, which is confusing (see the "before" screenshot).

Note: the field the original issue called `visible_to_students` was later **renamed to `published`**, so "unpublished/draft" is exactly the `visible_to_students=False` case from the issue.

### How?

- The `submission()` view passes a `quest_no_longer_available` flag (`not sub.quest.published`).
- The template (`quest_manager/submission.html`) shows a red notice at the top — mirroring the existing "Quest Preview" panel used for not-yet-available quests — and **hides the whole submission form** for students when the quest is no longer available. **Staff keep the form** so they can still manage the submission.

**Archived quests:** these are already unreachable in this view — the `QuestSubmission` manager excludes archived quests from both its lookup and the `all_completed` fallback, so the page returns **404 ("no longer viewable")**. That matches the fallback the issue explicitly accepts for the archived case ("a blank page saying this quest has been archived and is no longer viewable"), so no separate handling is needed; a test documents it.

### Testing?

New tests in `quest_manager/tests/test_views.py::SubmissionViewTests` (test-driven — the notice test fails without the change):

- **Unpublished quest** → student sees the notice, the form is gone.
- **Published quest** → form shown, no notice (unaffected).
- **Archived quest** → submission returns 404 (the accepted "not viewable" fallback).

Full `quest_manager` suite (322 tests) green; `ruff` clean; no migration (logic/template only).

### Screenshots (if front end is affected)

Captured on the real running `hackerspace` deck, logged in as a student viewing their approved submission of a quest that was then unpublished.

| Before (empty form, no submit button) | After (notice, form hidden) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/798/before-empty-form.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/798/after-notice.png) |

### Anything Else?

Nothing further — the change is scoped to the student's view of a submission; staff and the normal published-quest flow are untouched.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_