### PR TITLE
Cover update_conditions management command (0% → 100%)

### DIFF
--- a/src/prerequisites/tests/test_commands.py
+++ b/src/prerequisites/tests/test_commands.py
@@ -1,0 +1,20 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+from prerequisites.tasks import update_quest_conditions_all_users
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+
+
+class UpdateConditionsCommandTest(ByteDeckTenantTestCase):
+    """The `update_conditions` management command, which queues a full conditions-met recompute for all users."""
+
+    def test_update_conditions__queues_task_and_writes_status(self):
+        """Running the command writes a status line and schedules the recompute task on the default queue."""
+        out = StringIO()
+        with patch.object(update_quest_conditions_all_users, 'apply_async') as mock_apply_async:
+            call_command('update_conditions', stdout=out)
+
+        self.assertIn('Creating conditions met for all users', out.getvalue())
+        mock_apply_async.assert_called_once_with(args=[1], queue='default')


### PR DESCRIPTION
### What?

Next gap-closing PR. Adds the missing test for the `prerequisites` **`update_conditions`** management command, taking it from **0% → 100%**.

### Why?

`update_conditions` (queues a full conditions-met recompute for all users — `update_quest_conditions_all_users`) is a real, invokable management command that had no test at all. Small, self-contained gap worth closing.

### How?

New `prerequisites/tests/test_commands.py` — `UpdateConditionsCommandTest` runs the command via `call_command` with the Celery task's `apply_async` patched (the established `patch.object(update_quest_conditions_all_users, 'apply_async')` idiom used across `prerequisites/tests/test_tasks.py`), and asserts it:

- writes its "Creating conditions met for all users…" status line, and
- schedules the task with `args=[1]` on the `default` queue.

### Testing?

- `python manage.py test prerequisites.tests.test_commands` → **1 passing**; `ruff` clean; `test_conventions` passes.
- With coverage, `prerequisites/management/commands/update_conditions.py` reports **100%**, up from 0%.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Target came from a full-suite coverage run.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_