### PR TITLE
Cover TaggitSelect2Widget.options() branches (tags/widgets.py → 100%)

### DIFF
--- a/src/tags/tests/test_widgets.py
+++ b/src/tags/tests/test_widgets.py
@@ -23,3 +23,13 @@ class TestTaggitSelect2Widget(ByteDeckTenantTestCase):
         widget = TaggitSelect2Widget(attrs={'data-minimum-input-length': '3'})
         output = widget.render('name', 'value')
         assert 'data-minimum-input-length="3"' in output
+
+    def test_options__splits_raw_comma_separated_string(self):
+        """A raw (unvalidated) comma-separated string is split into individual tag option values."""
+        widget = TaggitSelect2Widget()
+        self.assertEqual(list(widget.options('tags', 'alpha,beta')), ['alpha', 'beta'])
+
+    def test_options__skips_empty_values(self):
+        """Empty entries in the value list are skipped, yielding only the non-empty tag option values."""
+        widget = TaggitSelect2Widget()
+        self.assertEqual(list(widget.options('tags', ['', 'gamma'])), ['gamma'])


### PR DESCRIPTION
### What?

Next gap-closing PR. Covers the two untested branches in `TaggitSelect2Widget.options()` (`tags/widgets.py`), taking it to **100%** (full-suite).

### Why?

`options()` is the tag widget's option-value generator. Two of its branches were never exercised:
- the raw-input path that **splits an unvalidated comma-separated string** (hit when a form's data hasn't validated and the value arrives as a plain string), and
- the **skip for empty entries** in the value list.

### How?

Two direct tests added to `TestTaggitSelect2Widget`:
- passing `'alpha,beta'` (a raw string) yields `['alpha', 'beta']`,
- passing `['', 'gamma']` skips the empty entry and yields `['gamma']`.

### Testing?

- `python manage.py test tags.tests.test_widgets` → **7 passing** (+2 new); `ruff` clean; `test_conventions` passes.
- Full `tags` app (53 tests) green; with coverage, `tags/widgets.py` reaches **100%** in the full suite.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test.

Related, from the same coverage sweep: I filed **#2195** flagging `ProfileQuerySet.get_semester()` as dead + broken code (it filters a non-existent field `active_in_current_semester` and has no callers) — that's the blocker to `profile_manager/models.py` reaching 100%, so I flagged it for removal rather than writing a contrived test.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_