### PR TITLE
Cover tenant initial-icon seeding + public-schema guard (initialization.py → 100%)

### DIFF
--- a/src/tenant/initialization.py
+++ b/src/tenant/initialization.py
@@ -324,7 +324,10 @@ def create_initial_badges():
         ),
     ])
 
-    if not settings.TESTING:
+    # Icons are uploaded from static files only outside the test harness (settings.TESTING is
+    # always True under tests), so this call site never runs during testing -- excluded from
+    # coverage. set_initial_icons itself is covered directly in test_initialization.py.
+    if not settings.TESTING:  # pragma: no cover
         set_initial_icons(award_badges + team_badges)
 
 
@@ -429,7 +432,9 @@ def create_orientation_campaign():
     message_quest.tags.add(intro_tag)
 
     # quests with icons need to have them uploaded programmatically from static files to be displayed properly in development, same as badges.
-    if not settings.TESTING:
+    # settings.TESTING is always True under the test harness, so this call site never runs during
+    # testing -- excluded from coverage. set_initial_icons itself is covered directly in test_initialization.py.
+    if not settings.TESTING:  # pragma: no cover
         set_initial_icons([message_quest, cc_quest, avatar_quest, contract_quest, screenshots_quest])
 
     # now link them to the welcome quest with pre-requisites:

--- a/src/tenant/tests/test_initialization.py
+++ b/src/tenant/tests/test_initialization.py
@@ -1,12 +1,18 @@
+import shutil
+import tempfile
+from unittest.mock import patch
+
 from django_tenants.utils import get_public_schema_name, schema_context, tenant_context
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from badges.models import Badge, BadgeRarity, BadgeType
 from courses.models import Block, Course, Grade, MarkRange, Rank
 from quest_manager.models import Category, Quest
 from siteconfig.models import SiteConfig
+from tenant.initialization import load_initial_tenant_data, set_initial_icons
 from tenant.models import Tenant
 from utilities.models import MenuItem
 
@@ -190,3 +196,65 @@ class CreateSiteConfigObjectTest(ByteDeckTenantTestCase):
         expected_title = deck_name.replace("-", " ").title()  # "Timberline Secondary Hackerspace"
         self.assertEqual(config.site_name_short, expected_title[:20])
         self.assertEqual(config.site_name, f"{expected_title} Deck"[:50])
+
+
+class LoadInitialTenantDataTest(ByteDeckTenantTestCase):
+    """Tests for the top-level load_initial_tenant_data entry point."""
+
+    def test_load_initial_tenant_data__public_schema_returns_early(self):
+        """Called from the public schema, load_initial_tenant_data returns immediately.
+
+        The public schema is the shared tenant registry, not a deck, so none of the
+        per-deck seeding should run there. Patch the first seeding step and assert it
+        is never reached.
+        """
+        with schema_context(get_public_schema_name()):
+            with patch("tenant.initialization.create_users") as mock_create_users:
+                load_initial_tenant_data()
+                mock_create_users.assert_not_called()
+
+
+class SetInitialIconsTest(ByteDeckTenantTestCase):
+    """Tests for set_initial_icons, which uploads a model's icon from a matching static file."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Isolate MEDIA_ROOT to a temp dir so uploaded icons don't touch the real media store."""
+        super().setUpClass()
+        cls._media_root = tempfile.mkdtemp()
+        cls._media_override = override_settings(MEDIA_ROOT=cls._media_root)
+        cls._media_override.enable()
+        cls.addClassCleanup(cls._media_override.disable)
+        cls.addClassCleanup(shutil.rmtree, cls._media_root, ignore_errors=True)
+
+    def test_set_initial_icons__uploads_matching_static_icon(self):
+        """A badge whose name matches a static icon file gets that icon saved to its ImageField.
+
+        "Dime" has a real static icon at badges/static/badges/img/Dime.png, so
+        set_initial_icons should locate it and populate the badge's icon field.
+        """
+        badge = Badge.objects.get(name="Dime")
+        self.assertFalse(badge.icon)  # icons aren't uploaded under the test harness by default
+
+        set_initial_icons([badge])
+
+        badge.refresh_from_db()
+        self.assertTrue(badge.icon)
+        self.assertTrue(badge.icon.name.endswith(".png"))
+
+    def test_set_initial_icons__missing_icon_does_not_raise(self):
+        """When no static icon matches the object's name, set_initial_icons swallows the error.
+
+        finders.find returns None, open() then raises OSError, and the function reports
+        the miss instead of crashing tenant creation.
+        """
+        badge = Badge.objects.create(name="No Such Icon Exists Here", xp=1, badge_type=BadgeType.objects.first())
+        self.assertFalse(badge.icon)
+
+        with patch("builtins.print") as mock_print:
+            set_initial_icons([badge])
+
+        badge.refresh_from_db()
+        self.assertFalse(badge.icon)  # nothing was uploaded
+        mock_print.assert_called_once()
+        self.assertIn("Couldn't open icon", mock_print.call_args[0][0])


### PR DESCRIPTION
## What

Brings `src/tenant/initialization.py` to 100% coverage (134 stmts, 6 branches, 0 missing) by testing the previously-uncovered `set_initial_icons` helper and the public-schema guard in `load_initial_tenant_data`, and by excluding two dev-only call sites that never run under the test harness.

## Why

`initialization.py` seeds every new deck. Most of it is already exercised because every `TenantTestCase` creates a tenant, but three regions were never hit:

- **`set_initial_icons` (lines 62–84)** — uploads a model's icon from a matching static file. It was only ever called from the two `if not settings.TESTING:` blocks, which are skipped during tests, so the whole function was uncovered.
- **The `if not settings.TESTING:` call sites (lines 328, 433)** — `settings.TESTING` is always `True` under the harness, so the icon-upload calls there genuinely never run in tests.
- **The public-schema early return in `load_initial_tenant_data` (line 36)** — the public schema is the shared tenant registry, not a deck, so seeding must be skipped there; no test drove that branch.

## How

- Added `SetInitialIconsTest` with an isolated temp `MEDIA_ROOT`:
  - **happy path** — a `Dime` badge (which has a real static icon at `badges/static/badges/img/Dime.png`) gets its `icon` field populated.
  - **OSError branch** — a badge whose name matches no static icon: `finders.find` returns `None`, `open()` raises, and the function reports the miss (`Couldn't open icon…`) instead of crashing tenant creation.
- Added `LoadInitialTenantDataTest.test_load_initial_tenant_data__public_schema_returns_early`, which calls the entry point from the public schema and asserts the first seeding step (`create_users`) is never reached.
- Excluded the two `if not settings.TESTING:` icon-upload call sites from coverage with `# pragma: no cover` and an explanatory comment (mirroring the existing `settings.py` production-security exclusion). `set_initial_icons` itself is now covered directly.

## Testing

- `python src/manage.py test tenant` → 244 tests OK.
- `coverage` over the tenant app reports `src/tenant/initialization.py` at **100%** (0 missing lines, 0 partial branches).
- `ruff check` clean.

## Screenshots

N/A — test-only + a coverage pragma; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing badge icons so setup continues without errors and reports the issue clearly.
  * Ensured initial tenant setup exits safely when run in the public schema.

* **Tests**
  * Added coverage for tenant initialization and icon seeding, including successful uploads and missing-icon scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->