### PR TITLE
Cover badges detail_all view (badges/views.py → 100%)

### DIFF
--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -120,6 +120,20 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.client.get(reverse('badges:badge_detail', args=[self.test_badge.pk]))
         self.assertNotContains(response, 'One btn-group keeps every action button')
 
+    def test_badge_detail_all__login_required_and_renders_for_authenticated_users(self):
+        """badge_detail_all (assertions of all students) redirects anonymous users to login and renders for any logged-in user."""
+        b_pk = self.test_badge.pk
+
+        # anonymous -> redirected to login
+        self.assertRedirectsLogin('badges:badge_detail_all', args=[b_pk])
+
+        # students and teachers can both view it (login_required, no staff gate)
+        self.client.force_login(self.test_student1)
+        self.assert200('badges:badge_detail_all', args=[b_pk])
+
+        self.client.force_login(self.test_teacher)
+        self.assert200('badges:badge_detail_all', args=[b_pk])
+
     def test_badge_create__creates_badge(self):
         """Posting valid data to the create view creates a new badge and redirects to the list."""
         # log in a teacher


### PR DESCRIPTION
### What?

Next gap-closing PR. Covers the `detail_all` view in `badges/views.py`, taking it to **100%** (full-suite).

### Why?

`badge_detail_all` (the "assertions of **all** students" variant of the badge detail page, vs. `badge_detail` which shows only current students) was the one untested view body left in `badges/views.py` — nothing exercised it.

### How?

Adds `test_badge_detail_all__login_required_and_renders_for_authenticated_users` to `BadgeViewTests`, mirroring the existing access-check style: asserts the view redirects anonymous users to login and returns 200 for both a student and a teacher (it's `@login_required` with no staff gate).

### Testing?

- `python manage.py test badges.tests.test_views.BadgeViewTests` → **passing** (+1 new); `ruff` clean; `test_conventions` passes.
- Full `badges` app (87 tests) green; with coverage the `detail_all` lines are now covered and `badges/views.py` reaches **100%** in the full suite.

### Screenshots (if front end is affected)

N/A — test-only (the view already renders the existing `badges/detail.html`).

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Target came from a fresh full-suite coverage run.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_