### PR TITLE
Copy a quest's submission questions when the quest is copied (#2161)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2254,13 +2254,16 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def test_quest_copy__copies_submission_questions(self):
         """Copying a quest duplicates its submission questions onto the copy (issue #2161).
-        Each question's fields are carried over, and the source quest keeps its own questions."""
+        Each question's fields — including marker_notes and the (shared) solution_file — are
+        carried over, and the source quest keeps its own questions."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
         from questions.models import Question
 
         # give the source quest a question of each type, in a specific order
         Question.objects.create(
             quest=self.quest, ordinal=1, type="short_answer", required=True,
             instructions="What is your name?", solution_text="Any name",
+            marker_notes="Accept any non-empty name.",
         )
         Question.objects.create(
             quest=self.quest, ordinal=2, type="long_answer", required=False,
@@ -2269,6 +2272,7 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         Question.objects.create(
             quest=self.quest, ordinal=3, type="file_upload", required=True,
             instructions="Attach your work.", allowed_file_type="image",
+            solution_file=SimpleUploadedFile("solution.png", b"file_content", content_type="image/png"),
         )
 
         self.client.force_login(self.test_teacher)
@@ -2289,7 +2293,10 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertEqual(copy_q.required, src_q.required)
             self.assertEqual(copy_q.instructions, src_q.instructions)
             self.assertEqual(copy_q.solution_text, src_q.solution_text)
+            self.assertEqual(copy_q.marker_notes, src_q.marker_notes)
             self.assertEqual(copy_q.allowed_file_type, src_q.allowed_file_type)
+            # the copy references the same solution file as the source (not re-uploaded)
+            self.assertEqual(copy_q.solution_file.name, src_q.solution_file.name)
         # the source quest still has exactly its own three questions
         self.assertEqual(Question.objects.filter(quest=self.quest).count(), 3)
 
@@ -2305,6 +2312,32 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         copied_quest = Quest.objects.get(name='Test Quest - COPY')
         self.assertRedirects(response, copied_quest.get_absolute_url())
         self.assertEqual(Question.objects.filter(quest=copied_quest).count(), 0)
+
+    def test_quest_copy__question_failure_rolls_back_whole_copy(self):
+        """If duplicating a question fails, the whole copy rolls back — no orphaned quest is
+        left behind (the copy, its prereqs and its questions commit or roll back together)."""
+        from django.core.exceptions import ValidationError
+        from questions.models import Question
+
+        Question.objects.create(
+            quest=self.quest, ordinal=1, type="short_answer", required=True,
+            instructions="What is your name?",
+        )
+
+        quests_before = Quest.objects.count()
+        self.client.force_login(self.test_teacher)
+
+        # force the second step (question duplication) to blow up
+        with patch.object(Question, "full_clean", side_effect=ValidationError("boom")):
+            with self.assertRaises(ValidationError):
+                self.client.post(
+                    reverse('quests:quest_copy', args=[self.quest.id]),
+                    data=self.valid_copy_form_data,
+                )
+
+        # the transaction rolled back: no copied quest, and the quest count is unchanged
+        self.assertFalse(Quest.objects.filter(name='Test Quest - COPY').exists())
+        self.assertEqual(Quest.objects.count(), quests_before)
 
 
 class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2252,6 +2252,60 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn("new-prereq-quest", str(copied_quest.prereqs()))
         self.assertIn("new-prereq-badge", str(copied_quest.prereqs()))
 
+    def test_quest_copy__copies_submission_questions(self):
+        """Copying a quest duplicates its submission questions onto the copy (issue #2161).
+        Each question's fields are carried over, and the source quest keeps its own questions."""
+        from questions.models import Question
+
+        # give the source quest a question of each type, in a specific order
+        Question.objects.create(
+            quest=self.quest, ordinal=1, type="short_answer", required=True,
+            instructions="What is your name?", solution_text="Any name",
+        )
+        Question.objects.create(
+            quest=self.quest, ordinal=2, type="long_answer", required=False,
+            instructions="Explain your reasoning.",
+        )
+        Question.objects.create(
+            quest=self.quest, ordinal=3, type="file_upload", required=True,
+            instructions="Attach your work.", allowed_file_type="image",
+        )
+
+        self.client.force_login(self.test_teacher)
+        self.client.post(
+            reverse('quests:quest_copy', args=[self.quest.id]),
+            data=self.valid_copy_form_data,
+        )
+        copied_quest = Quest.objects.get(name='Test Quest - COPY')
+
+        # the copy has the same questions, in the same order, with the same fields
+        source = list(Question.objects.filter(quest=self.quest).order_by("ordinal"))
+        copied = list(Question.objects.filter(quest=copied_quest).order_by("ordinal"))
+        self.assertEqual(len(copied), 3)
+        for src_q, copy_q in zip(source, copied):
+            self.assertNotEqual(src_q.pk, copy_q.pk)  # a distinct row
+            self.assertEqual(copy_q.ordinal, src_q.ordinal)
+            self.assertEqual(copy_q.type, src_q.type)
+            self.assertEqual(copy_q.required, src_q.required)
+            self.assertEqual(copy_q.instructions, src_q.instructions)
+            self.assertEqual(copy_q.solution_text, src_q.solution_text)
+            self.assertEqual(copy_q.allowed_file_type, src_q.allowed_file_type)
+        # the source quest still has exactly its own three questions
+        self.assertEqual(Question.objects.filter(quest=self.quest).count(), 3)
+
+    def test_quest_copy__questionless_quest_still_copies(self):
+        """A quest with no submission questions copies as before — the clone step is a no-op."""
+        from questions.models import Question
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.post(
+            reverse('quests:quest_copy', args=[self.quest.id]),
+            data=self.valid_copy_form_data,
+        )
+        copied_quest = Quest.objects.get(name='Test Quest - COPY')
+        self.assertRedirects(response, copied_quest.get_absolute_url())
+        self.assertEqual(Question.objects.filter(quest=copied_quest).count(), 0)
+
 
 class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """ Tests for:

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -396,23 +396,28 @@ class QuestCopy(QuestCreate):
         return kwargs
 
     def form_valid(self, form):
-        """Save the new (copied) quest, then duplicate the source quest's submission questions
+        """Save the new (copied) quest and duplicate the source quest's submission questions
         onto it, so a copied quest keeps its questions (issue #2161).
+
+        `form` is the validated QuestForm bound to the new (copied) quest instance. Returns the
+        redirect response from the parent view. Quest creation, prerequisite setup and question
+        duplication all run inside a single transaction, so a failure duplicating a question rolls
+        back the whole copy rather than leaving an orphaned quest with no (or partial) questions.
 
         Student answers are not copied — those belong to submissions, not to the quest. The
         solution_file reference is shared with the source question, matching how the copied
         quest already shares its icon file.
         """
-        # local import avoids a load-time dependency between quest_manager and the questions app
         from questions.models import Question
 
-        response = super().form_valid(form)  # saves self.object (the new quest) and sets prereqs
-
-        source_quest = get_object_or_404(Quest, pk=self.kwargs["quest_id"])
         with transaction.atomic():
+            response = super().form_valid(form)  # saves self.object (the new quest) and sets prereqs
+
+            source_quest = get_object_or_404(Quest, pk=self.kwargs["quest_id"])
             for question in Question.objects.filter(quest=source_quest):
                 question.pk = None
                 question.quest = self.object
+                question.full_clean()
                 question.save()
         return response
 

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -13,6 +13,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db import transaction
 from django.db.models import F, ExpressionWrapper, fields, BooleanField, Count, Exists, OuterRef, Q, Sum
 from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import Http404, get_object_or_404, redirect, render
@@ -393,6 +394,27 @@ class QuestCopy(QuestCreate):
 
         kwargs["instance"] = new_quest
         return kwargs
+
+    def form_valid(self, form):
+        """Save the new (copied) quest, then duplicate the source quest's submission questions
+        onto it, so a copied quest keeps its questions (issue #2161).
+
+        Student answers are not copied — those belong to submissions, not to the quest. The
+        solution_file reference is shared with the source question, matching how the copied
+        quest already shares its icon file.
+        """
+        # local import avoids a load-time dependency between quest_manager and the questions app
+        from questions.models import Question
+
+        response = super().form_valid(form)  # saves self.object (the new quest) and sets prereqs
+
+        source_quest = get_object_or_404(Quest, pk=self.kwargs["quest_id"])
+        with transaction.atomic():
+            for question in Question.objects.filter(quest=source_quest):
+                question.pk = None
+                question.quest = self.object
+                question.save()
+        return response
 
 
 class QuestSubmissionSummary(UserPassesTestMixin, DetailView):


### PR DESCRIPTION
### What?
Copying a quest now duplicates its **submission questions** onto the copy. Previously "Copy Quest" cloned the Quest row (plus prereqs and tags) but silently dropped its `Question` rows.

### Why?
Found in the submission-questions self-review (#2161). A teacher copying a questful quest ended up with an empty-form copy and no warning — and TAs, who also get a "Copy Quest" button, couldn't even recreate the questions because question management is staff-only.

### How?
`QuestCopy.form_valid` clones each of the source quest's questions onto the new quest after it's saved, inside a transaction. Every field is carried over (type, instructions, solution text/file, allowed file type, marker notes, required, ordinal); the `solution_file` reference is shared with the source question, matching how the copied quest already shares its icon file. Student answers are **not** copied — those belong to submissions, not the quest.

Implementation notes:
- The clone runs via a function-local `from questions.models import Question` import, avoiding any load-time coupling between `quest_manager` and the `questions` app.
- Self-contained to `quest_manager/views.py` — no new files, so it won't conflict with the in-flight #2099.

### Testing?
- Two new tests in `QuestCopyViewTest`: a quest with one question of each type copies all three (distinct rows, same fields, source keeps its own), and a question-less quest still copies fine (clone step is a no-op).
- `src/quest_manager` + `src/questions` suites (384 tests) pass; `ruff`, `manage.py check`, `makemigrations --check` clean.

### Screenshots
Captured from the running app on a dev deck — a real "Copy Quest" of a 3-question quest, then the copy's question list:

**Source quest's questions:**
![source questions](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2161/copy_source_questions.png)

**The copy's questions** (all three carried over, e.g. the short-answer solution "By the door"):
![copied questions](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2161/copy_new_questions.png)

Closes #2161.

- Claude Code (`Bytedeck - multiple submission types`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quest copying now duplicates submission questions, preserving their content and order.
  * Copied questions are created as independent records without copying student answers.
  * Copying a quest with no submission questions completes without adding any questions.

* **Bug Fixes**
  * Quest and question creation now completes consistently as a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->