### PR TITLE
Cover Notification.get_link() branches and recent() (notifications/models.py → 100%)

### DIFF
--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -46,6 +46,67 @@ class NotificationModelTest(ByteDeckTenantTestCase):
         notification.mark_read()
         self.assertFalse(notification.unread)
 
+    def test_recent__returns_at_most_five_unread(self):
+        """recent() returns only the five most recent unread notifications."""
+        Notification.objects.all().delete()  # clear any created as a side effect of user setup
+        for _ in range(6):
+            Notification.objects.create(
+                recipient=self.student,
+                sender_content_type=ContentType.objects.get_for_model(self.teacher),
+                sender_object_id=self.teacher.id,
+                verb="pinged you",
+                unread=True,
+            )
+        recent = Notification.objects.all().recent()
+        self.assertEqual(len(recent), 5)
+        self.assertTrue(all(note.unread for note in recent))
+
+    def _latest_notification(self):
+        """Return the most recently created Notification (new_notification returns nothing)."""
+        return Notification.objects.order_by('id').last()
+
+    def test_get_link__with_target_and_action_renders_both(self):
+        """get_link() emphasises the target and quotes the action when the notification has both."""
+        target = baker.make('announcements.Announcement')
+        action = baker.make('comments.Comment')
+        new_notification(
+            self.teacher,
+            recipient=self.student,
+            affected_users=[self.student],
+            target=target,
+            action=action,
+            verb="commented on",
+        )
+        link = self._latest_notification().get_link()
+        self.assertIn(f"<em>{target}</em>", link)
+        self.assertIn('with "', link)
+
+    def test_get_link__with_target_no_action_renders_target_only(self):
+        """get_link() emphasises the target but omits the 'with ...' clause when there is no action object."""
+        target = baker.make('announcements.Announcement')
+        new_notification(
+            self.teacher,
+            recipient=self.student,
+            affected_users=[self.student],
+            target=target,
+            verb="posted",
+        )
+        link = self._latest_notification().get_link()
+        self.assertIn(f"<em>{target}</em>", link)
+        self.assertNotIn('with "', link)
+
+    def test_get_link__without_target_has_no_emphasis(self):
+        """get_link() renders only the sender/verb (no <em> target) when there is no target object."""
+        new_notification(
+            self.teacher,
+            recipient=self.student,
+            affected_users=[self.student],
+            verb="sent you a notification",
+        )
+        link = self._latest_notification().get_link()
+        self.assertNotIn("<em>", link)
+        self.assertTrue(link.endswith("</a>"))
+
     def test_new_notification__creates_unread_for_recipient(self):
         """new_notification() creates a single unread notification for the recipient."""
         # make sure the student doesn't have any notifications yet


### PR DESCRIPTION
### What?

Next gap-closing PR. Covers the last untested spots in `notifications/models.py`, taking it to **100%** (full-suite).

### Why?

Two things had no coverage:

1. **`NotificationQuerySet.recent()`** — returns the five most recent unread notifications. A public queryset helper (alongside `get_unread`/`get_read`) that had no test and, as it happens, no current caller.
2. **`Notification.get_link()`** — builds the notification's HTML link. Its three rendering branches (target **and** action → emphasised target + quoted action; target only; no target) were never exercised — only the sibling `get_url()` was tested.

### How?

New tests in `NotificationModelTest`:

- **`recent()`** — creates six unread notifications and asserts it returns exactly five, all unread.
- **`get_link()`** — three focused tests, one per branch, building notifications via `new_notification` with explicit `target` (`announcements.Announcement`) and/or `action` (`comments.Comment`) objects and asserting on the rendered markup (`<em>target</em>`, the `with "…"` action clause, or neither).

### Testing?

- `python manage.py test notifications.tests.test_models` → **passing** (+4 new); `ruff` clean; `test_conventions` passes.
- Full `notifications` app (50 tests) green; with coverage the target lines are now covered and `notifications/models.py` reaches **100%** in the full suite.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. Target came from a fresh full-suite coverage run. Note: `recent()` currently has no caller in the codebase — it's a small public queryset helper, so I've locked its behaviour with a test rather than removing it; happy to drop it instead if you'd prefer.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_