### PR TITLE
refactor: remove dead map-generation methods, cover remaining branches (djcytoscape/models.py)

### DIFF
--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -625,20 +625,6 @@ class CytoScape(models.Model):
         title = title.replace('"', '\\"')
         return title + post
 
-    def get_last_node_in_campaign(self, parent_node, offset=0):
-        """
-        :param offset: offset from last node by this (i.e. 1 --> second last node)
-        :param parent_node: the compound node/parent, i.e. campaign
-        :return: the most recent node added to the campaign (added to the compound/parent node) by using the highest id
-        """
-        try:
-            # latest normally used with dates, but actually works with other fields too!
-            # return CytoElement.objects.all_for_campaign(self, parent_node).latest('id')
-            qs = CytoElement.objects.all_for_campaign(self, parent_node).order_by('-id')
-            return qs[offset]
-        except self.DoesNotExist:
-            return None
-
     def create_first_node(self, obj):
         """ Creates the first node from `obj`, then if this map has a parent, creates an aditiona node to link back to back to the parent scape/map.
         Returns the first node."""
@@ -666,43 +652,15 @@ class CytoScape(models.Model):
 
         return first_node
 
-    def create_child_map_node(self, obj, data_source):
-        """ If this obj is a transition node (to a new map, make a node to link to the next map"""
-        ct = ContentType.objects.get_for_model(obj)
-        # obj = ct.get_object_for_this_type(id=obj.id)
-
-        child_map_qs = CytoScape.objects.filter(initial_content_type=ct.id, initial_object_id=obj.id)
-        if child_map_qs.exists():
-            child_map = child_map_qs[0]
-            label = f"{child_map.name} Map"
-        else:
-            label = "The Void"
-
-        child_map_node, _ = CytoElement.objects.get_or_create(
-            scape=self,
-            group=CytoElement.NODES,
-            label=label,
-            href=reverse('maps:quest_map_interlink', args=[ct.id, obj.id, self.id]),  # <content_type_id>, <object_id>, <originating_scape_id>
-            classes="link child-map",
-        )
-
-        # link them together with an edge
-        CytoElement.objects.get_or_create(
-            scape=self,
-            group=CytoElement.EDGES,
-            data_source=data_source,
-            data_target=child_map_node,
-        )
-
-        return child_map_node
-
     def create_node_from_object(self, obj, initial_node=False):
         # If node node doesn't exist already, create a new one
 
         # check for an icon
         if hasattr(obj, 'get_icon_url'):
             img_url = obj.get_icon_url()
-        else:
+        # Defensive fallback: every object that reaches map generation (Quest, Badge) defines
+        # get_icon_url, so this branch is never taken in practice -- excluded from coverage.
+        else:  # pragma: no cover
             img_url = "none"
 
         # check for map transition
@@ -737,11 +695,8 @@ class CytoScape(models.Model):
 
     def get_temp_campaign(self, campaign_id) -> TempCampaign:
         for campaign in self.campaign_list:
-            try:
-                if campaign.node_id == campaign_id:
-                    return campaign
-            except ValueError:
-                pass
+            if campaign.node_id == campaign_id:
+                return campaign
         return None
 
     def add_to_campaign(self, obj, target_node, source_node):

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -637,6 +637,63 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
             self.assertEqual(result, expected)
 
 
+class CytoScapeCoverageGapTest(ByteDeckTenantTestCase):
+    """Targeted tests for previously-uncovered CytoScape map-generation branches."""
+
+    def test_generate_map__repeatable_reliant_quest_gets_repeat_edge_label(self):
+        """A repeatable reliant quest (max_repeats > 0) gets a circular 'x<n>' repeat edge."""
+        start = baker.make(Quest, name="Start")
+        repeatable = baker.make(Quest, name="Repeatable", max_repeats=3)
+        repeatable.add_simple_prereqs([start])
+
+        scape = CytoScape.generate_map(start, "repeat-test")
+
+        self.assertTrue(
+            CytoElement.objects.filter(scape=scape, label='x3', classes='repeat-edge').exists()
+        )
+
+    def test_generate_map__child_map_links_back_to_parent_scape(self):
+        """A map generated with a parent_scape gets a node linking back to the parent map."""
+        parent_quest = baker.make(Quest, name="ParentInit")
+        parent_scape = CytoScape.generate_map(parent_quest, "Parent Map")
+
+        child_quest = baker.make(Quest, name="ChildInit")
+        child_scape = CytoScape.generate_map(child_quest, "Child Map", parent_scape=parent_scape)
+
+        self.assertTrue(
+            CytoElement.objects.filter(
+                scape=child_scape,
+                label=f"{parent_scape.name} Quest Map",
+                classes__contains='parent-map',
+            ).exists()
+        )
+
+    def test_get_temp_campaign__returns_none_when_id_not_found(self):
+        """get_temp_campaign returns None when no TempCampaign matches the given node id."""
+        scape = bake_scape(name="temp-campaign-test")
+        scape.init_temp_campaign_list()
+        self.assertIsNone(scape.get_temp_campaign(999999))
+
+    def test_generate_map__campaign_as_prerequisite_adds_campaign_reliant(self):
+        """A quest whose prerequisite is a Campaign (Category) exercises the campaign-reliant path.
+
+        The campaign node is a compound/parent node, and a quest that relies on the whole
+        campaign is registered as a campaign-reliant during the recursive edge build, so map
+        generation completes and both quests are represented.
+        """
+        start = baker.make(Quest, name="Start")
+        campaign = baker.make(Category, title="Test Campaign")
+        in_campaign = baker.make(Quest, name="InCampaign", campaign=campaign)
+        in_campaign.add_simple_prereqs([start])
+        reliant_on_campaign = baker.make(Quest, name="ReliantOnCampaign")
+        reliant_on_campaign.add_simple_prereqs([campaign])
+
+        scape = CytoScape.generate_map(start, "campaign-reliant-test")
+
+        self.assertTrue(CytoElement.objects.filter(scape=scape, label__contains="InCampaign").exists())
+        self.assertTrue(CytoElement.objects.filter(scape=scape, label__contains="ReliantOnCampaign").exists())
+
+
 class CampaignMapOrderTest(ByteDeckTenantTestCase):
     """Campaigns are placed left-to-right on the quest map in Category.map_order (issue #1977,
     the ordering half). dagre orders same-rank nodes by crossing-minimization and ignores input


### PR DESCRIPTION
## What

Takes `src/djcytoscape/models.py` to an honest 100% coverage by removing dead code and covering the genuinely-reachable branches that were missing.

## Why

The file's ~24 uncovered lines were a mix of dead code and real gaps:

- **`get_last_node_in_campaign`** and **`create_child_map_node`** have **no callers anywhere** in the codebase (verified across `.py`, `.html`, and `.txt`). `get_last_node_in_campaign` also carried a latent bug: `qs[offset]` raises `IndexError` when out of range, but the method only catches `self.DoesNotExist`, so its `return None` was unreachable regardless.
- `get_temp_campaign` had an `except ValueError` around `campaign.node_id == campaign_id` — comparing two node ids (ints) can never raise `ValueError`, so that guard was dead.
- The rest were real but untested map-generation branches.

## How

- **Removed** the two uncalled methods and the dead `except ValueError` guard.
- **Added tests** (`CytoScapeCoverageGapTest`) for the reachable branches:
  - a repeatable reliant quest (`max_repeats > 0`) gets an `x<n>` circular repeat edge;
  - a map generated with a `parent_scape` gets a node linking back to the parent map;
  - `get_temp_campaign` returns `None` for an unknown node id;
  - a quest whose prerequisite is a whole Campaign (`Category`, which is an `IsAPrereqMixin`) exercises the campaign-reliant recursion (the compound-node / `add_campaign_reliant` path).
- **Excluded** the only-defensive `img_url = "none"` fallback with a `# pragma: no cover` and comment (every object reaching map generation — Quest, Badge — defines `get_icon_url`).

## Testing

- `python src/manage.py test djcytoscape` → 80 tests OK (nothing depended on the removed methods).
- `coverage` reports `src/djcytoscape/models.py` at **100%** (verified against a full-suite run).
- `ruff check` clean.

## Screenshots

N/A — dead-code removal + tests; no user-facing or front-end change (map generation output is unchanged).

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_