### PR TITLE
Cover utilities widgets/forms branches (widgets.py + forms.py → 100%)

### DIFF
--- a/src/utilities/tests/test_forms.py
+++ b/src/utilities/tests/test_forms.py
@@ -1,7 +1,11 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from prerequisites.forms import PrereqFormInline
+from utilities.fields import GFKChoiceField
 from utilities.forms import MenuItemForm
 
 
@@ -35,3 +39,15 @@ class MenuItemFormTest(ByteDeckTenantTestCase):
         }
         form = MenuItemForm(data=form_data)
         self.assertTrue(form.is_valid(), form.errors)
+
+
+class FutureModelFormTest(ByteDeckTenantTestCase):
+    """utilities.forms.FutureModelForm populates initial data from each field's value_from_object()."""
+
+    def test_init__field_whose_value_from_object_raises_is_skipped(self):
+        """A field whose value_from_object() raises is skipped during initial population instead of crashing the form."""
+        # PrereqFormInline is a FutureModelForm with GFKChoiceField fields; make their
+        # value_from_object blow up so __init__ takes the guarded except/continue path.
+        with patch.object(GFKChoiceField, "value_from_object", side_effect=ValueError("boom")):
+            form = PrereqFormInline()
+        self.assertNotIn("prereq_object", form.initial)

--- a/src/utilities/tests/test_widgets.py
+++ b/src/utilities/tests/test_widgets.py
@@ -63,6 +63,12 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         """Return the "<content_type_pk>-<object_pk>" string the GFK choice field uses to identify obj."""
         return f'{ContentType.objects.get_for_model(obj).pk}-{obj.pk}'
 
+    def test_filter_choices_to_render__single_empty_selection_renders_no_choices(self):
+        """A lone empty selected value is treated as no selection, so the widget renders no choices."""
+        widget = CustomGFKSelect2Widget()
+        widget.filter_choices_to_render([''])
+        self.assertEqual(list(widget.choices), [])
+
     def test_widget__renders_initial_data(self):
         """Widget renders the initial GFK value's string in the form output."""
         group = self.groups[0]

--- a/src/utilities/widgets.py
+++ b/src/utilities/widgets.py
@@ -164,7 +164,10 @@ class GFKSelect2Mixin:
         all_choices = copy.copy(self.choices)
         if self.get_url():
             self.filter_choices_to_render(selected_choices)
-        elif not self.allow_multiple_selected:
+        # The AJAX branch above always runs: this widget always has a data_view (defaulted in
+        # __init__), so get_url() never returns falsy. The static-choices fallback below is
+        # inherited from django-select2 but unreachable for a GFKSelect2Widget.
+        elif not self.allow_multiple_selected:  # pragma: no cover
             if self.attrs.get('data-placeholder'):
                 self.choices.insert(0, (None, ''))
         result = super().optgroups(name, value, attrs)


### PR DESCRIPTION
### What?

Closes the last gaps in `utilities/widgets.py` and `utilities/forms.py` (both → **100%**), mixing one real test each with one justified coverage exclusion.

### Why / How?

**`utilities/widgets.py`**
- **`filter_choices_to_render`** — added a test for the "single empty selection → render no choices" branch.
- **`optgroups` static-choices fallback** — marked `# pragma: no cover`. It's genuinely unreachable for `GFKSelect2Widget`: `get_url()` always returns a URL (the widget's `data_view` is always defaulted in `__init__`), so the AJAX branch always runs. The `elif` is inherited from django-select2's dual AJAX/static widget but this widget is always AJAX. Documented with a comment explaining why.

**`utilities/forms.py`**
- **`FutureModelForm.__init__`** — added a test that a field whose `value_from_object()` raises is skipped (the guarded `except/continue`) instead of crashing the form. Exercised by patching `GFKChoiceField.value_from_object` to raise and constructing a real `FutureModelForm` subclass (`PrereqFormInline`).

### Testing?

- `python manage.py test utilities` (71) + `prerequisites` green; `ruff` clean; `test_conventions` passes.
- With coverage, `utilities/widgets.py` = **100%** and `utilities/forms.py` = **100%** (full suite).

### Screenshots (if front end is affected)

N/A — test-only + one documented coverage pragma (no behaviour change).

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. The pragma follows the project's policy of excluding genuinely-unreachable code with a short reason rather than writing a contrived test for it.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_