### PR TITLE
Cover tenant deck-creation email branch + exclude unreachable schema normalization (tenant/views.py → 100%)

### DIFF
--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -587,6 +587,20 @@ class EmailVerificationRequiredMixinTest(TestCase):
         response = self.view(request)
         self.assertEqual(response.status_code, 403)
 
+    @patch("tenant.views.render")  # patch render to avoid template DB queries
+    def test_dispatch__verified_request_without_timestamp_is_cleared_and_denied(self, mock_render):
+        """A verified_deck_request carrying no verified_at is treated as malformed: it's dropped from the session and access is denied (403)."""
+        mock_render.side_effect = lambda request, template_name, context=None, status=None: HttpResponse(status=status or 200)
+
+        request = self.factory.get("/dummy/")
+        request.user = self.user
+        request.session = {"verified_deck_request": {"email": "john.doe@example.com"}}  # no verified_at
+
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("verified_deck_request", request.session)
+
 
 class DeckStatusBannerTest(ByteDeckTenantTestCase):
     """Rendering tests for the deck status banner in base.html (epic #1729 PR 3;

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -324,6 +324,33 @@ class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertEqual(site_config.deck_owner.email, "john.doe@example.com")
 
     @patch("tenant.models.Tenant.full_clean")
+    @patch("tenant.views.EmailAddress.objects.get_or_create")
+    def test_form_valid__existing_email_address_marked_verified_and_primary(self, mock_get_or_create, mock_full_clean):
+        """When the owner already has an EmailAddress, form_valid marks that record verified+primary
+        (the get_or_create 'not created' branch) instead of relying on the create-time defaults."""
+        existing_email = Mock()
+        mock_get_or_create.return_value = (existing_email, False)
+
+        nonce = DeckRequestService.create_request("John", "Doe", "john.doe@example.com")
+        request = self.factory.post(reverse("tenant:new"), data=self.form_data)
+        request.user = AnonymousUser()
+        request.session = {"verified_deck_request": {**self.form_data, "nonce": nonce}}
+
+        view = TenantCreate()
+        view.setup(request)
+
+        form = TenantForm(data=self.form_data, verified_data=self.form_data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        with tenant_context(self.public_tenant):
+            view.form_valid(form)
+
+        self.assertTrue(existing_email.verified)
+        self.assertTrue(existing_email.primary)
+        existing_email.full_clean.assert_called_once()
+        existing_email.save.assert_called_once()
+
+    @patch("tenant.models.Tenant.full_clean")
     def test_form_valid__verification_nonce_is_single_use(self, mock_full_clean):
         """A verification nonce provisions at most one deck: a successful creation
         consumes it, and a second attempt with the same nonce is rejected

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -175,7 +175,11 @@ class TenantCreate(PublicOnlyViewMixin, EmailVerificationRequiredMixin, CreateVi
         # Normalize: valid Postgres schema and subdomain
         name_slug = slugify(form.instance.name)
         schema = name_slug.replace("-", "_")[:63]
-        if not schema or not schema[0].isalpha():
+        # check_tenant_name (the Tenant.name validator, already run by the form) requires the
+        # name to start with a lowercase letter, so the slug -- and thus the schema -- always
+        # does too. This t_ prefix is defensive normalization that can't trigger for validated
+        # input, so it's excluded from coverage.
+        if not schema or not schema[0].isalpha():  # pragma: no cover
             schema = f"t_{schema}"[:63]
         form.instance.schema_name = schema
         current_domain = Site.objects.get_current().domain


### PR DESCRIPTION
### What?

Closes the last gaps in `tenant/views.py`, taking it to **100%** (statements + branches) — two real tests, one justified exclusion.

### Why / How?

- **Existing-EmailAddress branch** (`get_or_create(...)` → `not created`): when the deck owner already has an `EmailAddress`, `form_valid` marks that record verified + primary instead of relying on create-time defaults. Added a test that patches `EmailAddress.objects.get_or_create` to return `created=False` and asserts the record is updated and saved.
- **`EmailVerificationRequiredMixin.dispatch` malformed-request branch**: a `verified_deck_request` session entry that carries no `verified_at` timestamp. Added a test asserting the malformed entry is dropped from the session and access is denied (403) — covering the last partial branch.
- **`t_`-prefix schema normalization** (`if not schema or not schema[0].isalpha()`): marked `# pragma: no cover`. `check_tenant_name` — the `Tenant.name` validator the form runs before `form_valid` — **requires the name to begin with a lowercase letter**, so `slugify(name)` (and thus the schema) always starts with a letter. This defensive normalization can't trigger for validated input, so a real test would require constructing an invalid form state the validator prevents. Documented with a comment.

### Testing?

- New tests pass; `ruff` clean; `test_conventions` passes.
- With coverage (full suite), `tenant/views.py` = **100%** (statements + branches).

### Screenshots (if front end is affected)

N/A — test-only + one documented coverage pragma (no behaviour change).

### Anything Else?

Part of the ongoing push to 100% of the code we intend to test. The pragma follows the project's policy of excluding genuinely-unreachable code with a short reason rather than writing a contrived test.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - test suite review`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed email verification sessions by denying access and clearing invalid session data.
  * Ensured existing email addresses are correctly marked as verified and primary during tenant creation.

* **Tests**
  * Added coverage for tenant creation and email verification edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->