### PR TITLE
HOTFIX: Staff "Join a Course" on a student's profile targets the student, not the teacher

### DIFF
--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -90,6 +90,9 @@
               You have not joined a course yet this semester.
               {% if config.has_no_open_semester %}
                 <br><em>No semester is open yet, so you can’t join a course — ask your teacher to open one.</em>
+              {% elif request.user.is_staff and request.user != object.user %}
+                {# staff viewing someone else's profile: add THAT student, not self-register (which 403s an already-registered teacher) #}
+                <a href="{% url 'courses:join' object.user.id %}">Join a Course</a>
               {% else %}
                 <a href="{% url 'courses:create' %}">Join a Course</a>
               {% endif %}
@@ -152,6 +155,9 @@
             <li class="list-group-item">You have not joined a course yet for this semester.
               {% if config.has_no_open_semester %}
                 <br><em>No semester is open yet, so you can’t join a course — ask your teacher to open one.</em>
+              {% elif request.user.is_staff and request.user != object.user %}
+                {# staff viewing someone else's profile: add THAT student, not self-register (which 403s an already-registered teacher) #}
+                <a href="{% url 'courses:join' object.user.id %}" class="btn btn-info" role="button">Join a Course</a>
               {% else %}
                 <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
               {% endif %}

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -198,6 +198,25 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         request = self.client.get(reverse('profiles:profile_detail', args=[spk]))
         self.assertContains(request, course.title)
 
+    def test_profile_detail__staff_join_button_targets_the_student_not_themselves(self):
+        """On a courseless student's profile, the "Join a Course" button takes STAFF
+        to the staff add-student flow for THAT student (courses:join) -- not to
+        their own self-registration view (courses:create), which would register
+        the teacher instead of the student and 403s any teacher who is already
+        registered in a course this semester (staging live-testing find,
+        2026-07-24). The student still gets the self-registration link on their
+        own profile."""
+        spk = self.test_student1.profile.pk
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse('profiles:profile_detail', args=[spk]))
+        self.assertContains(response, reverse('courses:join', args=[self.test_student1.id]))
+        self.assertNotContains(response, reverse('courses:create'))
+
+        self.client.force_login(self.test_student1)
+        response = self.client.get(reverse('profiles:profile_detail', args=[spk]))
+        self.assertContains(response, reverse('courses:create'))
+
     def test_profile_detail__student_marks_button(self):
         """
         Student should be able to see marks button when `display_marks_calculation` is True.


### PR DESCRIPTION
### What?
Live-testing find (2026-07-24): as a teacher, clicking **Join a Course** on a student's profile page threw **403 Error: Permission Denied**.

Root cause: both "Join a Course" buttons on the profile page (XP panel and Courses panel) linked to `courses:create` — the student **self**-registration view — regardless of who was looking. Clicking it as staff tried to register **the teacher** (not the student), and that view 403s anyone already actively registered in a course this semester (`CourseStudentCreate.test_func`), which the reporting teacher's account was. The deck's suspended/at-capacity state was coincidental — the 403 fires on any deck once the teacher has their own registration.

Fix: when a staff member views someone else's profile, both buttons now route to `courses:join <student_id>` — the staff **Add student to course** flow, the same one behind the Courses panel's "Add" button. That flow registers the right person and already renders the friendly at-capacity page (with the free-up-seats and subscription links) instead of an error when the deck is full. Students on their own profile keep the self-registration link, as does anyone viewing their own profile.

### Why?
A teacher clicking a button on a student's profile expects to act on that student; instead the app tried to enroll the teacher and then slammed the door with a bare 403. With the deck at capacity it also contradicted the documented behavior (staff should reach the at-capacity explanation, not an error).

### How?
`profile_detail.html`: both Join-a-Course spots gain a `{% elif request.user.is_staff and request.user != object.user %}` branch linking to `courses:join object.user.id`. No view changes — `CourseAddStudent` already handles staff, capacity, and the target student correctly.

### Testing?
* Test-driven: `test_profile_detail__staff_join_button_targets_the_student_not_themselves` — staff viewing a courseless student's profile get the `courses:join` link and no `courses:create` link; the student on their own profile still gets `courses:create`. Fails without the fix.
* Reproduced the original 403 end-to-end before fixing (staff with an active course registration, suspended deck at cap) and verified the fixed click lands on the at-capacity page.
* Full serial suite: **OK**; `ruff` clean.

### Screenshots (if front end is affected)
Captured from the real dev deck in the reported state: suspended deck, cap 1 with 1 current student, logged in as a teacher who is registered in a course. FontAwesome served locally in the captures (the dev proxy blocks its CDN).

**The button** (unchanged visually) on the student's profile:
![profile](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/profile-join-staff/profile.png)

**Before** — clicking it as staff:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/profile-join-staff/before.png)

**After** — the same click now reaches the staff add-student flow with the at-capacity explanation:
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/profile-join-staff/after.png)

### Anything Else?
Hotfix to `staging`; flows back to `develop` with the next staging sync. Deliberately narrow: `CourseStudentCreate`'s bare-403 for already-registered users is unchanged (students who are registered never see the button, so they can't hit it from this page).

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Staff viewing a student’s profile can now use “Join a Course” to enroll that student, rather than being directed to their own enrollment flow.
  - Students continue to see the correct self-enrollment option on their own profiles.

- **Tests**
  - Added coverage verifying the correct course-joining link appears for staff and students.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->