### PR TITLE
Cover ImageResource/VideoResource __str__ (utilities/models.py → 100%)

### DIFF
--- a/src/utilities/tests/test_models.py
+++ b/src/utilities/tests/test_models.py
@@ -1,0 +1,15 @@
+from django.test import SimpleTestCase
+
+from utilities.models import ImageResource, VideoResource
+
+
+class UtilitiesModelStrTest(SimpleTestCase):
+    """__str__ rendering for the utilities media models (ImageResource / VideoResource)."""
+
+    def test_image_resource_str__returns_name(self):
+        """ImageResource is represented by its name."""
+        self.assertEqual(str(ImageResource(name="School Logo")), "School Logo")
+
+    def test_video_resource_str__combines_title_and_file(self):
+        """VideoResource is represented as 'title: <video_file>' (empty file part when none is attached)."""
+        self.assertEqual(str(VideoResource(title="Intro")), "Intro: ")

--- a/src/utilities/tests/test_models.py
+++ b/src/utilities/tests/test_models.py
@@ -1,3 +1,4 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import SimpleTestCase
 
 from utilities.models import ImageResource, VideoResource
@@ -11,5 +12,10 @@ class UtilitiesModelStrTest(SimpleTestCase):
         self.assertEqual(str(ImageResource(name="School Logo")), "School Logo")
 
     def test_video_resource_str__combines_title_and_file(self):
-        """VideoResource is represented as 'title: <video_file>' (empty file part when none is attached)."""
+        """VideoResource is represented as 'title: <video_file>', including the filename when a file is attached."""
+        video = VideoResource(title="Intro", video_file=SimpleUploadedFile("intro.mp4", b"data"))
+        self.assertEqual(str(video), "Intro: intro.mp4")
+
+    def test_video_resource_str__empty_file_part_when_no_file(self):
+        """With no attached file, the file part of the representation is empty."""
         self.assertEqual(str(VideoResource(title="Intro")), "Intro: ")


### PR DESCRIPTION
### What?

Small gap-closing PR. Covers the two untested `__str__` methods in `utilities/models.py`, taking it to **100%**.

### Why?

`ImageResource.__str__` (returns its name) and `VideoResource.__str__` (returns `"title: <video_file>"`) had no test — the only remaining uncovered lines in the file.

### How?

New `utilities/tests/test_models.py` — a `SimpleTestCase` exercising both `__str__` methods on **unsaved** instances (no DB, no media files needed):

- `ImageResource(name="School Logo")` → `"School Logo"`.
- `VideoResource` with a deterministic attached file → `"Intro: intro.mp4"` (asserts the filename is included).
- `VideoResource` with no file → `"Intro: "` (empty file part).

### Testing?

- `python manage.py test utilities.tests.test_models` → **3 passing**; `ruff` clean; `test_conventions` passes.
- Full `utilities` app (66 tests) green; with coverage, `utilities/models.py` reaches **100%**.

### Screenshots (if front end is affected)

N/A — test-only.

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. The attached-file `VideoResource` assertion was added per CodeRabbit review feedback.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)