### PR TITLE
HOTFIX: Deck notice emails carry full dates, seat usage, and the logo

### DIFF
--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -219,7 +219,8 @@ def _deliver(deck, kind):
         'grace_end_date': deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS) if deck.paid_until else None,
         'grace_days_left': deck.grace_days_remaining,
         'expired_days_ago': -days if days is not None and days < 0 else None,
-        'suspended_since': max(last_covered_days) + timedelta(days=1) if deck.is_suspended and last_covered_days else None,
+        # is_suspended requires at least one date field, so the list is never empty here
+        'suspended_since': max(last_covered_days) + timedelta(days=1) if deck.is_suspended else None,
         # the deck's own staff-facing subscription page (PR 6) -- emails go to the
         # deck owner, who is staff; the page falls back to the public subscribe
         # flatpage when Stripe isn't configured

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -187,19 +187,39 @@ def process_deck_notices(deck):
 
 def _deliver(deck, kind):
     """Send one notice through both channels: owner email + in-app notification."""
+    from django.utils.timezone import timedelta
+
+    from tenant.models import GRACE_PERIOD_DAYS
+
     from tenant.tasks import send_email_message
 
     config = SiteConfig.get()
+    days = deck.days_until_expiry
+    # the day the deck's suspension began (or would begin): the day after its LAST
+    # covered day -- trials end at trial_end_date, paid access after the grace window
+    last_covered_days = []
+    if deck.trial_end_date:
+        last_covered_days.append(deck.trial_end_date)
+    if deck.paid_until:
+        last_covered_days.append(deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS))
     context = {
         'deck': deck,
         'config': config,
-        'days': deck.days_until_expiry,
+        'days': days,
         'cap': deck.effective_max_active_users,
         # what a fresh suspension will RESET the cap to (reset_cap_on_new_suspension)
         # -- the grace email predicts it, and can't derive it from `cap`, which is
         # still the paid cap during grace
         'trial_cap': TRIAL_MAX_ACTIVE_USERS,
         'count': deck.active_user_count,
+        # every date the owner could want (maintainer request, 2026-07-25): when the
+        # paid period ended/ends, how long ago, when the grace window closes, and --
+        # for suspended decks -- the day the suspension began. None when not applicable.
+        'grace_days': GRACE_PERIOD_DAYS,
+        'grace_end_date': deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS) if deck.paid_until else None,
+        'grace_days_left': deck.grace_days_remaining,
+        'expired_days_ago': -days if days is not None and days < 0 else None,
+        'suspended_since': max(last_covered_days) + timedelta(days=1) if deck.is_suspended and last_covered_days else None,
         # the deck's own staff-facing subscription page (PR 6) -- emails go to the
         # deck owner, who is staff; the page falls back to the public subscribe
         # flatpage when Stripe isn't configured

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -1,17 +1,30 @@
+{% load utility_tags %}
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
 {% if days >= 0 %}
 <p>Your deck <strong>{{ deck.name }}</strong>'s
   {% if deck.is_on_trial %}free trial ends{% else %}subscription expires{% endif %}
-  in <strong>{{ days }} day{{ days|pluralize }}</strong>
-  ({% if deck.is_on_trial %}{{ deck.trial_end_date }}{% else %}{{ deck.paid_until }}{% endif %}).</p>
+  on <strong>{% if deck.is_on_trial %}{{ deck.trial_end_date }}{% else %}{{ deck.paid_until }}{% endif %}</strong>
+  &mdash; <strong>{{ days }} day{{ days|pluralize }}</strong> from now.
+  {% if not deck.is_on_trial %}After that, a {{ grace_days }}-day grace period keeps full access until
+  <strong>{{ grace_end_date }}</strong>; the deck then reverts to trial limits
+  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).{% endif %}</p>
 {% else %}
-<p>Your deck <strong>{{ deck.name }}</strong>'s subscription has expired and is in its grace period.
-  When the grace period ends, the deck will revert to trial limits
-  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
+<p>Your deck <strong>{{ deck.name }}</strong>'s subscription expired on
+  <strong>{{ deck.paid_until }}</strong> ({{ expired_days_ago }} day{{ expired_days_ago|pluralize }} ago)
+  and is in its {{ grace_days }}-day grace period, which ends on <strong>{{ grace_end_date }}</strong>
+  ({{ grace_days_left }} day{{ grace_days_left|pluralize }} left). When the grace period ends, the deck
+  will revert to trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
 {% endif %}
+
+<p>You are currently using <strong>{{ count }}</strong> of
+  <strong>{% if cap == -1 %}unlimited{% else %}{{ cap }}{% endif %}</strong> current student
+  seat{{ cap|pluralize }}.</p>
 
 <p><a href="{{ subscribe_url }}">Subscribe or renew here</a> to keep full access.
   Questions about which students count? Only <em>current</em> students &mdash; those registered in a course
   this semester &mdash; count toward your limit; see
   <a href="{{ archive_help_url }}">freeing up student seats</a>.</p>
+
+<p>{% firstof config.outgoing_email_signature config.site_name %}</p>
+<p><img alt="[Logo]" src="{% site_logo_url %}"></p>

--- a/src/tenant/templates/tenant/email/limit_warning.html
+++ b/src/tenant/templates/tenant/email/limit_warning.html
@@ -1,9 +1,19 @@
+{% load utility_tags %}
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
 <p>Your deck <strong>{{ deck.name }}</strong> has <strong>{{ count }}</strong> current
   student{{ count|pluralize }} of <strong>{{ cap }}</strong> allowed
   {% if count >= cap %}&mdash; the limit has been reached, so no more students can register in a course.{% else %}&mdash; you're approaching the limit.{% endif %}</p>
 
+{% if deck.subscription_active %}
+<p>Your deck's subscription is paid through <strong>{{ deck.paid_until }}</strong>.</p>
+{% elif deck.is_on_trial %}
+<p>Your deck's free trial ends on <strong>{{ deck.trial_end_date }}</strong>.</p>
+{% endif %}
+
 <p>Only <em>current</em> students (registered in a course in the active semester) count; staff and archived
   students never do. You can <a href="{{ archive_help_url }}">free up seats</a> by ending the semester or
   archiving past students, or <a href="{{ subscribe_url }}">upgrade your subscription</a> for a higher limit.</p>
+
+<p>{% firstof config.outgoing_email_signature config.site_name %}</p>
+<p><img alt="[Logo]" src="{% site_logo_url %}"></p>

--- a/src/tenant/templates/tenant/email/suspended_notice.html
+++ b/src/tenant/templates/tenant/email/suspended_notice.html
@@ -1,9 +1,20 @@
+{% load utility_tags %}
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
-<p>Your deck <strong>{{ deck.name }}</strong> has been <strong>suspended</strong>: its trial and/or
-  subscription period has ended, so it has reverted to trial limits
+<p>Your deck <strong>{{ deck.name }}</strong> has been <strong>suspended</strong>{% if suspended_since %}
+  since <strong>{{ suspended_since }}</strong>{% endif %}
+  {% if deck.paid_until %}(its subscription was paid through {{ deck.paid_until }}, and the
+  {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.trial_end_date %}(its
+  free trial ended on {{ deck.trial_end_date }}){% endif %}: it has reverted to trial limits
   (max {{ cap }} current student{{ cap|pluralize }}). Existing students keep their access and nothing has
   been deleted, but no new students can register in a course beyond the trial limit.</p>
 
+<p>You are currently using <strong>{{ count }}</strong> of
+  <strong>{% if cap == -1 %}unlimited{% else %}{{ cap }}{% endif %}</strong> current student
+  seat{{ cap|pluralize }}.</p>
+
 <p><a href="{{ subscribe_url }}">Subscribe here</a> to restore full access, or
   <a href="{{ archive_help_url }}">free up seats</a> if you're winding the deck down.</p>
+
+<p>{% firstof config.outgoing_email_signature config.site_name %}</p>
+<p><img alt="[Logo]" src="{% site_logo_url %}"></p>

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -400,6 +400,22 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('alt="[Logo]"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__comped_deck_limit_email_renders_without_any_dates(self):
+        """A comped/managed-manually deck (both date fields blank, days_until_expiry
+        None) can still hit its student cap; its limit email must render with no
+        expiry dates to lean on -- covering the dateless arms of the new context."""
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=None, paid_until=None, max_active_users=5, active_user_count=5)
+        self.tenant.refresh_from_db()
+
+        summary = self.run_engine_with_inline_email()
+        self.assertIn('limit', summary)
+        self.assertEqual(len(mail.outbox), 1)
+        html = mail.outbox[0].alternatives[0][0]
+        self.assertIn('limit has been reached', html)
+        self.assertIn('alt="[Logo]"', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_states_when_and_why_with_logo(self):
         """The suspension email says when the suspension began, which clock ran
         out (trial vs paid + grace), current seat usage, and carries the logo."""

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -375,3 +375,46 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         body = mail.outbox[0].body.replace('\n', ' ')  # textify hard-wraps lines
         self.assertIn('grace period', body)
         self.assertIn('max 5 current students', body)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__grace_email_includes_dates_seats_and_logo(self):
+        """The grace-period expiry email states every date the owner needs -- when
+        the subscription expired and how long ago, when the grace period ends and
+        how many days remain -- plus current seat usage and the site logo
+        (maintainer request from staging live testing, 2026-07-25: the old email
+        gave no dates at all)."""
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=None, paid_until=TODAY - timedelta(days=5),  # expired, in grace
+            max_active_users=30, active_user_count=2,
+        )
+        self.tenant.refresh_from_db()
+
+        summary = self.run_engine_with_inline_email()
+        self.assertEqual(len(mail.outbox), 1, summary)
+        html = mail.outbox[0].alternatives[0][0].replace('\n', ' ')
+        self.assertIn('Aug. 10, 2026', html)   # expired on paid_until...
+        self.assertIn('5 days ago', html)      # ...with the relative phrase
+        self.assertIn('Sept. 9, 2026', html)   # grace ends paid_until + 30 days...
+        self.assertIn('25 days left', html)    # ...with the countdown
+        self.assertIn('using <strong>2</strong> of <strong>30</strong> current student', ' '.join(html.split()))
+        self.assertIn('alt="[Logo]"', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__suspended_email_states_when_and_why_with_logo(self):
+        """The suspension email says when the suspension began, which clock ran
+        out (trial vs paid + grace), current seat usage, and carries the logo."""
+        from datetime import date
+
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=date(2026, 8, 1), paid_until=None,  # trial lapsed -> suspended Aug 2
+            max_active_users=5, active_user_count=0,
+        )
+        self.tenant.refresh_from_db()
+
+        summary = self.run_engine_with_inline_email()
+        self.assertIn('suspended', summary)
+        self.assertEqual(len(mail.outbox), 1, summary)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('since <strong>Aug. 2, 2026</strong>', html)
+        self.assertIn('free trial ended on Aug. 1, 2026', html)
+        self.assertIn('alt="[Logo]"', html)


### PR DESCRIPTION
### What?
Live-testing find (2026-07-25): the grace-period email said only "has expired and is in its grace period" — no dates, no numbers. All three deck notice emails now state every date and figure the owner needs:

* **Expiry reminder — grace branch** (the reported email): *"…subscription expired on **July 24, 2026** (5 days ago) and is in its 30-day grace period, which ends on **Aug. 23, 2026** (25 days left). When the grace period ends, the deck will revert to trial limits (max 5 current students)."*
* **Expiry reminder — pre-expiry branch**: states the deadline date + days from now, and (for paid decks) when the grace window would end.
* **Suspended notice**: *"…has been suspended since **July 20, 2026** (its subscription was paid through June 19, 2026, and the 30-day grace period ended on July 19, 2026)…"* — or the trial-end date for lapsed-trial decks.
* **Limit warning**: adds the deck's paid-through / trial-end date.
* **All three** now state current seat usage ("You are currently using **2** of **30** current student seats") and end with the **signature + logo block** — `{% firstof config.outgoing_email_signature config.site_name %}` and ``'&lt;img alt="[Logo]" src="{% site_logo_url %}"&gt;'``, the exact pattern the notification emails use (deck's own logo, falling back to the static `default_icon.png` served from CloudFront in production).

### Why?
An owner deciding whether to renew needs the when, not just the what — and the emails should look like ours (logo), consistent with every other email the app sends.

### How?
* `tenant/notices.py _deliver`: context gains `grace_days`, `grace_end_date` (paid_until + 30), `grace_days_left` (`grace_days_remaining`), `expired_days_ago`, and `suspended_since` (day after the last covered day — trial end, or paid_until + grace — mirroring the cap-reset engine's episode math).
* The three templates in `tenant/templates/tenant/email/` rewritten around those values; `-1` unlimited caps render as "unlimited".

### Testing?
* `test_process__grace_email_includes_dates_seats_and_logo` — pins the expiry date + "5 days ago", grace end date + "25 days left", the seats line, and the logo in the HTML part.
* `test_process__suspended_email_states_when_and_why_with_logo` — pins "since Aug. 2, 2026", "free trial ended on Aug. 1, 2026", and the logo.
* Existing delivery/cadence tests unchanged and green. Full serial suite: **OK**; `ruff` clean.

### Screenshots (if front end is affected)
Both captured from **real sends** on the dev deck (`process_deck_notices` → `send_email_message` → `_sent_mail/`, HTML part extracted and rendered; each message carries both `text/plain` and `text/html` parts).

**Grace-period expiry reminder — HTML rendered:**
![grace](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/notice-emails/grace_email.png)

Plain-text part, verbatim from the same send:
```
Hi owner,

Your deck **hackerspace** 's subscription expired on **July 24, 2026** (5 days
ago) and is in its 30-day grace period, which ends on **Aug. 23, 2026** (25
days left). When the grace period ends, the deck will revert to trial limits
(max 5 current students).

You are currently using **2** of **30** current student seats.

[Subscribe or renew
here](http://hackerspace.localhost:8000/decks/subscription/) to keep full
access. Questions about which students count? Only _current_ students -- those
registered in a course this semester -- count toward your limit; see [freeing
up student seats](http://hackerspace.localhost:8000/courses/students/archive-
help/).

Hackerspace Deck

[\[Logo\]](/static/img/default_icon.png)
```

**Suspended notice — HTML rendered:**
![suspended](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/notice-emails/suspended_email.png)

Plain-text part, verbatim from the same send:
```
Hi owner,

Your deck **hackerspace** has been **suspended** since **July 20, 2026** (its
subscription was paid through June 19, 2026, and the 30-day grace period ended
on July 19, 2026): it has reverted to trial limits (max 5 current students).
Existing students keep their access and nothing has been deleted, but no new
students can register in a course beyond the trial limit.

You are currently using **2** of **5** current student seats.

[Subscribe here](http://hackerspace.localhost:8000/decks/subscription/) to
restore full access, or [free up
seats](http://hackerspace.localhost:8000/courses/students/archive-help/) if
you're winding the deck down.
```
*(dev URLs and relative logo path are dev-environment artifacts — production renders the deck's real domain and the absolute CloudFront static URL, exactly as the notification emails do)*

### Anything Else?
Hotfix to `staging`; flows back to `develop` with the next staging sync. The epic PR #2110 adds a fourth notice email (`payment_failed.html`) — I'll give it the same date/logo treatment on the epic branch when this flows through.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_