### PR TITLE
HOTFIX: Admin cap is always authoritative (suspension resets it to 5 once) + Maintenance status

### DIFF
--- a/src/hackerspace_online/context_processors.py
+++ b/src/hackerspace_online/context_processors.py
@@ -38,7 +38,6 @@ def deck_status(request):
     """
     from django.urls import reverse
 
-    from tenant.models import TRIAL_MAX_ACTIVE_USERS
     from tenant.utils import get_current_deck
 
     deck = get_current_deck()
@@ -47,7 +46,4 @@ def deck_status(request):
     return {
         "current_deck": deck,
         "deck_subscribe_url": reverse('decks:subscription'),
-        # what a lapsed deck reverts to -- the grace banner can't derive this from
-        # the deck's effective cap, which is still the paid cap during grace
-        "trial_cap": TRIAL_MAX_ACTIVE_USERS,
     }

--- a/src/hackerspace_online/context_processors.py
+++ b/src/hackerspace_online/context_processors.py
@@ -38,6 +38,7 @@ def deck_status(request):
     """
     from django.urls import reverse
 
+    from tenant.models import TRIAL_MAX_ACTIVE_USERS
     from tenant.utils import get_current_deck
 
     deck = get_current_deck()
@@ -46,4 +47,8 @@ def deck_status(request):
     return {
         "current_deck": deck,
         "deck_subscribe_url": reverse('decks:subscription'),
+        # what a fresh suspension will RESET the cap to (reset_cap_on_new_suspension)
+        # -- the grace banner predicts it, and can't derive it from the deck's
+        # current cap, which is still the paid cap during grace
+        "trial_cap": TRIAL_MAX_ACTIVE_USERS,
     }

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -32,7 +32,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
                 {% if current_deck.days_until_expiry < 0 %}
                     <strong>Subscription expired</strong> &mdash; this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
-                    it will then revert to trial limits (max {{ trial_cap }} current students).
+                    it will then revert to trial limits (max {{ current_deck.suspension_cap }} current student{{ current_deck.suspension_cap|pluralize }}).
                 {% elif current_deck.is_on_trial %}
                     <strong>Trial ending soon:</strong> this deck's free trial ends in
                     {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -32,7 +32,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
                 {% if current_deck.days_until_expiry < 0 %}
                     <strong>Subscription expired</strong> &mdash; this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
-                    it will then revert to trial limits (max {{ current_deck.suspension_cap }} current student{{ current_deck.suspension_cap|pluralize }}).
+                    it will then revert to trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).
                 {% elif current_deck.is_on_trial %}
                     <strong>Trial ending soon:</strong> this deck's free trial ends in
                     {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -10,7 +10,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
             <i class="fa fa-fw fa-ban"></i>
             {% if request.user.is_staff %}
                 <strong>This deck is suspended</strong> &mdash; its trial or subscription has ended, and it has
-                reverted to trial limits (max {{ current_deck.effective_max_active_users }} current students).
+                reverted to trial limits (max {{ current_deck.effective_max_active_users }} current student{{ current_deck.effective_max_active_users|pluralize }}).
                 <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore full access.
             {% else %}
                 <strong>This deck is suspended.</strong> Please let your teacher know.

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -230,35 +230,37 @@ class Tenant(TenantMixin):
 
     @property
     def effective_max_active_users(self):
-        """The current-student cap that should be enforced right now.
+        """The current-student cap that should be enforced right now: ALWAYS the
+        admin-set ``max_active_users`` (-1 = unlimited).
 
-        -1 (unlimited, admin-set) passes through unchanged. A SUSPENDED deck
-        reverts to the trial cap ("back to trial mode", #1734) -- but the trial
-        cap is a CEILING, not a replacement: an admin-set cap BELOW the trial
-        limit still holds while suspended (production find, 2026-07-24: a
-        suspended deck with an admin-set cap of 1 showed and enforced 5). Every
-        other deck -- subscribed, on trial, or managed manually (no dates) --
-        uses its admin-set ``max_active_users``: new decks are created with the
-        trial default (5), so the trial cap is the default, not an override, and
-        an admin who deliberately raises a trial or comped deck's cap is honored.
-        (Production bug find, 2026-07-22: the old subscription_active-based rule
-        capped comped/managed-manually decks at 5, contradicting their admin-set
-        cap on the banner and subscription page.)
+        Suspension does NOT override the cap at read time. Instead, when a
+        deck's suspension episode begins, the nightly ``deck_status_check``
+        writes the trial default (TRIAL_MAX_ACTIVE_USERS) into the field once
+        ("revert to trial limits", #1734; see
+        ``tenant.notices.reset_cap_on_new_suspension``) -- after that, whatever
+        the admin sets, higher or lower, always wins (comps and special cases;
+        maintainer decision on #2178 after a production find where a lowered
+        cap of 1 was silently overridden back to 5).
         """
-        return self.suspension_cap if self.is_suspended else self.max_active_users
+        return self.max_active_users
 
     @property
-    def suspension_cap(self):
-        """The current-student cap this deck has -- or would have -- while
-        suspended: the trial cap acting as a CEILING over the admin-set
-        ``max_active_users`` (so a deliberately lowered cap keeps holding), with
-        the -1 unlimited sentinel passing through. Also feeds the "will revert
-        to trial limits (max N)" copy on the banner, subscription page, and
-        expiry-reminder email, so those predictions match what enforcement will
-        actually do."""
-        if self.max_active_users == -1:
-            return -1
-        return min(self.max_active_users, TRIAL_MAX_ACTIVE_USERS)
+    def is_on_maintenance(self):
+        """Whether the deck's active subscription is a MAINTENANCE subscription:
+        paid -- so the deck never suspends, and can never time out for deletion
+        (deletion requires suspension, #2044) -- but with the cap left at (or
+        below) the trial student limit.
+
+        The low-cost maintenance tier is simply a Stripe price whose metadata
+        cap IS the trial cap, so this is derived rather than stored: any active
+        subscription that doesn't lift the cap above trial limits is, by
+        definition, maintenance. Unlimited (-1) decks are never maintenance.
+        """
+        return (
+            self.subscription_active
+            and self.max_active_users != -1
+            and self.max_active_users <= TRIAL_MAX_ACTIVE_USERS
+        )
 
     @property
     def days_until_expiry(self):

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -245,11 +245,20 @@ class Tenant(TenantMixin):
         capped comped/managed-manually decks at 5, contradicting their admin-set
         cap on the banner and subscription page.)
         """
+        return self.suspension_cap if self.is_suspended else self.max_active_users
+
+    @property
+    def suspension_cap(self):
+        """The current-student cap this deck has -- or would have -- while
+        suspended: the trial cap acting as a CEILING over the admin-set
+        ``max_active_users`` (so a deliberately lowered cap keeps holding), with
+        the -1 unlimited sentinel passing through. Also feeds the "will revert
+        to trial limits (max N)" copy on the banner, subscription page, and
+        expiry-reminder email, so those predictions match what enforcement will
+        actually do."""
         if self.max_active_users == -1:
             return -1
-        if self.is_suspended:
-            return min(self.max_active_users, TRIAL_MAX_ACTIVE_USERS)
-        return self.max_active_users
+        return min(self.max_active_users, TRIAL_MAX_ACTIVE_USERS)
 
     @property
     def days_until_expiry(self):

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -233,18 +233,23 @@ class Tenant(TenantMixin):
         """The current-student cap that should be enforced right now.
 
         -1 (unlimited, admin-set) passes through unchanged. A SUSPENDED deck
-        reverts to the trial cap ("back to trial mode", #1734). Every other deck
-        -- subscribed, on trial, or managed manually (no dates) -- uses its
-        admin-set ``max_active_users``: new decks are created with the trial
-        default (5), so the trial cap is the default, not an override, and an
-        admin who deliberately raises a trial or comped deck's cap is honored.
+        reverts to the trial cap ("back to trial mode", #1734) -- but the trial
+        cap is a CEILING, not a replacement: an admin-set cap BELOW the trial
+        limit still holds while suspended (production find, 2026-07-24: a
+        suspended deck with an admin-set cap of 1 showed and enforced 5). Every
+        other deck -- subscribed, on trial, or managed manually (no dates) --
+        uses its admin-set ``max_active_users``: new decks are created with the
+        trial default (5), so the trial cap is the default, not an override, and
+        an admin who deliberately raises a trial or comped deck's cap is honored.
         (Production bug find, 2026-07-22: the old subscription_active-based rule
         capped comped/managed-manually decks at 5, contradicting their admin-set
         cap on the banner and subscription page.)
         """
         if self.max_active_users == -1:
             return -1
-        return TRIAL_MAX_ACTIVE_USERS if self.is_suspended else self.max_active_users
+        if self.is_suspended:
+            return min(self.max_active_users, TRIAL_MAX_ACTIVE_USERS)
+        return self.max_active_users
 
     @property
     def days_until_expiry(self):

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -29,7 +29,7 @@ from django.utils.timezone import localdate
 from notifications.signals import notify
 from siteconfig.models import SiteConfig
 
-from tenant.models import DeckNotice
+from tenant.models import DeckNotice, TRIAL_MAX_ACTIVE_USERS
 
 
 # expiry thresholds, most specific first: the first unfired one whose window has
@@ -39,10 +39,69 @@ EXPIRY_THRESHOLDS = (('d7', 7), ('d14', 14), ('d30', 30))
 
 LIMIT_WARNING_FRACTION = 0.8
 
+# How far back a suspension episode may have begun and still get its one-time
+# cap reset when the nightly task first sees it: covers multi-day beat outages
+# without rewriting caps on decks that were already suspended long before (whose
+# admins may have hand-adjusted the cap since -- exactly what the reset must
+# never clobber).
+CAP_RESET_CATCHUP_DAYS = 7
+
 
 def _unfired(deck, kind, threshold, period_key):
     """Whether this exact notice hasn't been recorded yet."""
     return not DeckNotice.objects.filter(tenant=deck, kind=kind, threshold=threshold, period_key=period_key).exists()
+
+
+def reset_cap_on_new_suspension(deck):
+    """Once per suspension episode, write the trial default back into the deck's
+    ``max_active_users`` -- the "revert to trial limits" moment (#1734).
+
+    Enforcement, not communication: unlike the notices below this is NOT gated
+    by ``settings.DECK_NOTICES_ENABLED``. The cap is applied exactly once per
+    episode (a `DeckNotice` ledger row with threshold 'cap-reset' keyed to the
+    episode's first suspended day), so an admin adjustment made afterwards --
+    lower for a wind-down, higher for a comp -- always sticks
+    (maintainer decision on #2178). Episodes that began more than
+    CAP_RESET_CATCHUP_DAYS ago are recorded but NOT reset: they predate this
+    feature (or a long beat outage), and their caps may already be deliberate.
+
+    Runs inside the deck's tenant context via ``deck_status_check``. Returns a
+    short summary string for the worker log.
+    """
+    from django.utils.timezone import timedelta
+
+    from tenant.models import GRACE_PERIOD_DAYS, Tenant
+    from tenant.utils import invalidate_current_deck_cache
+
+    if not deck.is_suspended:
+        return 'not suspended'
+
+    # First day of this suspension episode: the day after the LAST clock lapsed
+    # (trials end at trial_end_date; paid access ends after the grace window).
+    last_covered_days = []
+    if deck.trial_end_date:
+        last_covered_days.append(deck.trial_end_date)
+    if deck.paid_until:
+        last_covered_days.append(deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS))
+    episode_start = max(last_covered_days) + timedelta(days=1)
+
+    _, created = DeckNotice.objects.get_or_create(
+        tenant=deck, kind=DeckNotice.KIND_SUSPENDED, threshold='cap-reset', period_key=str(episode_start),
+    )
+    if not created:
+        return 'cap already reset this episode'
+    if localdate() - episode_start > timedelta(days=CAP_RESET_CATCHUP_DAYS):
+        return f'episode began {episode_start}, before the catch-up window; cap left alone'
+    if deck.max_active_users == TRIAL_MAX_ACTIVE_USERS:
+        return 'cap already at the trial default'
+
+    old_cap = deck.max_active_users
+    # targeted update (not save()) so a concurrent admin edit to another column
+    # can't be clobbered by this stale instance
+    Tenant.objects.filter(pk=deck.pk).update(max_active_users=TRIAL_MAX_ACTIVE_USERS)
+    deck.max_active_users = TRIAL_MAX_ACTIVE_USERS
+    invalidate_current_deck_cache(deck.schema_name)
+    return f'cap reset {old_cap} -> {TRIAL_MAX_ACTIVE_USERS}'
 
 
 def evaluate_deck_notices(deck):
@@ -136,6 +195,10 @@ def _deliver(deck, kind):
         'config': config,
         'days': deck.days_until_expiry,
         'cap': deck.effective_max_active_users,
+        # what a fresh suspension will RESET the cap to (reset_cap_on_new_suspension)
+        # -- the grace email predicts it, and can't derive it from `cap`, which is
+        # still the paid cap during grace
+        'trial_cap': TRIAL_MAX_ACTIVE_USERS,
         'count': deck.active_user_count,
         # the deck's own staff-facing subscription page (PR 6) -- emails go to the
         # deck owner, who is staff; the page falls back to the public subscribe

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -29,7 +29,7 @@ from django.utils.timezone import localdate
 from notifications.signals import notify
 from siteconfig.models import SiteConfig
 
-from tenant.models import TRIAL_MAX_ACTIVE_USERS, DeckNotice
+from tenant.models import DeckNotice
 
 
 # expiry thresholds, most specific first: the first unfired one whose window has
@@ -136,9 +136,6 @@ def _deliver(deck, kind):
         'config': config,
         'days': deck.days_until_expiry,
         'cap': deck.effective_max_active_users,
-        # what a lapsed deck reverts to -- during the paid grace period the effective
-        # cap is still the paid cap, so the grace email can't derive this from `cap`
-        'trial_cap': TRIAL_MAX_ACTIVE_USERS,
         'count': deck.active_user_count,
         # the deck's own staff-facing subscription page (PR 6) -- emails go to the
         # deck owner, who is staff; the page falls back to the public subscribe

--- a/src/tenant/tasks.py
+++ b/src/tenant/tasks.py
@@ -94,9 +94,16 @@ def deck_status_check():
     Takes no arguments (the schema comes from the task's tenant context);
     returns a short summary string for the worker log.
     """
-    from tenant.notices import process_deck_notices
+    from tenant.notices import process_deck_notices, reset_cap_on_new_suspension
 
     tenant = get_tenant_model().objects.get(schema_name=connection.schema_name)
     tenant.update_cached_fields()
+    # enforcement before communication: a fresh suspension reverts the cap to the
+    # trial default exactly once (admin adjustments stick afterwards), so the
+    # suspension notice below reports the cap the deck actually has now
+    cap_summary = reset_cap_on_new_suspension(tenant)
     notices_summary = process_deck_notices(tenant)
-    return f"Refreshed cached Tenant fields for deck '{tenant.schema_name}'; notices: {notices_summary}"
+    return (
+        f"Refreshed cached Tenant fields for deck '{tenant.schema_name}'; "
+        f"cap: {cap_summary}; notices: {notices_summary}"
+    )

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -8,7 +8,7 @@
 {% else %}
 <p>Your deck <strong>{{ deck.name }}</strong>'s subscription has expired and is in its grace period.
   When the grace period ends, the deck will revert to trial limits
-  (max {{ deck.suspension_cap }} current student{{ deck.suspension_cap|pluralize }}).</p>
+  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
 {% endif %}
 
 <p><a href="{{ subscribe_url }}">Subscribe or renew here</a> to keep full access.

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -8,7 +8,7 @@
 {% else %}
 <p>Your deck <strong>{{ deck.name }}</strong>'s subscription has expired and is in its grace period.
   When the grace period ends, the deck will revert to trial limits
-  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
+  (max {{ deck.suspension_cap }} current student{{ deck.suspension_cap|pluralize }}).</p>
 {% endif %}
 
 <p><a href="{{ subscribe_url }}">Subscribe or renew here</a> to keep full access.

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -10,14 +10,14 @@
 {% if deck.is_suspended %}
   <p><span class="label label-danger">Suspended</span>
     This deck's trial and/or subscription period has ended, so it has reverted to trial limits
-    (max {{ trial_cap }} current student{{ trial_cap|pluralize }}). Existing students keep their access and
+    (max {{ deck.suspension_cap }} current student{{ deck.suspension_cap|pluralize }}). Existing students keep their access and
     nothing has been deleted, but no new students can register in a course beyond the trial limit.</p>
 {% elif deck.in_grace_period %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
   <p><span class="label label-danger">Grace period</span>
     The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
     {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise it will revert to
-    trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
+    trial limits (max {{ deck.suspension_cap }} current student{{ deck.suspension_cap|pluralize }}).</p>
 {% elif deck.subscription_active %}
   <p><span class="label label-success">Subscribed</span>
     Paid through <strong>{{ deck.paid_until }}</strong>

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -10,14 +10,21 @@
 {% if deck.is_suspended %}
   <p><span class="label label-danger">Suspended</span>
     This deck's trial and/or subscription period has ended, so it has reverted to trial limits
-    (max {{ deck.suspension_cap }} current student{{ deck.suspension_cap|pluralize }}). Existing students keep their access and
+    (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}). Existing students keep their access and
     nothing has been deleted, but no new students can register in a course beyond the trial limit.</p>
 {% elif deck.in_grace_period %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
   <p><span class="label label-danger">Grace period</span>
     The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
     {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise it will revert to
-    trial limits (max {{ deck.suspension_cap }} current student{{ deck.suspension_cap|pluralize }}).</p>
+    trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
+{% elif deck.is_on_maintenance %}
+  <p><span class="label label-primary">Maintenance</span>
+    This deck is on a maintenance subscription through <strong>{{ deck.paid_until }}</strong>
+    ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining): it won't expire,
+    be suspended, or time out for deletion, but registration stays capped at the trial limit
+    (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}).
+    Upgrade any time to raise the cap.</p>
 {% elif deck.subscription_active %}
   <p><span class="label label-success">Subscribed</span>
     Paid through <strong>{{ deck.paid_until }}</strong>

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -215,16 +215,20 @@ class TenantBillingStatusTest(SimpleTestCase):
         """An actively subscribed deck's cap is its max_active_users field."""
         self.assertEqual(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=80).effective_max_active_users, 80)
 
-    def test_effective_max_active_users__only_suspended_reverts_to_trial_cap(self):
-        """Only a SUSPENDED deck reverts to TRIAL_MAX_ACTIVE_USERS ("back to trial
-        mode"); trial and managed-manually (comped, no dates) decks keep their
-        admin-set cap -- new decks default to the trial cap anyway, so a raised cap
-        is a deliberate admin grant. (Production find: the old rule capped a comped
-        deck with an admin-set cap of 40 at 5.)"""
-        # suspended (trial lapsed, no subscription): reverts to the trial cap
+    def test_effective_max_active_users__always_the_admin_field(self):
+        """The enforced cap is ALWAYS the admin-set field, in every billing state --
+        including suspended. Suspension "reverts to trial limits" by WRITING the
+        trial default into the field once (reset_cap_on_new_suspension), after
+        which the admin's value, higher or lower, always wins (maintainer decision
+        on #2178: a suspended deck's cap lowered to 1 was silently overridden back
+        to 5)."""
+        # suspended (trial lapsed): the field, untouched at read time -- both above
+        # and below the trial default (the 80 only drops when the nightly reset runs)
         self.assertEqual(
-            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=80).effective_max_active_users,
-            TRIAL_MAX_ACTIVE_USERS,
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=80).effective_max_active_users, 80,
+        )
+        self.assertEqual(
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=1).effective_max_active_users, 1,
         )
         # on trial with an admin-raised cap: the admin grant is honored
         self.assertEqual(
@@ -233,24 +237,22 @@ class TenantBillingStatusTest(SimpleTestCase):
         # managed manually (no dates at all): the admin-set cap is honored
         self.assertEqual(self.make_tenant(max_active_users=40).effective_max_active_users, 40)
 
-    def test_effective_max_active_users__suspended_honors_admin_cap_below_trial_limit(self):
-        """On a suspended deck the trial cap is a CEILING, not a replacement: an
-        admin who deliberately lowers max_active_users below the trial limit (e.g.
-        to 1) must see that cap enforced and displayed, not the default 5.
-        (Production find, 2026-07-24: a suspended deck with an admin-set cap of 1
-        still showed and enforced 'max 5 current students'.)"""
-        self.assertEqual(
-            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=1).effective_max_active_users,
-            1,
+    def test_is_on_maintenance__paid_at_or_below_trial_cap(self):
+        """A deck paying for a subscription that leaves the cap at (or below) the
+        trial limit is on MAINTENANCE: alive (never suspends or times out for
+        deletion) but capped. Higher caps are real subscriptions; unlimited (-1)
+        is never maintenance; unpaid states never are."""
+        self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=TRIAL_MAX_ACTIVE_USERS).is_on_maintenance)
+        self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=1).is_on_maintenance)
+        # grace still counts as paid, so a lapsing maintenance deck keeps the flag
+        self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=5), max_active_users=5).is_on_maintenance)
+        self.assertFalse(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=6).is_on_maintenance)
+        self.assertFalse(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=-1).is_on_maintenance)
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY, max_active_users=5).is_on_maintenance)  # trial
+        self.assertFalse(self.make_tenant(max_active_users=5).is_on_maintenance)  # managed manually
+        self.assertFalse(  # suspended
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=5).is_on_maintenance
         )
-
-    def test_suspension_cap__trial_limit_is_a_ceiling_with_unlimited_passthrough(self):
-        """suspension_cap -- what a deck has (or would have) while suspended, feeding
-        the revert-to copy on the banner/page/email -- is min(admin cap, trial cap),
-        with the -1 unlimited sentinel passing through."""
-        self.assertEqual(self.make_tenant(max_active_users=80).suspension_cap, TRIAL_MAX_ACTIVE_USERS)
-        self.assertEqual(self.make_tenant(max_active_users=1).suspension_cap, 1)
-        self.assertEqual(self.make_tenant(max_active_users=-1).suspension_cap, -1)
 
     def test_effective_max_active_users__unlimited_passthrough(self):
         """The admin-set unlimited sentinel (-1) is honored in every state."""

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -233,6 +233,17 @@ class TenantBillingStatusTest(SimpleTestCase):
         # managed manually (no dates at all): the admin-set cap is honored
         self.assertEqual(self.make_tenant(max_active_users=40).effective_max_active_users, 40)
 
+    def test_effective_max_active_users__suspended_honors_admin_cap_below_trial_limit(self):
+        """On a suspended deck the trial cap is a CEILING, not a replacement: an
+        admin who deliberately lowers max_active_users below the trial limit (e.g.
+        to 1) must see that cap enforced and displayed, not the default 5.
+        (Production find, 2026-07-24: a suspended deck with an admin-set cap of 1
+        still showed and enforced 'max 5 current students'.)"""
+        self.assertEqual(
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=1).effective_max_active_users,
+            1,
+        )
+
     def test_effective_max_active_users__unlimited_passthrough(self):
         """The admin-set unlimited sentinel (-1) is honored in every state."""
         self.assertEqual(self.make_tenant(max_active_users=-1).effective_max_active_users, -1)

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -244,6 +244,14 @@ class TenantBillingStatusTest(SimpleTestCase):
             1,
         )
 
+    def test_suspension_cap__trial_limit_is_a_ceiling_with_unlimited_passthrough(self):
+        """suspension_cap -- what a deck has (or would have) while suspended, feeding
+        the revert-to copy on the banner/page/email -- is min(admin cap, trial cap),
+        with the -1 unlimited sentinel passing through."""
+        self.assertEqual(self.make_tenant(max_active_users=80).suspension_cap, TRIAL_MAX_ACTIVE_USERS)
+        self.assertEqual(self.make_tenant(max_active_users=1).suspension_cap, 1)
+        self.assertEqual(self.make_tenant(max_active_users=-1).suspension_cap, -1)
+
     def test_effective_max_active_users__unlimited_passthrough(self):
         """The admin-set unlimited sentinel (-1) is honored in every state."""
         self.assertEqual(self.make_tenant(max_active_users=-1).effective_max_active_users, -1)

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -18,6 +18,76 @@ NOW = "2026-08-15 20:00:00"
 
 
 @freeze_time(NOW)
+@override_settings(DECK_NOTICES_ENABLED=False)  # the reset is enforcement: NOT gated by the notices rollout flag
+class SuspensionCapResetTest(ByteDeckTenantTestCase):
+    """Tests for reset_cap_on_new_suspension (#2178): when a suspension episode
+    begins, the cap is written back to the trial default exactly once, and any
+    admin adjustment afterwards -- lower or higher -- sticks."""
+
+    def setUp(self):
+        """Clear the cached deck row so each test reads its own billing state."""
+        cache.delete(deck_cache_key(self.tenant.schema_name))
+
+    def set_deck(self, **fields):
+        """Persist billing fields via update() + refresh (the reset reads the instance)."""
+        Tenant.objects.filter(pk=self.tenant.pk).update(**fields)
+        self.tenant.refresh_from_db()
+
+    def reset(self):
+        """Shorthand: run the reset for this deck and return its log summary."""
+        from tenant.notices import reset_cap_on_new_suspension
+        return reset_cap_on_new_suspension(self.tenant)
+
+    def test_reset__fresh_suspension_reverts_cap_once_then_admin_wins(self):
+        """A deck whose trial lapsed yesterday gets its cap written back to the
+        trial default exactly once; an admin adjustment made afterwards (e.g.
+        lowering to 1 for a wind-down, or raising for a comp) is never clobbered
+        by later runs of the same episode."""
+        self.set_deck(trial_end_date=TODAY - timedelta(days=1), paid_until=None, max_active_users=80)
+        self.assertEqual(self.reset(), 'cap reset 80 -> 5')
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.max_active_users, 5)
+        self.assertTrue(DeckNotice.objects.filter(tenant=self.tenant, threshold='cap-reset').exists())
+
+        self.set_deck(max_active_users=1)  # admin wind-down after the reset
+        self.assertEqual(self.reset(), 'cap already reset this episode')
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.max_active_users, 1)
+
+    def test_reset__paid_deck_episode_starts_after_the_grace_window(self):
+        """A paid deck's suspension episode begins the day after its grace window
+        ends (paid_until + 30 + 1), so the reset fires on the task's first run
+        after that day -- and -1 unlimited decks revert like any other."""
+        self.set_deck(trial_end_date=None, paid_until=TODAY - timedelta(days=31), max_active_users=-1)
+        self.assertEqual(self.reset(), 'cap reset -1 -> 5')
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.max_active_users, 5)
+
+    def test_reset__old_episodes_are_grandfathered(self):
+        """A deck already suspended for longer than the catch-up window keeps its
+        cap (its admin may have hand-set it since -- the production case that
+        motivated #2178); the episode is recorded so it is never revisited."""
+        self.set_deck(trial_end_date=TODAY - timedelta(days=60), paid_until=None, max_active_users=1)
+        self.assertIn('cap left alone', self.reset())
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.max_active_users, 1)
+        self.assertEqual(self.reset(), 'cap already reset this episode')
+
+    def test_reset__no_op_paths(self):
+        """Unsuspended decks are untouched (no ledger row), and a fresh suspension
+        whose cap is already the trial default records the episode without a write."""
+        self.set_deck(trial_end_date=TODAY + timedelta(days=60), paid_until=None, max_active_users=80)
+        self.assertEqual(self.reset(), 'not suspended')
+        self.assertFalse(DeckNotice.objects.filter(tenant=self.tenant, threshold='cap-reset').exists())
+
+        self.set_deck(trial_end_date=TODAY - timedelta(days=1), max_active_users=5)
+        self.assertEqual(self.reset(), 'cap already at the trial default')
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.max_active_users, 5)
+        self.assertTrue(DeckNotice.objects.filter(tenant=self.tenant, threshold='cap-reset').exists())
+
+
+@freeze_time(NOW)
 @override_settings(DECK_NOTICES_ENABLED=True)
 class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
     """Tests for the reminder cadence engine (epic #1729 PR 5, #1733)."""

--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -105,6 +105,24 @@ class DeckStatusCheckTaskTests(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.active_user_count, self.tenant.get_active_user_count())
         self.assertGreater(self.tenant.active_user_count, 0)
 
+    def test_deck_status_check__resets_cap_on_fresh_suspension(self):
+        """The nightly task applies the once-per-episode cap reset (#2178): a deck
+        whose trial lapsed yesterday comes out of the run at the trial default,
+        even with the notices rollout flag off (the reset is enforcement)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        from tenant.models import Tenant
+
+        Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
+            trial_end_date=localdate() - timedelta(days=1), paid_until=None, max_active_users=80,
+        )
+
+        self.assertTrue(tasks.deck_status_check.apply().successful())
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.max_active_users, 5)
+
     def test_daily_deck_status_check_for_all_tenants__dispatches_only_billable_decks(self):
         """The dispatcher schedules one per-schema check per deck, skipping the
         public schema and the shared-library tenant."""

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -851,15 +851,13 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'grace period')
         self.assertContains(response, 'max 5 current students')
 
-    def test_page__suspended_deck_shows_admin_cap_below_trial_limit(self):
-        """A suspended deck whose admin deliberately lowered the cap below the
-        trial limit shows THAT cap -- in the status copy and the seats table --
-        not the trial default of 5, and a grace deck's revert-to prediction
-        matches (production find, 2026-07-24: a cap set to 1 still showed and
-        enforced 'max 5' everywhere)."""
-        from datetime import date, timedelta
-
-        from django.utils.timezone import localdate
+    def test_page__suspended_deck_shows_its_admin_cap(self):
+        """A suspended deck shows its ADMIN-SET cap -- in the status copy and the
+        seats table -- whatever it is: the field is authoritative (the trial
+        default is written into it once per suspension by the nightly task, and
+        admin adjustments stick). Production find, 2026-07-24: a cap lowered to 1
+        still showed and enforced 'max 5' everywhere."""
+        from datetime import date
 
         self.set_deck(trial_end_date=date(2020, 1, 1), paid_until=None, max_active_users=1)
         response = self.get_page()
@@ -868,13 +866,23 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         text = ' '.join(response.content.decode().split())
         self.assertIn('<th>Maximum allowed</th> <td>1</td>', text)
 
-        # in grace, the revert-to prediction states the lowered cap, not 5
-        # (set_deck bypasses save(), so drop the cached deck row by hand)
-        from tenant.utils import deck_cache_key
+    def test_page__maintenance_subscription_gets_its_own_status(self):
+        """A paid deck whose cap sits at the trial limit is on MAINTENANCE: its own
+        status label and copy (kept alive, capped, upgradable) instead of the
+        plain green Subscribed badge -- while a paid deck with a higher cap keeps
+        the Subscribed status."""
+        self.set_deck(max_active_users=5)  # paid 100 days out from setUp
+        response = self.get_page()
+        self.assertContains(response, 'Maintenance')
+        self.assertContains(response, 'maintenance subscription')
+        self.assertContains(response, 'capped at the trial limit')
+        self.assertContains(response, 'max 5 current students')
+        self.assertNotContains(response, '>Subscribed</span>')
 
-        self.set_deck(paid_until=localdate() - timedelta(days=5))
-        cache.delete(deck_cache_key(self.tenant.schema_name))
-        self.assertContains(self.get_page(), 'revert to trial limits (max 1 current student)')
+        self.set_deck(max_active_users=30)
+        response = self.get_page()
+        self.assertContains(response, 'Subscribed')
+        self.assertNotContains(response, 'Maintenance')
 
     def test_page__trial_suspended_and_manual_states(self):
         """The status section adapts to trial, suspended, and never-expires decks."""

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -851,6 +851,31 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'grace period')
         self.assertContains(response, 'max 5 current students')
 
+    def test_page__suspended_deck_shows_admin_cap_below_trial_limit(self):
+        """A suspended deck whose admin deliberately lowered the cap below the
+        trial limit shows THAT cap -- in the status copy and the seats table --
+        not the trial default of 5, and a grace deck's revert-to prediction
+        matches (production find, 2026-07-24: a cap set to 1 still showed and
+        enforced 'max 5' everywhere)."""
+        from datetime import date, timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=date(2020, 1, 1), paid_until=None, max_active_users=1)
+        response = self.get_page()
+        self.assertContains(response, 'max 1 current student')
+        self.assertNotContains(response, 'max 5 current students')
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('<th>Maximum allowed</th> <td>1</td>', text)
+
+        # in grace, the revert-to prediction states the lowered cap, not 5
+        # (set_deck bypasses save(), so drop the cached deck row by hand)
+        from tenant.utils import deck_cache_key
+
+        self.set_deck(paid_until=localdate() - timedelta(days=5))
+        cache.delete(deck_cache_key(self.tenant.schema_name))
+        self.assertContains(self.get_page(), 'revert to trial limits (max 1 current student)')
+
     def test_page__trial_suspended_and_manual_states(self):
         """The status section adapts to trial, suspended, and never-expires decks."""
         from datetime import date, timedelta

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -436,7 +436,7 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         from datetime import timedelta
 
         from .billing import billing_configured
-        from .models import GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS
+        from .models import GRACE_PERIOD_DAYS
         from .utils import get_public_subscribe_url
 
         context = super().get_context_data(**kwargs)
@@ -460,7 +460,6 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             # None for unlimited decks; clamped at 0 when over the limit (the
             # template's at-limit warning covers the overage)
             'remaining_seats': None if cap == -1 else max(0, cap - current_student_count),
-            'trial_cap': TRIAL_MAX_ACTIVE_USERS,
             'grace_days': GRACE_PERIOD_DAYS,
             'stripe_configured': billing_configured(),
             # inside its paid period with no Stripe link: the subscription is managed

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -436,7 +436,7 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         from datetime import timedelta
 
         from .billing import billing_configured
-        from .models import GRACE_PERIOD_DAYS
+        from .models import GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS
         from .utils import get_public_subscribe_url
 
         context = super().get_context_data(**kwargs)
@@ -460,6 +460,9 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             # None for unlimited decks; clamped at 0 when over the limit (the
             # template's at-limit warning covers the overage)
             'remaining_seats': None if cap == -1 else max(0, cap - current_student_count),
+            # what a fresh suspension will RESET the cap to -- the grace copy
+            # predicts it, and can't derive it from the deck's current paid cap
+            'trial_cap': TRIAL_MAX_ACTIVE_USERS,
             'grace_days': GRACE_PERIOD_DAYS,
             'stripe_configured': billing_configured(),
             # inside its paid period with no Stripe link: the subscription is managed


### PR DESCRIPTION
### What?
Two maintainer requests from live testing (2026-07-24), reworked per review feedback on this PR:

* **The admin-set cap is always the enforced cap.** Lowering a suspended deck's **Max active users to 1** used to change nothing — the code overrode every suspended deck to the trial constant (5) at read time. Now `effective_max_active_users` is simply the field, in every state. **"Revert to trial limits" happens as a one-time WRITE instead**: when a deck's suspension episode begins, the nightly `deck_status_check` writes the trial default (5) into `max_active_users` exactly once (`reset_cap_on_new_suspension`), after which the admin's value — higher for a comp, lower for a wind-down — always wins.
* **New Maintenance status.** A minimal-cost subscription (e.g. $5/year) that keeps a deck alive — it never expires or suspends, and (since deletion requires suspension, #2146/#2044) can never time out for deletion — while registration stays capped at the trial limit. Derived, not stored: `is_on_maintenance` = actively paid AND cap at (or below) the trial limit, which is exactly what the maintenance Stripe price's `metadata.max_active_users = 5` produces. The Subscription details page gives it its own label and copy (see screenshot); paid decks with higher caps keep the green Subscribed status.

### Why?
An admin adjusting a cap is making a deliberate access decision; the old read-time override silently reversed it (the "cap set to 1 still shows 5" report). And schools that only want to *preserve* a deck between active years need a cheap way to keep it from suspending (and eventually deleting) without paying for seats they aren't using — that's the Maintenance tier.

### How?
* `Tenant.effective_max_active_users` → returns `max_active_users`, always. `Tenant.is_on_maintenance` (new, derived).
* `tenant/notices.py reset_cap_on_new_suspension` (new): computes the episode's first suspended day (day after `trial_end_date`, or after `paid_until` + 30-day grace — whichever is later), records a `cap-reset` `DeckNotice` ledger row for exactly-once semantics, and applies the write via a targeted `QuerySet.update()` + deck-cache invalidation. **Not** gated by `DECK_NOTICES_ENABLED` (it's enforcement, not communication). Episodes that began more than 7 days ago (`CAP_RESET_CATCHUP_DAYS`) are recorded but **not** reset — decks already suspended when this ships (like the live `bingo` deck with its hand-set cap of 1) are grandfathered and never clobbered, while multi-day beat outages still catch up.
* `deck_status_check` runs the reset between the cached-field refresh and the notices pass. No migration needed (the ledger row reuses the existing `KIND_SUSPENDED` kind with a distinct threshold).
* Copy: the suspended banner/status show the live field; the grace-period "will revert to trial limits (max 5)" predictions (banner, page, expiry email) state the constant the reset will write; the Maintenance branch renders before Subscribed on the subscription page.

### Testing?
Test-driven — these fail without the fix:
* `test_effective_max_active_users__always_the_admin_field` — suspended cap-1 → 1 **and** suspended cap-80 → 80 (the revert is now the nightly write, deliberately pinned).
* `test_page__suspended_deck_shows_its_admin_cap` — the original report's scenario: status copy + seats table show 1, not 5.
* `SuspensionCapResetTest` — fresh episode resets 80→5 (and −1→5) exactly once; an admin adjustment afterwards sticks; **old episodes are grandfathered** (recorded, cap untouched); unsuspended decks untouched; runs with `DECK_NOTICES_ENABLED=False` to prove it isn't gated.
* `test_deck_status_check__resets_cap_on_fresh_suspension` — the task wiring.
* `test_is_on_maintenance__paid_at_or_below_trial_cap` + `test_page__maintenance_subscription_gets_its_own_status` — the new status, including "paid with higher cap stays Subscribed".
* Full serial suite: **OK**; `ruff` and `makemigrations --check` clean.

### Screenshots (if front end is affected)
Captured from the real dev deck (staff login). FontAwesome served locally in the captures (the dev proxy blocks its CDN); identical assets to production.

**Before** — suspended deck, admin cap set to 1, but banner and page say max 5 / 4 remaining (the report):
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspended-cap-floor/before.png)

**After** — banner, status copy, and seats table all show the admin's cap (1 of 1 seats used, at-limit warning appears):
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspended-cap-floor/after.png)

**New Maintenance status** — paid deck with the trial-limit cap:
![maintenance](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspended-cap-floor/maintenance.png)

### Anything Else?
* **Ops for the Maintenance tier**: create the $5/year Price in the Stripe dashboard with `metadata.max_active_users = 5` — checkout/sync (PR 6 / #2110) then produces maintenance decks with no further code. Decks can also be put on maintenance by hand (set `paid_until` + cap 5 in the tenant admin).
* Deliberate behavior notes: a suspended deck that was ALREADY suspended before this deploys keeps its current cap (grandfathered — protects hand-set caps like bingo's 1); an admin who wants such a deck at 5 just sets it. A maintenance deck that lapses goes through the normal grace → suspension flow; the reset then finds the cap already at 5.
* Hotfix to `staging`; flows back to `develop` with the next staging sync. Heads-up for that sync: open epic PR #2110 touches the same `tenant/models.py` region — I'll resolve the overlap on the epic branch as usual when this lands.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)