### PR TITLE
test: cover the _shortcut contenttypes monkey-patch (tenant/apps.py → 100%)

### DIFF
--- a/src/tenant/tests/test_apps.py
+++ b/src/tenant/tests/test_apps.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from django.http import Http404, HttpResponseRedirect
+from django.test import RequestFactory
+
+from badges.models import Badge
+
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from tenant.apps import _shortcut
+
+
+class ShortcutMonkeyPatchTest(ByteDeckTenantTestCase):
+    """Tests for tenant.apps._shortcut, the tenant-aware replacement for
+    django.contrib.contenttypes.views.shortcut (the "view on site" redirect).
+
+    The stock Django view pulls the domain from django.contrib.sites, which is
+    not installed per tenant; _shortcut strips that out and simply redirects to
+    the object's get_absolute_url. These tests drive every branch directly, since
+    nothing in the normal test flow hits the patched view.
+    """
+
+    def setUp(self):
+        """Provide a throwaway request and a seeded badge to redirect to."""
+        self.request = RequestFactory().get("/")
+        self.badge = Badge.objects.first()
+        self.badge_ct = ContentType.objects.get_for_model(Badge)
+
+    def test_shortcut__relative_url_redirects_to_object(self):
+        """A found object redirects to its (relative) get_absolute_url."""
+        response = _shortcut(self.request, self.badge_ct.pk, self.badge.pk)
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response.url, self.badge.get_absolute_url())
+
+    def test_shortcut__absolute_url_redirects_unchanged(self):
+        """When get_absolute_url already includes a scheme/host, it is used as-is."""
+        absolute = "http://example.com/somewhere/"
+        with patch.object(Badge, "get_absolute_url", return_value=absolute):
+            response = _shortcut(self.request, self.badge_ct.pk, self.badge.pk)
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response.url, absolute)
+
+    def test_shortcut__unknown_content_type_raises_404(self):
+        """A content-type id with no matching ContentType raises Http404."""
+        missing_ct_pk = ContentType.objects.order_by("-pk").first().pk + 1000
+        with self.assertRaises(Http404):
+            _shortcut(self.request, missing_ct_pk, self.badge.pk)
+
+    def test_shortcut__content_type_without_model_raises_404(self):
+        """A stale ContentType whose model class no longer exists raises Http404."""
+        stale_ct = ContentType.objects.create(app_label="ghost_app", model="ghostmodel")
+        self.assertIsNone(stale_ct.model_class())  # sanity: truly no backing model
+        with self.assertRaises(Http404):
+            _shortcut(self.request, stale_ct.pk, 1)
+
+    def test_shortcut__missing_object_raises_404(self):
+        """A valid content type but non-existent object id raises Http404."""
+        missing_obj_pk = (Badge.objects.order_by("-pk").first().pk) + 1000
+        with self.assertRaises(Http404):
+            _shortcut(self.request, self.badge_ct.pk, missing_obj_pk)
+
+    def test_shortcut__object_without_get_absolute_url_raises_404(self):
+        """An object whose model has no get_absolute_url raises Http404.
+
+        Group is a real model with instances but no get_absolute_url method.
+        """
+        group = Group.objects.create(name="No Absolute URL Group")
+        group_ct = ContentType.objects.get_for_model(Group)
+        with self.assertRaises(Http404):
+            _shortcut(self.request, group_ct.pk, group.pk)

--- a/src/tenant/tests/test_apps.py
+++ b/src/tenant/tests/test_apps.py
@@ -60,6 +60,20 @@ class ShortcutMonkeyPatchTest(ByteDeckTenantTestCase):
         with self.assertRaises(Http404):
             _shortcut(self.request, self.badge_ct.pk, missing_obj_pk)
 
+    def test_shortcut__malformed_object_id_raises_404(self):
+        """A non-numeric object id (against an integer pk) raises Http404.
+
+        The lookup casts the id to the model's pk type, raising ValueError for a
+        malformed value; _shortcut catches it alongside ObjectDoesNotExist.
+        """
+        with self.assertRaises(Http404):
+            _shortcut(self.request, self.badge_ct.pk, "not-a-number")
+
+    def test_shortcut__malformed_content_type_id_raises_404(self):
+        """A non-numeric content-type id raises Http404 via the same ValueError path."""
+        with self.assertRaises(Http404):
+            _shortcut(self.request, "not-a-number", self.badge.pk)
+
     def test_shortcut__object_without_get_absolute_url_raises_404(self):
         """An object whose model has no get_absolute_url raises Http404.
 


### PR DESCRIPTION
## What

Brings `src/tenant/apps.py` to 100% coverage (33 stmts, 4 branches, 0 missing) by testing `_shortcut`, the tenant-aware monkey-patch of `django.contrib.contenttypes.views.shortcut`.

## Why

`_shortcut` replaces Django's contenttypes "view on site" redirect view (the stock version pulls the domain from `django.contrib.sites`, which isn't installed per tenant, so django-tenants needs it stripped out). Nothing in the normal test flow routes through that view, so the entire function body (lines 12–45) was uncovered even though it contains real branching logic (four `Http404` paths plus the redirect).

## How

Added `src/tenant/tests/test_apps.py` with `ShortcutMonkeyPatchTest`, calling `_shortcut` directly to drive every branch:

- **relative URL** — a found object redirects to its (relative) `get_absolute_url`.
- **absolute URL** — when `get_absolute_url` already includes a scheme/host, it's used as-is (patched to `http://…`).
- **unknown content-type id** → `Http404` (the `ContentType.DoesNotExist` path).
- **stale ContentType** whose `model_class()` is `None` → `Http404`.
- **missing object id** (valid content type, non-existent pk) → `Http404`.
- **malformed content-type id / object id** (non-numeric string) → `Http404` via the `ValueError` arm of `except (ObjectDoesNotExist, ValueError)` (added after review feedback).
- **object whose model has no `get_absolute_url`** (a `Group` instance) → `Http404`.

## Testing

- `python src/manage.py test tenant.tests.test_apps` → 8 tests OK.
- `coverage` reports `src/tenant/apps.py` at **100%** (0 missing lines, 0 partial branches).
- `ruff check` clean.

## Screenshots

N/A — test-only; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)