### PR TITLE
Cover ForceDebugCursorMiddleware (middleware.py → 100%)

### DIFF
--- a/src/hackerspace_online/tests/test_middleware.py
+++ b/src/hackerspace_online/tests/test_middleware.py
@@ -1,15 +1,17 @@
 from functools import wraps
 
 from django.conf import settings
+from django.db import connections
 from django.urls import reverse, path
 from django.contrib.messages import get_messages
-from django.test import override_settings
+from django.test import override_settings, RequestFactory, SimpleTestCase
 from django.http import HttpResponse
 
 from django_tenants.test.client import TenantClient
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
+from hackerspace_online.middleware import ForceDebugCursorMiddleware
 from hackerspace_online.urls import urlpatterns as hackerspace_urlpatterns
 
 
@@ -122,3 +124,23 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
         # should receive an empty response (ok) as if nothing has happened
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"")
+
+
+class ForceDebugCursorMiddlewareTestCase(SimpleTestCase):
+    """Tests for `hackerspace_online.middleware.ForceDebugCursorMiddleware`, which forces the
+    default DB connection's debug cursor on so queries get logged (enabled only when DEBUG)."""
+
+    def test_call__enables_force_debug_cursor_and_returns_response(self):
+        """Calling the middleware turns on the default connection's debug cursor and returns get_response's result."""
+        # restore the flag afterwards so this test can't leak state into others
+        original = connections['default'].force_debug_cursor
+        self.addCleanup(setattr, connections['default'], 'force_debug_cursor', original)
+        connections['default'].force_debug_cursor = False
+
+        expected_response = HttpResponse()
+        middleware = ForceDebugCursorMiddleware(get_response=lambda request: expected_response)
+
+        result = middleware(RequestFactory().get('/'))
+
+        self.assertIs(result, expected_response)
+        self.assertTrue(connections['default'].force_debug_cursor)


### PR DESCRIPTION
### What?

Next gap-closing PR. Adds the missing test for `ForceDebugCursorMiddleware`, closing the last untested spot in `hackerspace_online/middleware.py` (**→ 100%**).

### Why?

`RequestDataTooBigMiddleware` in that module is thoroughly tested, but its sibling `ForceDebugCursorMiddleware` — the debug-only middleware (inserted at `settings.py:365` when `DEBUG`) that flips the default DB connection's `force_debug_cursor` on so queries get logged — had no test.

### How?

New `ForceDebugCursorMiddlewareTestCase` in `hackerspace_online/tests/test_middleware.py` — a direct unit test that constructs the middleware with a stub `get_response`, calls it, and asserts it (a) turns on `connections['default'].force_debug_cursor` and (b) returns the wrapped response unchanged. The original flag value is restored via `addCleanup` so the test can't leak the debug-cursor state into other tests.

### Testing?

- `python manage.py test hackerspace_online.tests.test_middleware` → **passing** (+1 new); `ruff` clean; `test_conventions` passes.
- With coverage, the target lines (`__init__` + `__call__`) are now covered; `hackerspace_online/middleware.py` reaches **100%** in the full suite.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Target came from a fresh full-suite coverage run.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_