### PR TITLE
Exclude dev-only DEBUG url wiring from coverage (urls.py → 100%)

### DIFF
--- a/src/hackerspace_online/urls.py
+++ b/src/hackerspace_online/urls.py
@@ -77,7 +77,9 @@ urlpatterns += [
 ]
 
 
-if settings.DEBUG:
+# Dev-only wiring (static/media serving + debug toolbar). Tests run with DEBUG=False,
+# so this block never executes under the test harness -- excluded from coverage.
+if settings.DEBUG:  # pragma: no cover
     urlpatterns += static(settings.STATIC_URL,
                           document_root=settings.STATIC_ROOT)
     urlpatterns += static(settings.MEDIA_URL,


### PR DESCRIPTION
### What?

Brings `hackerspace_online/urls.py` to **100%** by excluding its dev-only block from coverage.

### Why / How?

The `if settings.DEBUG:` block at the bottom of `urls.py` wires up static/media file serving and the debug toolbar. The test harness runs with `DEBUG=False`, so this block **never executes under tests** — its body was the file's only uncovered code.

Marked the block `# pragma: no cover` with a short comment explaining why, mirroring the existing documented pragma on the production-security block in `settings.py`. This is the project's sanctioned way (`.coveragerc` policy) to keep the reported percentage honest for code that legitimately can't run under the harness — not a dodge for a testable branch.

### Testing?

- `ruff` clean; `python manage.py check` clean.
- With coverage, `hackerspace_online/urls.py` = **100%**.

### Screenshots (if front end is affected)

N/A — no behaviour change (a coverage-only comment/pragma).

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_