### PR TITLE
HOTFIX: fix: deck notices come from Bytedeck and read as complete sentences

### DIFF
--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -192,6 +192,19 @@ class Notification(models.Model):
 
         return str(result) + ("..." if truncated else "")
 
+    def get_sender_display(self):
+        """The actor name rendered at the start of the notification text.
+
+        The deck's ByteDeck support account (settings.TENANT_DEFAULT_ADMIN_USERNAME)
+        displays as "Bytedeck": it sends the automated deck status notices, and its
+        raw username reads like any other user (maintainer request, 2026-07-31).
+        Every other sender keeps its normal string form.
+        """
+        sender = self.sender_object
+        if getattr(sender, 'username', None) == settings.TENANT_DEFAULT_ADMIN_USERNAME:
+            return "Bytedeck"
+        return sender
+
     def __str__(self):
         try:
             target_url = self.target_object.get_absolute_url()
@@ -210,7 +223,7 @@ class Notification(models.Model):
         # absolute url needed for when notifications are sent via email
         root_url = get_root_url()
         context = {
-            "sender": self.sender_object,
+            "sender": self.get_sender_display(),
             "verb": self.verb,
             "action": action,  # notif text
             "target": self.target_object,  # basically quest name
@@ -268,7 +281,7 @@ class Notification(models.Model):
         action = Notification.html_strip(str(self.action_object))
 
         context = {
-            "sender": self.sender_object,
+            "sender": self.get_sender_display(),
             "verb": self.verb,
             "action": action,
             "target": self.target_object,

--- a/src/notifications/tests/test_models.py
+++ b/src/notifications/tests/test_models.py
@@ -173,6 +173,29 @@ class NotificationModelTest(ByteDeckTenantTestCase):
         self.assertIn(comment_hash, notification.get_url())
         self.assertIn(comment_hash, str(notification))
 
+    def test_get_sender_display__support_admin_renders_as_bytedeck(self):
+        """A notification sent by the deck's ByteDeck support account displays its
+        actor as "Bytedeck" (the raw `admin` username would read like any other
+        user), in both the notification-page rendering and the string form."""
+        from django.conf import settings
+
+        support_admin, _ = User.objects.get_or_create(username=settings.TENANT_DEFAULT_ADMIN_USERNAME)
+        new_notification(support_admin, recipient=self.student, verb='sent a deck suspended warning.')
+
+        notification = self.student.notifications.get()
+        self.assertEqual(notification.get_sender_display(), 'Bytedeck')
+        self.assertIn('Bytedeck sent a deck suspended warning.', notification.get_link())
+        self.assertIn('Bytedeck sent a deck suspended warning.', str(notification))
+
+    def test_get_sender_display__other_senders_keep_their_normal_form(self):
+        """Any other sender renders exactly as before: its own string form (for a
+        user, the username)."""
+        new_notification(self.teacher, recipient=self.student, verb='tested.')
+
+        notification = self.student.notifications.get()
+        self.assertEqual(str(notification.get_sender_display()), str(self.teacher))
+        self.assertIn(f'{self.teacher} tested.', notification.get_link())
+
 
 class NotificationModel_html_strip_Test(TestCase):
     """

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -234,10 +234,13 @@ def _deliver(deck, kind):
         'subscribe_url': deck.get_root_url() + reverse('decks:subscription'),
         'archive_help_url': deck.get_root_url() + reverse('courses:archive_students_help'),
     }
+    # Each label must read naturally in BOTH places it appears (kept deliberately
+    # coupled, maintainer decision 2026-07-31): the email subject
+    # "{site}: {label}" and the in-app notification sentence "sent a {label}."
     templates = {
-        DeckNotice.KIND_EXPIRY: ('expiry_reminder', 'trial/subscription expiry reminder'),
+        DeckNotice.KIND_EXPIRY: ('expiry_reminder', 'subscription expiry reminder'),
         DeckNotice.KIND_LIMIT: ('limit_warning', 'current-student limit warning'),
-        DeckNotice.KIND_SUSPENDED: ('suspended_notice', 'deck suspended'),
+        DeckNotice.KIND_SUSPENDED: ('suspended_notice', 'deck suspended warning'),
     }
     template_name, verb = templates[kind]
     subject = f"{config.site_name_short}: {verb}"
@@ -245,16 +248,22 @@ def _deliver(deck, kind):
 
     # In-app notification first (DB-only, rolls back cleanly with the ledger row);
     # deck_owner is a non-nullable PROTECT FK, so there is always an owner to notify.
-    # Edge: if deck_ai IS the owner (the seeded default on decks that never set a
-    # dedicated AI user), the notifications app skips the self-notification -- such
-    # owners are still covered by the email and the status banner.
+    # The sender is the ByteDeck support account (displayed as "Bytedeck" by the
+    # notifications app), falling back to deck_ai on older decks that predate the
+    # support account (maintainer request, 2026-07-31: these notices come from
+    # Bytedeck, not from the deck owner's own account). Fallback edge: if deck_ai
+    # IS the owner (the seeded default on decks that never set a dedicated AI
+    # user), the notifications app skips the self-notification -- such owners are
+    # still covered by the email and the status banner.
     from django.contrib.auth import get_user_model
-    staff = get_user_model().objects.filter(is_staff=True, is_active=True)
+    User = get_user_model()
+    staff = User.objects.filter(is_staff=True, is_active=True)
+    sender = User.objects.filter(username=settings.TENANT_DEFAULT_ADMIN_USERNAME, is_active=True).first() or config.deck_ai
     notify.send(
-        config.deck_ai,
+        sender,
         recipient=config.deck_owner,
         affected_users=staff,
-        verb=f'sent a {verb} for this deck:',
+        verb=f'sent a {verb}.',
         icon="<i class='fa fa-lg fa-fw fa-credit-card text-warning'></i>",
     )
 

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -254,7 +254,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__records_ledger_and_delivers_both_channels(self):
         """When enabled, a due notice writes its ledger row, emails the deck owner, and
-        creates an in-app notification from the deck AI."""
+        creates an in-app notification (sender choice has its own tests below)."""
         summary = self.run_engine_with_inline_email()
         self.assertIn('sent 1 notice(s)', summary)
 
@@ -271,10 +271,50 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         from django.urls import reverse
         self.assertIn(self.tenant.get_root_url() + reverse('decks:subscription'), mail.outbox[0].body)
 
-        # in-app notification exists for the deck owner
+        # in-app notification exists for the deck owner, phrased as a complete
+        # sentence: no dangling "for this deck:" pointing at an object that was
+        # never attached (maintainer find, 2026-07-31)
         from siteconfig.models import SiteConfig
         owner = SiteConfig.get().deck_owner
-        self.assertTrue(Notification.objects.filter(recipient=owner, verb__contains='limit warning').exists())
+        notification = Notification.objects.get(recipient=owner, verb__contains='limit warning')
+        self.assertEqual(notification.verb, 'sent a current-student limit warning.')
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__notification_comes_from_support_admin_when_present(self):
+        """The in-app notice's sender is the ByteDeck support account when the deck
+        has one, so it renders as "Bytedeck sent a ..." instead of coming from a
+        deck user's own account (maintainer request, 2026-07-31)."""
+        from django.conf import settings
+        from django.contrib.auth import get_user_model
+
+        from siteconfig.models import SiteConfig
+
+        support_admin, _ = get_user_model().objects.get_or_create(
+            username=settings.TENANT_DEFAULT_ADMIN_USERNAME)
+        self.run_engine_with_inline_email()
+
+        owner = SiteConfig.get().deck_owner
+        notification = Notification.objects.get(recipient=owner, verb__contains='limit warning')
+        self.assertEqual(notification.sender_object, support_admin)
+        self.assertIn('Bytedeck sent a current-student limit warning.', notification.get_link())
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__notification_sender_falls_back_to_deck_ai(self):
+        """Decks without a usable support account (older decks predate it; here it
+        is deactivated) still get their notice: the sender falls back to the deck
+        AI user."""
+        from django.conf import settings
+        from django.contrib.auth import get_user_model
+
+        from siteconfig.models import SiteConfig
+
+        get_user_model().objects.filter(
+            username=settings.TENANT_DEFAULT_ADMIN_USERNAME).update(is_active=False)
+        self.run_engine_with_inline_email()
+
+        owner = SiteConfig.get().deck_owner
+        notification = Notification.objects.get(recipient=owner, verb__contains='limit warning')
+        self.assertEqual(notification.sender_object, SiteConfig.get().deck_ai)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__second_run_sends_nothing_new(self):


### PR DESCRIPTION
### What?
Fixes the two problems @tylerecouture spotted in the in-app deck status notifications:

1. **The copy ended mid-sentence** ("tylere.couture sent a deck suspended for this deck:"): the verb string anticipated a target object that is never attached, so the sentence just stopped at the colon. Each notice verb is now a complete sentence built from its label:
   * "sent a subscription expiry reminder." (the "trial/" prefix is dropped: under the new lifecycle a trial is just a kind of subscription)
   * "sent a current-student limit warning."
   * "sent a deck suspended warning."
2. **The sender was the deck owner's own account**: notices were sent from `SiteConfig.deck_ai`, which defaults to the owner. They are now sent from the deck's ByteDeck support account (`TENANT_DEFAULT_ADMIN_USERNAME`), falling back to `deck_ai` on older decks that predate it, and the notifications app **displays that account as "Bytedeck"** (a small `get_sender_display()` rule in `notifications/models.py`, used by both render paths). No per-deck data backfill needed, and it also covers any other notification the support account sends.

Bonus fix that falls out of the sender change: on decks where `deck_ai` IS the owner, the notifications app used to skip the owner's notice entirely as a self-notification: with the support account as sender, the owner actually receives it.

### Why?
Maintainer report (2026-07-31) with a production screenshot: the notifications read as cut off and appeared to come from the owner personally. Copy approved by the maintainer in chat, including keeping the email subject coupled to the same label and rendering the sender as "Bytedeck".

### How?
* `tenant/notices.py`: label table reworded; verb is now `f'sent a {label}.'`; sender = active support account or `deck_ai` fallback. Email subjects stay `f'{site}: {label}'`, so the suspended subject becomes "Deckname: deck suspended warning" and the expiry subject "Deckname: subscription expiry reminder"; email bodies are untouched (#2200's copy).
* `notifications/models.py`: `get_sender_display()` returns "Bytedeck" when the sender is the support account, else the sender's normal string form; `__str__` and `get_link` both use it.
* The #2110 branch's payment-failure notice will get the matching label ("failed-payment warning") when this flows into `develop` and that branch syncs.

### Testing?
* Full serial suite on this branch: **1551 tests, OK**, plus `ruff` clean.
* New/updated tests: the delivery test pins the full sentence verb; new tests pin the support-admin sender, the `deck_ai` fallback (support account deactivated), and `get_sender_display()` for both the support account ("Bytedeck") and ordinary senders (unchanged rendering).

### Screenshots (if front end is affected)
Real `hackerspace` dev deck, signed in as the deck owner, after triggering all three notices through the real notice engine (`process_deck_notices` with `DECK_NOTICES_ENABLED` on):

![Notifications from Bytedeck, complete sentences](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/notice-sender-copy/notifications_bytedeck.png)

(The maintainer's report screenshot is the "before". Note the last row: an old "New user registered" notification the support account sent now also displays as "Bytedeck".)

### Email
Only the subject line changes (label coupling); the body is #2200's copy, unchanged. The real send captured from `_sent_mail/` during the trigger above, plain-text part verbatim:

```
Subject: Hackerspace: deck suspended warning

Hi owner,

Your deck [hackerspace](http://hackerspace.localhost:8000) is **scheduled for
deletion on June 21, 2027 (326 days from now)** , unless it gets a valid
subscription before then.

The deck has been **suspended** since **June 21, 2026** (its free trial ended
on June 20, 2026): only the deck owner can sign in until the deck has a valid
subscription. Nothing has been deleted yet: your content and student data are
intact until the deletion date above.

[Subscribe here](http://hackerspace.localhost:8000/decks/subscription/) to
restore access: any level works, including the low-cost _Maintenance_
subscription, which keeps the deck online with trial-level limits (max 5
current students) and stops the deletion countdown (ideal if you just want to
keep the deck for later).

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck

[\[Logo\]](/static/img/default_icon.png)
```

### Anything Else?
The "None . New user registered:" and "student1 . New user registered:" rows visible in the screenshot are pre-existing quirks of old seeded notifications, out of scope here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_