### PR TITLE
Run the current-XP recalculation as a background task (#2081)

### DIFF
--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -125,10 +125,12 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
-    def test_recalculate_current_xp__invalidates_active_semester_profiles(self):
-        """recalculate_current_xp invalidates the XP cache of each active-semester profile."""
+    def test_recalculate_current_xp__dispatches_background_task(self):
+        """recalculate_current_xp hands the all-student XP recompute to a background task
+        rather than looping over every active-semester profile synchronously in the request,
+        which had grown a web worker large enough to be OOM-killed (issue #2081).
+        """
         # a student registered in the active semester so all_for_active_semester() is non-empty
-        # and the loop body actually runs
         baker.make(
             'courses.CourseStudent', user=self.test_student1,
             semester=self.active_sem, course=baker.make('courses.Course'),
@@ -136,12 +138,15 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertTrue(Profile.objects.all_for_active_semester().exists())
         self.client.force_login(self.test_teacher)
 
-        with patch.object(Profile, 'xp_invalidate_cache') as mock_invalidate:
+        # The view must NOT recompute in-request; it must dispatch the celery task instead.
+        with patch('profile_manager.views.invalidate_profile_xp_cache_on_schema.apply_async') as mock_dispatch, \
+                patch.object(Profile, 'xp_invalidate_cache') as mock_invalidate:
             response = self.client.get(reverse('profiles:recalculate_xp_current'))
 
         self.assertEqual(response.status_code, 302)
-        # the view actually invalidated the XP cache (would still pass on a bare redirect otherwise)
-        self.assertTrue(mock_invalidate.called)
+        mock_dispatch.assert_called_once()
+        # nothing was recomputed synchronously in the request
+        self.assertFalse(mock_invalidate.called)
 
     def test_tour_complete__marks_completed_and_redirects_to_quests(self):
         """tour_complete sets the profile's intro_tour_completed flag and redirects to the quests page."""

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -17,6 +17,7 @@ from siteconfig.models import SiteConfig
 
 from .models import Profile
 from .forms import ProfileForm, UserForm
+from .tasks import invalidate_profile_xp_cache_on_schema
 from badges.models import BadgeAssertion
 from courses.models import CourseStudent, Block
 from notifications.signals import notify
@@ -478,9 +479,18 @@ def oauth_merge_account(request):
 @non_public_only_view
 @staff_member_required
 def recalculate_current_xp(request):
-    profiles_qs = Profile.objects.all_for_active_semester()
-    for profile in profiles_qs:
-        profile.xp_invalidate_cache()
+    # Recalculating XP for every current student invalidates and recomputes a cache per
+    # profile; on a busy deck that is hundreds of profiles in one request, which has grown a
+    # uwsgi worker large enough to get OOM-killed and time out the page (issue #2081). Hand it
+    # to the existing background task instead -- it does the same all_for_active_semester()
+    # recompute (with per-profile error handling) and, dispatched from this request, runs in
+    # this tenant's schema via tenant-schemas-celery.
+    invalidate_profile_xp_cache_on_schema.apply_async(queue='default')
+    messages.success(
+        request,
+        "Recalculating XP for all current students in the background. "
+        "It may take a minute; refresh the page to see updated totals.",
+    )
     return redirect_to_previous_page(request)
 
 


### PR DESCRIPTION
### What?

The staff **"recalculate current XP"** endpoint (`recalculate_current_xp`) no longer recomputes every student's XP synchronously in the web request — it hands the work to the existing background task instead.

### Why?

Part of #2081 (per-request memory blowups OOM-killing the web host). Item 4 of that issue:

> `recalculate_current_xp` — `profile_manager/views.py`: `for profile in Profile.objects.all_for_active_semester(): profile.xp_invalidate_cache()` **synchronously in the request** — an all-user XP recompute in a view.

On a busy deck that's hundreds of profiles, each invalidating and recomputing a cache, all in one request — enough to grow a uwsgi worker until it's OOM-killed and the page times out (the issue documents real `dmesg` OOM kills on the single-host box).

### How?

Dispatch `profile_manager.tasks.invalidate_profile_xp_cache_on_schema` (which already exists and is used by the nightly all-schemas refresh) instead of looping in-request:

```python
invalidate_profile_xp_cache_on_schema.apply_async(queue='default')
messages.success(request, "Recalculating XP for all current students in the background. ...")
return redirect_to_previous_page(request)
```

- The task does the **same** `all_for_active_semester()` recompute, and it already has **per-profile error handling** (one bad row is logged and skipped instead of aborting the run) — strictly better than the old inline loop.
- Dispatched from the request, it runs in the **current tenant's schema** via `tenant-schemas-celery`, so it only touches the deck the staff member is on.
- The staff user gets a "recalculating in the background" message and is redirected back as before.

No schema change; no new task (reuses the existing one).

### Testing?

Updated `profile_manager/tests/test_views.py`:

- `test_recalculate_current_xp__dispatches_background_task` — asserts the view dispatches the celery task **and does not** recompute any profile synchronously in the request (test-driven; fails against the old inline-loop view).
- `test_profile_recalculate_xp__status_codes` — still returns the 302 redirect.

Full `profile_manager` suite (104 tests) green; `ruff` clean.

### Screenshots (if front end is affected)

N/A — this endpoint has **no template link** (it's defined only in `urls.py` and reached by direct URL, redirecting back via the referer), so there's no discoverable UI element to capture. The only visible artifact is the new "recalculating in the background" flash message, which is covered by the behavior change above and the test.

### Anything Else?

This is one item of the larger #2081 memory work, so it does **not** close the issue. The other ranked culprits (unbounded admin exports, unpaginated `ProfileList`, the latent `ajax_quest_info` all-quests branch, etc.) remain as separate follow-ups.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_