### PR TITLE
Fix flaky GFKChoiceField choices test (deterministic queryset order)

### DIFF
--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -28,9 +28,14 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
 
     def test_GFKChoiceField__choices_and_clean(self):
         """Field groups choices by content type and clean() validates and resolves GFK values."""
+        # order_by('pk') keeps the grouped-choices order deterministic: without
+        # an explicit ordering Postgres returns rows in arbitrary order, so the
+        # user sublist in the assertion below flaked intermittently in CI. The
+        # field respects the caller's queryset order, so the fix belongs on the
+        # queryset here rather than forcing an order inside the field.
         f = GFKChoiceField(
             queryset=QuerySetSequence(
-                User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]),
+                User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]).order_by('pk'),
                 Group.objects.filter(pk__in=[self.group1.pk]),
             ),
         )


### PR DESCRIPTION
### What?
Makes `test_GFKChoiceField__choices_and_clean` deterministic so it stops intermittently red-failing CI.

### Why?
The test builds a `QuerySetSequence` from an **unordered** `User.objects.filter(...)` and asserts a specific grouped-choice order:
```python
("user", [
    (self._ct_pk(self.user1), "johndoe"),
    (self._ct_pk(self.user2), "janedoe"),
]),
```
Postgres returns rows in **arbitrary order** without an explicit `ORDER BY`, so the two users occasionally come back swapped and the assertion fails. This has hit CI on unrelated PRs, e.g. on #2082:
```
FAIL: test_GFKChoiceField__choices_and_clean
  ('user', [('7-624', 'janedoe'), ('7-623', 'johndoe')]),   # got
  ('user', [('7-623', 'johndoe'), ('7-624', 'janedoe')]),   # expected
```

### How?
Add `.order_by('pk')` to the test's `User` queryset. `GFKChoiceIterator` intentionally **respects the caller's queryset order**, so the fix belongs on the queryset in the test rather than forcing an order inside the field (which would override caller intent for every consumer). `order_by('pk')` yields `user1` (johndoe, created first → lower pk) before `user2` (janedoe), matching the existing assertion, so no assertion change is needed.

### Testing?
- `python src/manage.py test utilities.tests.test_fields.GFKChoiceFieldTest` — passes; ran the target test **3×** to confirm it's now deterministic.
- `ruff check src` — clean.

### Screenshots (if front end is affected)
N/A — test-only change.

### Anything Else?
- One-line, test-only; no production behavior change.
- Note (out of scope): the same "unordered queryset" pattern exists in `AllowedGFKChoiceField._build_querysetsequence` (`x.objects.all()`), so the prereq-object dropdown lists items in arbitrary order for users. That's a minor pre-existing UX nit, not a CI flake — happy to follow up separately if you want deterministic dropdown ordering there too.

- Claude Code (`Bytedeck - infrastructure stack`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_