### PR TITLE
Reject the unbounded "all quests" ajax_quest_info branch (#2081)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3013,7 +3013,7 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_ajax_quest_info__returns_json(self):
-        """An ajax POST (with or without a quest id) returns a JsonResponse with a 200 status."""
+        """An ajax POST with a quest id returns a JsonResponse with a 200 status."""
         response = self.client.post(
             reverse('quests:ajax_quest_info', args=[self.quest.id]),
             content_type='application/json',
@@ -3023,15 +3023,19 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         self.assertEqual(type(response), JsonResponse)
 
-        # Same without a quest ID:
+    def test_ajax_quest_info__no_quest_id_returns_404(self):
+        """An ajax POST without a quest id is rejected (404) rather than rendering every quest.
+
+        The accordion UI always requests one quest by id; the "all quests" branch was an unbounded
+        per-request memory hog with no staff gate that any logged-in user could POST directly
+        (issue #2081), so it now 404s like the view's other invalid requests.
+        """
         response = self.client.post(
             reverse('quests:ajax_quest_all'),
             content_type='application/json',
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
-        self.assertEqual(response.status_code, 200)
-
-        self.assertEqual(type(response), JsonResponse)
+        self.assertEqual(response.status_code, 404)
 
     def test_ajax_quest_info__can_export_student_false(self):
         """

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -912,17 +912,14 @@ def ajax_quest_info(request, quest_id=None):
 
                 return JsonResponse(data)
 
-            else:  # all quests, used for staff only.
-                quests = Quest.objects.all()
-                all_quest_info_html = {}
-
-                for q in quests:
-                    all_quest_info_html[q.id] = render_to_string(template,
-                                                                 {'q': q, 'is_library_view': is_library_view, 'can_export': can_export},
-                                                                 request=request)
-
-                data = json.dumps(all_quest_info_html)
-                return JsonResponse(data, safe=False)
+            else:
+                # No quest_id: the accordion UI always requests one quest at a time by id, so there
+                # is no legitimate caller for an "all quests" response. Rendering every quest's
+                # preview HTML into a single JSON blob (held twice in memory -- the dict of rendered
+                # strings and then the json.dumps of it) is an unbounded per-request memory hog that
+                # any logged-in user could trigger by POSTing the bare URL, and it had no staff gate
+                # (issue #2081). Reject it like the view's other invalid requests.
+                raise Http404
 
     else:
         raise Http404


### PR DESCRIPTION
### What?

`ajax_quest_info`'s no-`quest_id` branch — which rendered **every** quest's preview HTML into one JSON response — is removed; that path now returns 404. The normal per-quest path is unchanged.

### Why?

Part of #2081 (per-request memory blowups OOM-killing the web host). Item 5:

> `ajax_quest_info` all-quests branch — POST with no `quest_id` → `Quest.objects.all()` rendered per-quest into a dict, then `json.dumps` (two full copies of all rendered HTML). The accordion JS always sends an id, so the UI hits the cheap branch, but any staff user can POST the unbounded branch directly.

Two problems with the branch:
- **Unbounded memory:** it built a dict of every quest's rendered preview HTML and then `json.dumps`'d it — the full set of rendered HTML held twice in memory, scaling with the quest count, all in a single request.
- **No access gate:** the comment said "used for staff only" but there was no `is_staff` check, so *any* logged-in user could POST the bare `/quests/ajax_quest_info/` URL and trigger it.

And nothing actually uses it: the accordion (`bootstrap-table-accordion.js`) always builds its URL as `${ajax_quest_root}${id}/`, i.e. it always requests a single quest by id and hits the cheap per-quest branch.

### How?

Replace the "all quests" branch with `raise Http404`, matching how the view already rejects its other invalid requests (non-POST, GET, etc.). The `ajax_quest_root` URL name stays (the JS still reverses it to build the per-quest base URL); only the id-less *response* is removed.

### Testing?

`quest_manager/tests/test_views.py::AjaxQuestInfoTest`:

- `test_ajax_quest_info__no_quest_id_returns_404` — a no-id ajax POST now returns 404 (test-driven; returned 200 against the old branch).
- `test_ajax_quest_info__returns_json` — the per-quest branch still returns a 200 `JsonResponse` (unchanged).

Full `quest_manager` suite (323 tests) green; `ruff` clean; no migration.

### Screenshots (if front end is affected)

N/A — no template, CSS, or JS changed. The accordion UI never called the removed branch (it always requests a single quest by id), so there is no user-visible change; this only closes a directly-POSTable unbounded endpoint.

### Anything Else?

One item of the larger #2081 memory work, so it does **not** close the issue. Remaining ranked culprits (unbounded admin exports, unpaginated `ProfileList`, in-request map regeneration, etc.) are separate follow-ups.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_