### PR TITLE
HOTFIX: deck_status_check bails cleanly on non-deck schemas instead of crashing

### DIFF
--- a/src/tenant/tasks.py
+++ b/src/tenant/tasks.py
@@ -96,6 +96,15 @@ def deck_status_check():
     """
     from tenant.notices import process_deck_notices, reset_cap_on_new_suspension
 
+    # Defensive mirror of the dispatcher's exclusions: the public and shared-library
+    # schemas aren't billable decks and SiteConfig.get() returns None on the public
+    # schema, so an ad-hoc invocation (e.g. a shell loop over Tenant.objects.all(),
+    # which includes the public tenant) or a mis-routed message must report and
+    # bail, not crash mid-refresh (staging ops find, 2026-07-25).
+    schema_name = connection.schema_name
+    if schema_name in (get_public_schema_name(), get_library_schema_name()):
+        return f"'{schema_name}' is not a billable deck schema; skipped"
+
     tenant = get_tenant_model().objects.get(schema_name=connection.schema_name)
     tenant.update_cached_fields()
     # enforcement before communication: a fresh suspension reverts the cap to the

--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -105,6 +105,24 @@ class DeckStatusCheckTaskTests(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.active_user_count, self.tenant.get_active_user_count())
         self.assertGreater(self.tenant.active_user_count, 0)
 
+    def test_deck_status_check__skips_non_deck_schemas_instead_of_crashing(self):
+        """Invoked on the public or shared-library schema -- an ad-hoc shell loop
+        over Tenant.objects.all() (which includes the public tenant), or a
+        mis-routed message -- the task reports and bails instead of crashing:
+        SiteConfig.get() returns None on the public schema, so the refresh blew
+        up with an AttributeError (staging ops find, 2026-07-25). The beat
+        dispatcher already excludes these schemas; this mirrors that rule at the
+        worker."""
+        from django_tenants.utils import get_public_schema_name, schema_context
+
+        from library.utils import get_library_schema_name
+
+        for schema_name in (get_public_schema_name(), get_library_schema_name()):
+            with schema_context(schema_name):
+                result = tasks.deck_status_check.apply()
+            self.assertTrue(result.successful())
+            self.assertIn('skipped', result.result)
+
     def test_deck_status_check__resets_cap_on_fresh_suspension(self):
         """The nightly task applies the once-per-episode cap reset (#2178): a deck
         whose trial lapsed yesterday comes out of the run at the trial default,


### PR DESCRIPTION
### What?
Ops find from staging (2026-07-25): an ad-hoc shell loop running `deck_status_check` over `Tenant.objects.all()` crashed with `AttributeError: 'NoneType' object has no attribute 'deck_owner'`, which read as "a deck has no owner".

**No deck data was at fault.** `Tenant.objects.all()` includes the **public tenant**, and `SiteConfig.get()` deliberately returns `None` on the public schema — so `update_cached_fields` blew up dereferencing it. The six decks printed before the crash were just arbitrary row order. The nightly beat run was never affected (its dispatcher already excludes the public and shared-library schemas), on staging or production.

Fix: the worker task now mirrors the dispatcher's exclusions — invoked on the public or shared-library schema it returns `"'public' is not a billable deck schema; skipped"` instead of crashing. Ad-hoc loops and mis-routed messages become self-explanatory no-ops.

### Why?
A crash that masquerades as data corruption ("somehow a deck doesn't have an owner") costs real diagnostic time; the task should state the actual situation. Guarding at the worker also makes the exclusion rule hold no matter how the task is invoked, not only via the dispatcher.

### How?
`tenant/tasks.py deck_status_check`: early return when `connection.schema_name` is the public or library schema, before any tenant lookup or SiteConfig access.

### Testing?
* Test-driven: `test_deck_status_check__skips_non_deck_schemas_instead_of_crashing` runs the task under both non-deck schema contexts and asserts a successful "skipped" summary — fails (task crashes) without the guard.
* Full serial suite: **OK** (one run hit the known `GFKChoiceField` ordering flake — already fixed on develop by #2174, not yet flowed to staging; passes standalone and on rerun); `ruff` clean.

### Screenshots (if front end is affected)
N/A — background task only, no user-facing change.

### Anything Else?
* Safe ad-hoc loop for staging/production checks in the meantime:
  ```bash
  docker compose exec web bash -c "python src/manage.py shell -c \"
  from django_tenants.utils import tenant_context
  from tenant.models import Tenant
  from tenant.tasks import deck_status_check
  from library.utils import get_library_schema_name
  for t in Tenant.objects.exclude(schema_name__in=['public', get_library_schema_name()]):
      with tenant_context(t):
          print(deck_status_check())
  \""
  ```
* Hotfix to `staging`; flows back to `develop` with the next staging sync. The epic PR #2110 adds a Stripe-reconcile step to this same task — I'll place the guard above it when resolving that sync overlap.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_