### PR TITLE
Add a UI to reorder a quest's submission questions (#2171)

### DIFF
--- a/src/questions/templates/questions/snippets/question_table.html
+++ b/src/questions/templates/questions/snippets/question_table.html
@@ -55,7 +55,19 @@
           -
         {% endif %}
       </td>
-      <td>
+      <td class="text-nowrap">
+        <form method="post" action="{% url 'questions:move' quest.id question.id 'up' %}" class="preview-action-form">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-default" title="Move up"{% if forloop.first %} disabled{% endif %}>
+            <i class="fa fa-fw fa-arrow-up"></i>
+          </button>
+        </form>
+        <form method="post" action="{% url 'questions:move' quest.id question.id 'down' %}" class="preview-action-form">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-default" title="Move down"{% if forloop.last %} disabled{% endif %}>
+            <i class="fa fa-fw fa-arrow-down"></i>
+          </button>
+        </form>
         <a class="btn btn-warning" href="{{ question.get_absolute_url }}" title="Edit">
           <i class="fa fa-edit"></i>
         </a>

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -273,6 +273,8 @@ class QuestionViewsFeatureDisabledTest(ViewTestUtilsMixin, ByteDeckTenantTestCas
             "questions:update", kwargs={"quest_id": self.quest.id, "pk": self.question.id})
         self.assert404(
             "questions:delete", kwargs={"quest_id": self.quest.id, "pk": self.question.id})
+        self.assert404(
+            "questions:move", kwargs={"quest_id": self.quest.id, "pk": self.question.id, "direction": "up"})
 
     def test_all_question_pages__404_for_anonymous_when_disabled(self):
         """Anonymous users get a 404 (not a login redirect) while the feature is off — the
@@ -280,3 +282,113 @@ class QuestionViewsFeatureDisabledTest(ViewTestUtilsMixin, ByteDeckTenantTestCas
         self.assert404("questions:list", kwargs={"quest_id": self.quest.id})
         self.assert404(
             "questions:create", kwargs={"quest_id": self.quest.id, "question_type": "short_answer"})
+
+
+class QuestionMoveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+    """Tests for QuestionMoveView: staff-only up/down reordering of a quest's questions."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Enable the feature, plus a teacher, a student, and a quest with three questions at
+        ordinals 1, 2, 3 (and a second quest to test cross-quest URL rejection)."""
+        config = SiteConfig.get()
+        config.enable_submission_questions = True
+        config.save()
+
+        cls.test_teacher = User.objects.create_user("test_teacher", password="password", is_staff=True)
+        cls.test_student = User.objects.create_user("test_student", password="password")
+
+        cls.quest = baker.make(Quest)
+        cls.other_quest = baker.make(Quest)
+        cls.q1 = baker.make(Question, quest=cls.quest, ordinal=1, instructions="Q1")
+        cls.q2 = baker.make(Question, quest=cls.quest, ordinal=2, instructions="Q2")
+        cls.q3 = baker.make(Question, quest=cls.quest, ordinal=3, instructions="Q3")
+
+    def setUp(self):
+        """Set up a tenant test client for each test."""
+        self.client = TenantClient(self.tenant)
+
+    def _move(self, question, direction, quest=None):
+        """POST to move `question` in `direction`, scoped to `quest` (defaults to its own quest)."""
+        quest = quest or self.quest
+        return self.client.post(reverse(
+            "questions:move", kwargs={"quest_id": quest.id, "pk": question.id, "direction": direction}))
+
+    def _ordinals(self):
+        """Return {instructions: ordinal} for the quest's questions, read fresh from the DB."""
+        return {q.instructions: q.ordinal for q in Question.objects.filter(quest=self.quest)}
+
+    def test_move__anonymous_redirected_to_login(self):
+        """Anonymous users are redirected to login and can't reorder questions."""
+        self.assertRedirectsLogin(
+            "questions:move", kwargs={"quest_id": self.quest.id, "pk": self.q2.id, "direction": "up"})
+
+    def test_move__student_denied(self):
+        """A student gets a 403 and the ordering is unchanged: reordering is staff-only."""
+        self.client.force_login(self.test_student)
+        response = self._move(self.q2, "up")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
+
+    def test_move__down_swaps_with_next(self):
+        """Moving a question down swaps its ordinal with the next question's, and redirects
+        back to the question list."""
+        self.client.force_login(self.test_teacher)
+        response = self._move(self.q1, "down")
+        self.assertRedirects(response, reverse("questions:list", kwargs={"quest_id": self.quest.id}))
+        self.assertEqual(self._ordinals(), {"Q1": 2, "Q2": 1, "Q3": 3})
+
+    def test_move__up_swaps_with_previous(self):
+        """Moving a question up swaps its ordinal with the previous question's."""
+        self.client.force_login(self.test_teacher)
+        self._move(self.q3, "up")
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 3, "Q3": 2})
+
+    def test_move__up_at_top_is_noop(self):
+        """Moving the first question up does nothing (there is no neighbour above it)."""
+        self.client.force_login(self.test_teacher)
+        response = self._move(self.q1, "up")
+        self.assertRedirects(response, reverse("questions:list", kwargs={"quest_id": self.quest.id}))
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
+
+    def test_move__down_at_bottom_is_noop(self):
+        """Moving the last question down does nothing (there is no neighbour below it)."""
+        self.client.force_login(self.test_teacher)
+        self._move(self.q3, "down")
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
+
+    def test_move__follows_display_order_across_ordinal_gaps(self):
+        """Reordering follows display order, not ordinal arithmetic: a question moves past its
+        nearest neighbour even when ordinals are non-contiguous (e.g. after deletions)."""
+        self.client.force_login(self.test_teacher)
+        # open gaps so ordinals are 1, 5, 9 (as could happen after deleting questions)
+        Question.objects.filter(pk=self.q2.pk).update(ordinal=5)
+        Question.objects.filter(pk=self.q3.pk).update(ordinal=9)
+        # moving Q3 (last, ordinal 9) up swaps it with its nearest neighbour Q2 (ordinal 5)
+        self._move(self.q3, "up")
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 9, "Q3": 5})
+        # the resulting display order is Q1, Q3, Q2
+        ordered = list(Question.objects.filter(quest=self.quest).values_list("instructions", flat=True))
+        self.assertEqual(ordered, ["Q1", "Q3", "Q2"])
+
+    def test_move__invalid_direction_404(self):
+        """A direction other than up/down in the URL is a 404, and nothing is reordered."""
+        self.client.force_login(self.test_teacher)
+        response = self.client.post(reverse(
+            "questions:move", kwargs={"quest_id": self.quest.id, "pk": self.q1.id, "direction": "sideways"}))
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
+
+    def test_move__wrong_quest_404(self):
+        """A question can't be moved through another quest's URL; the ordering is unchanged."""
+        self.client.force_login(self.test_teacher)
+        response = self._move(self.q1, "down", quest=self.other_quest)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
+
+    def test_move__get_not_allowed(self):
+        """The move endpoint is POST-only; a GET returns 405 Method Not Allowed."""
+        self.client.force_login(self.test_teacher)
+        response = self.client.get(reverse(
+            "questions:move", kwargs={"quest_id": self.quest.id, "pk": self.q1.id, "direction": "up"}))
+        self.assertEqual(response.status_code, 405)

--- a/src/questions/urls.py
+++ b/src/questions/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('quest/<int:quest_id>/create/<str:question_type>/', views.QuestionCreateView.as_view(), name='create'),
     path('quest/<int:quest_id>/<int:pk>/update/', views.QuestionUpdateView.as_view(), name='update'),
     path('quest/<int:quest_id>/<int:pk>/delete/', views.QuestionDeleteView.as_view(), name='delete'),
+    path('quest/<int:quest_id>/<int:pk>/move/<str:direction>/', views.QuestionMoveView.as_view(), name='move'),
 ]

--- a/src/questions/views.py
+++ b/src/questions/views.py
@@ -1,7 +1,9 @@
+from django.db import transaction
+from django.db.models import Max
 from django.http import Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.views.generic import ListView, CreateView, UpdateView, DeleteView
+from django.views.generic import ListView, CreateView, UpdateView, DeleteView, View
 
 from hackerspace_online.decorators import StaffMemberRequiredMixin
 from siteconfig.models import SiteConfig
@@ -145,3 +147,59 @@ class QuestionDeleteView(NonPublicOnlyViewMixin, SubmissionQuestionsEnabledMixin
     def get_success_url(self):
         """Back to the quest's question list."""
         return reverse('questions:list', kwargs={'quest_id': self.kwargs['quest_id']})
+
+
+class QuestionMoveView(
+    NonPublicOnlyViewMixin, SubmissionQuestionsEnabledMixin, StaffMemberRequiredMixin,
+    QuestionQuestScopedMixin, View,
+):
+    """Staff-only POST endpoint that moves a question up or down within its quest's ordering.
+
+    Students see a quest's questions in ascending ``ordinal`` order, so reordering is just
+    swapping ordinals. The question swaps with the nearest question in the requested direction;
+    ordinals aren't necessarily contiguous (deleting a question leaves a gap), so the neighbour is
+    found by ordering rather than by ``ordinal ± 1``. Moving the first question up or the last
+    question down is a no-op. Always redirects back to the quest's question list.
+    """
+
+    http_method_names = ['post']
+
+    def post(self, request, *args, **kwargs):
+        """Swap the question's ordinal with its up/down neighbour (if any), then redirect to
+        the list. `direction` comes from the URL and must be 'up' or 'down' (else 404)."""
+        direction = self.kwargs['direction']
+        if direction not in ('up', 'down'):
+            raise Http404(f"Cannot move a question '{direction}'.")
+
+        # get_queryset() (QuestionQuestScopedMixin) scopes to the URL's quest, so a question
+        # can only be moved through its own quest's URL.
+        question = get_object_or_404(self.get_queryset(), pk=self.kwargs['pk'])
+        siblings = Question.objects.filter(quest_id=question.quest_id)
+        if direction == 'up':
+            neighbour = siblings.filter(ordinal__lt=question.ordinal).order_by('-ordinal').first()
+        else:
+            neighbour = siblings.filter(ordinal__gt=question.ordinal).order_by('ordinal').first()
+
+        if neighbour is not None:
+            self._swap_ordinals(question, neighbour)
+
+        return redirect('questions:list', quest_id=question.quest_id)
+
+    @staticmethod
+    def _swap_ordinals(question, neighbour):
+        """Swap two questions' ordinals inside a transaction, parking one at a temporary
+        out-of-range ordinal first so the (quest, ordinal) unique constraint is never violated
+        mid-swap (Postgres enforces it per statement, not just at commit)."""
+        question_ordinal, neighbour_ordinal = question.ordinal, neighbour.ordinal
+        # a value guaranteed not to collide with any existing ordinal in this quest
+        temp_ordinal = Question.objects.filter(quest_id=question.quest_id).aggregate(Max('ordinal'))['ordinal__max'] + 1
+        with transaction.atomic():
+            question.ordinal = temp_ordinal
+            question.full_clean()
+            question.save()
+            neighbour.ordinal = question_ordinal
+            neighbour.full_clean()
+            neighbour.save()
+            question.ordinal = neighbour_ordinal
+            question.full_clean()
+            question.save()


### PR DESCRIPTION
### What?
Teachers can now **reorder** a quest's submission questions directly from the question-list page, using **up/down arrow buttons** in each row's Action column. Students see a quest's questions in ascending order, so this simply changes the order students answer them in.

Before this, questions could only be ordered by the sequence they were created in — to move question 3 to the top you had to delete and recreate questions. The #1304 design explicitly called for teachers to "have the ability to reorder the questions"; this closes that gap (#2171).

### Why?
`Question.ordinal` already drives display order and new questions auto-assign the next ordinal, but there was **no way to change an existing question's position**. Delete-and-recreate is destructive (and loses the question's answers via `SET_NULL`), so a real reorder control was needed.

### How?
- **`QuestionMoveView`** — a staff-only, **POST-only** endpoint (`questions:move`, `…/<pk>/move/<direction>/`) that swaps a question's `ordinal` with its nearest neighbour in the requested direction. It reuses the same mixins as the other question views (tenant-only, feature-gated, staff-only, quest-scoped), so a question can only be moved through its own quest's URL.
  - Ordinals aren't necessarily contiguous (deleting a question leaves a gap), so the neighbour is found **by ordering** (`ordinal__lt/gt … order_by`), not by `ordinal ± 1`.
  - Moving the first question up or the last question down is a **no-op**; an unknown direction is a 404.
  - The swap parks one question at a temporary out-of-range ordinal inside a **`transaction.atomic()`** block, so the `UniqueConstraint(quest, ordinal)` is never violated mid-swap (Postgres enforces it per statement, not just at commit). `full_clean()` runs before each save, per the project convention.
- **Template** — `snippets/question_table.html` gains an up and a down button per row, as small inline POST forms reusing the existing **`.preview-action-form`** style (no new CSS). The up button is `disabled` on the first row and the down button on the last (`forloop.first` / `forloop.last`). Tooltips use the native `title` attribute, matching the existing Edit/Delete buttons.

No model change, so **no migration**.

### Testing?
- New `QuestionMoveViewTest` covers: down-swaps-with-next, up-swaps-with-previous, top/bottom no-ops, reordering across **non-contiguous ordinals** (the gap case), invalid-direction 404, cross-quest 404, GET-not-allowed (405), student 403, and anonymous login-redirect. The feature-disabled test also asserts the move URL 404s when the deck hasn't opted in.
- `python src/manage.py test src/questions` (70 tests) green; `ruff check src/questions`, `manage.py check`, and `makemigrations --check --dry-run` all clean.
- Exercised live on a dev deck: logged in as a teacher, clicked Move-down on the first question and confirmed the order changed (screenshots below are from that session).

### Screenshots (if front end is affected)
Captured from the running app on a dev deck (`Lab Safety Quiz`, three questions), logged in as a teacher.

**Before** — Action column had only Edit/Delete:
![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2171/before.png)

**After** — up/down arrows added, disabled at the ends (first row's up and last row's down are greyed out):
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2171/after.png)

**After clicking "Move down" on the first question (Short Answer)** — it moves below Long Answer, and the disabled states follow the new order:
![after reorder](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2171/after_reorder.png)

### Anything Else?
- **Interaction with #2099:** this PR is built on `develop`, where the deck-level `enable_submission_questions` flag still exists, so `QuestionMoveView` uses `SubmissionQuestionsEnabledMixin` like the other question views (and there's a matching flag-off 404 test). #2099 removes that flag; when it merges first, this branch needs a trivial rebase to drop the mixin from the move view and that one test assertion. Happy to rebase whenever #2099 lands.
- Scope kept to up/down buttons (the simplest robust option from the issue) rather than drag-and-drop — no JS dependency, works without JavaScript, and accessible.

Closes #2171.

- Claude Code (`Bytedeck - multiple submission types`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff can move questions up or down directly from the question list.
  * Questions are reordered based on their displayed positions, including lists with gaps.
  * Movement controls are disabled when a question is already first or last.

* **Bug Fixes**
  * Added access and validation safeguards for unauthorized, invalid, or cross-quest move requests.
  * Moving questions remains unavailable when submission questions are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->