### PR TITLE
Bound admin Quest/Badge exports by dropping bulky HTML columns (#2081)

### DIFF
--- a/src/badges/admin.py
+++ b/src/badges/admin.py
@@ -163,6 +163,25 @@ class BadgeResource(NonPublicSchemaOnlyAdminAccessMixin, resources.ModelResource
                 self.generate_simple_prereqs(parent_badge, data_dict)
 
 
+# Badge.short_description holds summernote HTML; drop it from the admin export for the
+# same #2081 memory reason -- the Shared Library uses the full BadgeResource, unchanged.
+BADGE_EXPORT_EXCLUDED_HTML_FIELDS = ('short_description',)
+
+
+class BadgeAdminExportResource(BadgeResource):
+    """Export-only ``BadgeResource`` for the admin that drops the bulky HTML field.
+
+    Wired in via ``BadgeAdmin.get_export_resource_classes`` only; import keeps using the
+    full ``BadgeResource``. The column is filtered out at export time (rather than via
+    ``Meta.exclude``) because it is an already-declared field inherited from ``BadgeResource``.
+    """
+
+    def get_export_fields(self, selected_fields=None):
+        """Return the parent export fields minus the bulky summernote HTML column."""
+        fields = super().get_export_fields(selected_fields)
+        return [f for f in fields if f.column_name not in BADGE_EXPORT_EXCLUDED_HTML_FIELDS]
+
+
 class BadgeAdmin(NonPublicSchemaOnlyAdminAccessMixin, ImportExportActionModelAdmin):
     resource_classes = [BadgeResource]  # replaces resource_class, removed in django-import-export 4.0
     list_display = ('name', 'xp', 'published')
@@ -177,6 +196,10 @@ class BadgeAdmin(NonPublicSchemaOnlyAdminAccessMixin, ImportExportActionModelAdm
     def get_export_formats(self):
         """ file formats for exporting """
         return [CSV]
+
+    def get_export_resource_classes(self, request):
+        """Export uses the slim, HTML-free resource to bound per-request memory (#2081)."""
+        return [BadgeAdminExportResource]
 
 
 class BadgeSeriesAdmin(NonPublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):

--- a/src/badges/admin.py
+++ b/src/badges/admin.py
@@ -177,7 +177,16 @@ class BadgeAdminExportResource(BadgeResource):
     """
 
     def get_export_fields(self, selected_fields=None):
-        """Return the parent export fields minus the bulky summernote HTML column."""
+        """Return the parent export fields minus the bulky summernote HTML column.
+
+        Args:
+            selected_fields: Optional subset of fields to export (passed through to the
+                parent resource); ``None`` means export all of the resource's fields.
+
+        Returns:
+            list[Field]: The parent's export fields with any field whose ``column_name``
+            is in ``BADGE_EXPORT_EXCLUDED_HTML_FIELDS`` removed.
+        """
         fields = super().get_export_fields(selected_fields)
         return [f for f in fields if f.column_name not in BADGE_EXPORT_EXCLUDED_HTML_FIELDS]
 
@@ -198,7 +207,17 @@ class BadgeAdmin(NonPublicSchemaOnlyAdminAccessMixin, ImportExportActionModelAdm
         return [CSV]
 
     def get_export_resource_classes(self, request):
-        """Export uses the slim, HTML-free resource to bound per-request memory (#2081)."""
+        """Export uses the slim, HTML-free resource to bound per-request memory (#2081).
+
+        Import is left on the full ``BadgeResource`` (via ``resource_classes``).
+
+        Args:
+            request: The current admin request (unused; part of the django-import-export
+                ``ExportMixin`` hook signature).
+
+        Returns:
+            list[type[Resource]]: ``[BadgeAdminExportResource]`` -- the export-only resource.
+        """
         return [BadgeAdminExportResource]
 
 

--- a/src/badges/tests/test_admin.py
+++ b/src/badges/tests/test_admin.py
@@ -6,9 +6,14 @@ from django.contrib.auth import get_user_model
 import tablib
 from model_bakery import baker
 
-from badges.admin import BadgeAdmin, BadgeResource
+from badges.admin import (
+    BADGE_EXPORT_EXCLUDED_HTML_FIELDS,
+    BadgeAdmin,
+    BadgeAdminExportResource,
+    BadgeResource,
+)
 from badges.models import Badge, BadgeType
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase, request_with_messages
 from prerequisites.models import Prereq
 from quest_manager.models import Category, Quest
 
@@ -205,3 +210,33 @@ class BadgeAdminFormatsTest(ByteDeckTenantTestCase):
         modeladmin = BadgeAdmin(Badge, django_admin.site)
         formats = modeladmin.get_export_formats()
         self.assertEqual([fmt().get_title() for fmt in formats], ['csv'])
+
+
+class BadgeAdminExportResourceTest(ByteDeckTenantTestCase):
+    """The admin Export button drops the bulky HTML columns to bound per-request memory
+    (#2081); the full BadgeResource (import / Shared Library) keeps them."""
+
+    def test_admin_export_resource__omits_bulky_html_columns(self):
+        """BadgeAdminExportResource's export has no short_description column."""
+        badge = baker.make(Badge, short_description='<p>lots of html</p>')
+
+        headers = BadgeAdminExportResource().export([badge]).headers
+
+        for field in BADGE_EXPORT_EXCLUDED_HTML_FIELDS:
+            self.assertNotIn(field, headers)
+        # Identifying/lightweight columns are still exported.
+        self.assertIn('name', headers)
+
+    def test_full_resource__still_exports_short_description(self):
+        """The full BadgeResource still carries the HTML field for import / sharing."""
+        badge = baker.make(Badge, short_description='<p>keep me</p>')
+
+        self.assertIn('short_description', BadgeResource().export([badge]).headers)
+
+    def test_badge_admin__export_uses_slim_resource_import_uses_full(self):
+        """BadgeAdmin exports with the slim resource but imports with the full one."""
+        modeladmin = BadgeAdmin(Badge, django_admin.site)
+        request = request_with_messages()
+
+        self.assertEqual(modeladmin.get_export_resource_classes(request), [BadgeAdminExportResource])
+        self.assertEqual(modeladmin.get_import_resource_classes(request), [BadgeResource])

--- a/src/badges/tests/test_admin.py
+++ b/src/badges/tests/test_admin.py
@@ -7,7 +7,6 @@ import tablib
 from model_bakery import baker
 
 from badges.admin import (
-    BADGE_EXPORT_EXCLUDED_HTML_FIELDS,
     BadgeAdmin,
     BadgeAdminExportResource,
     BadgeResource,
@@ -222,8 +221,9 @@ class BadgeAdminExportResourceTest(ByteDeckTenantTestCase):
 
         headers = BadgeAdminExportResource().export([badge]).headers
 
-        for field in BADGE_EXPORT_EXCLUDED_HTML_FIELDS:
-            self.assertNotIn(field, headers)
+        # Assert the bulky column explicitly (not by iterating the constant) so an
+        # incorrect or incomplete BADGE_EXPORT_EXCLUDED_HTML_FIELDS is caught here too.
+        self.assertNotIn('short_description', headers)
         # Identifying/lightweight columns are still exported.
         self.assertIn('name', headers)
 

--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -319,6 +319,32 @@ class QuestResource(resources.ModelResource):
                     self.generate_campaign(parent_quest, data_dict)
 
 
+# Fields holding large summernote/WYSIWYG HTML. Exporting them for every quest builds
+# the whole set of rendered HTML into an in-memory tablib Dataset, then a second full
+# copy as the CSV string -- a primary cause of the per-request memory blowups tracked in
+# #2081 (a single admin Export could grow a web worker to ~1.6 GiB and OOM the host).
+QUEST_EXPORT_EXCLUDED_HTML_FIELDS = ('instructions', 'submission_details', 'instructor_notes')
+
+
+class QuestAdminExportResource(QuestResource):
+    """Export-only ``QuestResource`` for the admin that drops the bulky HTML fields.
+
+    The admin "Export" button is a table dump, so the large summernote HTML columns are
+    of little use there and are the main memory cost. This slim resource is wired in via
+    ``QuestAdmin.get_export_resource_classes`` only; import and the Shared Library
+    importer/exporter keep using the full ``QuestResource``, so cross-deck sharing (which
+    needs the full quest content) is unaffected.
+
+    ``Meta.exclude`` can't drop these here -- they are already declared fields inherited
+    from ``QuestResource`` -- so the bulky columns are filtered out at export time instead.
+    """
+
+    def get_export_fields(self, selected_fields=None):
+        """Return the parent export fields minus the bulky summernote HTML columns."""
+        fields = super().get_export_fields(selected_fields)
+        return [f for f in fields if f.column_name not in QUEST_EXPORT_EXCLUDED_HTML_FIELDS]
+
+
 class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteAdvancedModelAdmin, ImportExportActionModelAdmin):  # use SummenoteModelAdmin
     resource_classes = [QuestResource]  # replaces resource_class, removed in django-import-export 4.0
     list_display = ('id', 'name', 'xp', 'archived', 'published', 'blocking', 'sort_order', 'max_repeats', 'date_expired',
@@ -351,6 +377,13 @@ class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteAdvanced
     def get_export_formats(self):
         """ file formats for exporting """
         return [CSV]
+
+    def get_export_resource_classes(self, request):
+        """Export uses the slim, HTML-free resource to bound per-request memory (#2081).
+
+        Import is left on the full ``QuestResource`` (via ``resource_classes``).
+        """
+        return [QuestAdminExportResource]
 
 
 class CategoryAdmin(NonPublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):

--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -340,7 +340,16 @@ class QuestAdminExportResource(QuestResource):
     """
 
     def get_export_fields(self, selected_fields=None):
-        """Return the parent export fields minus the bulky summernote HTML columns."""
+        """Return the parent export fields minus the bulky summernote HTML columns.
+
+        Args:
+            selected_fields: Optional subset of fields to export (passed through to the
+                parent resource); ``None`` means export all of the resource's fields.
+
+        Returns:
+            list[Field]: The parent's export fields with any field whose ``column_name``
+            is in ``QUEST_EXPORT_EXCLUDED_HTML_FIELDS`` removed.
+        """
         fields = super().get_export_fields(selected_fields)
         return [f for f in fields if f.column_name not in QUEST_EXPORT_EXCLUDED_HTML_FIELDS]
 
@@ -382,6 +391,13 @@ class QuestAdmin(NonPublicSchemaOnlyAdminAccessMixin, ByteDeckSummernoteAdvanced
         """Export uses the slim, HTML-free resource to bound per-request memory (#2081).
 
         Import is left on the full ``QuestResource`` (via ``resource_classes``).
+
+        Args:
+            request: The current admin request (unused; part of the django-import-export
+                ``ExportMixin`` hook signature).
+
+        Returns:
+            list[type[Resource]]: ``[QuestAdminExportResource]`` -- the export-only resource.
         """
         return [QuestAdminExportResource]
 

--- a/src/quest_manager/tests/test_admin.py
+++ b/src/quest_manager/tests/test_admin.py
@@ -9,7 +9,6 @@ from badges.models import Badge
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase, request_with_messages
 from prerequisites.models import Prereq
 from quest_manager.admin import (
-    QUEST_EXPORT_EXCLUDED_HTML_FIELDS,
     QuestAdmin,
     QuestAdminExportResource,
     QuestResource,
@@ -138,19 +137,23 @@ class QuestAdminExportResourceTest(ByteDeckTenantTestCase):
 
         headers = QuestAdminExportResource().export([quest]).headers
 
-        for field in QUEST_EXPORT_EXCLUDED_HTML_FIELDS:
-            self.assertNotIn(field, headers)
+        # Assert each bulky column explicitly (not by iterating the constant) so an
+        # incorrect or incomplete QUEST_EXPORT_EXCLUDED_HTML_FIELDS is caught here too.
+        self.assertNotIn('instructions', headers)
+        self.assertNotIn('submission_details', headers)
+        self.assertNotIn('instructor_notes', headers)
         # Identifying/lightweight columns are still exported.
         self.assertIn('name', headers)
 
-    def test_full_resource__still_exports_instructions(self):
-        """The full QuestResource (import + Shared Library) still carries the HTML fields."""
+    def test_full_resource__still_exports_html_columns(self):
+        """The full QuestResource (import + Shared Library) still carries every bulky HTML field."""
         quest = baker.make(Quest, instructions='<p>keep me</p>')
 
         dataset = QuestResource().export([quest])
 
         self.assertIn('instructions', dataset.headers)
         self.assertIn('submission_details', dataset.headers)
+        self.assertIn('instructor_notes', dataset.headers)
 
     def test_quest_admin__export_uses_slim_resource_import_uses_full(self):
         """QuestAdmin exports with the slim resource but imports with the full one."""

--- a/src/quest_manager/tests/test_admin.py
+++ b/src/quest_manager/tests/test_admin.py
@@ -9,7 +9,9 @@ from badges.models import Badge
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase, request_with_messages
 from prerequisites.models import Prereq
 from quest_manager.admin import (
+    QUEST_EXPORT_EXCLUDED_HTML_FIELDS,
     QuestAdmin,
+    QuestAdminExportResource,
     QuestResource,
     QuestSubmissionAdmin,
     archive_selected_quests,
@@ -123,6 +125,40 @@ class QuestAdminQuerysetAndFormatsTest(ByteDeckTenantTestCase):
         modeladmin = QuestAdmin(Quest, django_admin.site)
         formats = modeladmin.get_export_formats()
         self.assertEqual([fmt().get_title() for fmt in formats], ['csv'])
+
+
+class QuestAdminExportResourceTest(ByteDeckTenantTestCase):
+    """The admin Export button drops bulky summernote HTML columns to bound per-request
+    memory (#2081), while the full QuestResource used by import / the Shared Library keeps
+    them so cross-deck sharing is unaffected."""
+
+    def test_admin_export_resource__omits_bulky_html_columns(self):
+        """QuestAdminExportResource's export has no instructions/submission_details/instructor_notes columns."""
+        quest = baker.make(Quest, instructions='<p>lots of html</p>', submission_details='<p>details</p>')
+
+        headers = QuestAdminExportResource().export([quest]).headers
+
+        for field in QUEST_EXPORT_EXCLUDED_HTML_FIELDS:
+            self.assertNotIn(field, headers)
+        # Identifying/lightweight columns are still exported.
+        self.assertIn('name', headers)
+
+    def test_full_resource__still_exports_instructions(self):
+        """The full QuestResource (import + Shared Library) still carries the HTML fields."""
+        quest = baker.make(Quest, instructions='<p>keep me</p>')
+
+        dataset = QuestResource().export([quest])
+
+        self.assertIn('instructions', dataset.headers)
+        self.assertIn('submission_details', dataset.headers)
+
+    def test_quest_admin__export_uses_slim_resource_import_uses_full(self):
+        """QuestAdmin exports with the slim resource but imports with the full one."""
+        modeladmin = QuestAdmin(Quest, django_admin.site)
+        request = request_with_messages()
+
+        self.assertEqual(modeladmin.get_export_resource_classes(request), [QuestAdminExportResource])
+        self.assertEqual(modeladmin.get_import_resource_classes(request), [QuestResource])
 
 
 class QuestResourceDehydratePrereqsTest(ByteDeckTenantTestCase):


### PR DESCRIPTION
### What?

The admin **Export** button on `QuestAdmin` and `BadgeAdmin` now omits the bulky summernote/WYSIWYG HTML columns (`instructions`, `submission_details`, `instructor_notes` for quests; `short_description` for badges) from the exported CSV. Import and the Shared Library importer/exporter are unchanged.

### Why?

Part of #2081 (per-request memory blowups OOM-killing the single-host web box — `dmesg` shows uwsgi workers grown to ~1.6 GiB RSS on one request). This is culprit **#1** in the issue's ranking ("Most probable 1.6 GiB offender"):

> `QuestAdmin`/`BadgeAdmin` are `ImportExportActionModelAdmin` … The admin Export button serializes the *entire* table into an in-memory `tablib.Dataset` (all rows at once, then a second full copy as the CSV/XLSX string). `QuestResource` still exports the full `instructions` summernote HTML per quest … Hundreds of quests with large WYSIWYG HTML = the classic hundreds-of-MB→GB single request.

django-import-export 4.4.1 already iterates the queryset in chunks (`.iterator(chunk_size=…)`), so the *model instances* aren't all held at once. The remaining cost is the exported **rows**: every quest's full rendered `instructions` HTML is held in the `Dataset`, then copied again into the CSV string. Dropping those columns collapses each row from potentially megabytes of HTML to a handful of small fields, which is the durable fix. The issue author's own suggested remedy was to "drop `instructions` from the default export".

### How?

- New **export-only** resources `QuestAdminExportResource` / `BadgeAdminExportResource` subclass the existing `QuestResource` / `BadgeResource` and override `get_export_fields()` to filter the bulky HTML columns out of the exported dataset (headers *and* data). `Meta.exclude` can't be used here because those columns are already-declared fields inherited from the parent resource, so filtering happens at export time.
- Each admin wires the slim resource in via `get_export_resource_classes(request)`, leaving `resource_classes` (used for **import**) on the full resource.
- **The full `QuestResource`/`BadgeResource` are untouched.** The Shared Library importer/exporter (`src/library/`) instantiate them directly, so cross-deck sharing — which needs the full quest/badge content — still carries every field. Import (including admin CSV import) is likewise unchanged.

### Testing?

Test-driven, added to `quest_manager/tests/test_admin.py` and `badges/tests/test_admin.py`:

- the slim export resource's dataset **omits** the bulky HTML columns but keeps identifying columns (`name`);
- the full `QuestResource`/`BadgeResource` **still export** those columns (proving library/import are unaffected);
- each admin returns the slim resource from `get_export_resource_classes` and the full resource from `get_import_resource_classes`.

Ran `quest_manager.tests.test_admin`, `badges.tests.test_admin`, and the full `library` suite (87 tests) — all green; `ruff` clean; no model changes / no migration.

### Screenshots (if front end is affected)

N/A — admin-only export behaviour; no template, CSS, or JS changed. The visible effect is that the admin's exported CSV no longer contains the raw summernote HTML columns (which were unusable in a spreadsheet cell anyway).

### Anything Else?

One item of the larger #2081 memory work, so it does **not** close the issue. Remaining ranked culprits (unpaginated `ProfileList` / `quest_user_status`, in-request djcytoscape map regeneration, other unbounded `ListView`s) are separate follow-ups. Note: `ProfileList` uses a client-side bootstrap-table (search/sort/CSV export over the full DOM), so a naive `paginate_by` would break those features — that item needs a design decision (server-side table vs. accepting the tradeoff) rather than a drop-in fix.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Admin exports for badges and quests now omit bulky HTML content, producing smaller and more efficient export files.
  * Imports and full resource exports continue to include all available fields.
* **Bug Fixes**
  * Ensured admin export and import actions use the appropriate field sets.
* **Tests**
  * Added coverage verifying excluded HTML fields, retained lightweight fields, and correct export/import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->