### PR TITLE
HOTFIX: Suspension lifecycle copy — owner-only sign-in, deletion countdown, Maintenance pitch, Bytedeck-signed emails

### DIFF
--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -9,10 +9,10 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
         <div class="alert alert-danger" id="deck-status-banner">
             <i class="fa fa-fw fa-ban"></i>
             {% if request.user.is_staff %}
-                <strong>This deck is suspended</strong> &mdash; its trial or subscription has ended: only the deck
+                <strong>This deck is suspended:</strong> its trial or subscription has ended. Only the deck
                 owner can sign in, and a deck suspended for 365 days may be permanently deleted.
-                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore access &mdash;
-                even the low-cost Maintenance subscription keeps the deck safe.
+                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore access
+                (even the low-cost Maintenance subscription keeps the deck safe).
             {% else %}
                 <strong>This deck is suspended.</strong> Only the deck owner can sign in until the deck has a
                 valid subscription.
@@ -32,7 +32,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
             <div class="alert {% if current_deck.days_until_expiry < 0 %}alert-danger{% else %}alert-warning{% endif %}" id="deck-status-banner">
                 <i class="fa fa-fw fa-exclamation-triangle"></i>
                 {% if current_deck.days_until_expiry < 0 %}
-                    <strong>Subscription expired</strong> &mdash; this deck is in its grace period, which ends in
+                    <strong>Subscription expired:</strong> this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
                     the deck will then be suspended (only the deck owner will be able to sign in).
                 {% elif current_deck.is_on_trial %}

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -9,11 +9,13 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
         <div class="alert alert-danger" id="deck-status-banner">
             <i class="fa fa-fw fa-ban"></i>
             {% if request.user.is_staff %}
-                <strong>This deck is suspended</strong> &mdash; its trial or subscription has ended, and it has
-                reverted to trial limits (max {{ current_deck.effective_max_active_users }} current student{{ current_deck.effective_max_active_users|pluralize }}).
-                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore full access.
+                <strong>This deck is suspended</strong> &mdash; its trial or subscription has ended: only the deck
+                owner can sign in, and a deck suspended for 365 days may be permanently deleted.
+                <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore access &mdash;
+                even the low-cost Maintenance subscription keeps the deck safe.
             {% else %}
-                <strong>This deck is suspended.</strong> Please let your teacher know.
+                <strong>This deck is suspended.</strong> Only the deck owner can sign in until the deck has a
+                valid subscription.
             {% endif %}
         </div>
     {% elif request.user.is_staff %}
@@ -32,7 +34,7 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
                 {% if current_deck.days_until_expiry < 0 %}
                     <strong>Subscription expired</strong> &mdash; this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
-                    it will then revert to trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).
+                    the deck will then be suspended (only the deck owner will be able to sign in).
                 {% elif current_deck.is_on_trial %}
                     <strong>Trial ending soon:</strong> this deck's free trial ends in
                     {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -53,6 +53,11 @@ GRACE_PERIOD_DAYS = 30
 # paid_until) is this many days away or closer (#1733's "2 week notice").
 EXPIRY_WARNING_DAYS = 14
 
+# A deck may be DELETED from the admin only once no staff member has signed in
+# for this long (#2044 retirement policy): a year of staff silence means the
+# deck is abandoned, not merely dormant over a summer or a leave.
+INACTIVE_DELETE_DAYS = 365
+
 
 class Tenant(TenantMixin):
     # for reference: https://django-tenants.readthedocs.io/en/stable/use.html#deleting-a-tenant

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -189,7 +189,7 @@ def _deliver(deck, kind):
     """Send one notice through both channels: owner email + in-app notification."""
     from django.utils.timezone import timedelta
 
-    from tenant.models import GRACE_PERIOD_DAYS
+    from tenant.models import GRACE_PERIOD_DAYS, INACTIVE_DELETE_DAYS
 
     from tenant.tasks import send_email_message
 
@@ -202,6 +202,12 @@ def _deliver(deck, kind):
         last_covered_days.append(deck.trial_end_date)
     if deck.paid_until:
         last_covered_days.append(deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS))
+    # is_suspended requires at least one date field, so the list is never empty here
+    suspended_since = max(last_covered_days) + timedelta(days=1) if deck.is_suspended else None
+    # the scheduled deletion day under the suspension policy -- INACTIVE_DELETE_DAYS
+    # after the suspension began; the suspended email LEADS with it (maintainer
+    # request, 2026-07-30: put the bottom line up front)
+    deletion_date = suspended_since + timedelta(days=INACTIVE_DELETE_DAYS) if suspended_since else None
     context = {
         'deck': deck,
         'config': config,
@@ -219,8 +225,9 @@ def _deliver(deck, kind):
         'grace_end_date': deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS) if deck.paid_until else None,
         'grace_days_left': deck.grace_days_remaining,
         'expired_days_ago': -days if days is not None and days < 0 else None,
-        # is_suspended requires at least one date field, so the list is never empty here
-        'suspended_since': max(last_covered_days) + timedelta(days=1) if deck.is_suspended else None,
+        'suspended_since': suspended_since,
+        'deletion_date': deletion_date,
+        'deletion_days_left': (deletion_date - localdate()).days if deletion_date else None,
         # the deck's own staff-facing subscription page (PR 6) -- emails go to the
         # deck owner, who is staff; the page falls back to the public subscribe
         # flatpage when Stripe isn't configured

--- a/src/tenant/templates/tenant/email/_email_footer.html
+++ b/src/tenant/templates/tenant/email/_email_footer.html
@@ -1,0 +1,10 @@
+{% load utility_tags %}
+{# shared closing block for every subscription lifecycle email (maintainer requests, 2026-07-30): #}
+{# the non-profit Society note, a contact address for questions, and a fixed "Bytedeck" sign-off -- #}
+{# billing emails come from the platform, so they are signed Bytedeck rather than the deck's name. #}
+<p><em>Bytedeck is a non-profit Society. The board members are volunteers, and put many hours into
+  running and further developing Bytedeck. Our subscription pricing is competitive, and funds are
+  only utilized for maintaining systems and development.</em></p>
+<p>If you have any questions, contact us at <a href="mailto:contact@bytedeck.com">contact@bytedeck.com</a>.</p>
+<p>Bytedeck</p>
+<p><img alt="[Logo]" src="{% site_logo_url %}"></p>

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -1,4 +1,3 @@
-{% load utility_tags %}
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
 {% if days >= 0 %}
@@ -6,15 +5,17 @@
   {% if deck.is_on_trial %}free trial ends{% else %}subscription expires{% endif %}
   on <strong>{% if deck.is_on_trial %}{{ deck.trial_end_date }}{% else %}{{ deck.paid_until }}{% endif %}</strong>
   &mdash; <strong>{{ days }} day{{ days|pluralize }}</strong> from now.
-  {% if not deck.is_on_trial %}After that, a {{ grace_days }}-day grace period keeps full access until
-  <strong>{{ grace_end_date }}</strong>; the deck then reverts to trial limits
-  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).{% endif %}</p>
+  {% if deck.is_on_trial %}When the trial ends, the deck is suspended: only the deck owner can sign in,
+  and the 365-day countdown to deck deletion begins.{% else %}After that, a {{ grace_days }}-day grace
+  period keeps full access until <strong>{{ grace_end_date }}</strong>; the deck is then suspended:
+  only the deck owner can sign in, and the 365-day countdown to deck deletion begins.{% endif %}</p>
 {% else %}
 <p>Your deck <strong>{{ deck.name }}</strong>'s subscription expired on
   <strong>{{ deck.paid_until }}</strong> ({{ expired_days_ago }} day{{ expired_days_ago|pluralize }} ago)
   and is in its {{ grace_days }}-day grace period, which ends on <strong>{{ grace_end_date }}</strong>
   ({{ grace_days_left }} day{{ grace_days_left|pluralize }} left). When the grace period ends, the deck
-  will revert to trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
+  will be suspended: only the deck owner will be able to sign in, and the 365-day countdown to deck
+  deletion begins.</p>
 {% endif %}
 
 <p>You are currently using <strong>{{ count }}</strong> of
@@ -26,5 +27,8 @@
   this semester &mdash; count toward your limit; see
   <a href="{{ archive_help_url }}">freeing up student seats</a>.</p>
 
-<p>{% firstof config.outgoing_email_signature config.site_name %}</p>
-<p><img alt="[Logo]" src="{% site_logo_url %}"></p>
+<p>Not planning to use the deck for a while? The low-cost <em>Maintenance</em> subscription keeps it
+  online with trial-level limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}) and
+  stops it from ever being deleted.</p>
+
+{% include "tenant/email/_email_footer.html" %}

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -4,7 +4,7 @@
 <p>Your deck <strong>{{ deck.name }}</strong>'s
   {% if deck.is_on_trial %}free trial ends{% else %}subscription expires{% endif %}
   on <strong>{% if deck.is_on_trial %}{{ deck.trial_end_date }}{% else %}{{ deck.paid_until }}{% endif %}</strong>
-  &mdash; <strong>{{ days }} day{{ days|pluralize }}</strong> from now.
+  (<strong>{{ days }} day{{ days|pluralize }}</strong> from now).
   {% if deck.is_on_trial %}When the trial ends, the deck is suspended: only the deck owner can sign in,
   and the 365-day countdown to deck deletion begins.{% else %}After that, a {{ grace_days }}-day grace
   period keeps full access until <strong>{{ grace_end_date }}</strong>; the deck is then suspended:
@@ -23,8 +23,8 @@
   seat{{ cap|pluralize }}.</p>
 
 <p><a href="{{ subscribe_url }}">Subscribe or renew here</a> to keep full access.
-  Questions about which students count? Only <em>current</em> students &mdash; those registered in a course
-  this semester &mdash; count toward your limit; see
+  Questions about which students count? Only <em>current</em> students (those registered in a course
+  this semester) count toward your limit; see
   <a href="{{ archive_help_url }}">freeing up student seats</a>.</p>
 
 <p>Not planning to use the deck for a while? The low-cost <em>Maintenance</em> subscription keeps it

--- a/src/tenant/templates/tenant/email/limit_warning.html
+++ b/src/tenant/templates/tenant/email/limit_warning.html
@@ -1,8 +1,7 @@
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
 <p>Your deck <strong>{{ deck.name }}</strong> has <strong>{{ count }}</strong> current
-  student{{ count|pluralize }} of <strong>{{ cap }}</strong> allowed
-  {% if count >= cap %}&mdash; the limit has been reached, so no more students can register in a course.{% else %}&mdash; you're approaching the limit.{% endif %}</p>
+  student{{ count|pluralize }} of <strong>{{ cap }}</strong> allowed{% if count >= cap %}: the limit has been reached, so no more students can register in a course.{% else %}: you're approaching the limit.{% endif %}</p>
 
 {% if deck.subscription_active %}
 <p>Your deck's subscription is paid through <strong>{{ deck.paid_until }}</strong>.</p>

--- a/src/tenant/templates/tenant/email/limit_warning.html
+++ b/src/tenant/templates/tenant/email/limit_warning.html
@@ -1,4 +1,3 @@
-{% load utility_tags %}
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
 <p>Your deck <strong>{{ deck.name }}</strong> has <strong>{{ count }}</strong> current
@@ -15,5 +14,4 @@
   students never do. You can <a href="{{ archive_help_url }}">free up seats</a> by ending the semester or
   archiving past students, or <a href="{{ subscribe_url }}">upgrade your subscription</a> for a higher limit.</p>
 
-<p>{% firstof config.outgoing_email_signature config.site_name %}</p>
-<p><img alt="[Logo]" src="{% site_logo_url %}"></p>
+{% include "tenant/email/_email_footer.html" %}

--- a/src/tenant/templates/tenant/email/suspended_notice.html
+++ b/src/tenant/templates/tenant/email/suspended_notice.html
@@ -2,8 +2,8 @@
 
 {# the deck link stays OUTSIDE the <strong>: textify/html2text swallows the space before a link that opens inside one #}
 <p>Your deck <a href="{{ deck.get_root_url }}">{{ deck.name }}</a> is <strong>scheduled for deletion
-  on {{ deletion_date }}{% if deletion_days_left and deletion_days_left > 0 %} &mdash;
-  {{ deletion_days_left }} day{{ deletion_days_left|pluralize }} from now{% endif %}</strong>,
+  on {{ deletion_date }}{% if deletion_days_left and deletion_days_left > 0 %}
+  ({{ deletion_days_left }} day{{ deletion_days_left|pluralize }} from now){% endif %}</strong>,
   unless it gets a valid subscription before then.</p>
 
 <p>The deck has been <strong>suspended</strong>{% if suspended_since %}
@@ -11,12 +11,12 @@
   {% if deck.paid_until %}(its subscription was paid through {{ deck.paid_until }}, and the
   {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.trial_end_date %}(its
   free trial ended on {{ deck.trial_end_date }}){% endif %}: only the deck owner can sign in until the
-  deck has a valid subscription. Nothing has been deleted yet &mdash; your content and student data
+  deck has a valid subscription. Nothing has been deleted yet: your content and student data
   are intact until the deletion date above.</p>
 
-<p><a href="{{ subscribe_url }}">Subscribe here</a> to restore access &mdash; any level works, including
+<p><a href="{{ subscribe_url }}">Subscribe here</a> to restore access: any level works, including
   the low-cost <em>Maintenance</em> subscription, which keeps the deck online with trial-level limits
-  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}) and stops the deletion countdown &mdash;
-  ideal if you just want to keep the deck for later.</p>
+  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}) and stops the deletion countdown
+  (ideal if you just want to keep the deck for later).</p>
 
 {% include "tenant/email/_email_footer.html" %}

--- a/src/tenant/templates/tenant/email/suspended_notice.html
+++ b/src/tenant/templates/tenant/email/suspended_notice.html
@@ -1,20 +1,16 @@
-{% load utility_tags %}
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
 <p>Your deck <strong>{{ deck.name }}</strong> has been <strong>suspended</strong>{% if suspended_since %}
   since <strong>{{ suspended_since }}</strong>{% endif %}
   {% if deck.paid_until %}(its subscription was paid through {{ deck.paid_until }}, and the
   {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.trial_end_date %}(its
-  free trial ended on {{ deck.trial_end_date }}){% endif %}: it has reverted to trial limits
-  (max {{ cap }} current student{{ cap|pluralize }}). Existing students keep their access and nothing has
-  been deleted, but no new students can register in a course beyond the trial limit.</p>
+  free trial ended on {{ deck.trial_end_date }}){% endif %}: only the deck owner can sign in until the
+  deck has a valid subscription, and a deck suspended for 365 days may be permanently deleted.
+  Nothing has been deleted &mdash; your content and student data are intact.</p>
 
-<p>You are currently using <strong>{{ count }}</strong> of
-  <strong>{% if cap == -1 %}unlimited{% else %}{{ cap }}{% endif %}</strong> current student
-  seat{{ cap|pluralize }}.</p>
+<p><a href="{{ subscribe_url }}">Subscribe here</a> to restore access &mdash; any level works, including
+  the low-cost <em>Maintenance</em> subscription, which keeps the deck online with trial-level limits
+  (max {{ trial_cap }} current student{{ trial_cap|pluralize }}) and stops the deletion countdown &mdash;
+  ideal if you just want to keep the deck for later.</p>
 
-<p><a href="{{ subscribe_url }}">Subscribe here</a> to restore full access, or
-  <a href="{{ archive_help_url }}">free up seats</a> if you're winding the deck down.</p>
-
-<p>{% firstof config.outgoing_email_signature config.site_name %}</p>
-<p><img alt="[Logo]" src="{% site_logo_url %}"></p>
+{% include "tenant/email/_email_footer.html" %}

--- a/src/tenant/templates/tenant/email/suspended_notice.html
+++ b/src/tenant/templates/tenant/email/suspended_notice.html
@@ -1,12 +1,18 @@
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
-<p>Your deck <strong>{{ deck.name }}</strong> has been <strong>suspended</strong>{% if suspended_since %}
+{# the deck link stays OUTSIDE the <strong>: textify/html2text swallows the space before a link that opens inside one #}
+<p>Your deck <a href="{{ deck.get_root_url }}">{{ deck.name }}</a> is <strong>scheduled for deletion
+  on {{ deletion_date }}{% if deletion_days_left and deletion_days_left > 0 %} &mdash;
+  {{ deletion_days_left }} day{{ deletion_days_left|pluralize }} from now{% endif %}</strong>,
+  unless it gets a valid subscription before then.</p>
+
+<p>The deck has been <strong>suspended</strong>{% if suspended_since %}
   since <strong>{{ suspended_since }}</strong>{% endif %}
   {% if deck.paid_until %}(its subscription was paid through {{ deck.paid_until }}, and the
   {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.trial_end_date %}(its
   free trial ended on {{ deck.trial_end_date }}){% endif %}: only the deck owner can sign in until the
-  deck has a valid subscription, and a deck suspended for 365 days may be permanently deleted.
-  Nothing has been deleted &mdash; your content and student data are intact.</p>
+  deck has a valid subscription. Nothing has been deleted yet &mdash; your content and student data
+  are intact until the deletion date above.</p>
 
 <p><a href="{{ subscribe_url }}">Subscribe here</a> to restore access &mdash; any level works, including
   the low-cost <em>Maintenance</em> subscription, which keeps the deck online with trial-level limits

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -10,13 +10,13 @@
 {% if deck.is_suspended %}
   <p><span class="label label-danger">Suspended</span>
     This deck's trial and/or subscription period has ended: only the deck owner can sign in, and a deck
-    suspended for 365 days may be permanently deleted. Nothing has been deleted yet &mdash; subscribe
+    suspended for 365 days may be permanently deleted. Nothing has been deleted yet: subscribe
     (any level, including the low-cost Maintenance subscription) to restore access.</p>
 {% elif deck.in_grace_period %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
   <p><span class="label label-danger">Grace period</span>
     The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
-    {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise the deck will be
+    {{ grace_days }}-day grace period: renew to keep full access; otherwise the deck will be
     suspended (only the deck owner will be able to sign in, and the 365-day countdown to deck
     deletion begins).</p>
 {% elif deck.is_on_maintenance %}
@@ -49,7 +49,7 @@
   {% elif deck.trial_end_date %}
     <tr><th>Trial ends</th><td>{{ deck.trial_end_date }} ({{ trial_end_phrase }})</td></tr>
   {% else %}
-    <tr><th>Expires</th><td>Never &mdash; this deck is managed manually</td></tr>
+    <tr><th>Expires</th><td>Never (this deck is managed manually)</td></tr>
   {% endif %}
 </table>
 
@@ -70,10 +70,10 @@
 </table>
 {% if cap != -1 and current_student_count >= cap %}
   <p class="text-danger"><i class="fa fa-exclamation-triangle"></i>
-    The limit has been reached &mdash; no more students can register in a course.</p>
+    The limit has been reached: no more students can register in a course.</p>
 {% endif %}
 <p>
-  Only <em>current</em> students &mdash; those registered in a course in the active semester &mdash; count
+  Only <em>current</em> students (those registered in a course in the active semester) count
   toward the limit; staff and archived students never do. See
   <a href="{% url 'courses:archive_students_help' %}">freeing up student seats</a>.
 </p>
@@ -81,23 +81,23 @@
 <h3>How subscriptions work</h3>
 {# the full lifecycle, so an owner always knows what happens next (maintainer request, 2026-07-30) #}
 <ol>
-  <li><strong>Valid subscription</strong> &mdash; full use of the deck at your subscription level.</li>
-  <li><strong>Grace period</strong> &mdash; when a subscription expires, everything keeps working as
+  <li><strong>Valid subscription:</strong> full use of the deck at your subscription level.</li>
+  <li><strong>Grace period:</strong> when a subscription expires, everything keeps working as
     before for {{ grace_days }} more days while you renew.</li>
-  <li><strong>Suspension</strong> &mdash; after the grace period (or when a free trial ends), the deck
-    is suspended: only the deck owner can sign in, and the 365-day countdown to deck deletion begins.
+  <li><strong>Suspension:</strong> after the grace period (or when a free trial ends), the deck
+    is suspended. Only the deck owner can sign in, and the 365-day countdown to deck deletion begins.
     Content and student data stay intact.</li>
-  <li><strong>Deletion</strong> &mdash; a deck with no valid subscription for 365 days may be
+  <li><strong>Deletion:</strong> a deck with no valid subscription for 365 days may be
     permanently deleted.</li>
 </ol>
 <p>Not using the deck right now? The low-cost <strong>Maintenance</strong> subscription keeps it online
   indefinitely with trial-level limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }})
-  &mdash; ideal for building or testing between active use &mdash; and stops the deletion countdown.</p>
+  and stops the deletion countdown (ideal for building or testing between active use).</p>
 
 <h3>Upgrade or renew</h3>
 {% if stripe_configured %}
   {% if manually_subscribed %}
-    <p>This deck's subscription is <strong>managed manually</strong> &mdash; starting a new online
+    <p>This deck's subscription is <strong>managed manually</strong>: starting a new online
       subscription here would double-bill you. Contact ByteDeck to renew, upgrade, or switch this
       deck to online billing.</p>
   {% else %}
@@ -117,7 +117,7 @@
   </p>
   {% endif %}
 {% else %}
-  <p>Online billing isn't configured on this server &mdash;
+  <p>Online billing isn't configured on this server:
     <a href="{{ public_subscribe_url }}" class="btn btn-primary">
       <i class="fa fa-credit-card"></i>&nbsp;Subscribe, renew, or upgrade
     </a>

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -9,15 +9,16 @@
 <h3>Status</h3>
 {% if deck.is_suspended %}
   <p><span class="label label-danger">Suspended</span>
-    This deck's trial and/or subscription period has ended, so it has reverted to trial limits
-    (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}). Existing students keep their access and
-    nothing has been deleted, but no new students can register in a course beyond the trial limit.</p>
+    This deck's trial and/or subscription period has ended: only the deck owner can sign in, and a deck
+    suspended for 365 days may be permanently deleted. Nothing has been deleted yet &mdash; subscribe
+    (any level, including the low-cost Maintenance subscription) to restore access.</p>
 {% elif deck.in_grace_period %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
   <p><span class="label label-danger">Grace period</span>
     The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
-    {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise it will revert to
-    trial limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }}).</p>
+    {{ grace_days }}-day grace period &mdash; renew to keep full access; otherwise the deck will be
+    suspended (only the deck owner will be able to sign in, and the 365-day countdown to deck
+    deletion begins).</p>
 {% elif deck.is_on_maintenance %}
   <p><span class="label label-primary">Maintenance</span>
     This deck is on a maintenance subscription through <strong>{{ deck.paid_until }}</strong>
@@ -76,6 +77,22 @@
   toward the limit; staff and archived students never do. See
   <a href="{% url 'courses:archive_students_help' %}">freeing up student seats</a>.
 </p>
+
+<h3>How subscriptions work</h3>
+{# the full lifecycle, so an owner always knows what happens next (maintainer request, 2026-07-30) #}
+<ol>
+  <li><strong>Valid subscription</strong> &mdash; full use of the deck at your subscription level.</li>
+  <li><strong>Grace period</strong> &mdash; when a subscription expires, everything keeps working as
+    before for {{ grace_days }} more days while you renew.</li>
+  <li><strong>Suspension</strong> &mdash; after the grace period (or when a free trial ends), the deck
+    is suspended: only the deck owner can sign in, and the 365-day countdown to deck deletion begins.
+    Content and student data stay intact.</li>
+  <li><strong>Deletion</strong> &mdash; a deck with no valid subscription for 365 days may be
+    permanently deleted.</li>
+</ol>
+<p>Not using the deck right now? The low-cost <strong>Maintenance</strong> subscription keeps it online
+  indefinitely with trial-level limits (max {{ trial_cap }} current student{{ trial_cap|pluralize }})
+  &mdash; ideal for building or testing between active use &mdash; and stops the deletion countdown.</p>
 
 <h3>Upgrade or renew</h3>
 {% if stripe_configured %}

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -456,3 +456,39 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         # billing emails are signed by the platform, never the deck (maintainer request, 2026-07-30)
         self.assertIn('<p>Bytedeck</p>', html)
         self.assertIn('alt="[Logo]"', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__suspended_email_paid_clock_and_overdue_countdown(self):
+        """A deck suspended after a PAID subscription lapsed explains the paid
+        clock (paid-through and grace-end dates) in its suspension email, with the
+        bottom line carried by the plain-text part too; a deck already suspended
+        past the deletion horizon still shows its (past) scheduled deletion date
+        but drops the "days from now" countdown."""
+        # paid clock: paid through Jul 6, grace ends Aug 5 -> suspended Aug 6, 2026
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=None, paid_until=TODAY - timedelta(days=40),
+            max_active_users=5, active_user_count=0,
+        )
+        self.tenant.refresh_from_db()
+
+        summary = self.run_engine_with_inline_email()
+        self.assertEqual(len(mail.outbox), 1, summary)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('subscription was paid through July 6, 2026', html)
+        self.assertIn('grace period ended on Aug. 5, 2026', html)
+        self.assertIn('scheduled for deletion on Aug. 6, 2027', html)
+        self.assertIn('356 days from now', html)
+        body = mail.outbox[0].body.replace('\n', ' ')  # textify hard-wraps lines
+        self.assertIn('scheduled for deletion on Aug. 6, 2027', body)
+
+        # overdue: suspended Aug 11, 2025 -> deletion day Aug 11, 2026 already passed,
+        # so the date still shows but no "days from now" countdown is promised
+        mail.outbox.clear()
+        Tenant.objects.filter(pk=self.tenant.pk).update(paid_until=TODAY - timedelta(days=400))
+        self.tenant.refresh_from_db()
+
+        summary = self.run_engine_with_inline_email()
+        self.assertEqual(len(mail.outbox), 1, summary)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('scheduled for deletion on Aug. 11, 2026', html)
+        self.assertNotIn('days from now', html)

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -438,12 +438,17 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('suspended', summary)
         self.assertEqual(len(mail.outbox), 1, summary)
         html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        # the bottom line LEADS (maintainer request, 2026-07-30): the scheduled
+        # deletion date (suspension start + 365 days) with the countdown, and the
+        # deck name links to the deck itself
+        self.assertIn('scheduled for deletion on Aug. 2, 2027', html)
+        self.assertIn('352 days from now', html)  # frozen TODAY Aug 15, 2026 -> Aug 2, 2027
+        self.assertIn(f'<a href="{self.tenant.get_root_url()}">', html)
         self.assertIn('since <strong>Aug. 2, 2026</strong>', html)
         self.assertIn('free trial ended on Aug. 1, 2026', html)
-        # the new suspension rules (redesign, 2026-07-30): owner-only sign-in, the
-        # deletion countdown, data intact, and the Maintenance escape hatch
+        # the new suspension rules (redesign, 2026-07-30): owner-only sign-in,
+        # data intact, and the Maintenance escape hatch
         self.assertIn('only the deck owner can sign in', html)
-        self.assertIn('suspended for 365 days', html)
         self.assertIn('your content and student data are intact', html)
         self.assertIn('<em>Maintenance</em> subscription', html)
         self.assertIn('non-profit Society', html)  # every subscription email carries the Society blurb

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -359,10 +359,11 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertTrue(Notification.objects.filter(recipient=owner, verb__contains='limit warning').exists())
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__grace_period_email_states_the_trial_cap(self):
-        """The grace-period expiry email tells the owner what the deck will revert to:
-        the TRIAL cap (5), not the deck's current (still-paid) cap -- during grace the
-        effective cap is the paid one, so the template can't derive this from `cap`."""
+    def test_process__grace_period_email_states_suspension_ahead(self):
+        """The grace-period expiry email tells the owner what follows the grace
+        window: suspension, with only the deck owner able to sign in and the
+        365-day deletion countdown starting (suspension redesign, 2026-07-30) --
+        checked on the plain-text part, which must carry the same message."""
         Tenant.objects.filter(pk=self.tenant.pk).update(
             trial_end_date=None, paid_until=TODAY - timedelta(days=5),  # expired, in grace
             max_active_users=30, active_user_count=0,  # paid cap 30; no limit notice due
@@ -374,7 +375,9 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 1)
         body = mail.outbox[0].body.replace('\n', ' ')  # textify hard-wraps lines
         self.assertIn('grace period', body)
-        self.assertIn('max 5 current students', body)
+        self.assertIn('the deck will be suspended', body)
+        self.assertIn('only the deck owner will be able to sign in', body)
+        self.assertIn('365-day countdown to deck deletion', body)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__grace_email_includes_dates_seats_and_logo(self):
@@ -397,6 +400,8 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('Sept. 9, 2026', html)   # grace ends paid_until + 30 days...
         self.assertIn('25 days left', html)    # ...with the countdown
         self.assertIn('using <strong>2</strong> of <strong>30</strong> current student', ' '.join(html.split()))
+        self.assertIn('non-profit Society', html)  # every subscription email carries the Society blurb
+        self.assertIn('contact@bytedeck.com', html)  # ...and a contact address for questions
         self.assertIn('alt="[Logo]"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
@@ -413,6 +418,8 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 1)
         html = mail.outbox[0].alternatives[0][0]
         self.assertIn('limit has been reached', html)
+        self.assertIn('non-profit Society', html)  # every subscription email carries the Society blurb
+        self.assertIn('contact@bytedeck.com', html)  # ...and a contact address for questions
         self.assertIn('alt="[Logo]"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
@@ -433,4 +440,14 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         html = ' '.join(mail.outbox[0].alternatives[0][0].split())
         self.assertIn('since <strong>Aug. 2, 2026</strong>', html)
         self.assertIn('free trial ended on Aug. 1, 2026', html)
+        # the new suspension rules (redesign, 2026-07-30): owner-only sign-in, the
+        # deletion countdown, data intact, and the Maintenance escape hatch
+        self.assertIn('only the deck owner can sign in', html)
+        self.assertIn('suspended for 365 days', html)
+        self.assertIn('your content and student data are intact', html)
+        self.assertIn('<em>Maintenance</em> subscription', html)
+        self.assertIn('non-profit Society', html)  # every subscription email carries the Society blurb
+        self.assertIn('contact@bytedeck.com', html)  # ...and a contact address for questions
+        # billing emails are signed by the platform, never the deck (maintainer request, 2026-07-30)
+        self.assertIn('<p>Bytedeck</p>', html)
         self.assertIn('alt="[Logo]"', html)

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -632,8 +632,9 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
 
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'This deck is suspended')
-        self.assertContains(response, 'only the deck')  # owner-only sign-in rule
-        self.assertContains(response, 'suspended for 365 days')  # deletion countdown
+        text = ' '.join(response.content.decode().split())  # template line-wraps mid-phrase
+        self.assertIn('Only the deck owner can sign in', text)  # owner-only sign-in rule
+        self.assertIn('suspended for 365 days', text)  # deletion countdown
         self.assertContains(response, 'fa-ban')  # danger-level banner icon
         self.assertContains(response, reverse('decks:subscription'))
 
@@ -882,7 +883,7 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'Suspension')
         self.assertContains(response, 'Deletion')
         text = ' '.join(response.content.decode().split())
-        self.assertIn('only the deck owner can sign in, and the 365-day countdown to deck deletion begins', text)
+        self.assertIn('Only the deck owner can sign in, and the 365-day countdown to deck deletion begins', text)
         self.assertIn('max 5 current students', text)  # the Maintenance pitch states the trial cap
 
     def test_page__maintenance_subscription_gets_its_own_status(self):

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -619,18 +619,21 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.assertNotContains(response, 'deck-status-banner')
 
     def test_banner__suspended_deck_warns_everyone(self):
-        """On a suspended deck, staff get the subscribe call-to-action and students
-        get the 'let your teacher know' variant."""
+        """On a suspended deck, staff get the subscribe call-to-action (with the
+        owner-only sign-in rule and the 365-day deletion countdown), and students
+        are told only the deck owner can sign in (suspension redesign, 2026-07-30)."""
         from datetime import date
 
         self.set_deck(trial_end_date=date(2020, 1, 1), paid_until=None)
 
         response = self.get_quests_page(self.student)
         self.assertContains(response, 'This deck is suspended')
-        self.assertContains(response, 'let your teacher know')
+        self.assertContains(response, 'Only the deck owner can sign in')
 
         response = self.get_quests_page(self.staff)
         self.assertContains(response, 'This deck is suspended')
+        self.assertContains(response, 'only the deck')  # owner-only sign-in rule
+        self.assertContains(response, 'suspended for 365 days')  # deletion countdown
         self.assertContains(response, 'fa-ban')  # danger-level banner icon
         self.assertContains(response, reverse('decks:subscription'))
 
@@ -670,13 +673,11 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
     def test_banner__expired_grace_deck_gets_danger_styling_and_grace_copy(self):
         """A deck past paid_until (in grace) gets the DANGER (red) banner -- not the
         approaching-deadline warning style -- and the copy states when the grace
-        period ends and that the deck then reverts to the trial cap (maintainer
-        requests from staging live testing)."""
+        period ends and that the deck will then be suspended with only the owner
+        able to sign in (suspension redesign, 2026-07-30)."""
         from datetime import timedelta
 
         from django.utils.timezone import localdate
-
-        from tenant.models import TRIAL_MAX_ACTIVE_USERS
 
         self.set_deck(trial_end_date=None, paid_until=localdate() - timedelta(days=10))
         response = self.get_quests_page(self.staff)
@@ -685,7 +686,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'fa-exclamation-triangle')  # banner level icon (review request)
         text = ' '.join(response.content.decode().split())
         self.assertIn('which ends in 20 days', text)
-        self.assertIn(f'revert to trial limits (max {TRIAL_MAX_ACTIVE_USERS} current students)', text)
+        self.assertIn('the deck will then be suspended (only the deck owner will be able to sign in)', text)
         # the approaching-deadline variants keep the warning style
         self.set_deck(paid_until=localdate() + timedelta(days=3))
         self.assertContains(self.get_quests_page(self.staff), 'alert-warning')
@@ -835,10 +836,11 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.set_deck(max_active_users=-1)
         self.assertIsNone(self.get_page().context['remaining_seats'])
 
-    def test_page__grace_period_states_trial_cap(self):
+    def test_page__grace_period_states_suspension_ahead(self):
         """A deck in its paid grace window gets its own DANGER "Grace period" label --
         never the green "Subscribed" badge (maintainer review find) -- and explains
-        the trial cap it will revert to (5), not its current paid cap."""
+        what follows: suspension, with only the deck owner able to sign in and the
+        deletion countdown starting (suspension redesign, 2026-07-30)."""
         from datetime import timedelta
 
         from django.utils.timezone import localdate
@@ -848,23 +850,40 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'Grace period</span>')
         self.assertContains(response, 'label-danger')
         self.assertNotContains(response, 'Subscribed')
-        self.assertContains(response, 'grace period')
-        self.assertContains(response, 'max 5 current students')
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('otherwise the deck will be suspended (only the deck owner will be able to sign in, '
+                      'and the 365-day countdown to deck deletion begins)', text)
 
-    def test_page__suspended_deck_shows_its_admin_cap(self):
-        """A suspended deck shows its ADMIN-SET cap -- in the status copy and the
-        seats table -- whatever it is: the field is authoritative (the trial
-        default is written into it once per suspension by the nightly task, and
-        admin adjustments stick). Production find, 2026-07-24: a cap lowered to 1
-        still showed and enforced 'max 5' everywhere."""
+    def test_page__suspended_deck_states_owner_only_and_deletion_countdown(self):
+        """A suspended deck's status copy states the new suspension rules -- only
+        the deck owner can sign in, and the 365-day deletion countdown -- while
+        the seats table still shows the ADMIN-SET cap, whatever it is (the field
+        stays authoritative; production find, 2026-07-24)."""
         from datetime import date
 
         self.set_deck(trial_end_date=date(2020, 1, 1), paid_until=None, max_active_users=1)
         response = self.get_page()
-        self.assertContains(response, 'max 1 current student')
-        self.assertNotContains(response, 'max 5 current students')
+        self.assertContains(response, 'only the deck owner can sign in')
+        self.assertContains(response, 'suspended for 365 days')
+        # page status copy specifically (the banner says similar things): data intact + how to restore
+        self.assertContains(response, 'Nothing has been deleted yet')
         text = ' '.join(response.content.decode().split())
         self.assertIn('<th>Maximum allowed</th> <td>1</td>', text)
+
+    def test_page__lifecycle_overview_lists_every_stage(self):
+        """The "How subscriptions work" section walks the owner through the whole
+        lifecycle -- valid subscription, grace period, suspension (owner-only
+        sign-in + deletion countdown), deletion -- and pitches the Maintenance
+        subscription as the keep-it-safe option (maintainer request, 2026-07-30)."""
+        response = self.get_page()
+        self.assertContains(response, 'How subscriptions work')
+        self.assertContains(response, 'Valid subscription')
+        self.assertContains(response, 'Grace period')
+        self.assertContains(response, 'Suspension')
+        self.assertContains(response, 'Deletion')
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('only the deck owner can sign in, and the 365-day countdown to deck deletion begins', text)
+        self.assertIn('max 5 current students', text)  # the Maintenance pitch states the trial cap
 
     def test_page__maintenance_subscription_gets_its_own_status(self):
         """A paid deck whose cap sits at the trial limit is on MAINTENANCE: its own
@@ -873,7 +892,7 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         the Subscribed status."""
         self.set_deck(max_active_users=5)  # paid 100 days out from setUp
         response = self.get_page()
-        self.assertContains(response, 'Maintenance')
+        self.assertContains(response, 'Maintenance</span>')  # the status label itself
         self.assertContains(response, 'maintenance subscription')
         self.assertContains(response, 'capped at the trial limit')
         self.assertContains(response, 'max 5 current students')
@@ -882,7 +901,8 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.set_deck(max_active_users=30)
         response = self.get_page()
         self.assertContains(response, 'Subscribed')
-        self.assertNotContains(response, 'Maintenance')
+        # the lifecycle overview always PITCHES Maintenance, so pin the status label only
+        self.assertNotContains(response, 'Maintenance</span>')
 
     def test_page__trial_suspended_and_manual_states(self):
         """The status section adapts to trial, suspended, and never-expires decks."""


### PR DESCRIPTION
### What?
Copy-only corrections for the redesigned suspension model, so every user-facing surface states the **new** lifecycle instead of the old "reverted to trial limits" story:

* **Deck status banner**: suspended copy now states the real rules for both audiences. Staff/owner see "Only the deck owner can sign in, and a deck suspended for 365 days may be permanently deleted" with the Subscribe link (and a Maintenance mention); students and **non-authenticated visitors** (e.g. on the sign-in page) see "Only the deck owner can sign in until the deck has a valid subscription" instead of "Please let your teacher know". The grace-period banner now warns that the deck "will then be suspended (only the deck owner will be able to sign in)" instead of promising trial limits.
* **Subscription details page**: the Suspended and Grace period statuses restated the same way, plus a new **"How subscriptions work"** section that walks the owner through the whole lifecycle (valid subscription, 30-day grace period, suspension with owner-only sign-in and the 365-day deletion countdown, deletion), with the low-cost **Maintenance** subscription pitched as the keep-it-safe option.
* **Notice emails** (expiry reminder, limit warning, suspended notice): same lifecycle corrections, a Maintenance pitch where relevant, and a shared footer (`_email_footer.html`) on every subscription email: the **non-profit Society note**, a **contact line** (contact@bytedeck.com) for questions, and a fixed **"Bytedeck" sign-off** (billing emails come from the platform, so they no longer sign off with the local deck's name).
* **Suspended email leads with the bottom line**: it now opens with "Your deck *name* is **scheduled for deletion on \<date\> (N days from now)**, unless it gets a valid subscription before then", with the deck name linking to the deck itself (maintainer follow-up, 2026-07-30). The scheduled deletion date (suspension start + 365 days) and countdown join the notice context as `deletion_date` / `deletion_days_left`.
* **No em dashes anywhere in the copy** (maintainer follow-up, 2026-07-30): every em dash in these files (including pre-existing ones) is replaced with a colon for substatements or (brackets) for parentheticals. The companion CLAUDE.md guideline ships separately as #2208.

### Why?
Maintainer decision (2026-07-30): a suspended deck should **not** operate in "trial mode". The new model is owner-only sign-in, the open semester gets closed, and the 365-day deletion countdown starts; the trial-style 5-student cap now belongs to the **Maintenance** tier instead. The goal of this hotfix is that the *information* shown to users is correct in production **now**; the enforcement automation (owner-only login middleware, semester auto-close, deletion clock keyed to the suspension date, grace period for trials) follows as a feature on `develop`.

### How?
Templates plus two new email-context values (`deletion_date`, `deletion_days_left` in `tenant/notices.py`); no model, view, or task behavior changes:
* `src/templates/deck_status_banner.html`: suspended (both variants) + grace copy.
* `src/tenant/templates/tenant/subscription_detail.html`: Suspended/Grace statuses + the new "How subscriptions work" section.
* `src/tenant/templates/tenant/email/{expiry_reminder,limit_warning,suspended_notice}.html` + new shared `_email_footer.html` include (Society note, contact line, Bytedeck sign-off, logo) replacing the per-deck `{% firstof config.outgoing_email_signature config.site_name %}` sign-off.
* Test pins updated to the new copy (`test_views.py`, `test_notices.py`), plus a new test for the lifecycle section, boundary coverage for the deletion countdown (paid clock + overdue), and Society-note / contact-address / platform-sign-off assertions on the emails.
* `INACTIVE_DELETE_DAYS = 365` is defined in `tenant/models.py`: the constant arrived with #2146 on `develop`, which this recreated `staging` predates; the definition is copied verbatim from develop so the next staging→develop sync merges it cleanly.

> **Base branch:** retargeted to the recreated `staging` (maintainer request, 2026-07-30) and rebased onto its tip, ready to flow to `master`.

### Testing?
* Full serial test suite (`python src/manage.py test src`, 1547 tests on the staging base) + `ruff check src`: green.
* All screenshots and emails below are captured from the real running `hackerspace` dev deck; the emails are real sends read from `_sent_mail/` (both MIME parts).

### Screenshots (if front end is affected)

**Suspended: banner (staff/owner view)**

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_susp_banner_before.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_susp_banner_after.png) |

**Suspended: sign-in page as a non-authenticated visitor**

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_susp_login_before.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_susp_login_after.png) |

**Suspended: Subscription details page**

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_susp_page_before.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_susp_page_after.png) |

**Grace period: banner and Subscription details page**

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_grace_banner_before.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_grace_banner_after.png) |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_grace_page_before.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_grace_page_after.png) |

**New "How subscriptions work" section (subscribed deck)**

![lifecycle](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_lifecycle_page_after.png)

### Email

Real sends from the dev deck: HTML part rendered, plain-text part verbatim below each.

**Suspended notice** (deletion-date bottom line up front, deck name linked)

![suspended email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_suspended_email.png)

```
Hi owner,

Your deck [hackerspace](http://hackerspace.localhost:8000) is **scheduled for
deletion on July 21, 2027 (356 days from now)** , unless it gets a valid
subscription before then.

The deck has been **suspended** since **July 21, 2026** (its subscription was
paid through June 20, 2026, and the 30-day grace period ended on July 20,
2026): only the deck owner can sign in until the deck has a valid
subscription. Nothing has been deleted yet: your content and student data are
intact until the deletion date above.

[Subscribe here](http://hackerspace.localhost:8000/decks/subscription/) to
restore access: any level works, including the low-cost _Maintenance_
subscription, which keeps the deck online with trial-level limits (max 5
current students) and stops the deletion countdown (ideal if you just want to
keep the deck for later).

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck

[\[Logo\]](/static/img/default_icon.png)
```

**Expiry reminder (in grace)**

![grace email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_grace_email.png)

```
Hi owner,

Your deck **hackerspace** 's subscription expired on **July 25, 2026** (5 days
ago) and is in its 30-day grace period, which ends on **Aug. 24, 2026** (25
days left). When the grace period ends, the deck will be suspended: only the
deck owner will be able to sign in, and the 365-day countdown to deck deletion
begins.

You are currently using **2** of **30** current student seats.

[Subscribe or renew
here](http://hackerspace.localhost:8000/decks/subscription/) to keep full
access. Questions about which students count? Only _current_ students (those
registered in a course this semester) count toward your limit; see [freeing up
student seats](http://hackerspace.localhost:8000/courses/students/archive-
help/).

Not planning to use the deck for a while? The low-cost _Maintenance_
subscription keeps it online with trial-level limits (max 5 current students)
and stops it from ever being deleted.

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck

[\[Logo\]](/static/img/default_icon.png)
```

**Limit warning (shared footer added; copy de-dashed)**

![limit email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-lifecycle-copy/lc_limit_email.png)

```
Hi owner,

Your deck **hackerspace** has **2** current students of **2** allowed: the
limit has been reached, so no more students can register in a course.

Your deck's subscription is paid through **Nov. 7, 2026**.

Only _current_ students (registered in a course in the active semester) count;
staff and archived students never do. You can [free up
seats](http://hackerspace.localhost:8000/courses/students/archive-help/) by
ending the semester or archiving past students, or [upgrade your
subscription](http://hackerspace.localhost:8000/decks/subscription/) for a
higher limit.

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck

[\[Logo\]](/static/img/default_icon.png)
```

### Anything Else?
The copy intentionally describes suspension rules that automation doesn't enforce yet (owner-only login, the deletion clock). Per the maintainer's direction, the information goes out first; the enforcement lands on `develop` as the next feature (owner-only login middleware, semester auto-close on suspension, deletion countdown keyed to the suspension date, and grace period for trials).

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn