### PR TITLE
HOTFIX: fix: deletion clock never starts before the deck was first warned

### DIFF
--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -204,10 +204,22 @@ def _deliver(deck, kind):
         last_covered_days.append(deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS))
     # is_suspended requires at least one date field, so the list is never empty here
     suspended_since = max(last_covered_days) + timedelta(days=1) if deck.is_suspended else None
-    # the scheduled deletion day under the suspension policy -- INACTIVE_DELETE_DAYS
-    # after the suspension began; the suspended email LEADS with it (maintainer
-    # request, 2026-07-30: put the bottom line up front)
-    deletion_date = suspended_since + timedelta(days=INACTIVE_DELETE_DAYS) if suspended_since else None
+    # The scheduled deletion day under the suspension policy: INACTIVE_DELETE_DAYS
+    # after the deletion CLOCK starts; the suspended email LEADS with it (maintainer
+    # request, 2026-07-30: put the bottom line up front). The clock never starts
+    # before the deck was actually WARNED (maintainer decision, 2026-07-31): a
+    # legacy deck whose dates lapsed long before this machinery went live gets its
+    # full year measured from its first suspended notice (this episode's ledger
+    # row, written moments before delivery; sent-today fallback covers a
+    # not-yet-committed row), never from a backdated lapse date.
+    deletion_date = None
+    if suspended_since:
+        first_warned_row = DeckNotice.objects.filter(
+            tenant=deck, kind=DeckNotice.KIND_SUSPENDED, threshold='suspended',
+            period_key=str(max(last_covered_days)),
+        ).order_by('sent_on').first()
+        warned_on = first_warned_row.sent_on if first_warned_row else localdate()
+        deletion_date = max(suspended_since, warned_on) + timedelta(days=INACTIVE_DELETE_DAYS)
     context = {
         'deck': deck,
         'config': config,

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -479,10 +479,12 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 1, summary)
         html = ' '.join(mail.outbox[0].alternatives[0][0].split())
         # the bottom line LEADS (maintainer request, 2026-07-30): the scheduled
-        # deletion date (suspension start + 365 days) with the countdown, and the
-        # deck name links to the deck itself
-        self.assertIn('scheduled for deletion on Aug. 2, 2027', html)
-        self.assertIn('352 days from now', html)  # frozen TODAY Aug 15, 2026 -> Aug 2, 2027
+        # deletion date with the countdown, and the deck name links to the deck
+        # itself. The deletion clock starts at the FIRST WARNING (this email,
+        # sent on frozen TODAY Aug 15), never at the earlier lapse date
+        # (maintainer decision, 2026-07-31).
+        self.assertIn('scheduled for deletion on Aug. 15, 2027', html)
+        self.assertIn('365 days from now', html)
         self.assertIn(f'<a href="{self.tenant.get_root_url()}">', html)
         self.assertIn('since <strong>Aug. 2, 2026</strong>', html)
         self.assertIn('free trial ended on Aug. 1, 2026', html)
@@ -498,13 +500,15 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('alt="[Logo]"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__suspended_email_paid_clock_and_overdue_countdown(self):
+    def test_process__suspended_email_paid_clock_and_legacy_full_year(self):
         """A deck suspended after a PAID subscription lapsed explains the paid
         clock (paid-through and grace-end dates) in its suspension email, with the
-        bottom line carried by the plain-text part too; a deck already suspended
-        past the deletion horizon still shows its (past) scheduled deletion date
-        but drops the "days from now" countdown."""
-        # paid clock: paid through Jul 6, grace ends Aug 5 -> suspended Aug 6, 2026
+        bottom line carried by the plain-text part too. A LEGACY deck whose dates
+        lapsed long before the notice machinery existed gets its full year from
+        its first warning: no email can ever carry an already-passed deletion
+        date (maintainer decision, 2026-07-31)."""
+        # paid clock: paid through Jul 6, grace ends Aug 5 -> suspended Aug 6, 2026;
+        # first warned on frozen TODAY (Aug 15) -> deletion Aug 15, 2027
         Tenant.objects.filter(pk=self.tenant.pk).update(
             trial_end_date=None, paid_until=TODAY - timedelta(days=40),
             max_active_users=5, active_user_count=0,
@@ -516,13 +520,14 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         html = ' '.join(mail.outbox[0].alternatives[0][0].split())
         self.assertIn('subscription was paid through July 6, 2026', html)
         self.assertIn('grace period ended on Aug. 5, 2026', html)
-        self.assertIn('scheduled for deletion on Aug. 6, 2027', html)
-        self.assertIn('356 days from now', html)
+        self.assertIn('scheduled for deletion on Aug. 15, 2027', html)
+        self.assertIn('365 days from now', html)
         body = mail.outbox[0].body.replace('\n', ' ')  # textify hard-wraps lines
-        self.assertIn('scheduled for deletion on Aug. 6, 2027', body)
+        self.assertIn('scheduled for deletion on Aug. 15, 2027', body)
 
-        # overdue: suspended Aug 11, 2025 -> deletion day Aug 11, 2026 already passed,
-        # so the date still shows but no "days from now" countdown is promised
+        # legacy: suspended Aug 11, 2025 (400 days ago). Unclamped this deck's
+        # deletion day would already be past; the warned-on clamp grants the full
+        # year from today's first warning instead.
         mail.outbox.clear()
         Tenant.objects.filter(pk=self.tenant.pk).update(paid_until=TODAY - timedelta(days=400))
         self.tenant.refresh_from_db()
@@ -530,5 +535,49 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         summary = self.run_engine_with_inline_email()
         self.assertEqual(len(mail.outbox), 1, summary)
         html = ' '.join(mail.outbox[0].alternatives[0][0].split())
-        self.assertIn('scheduled for deletion on Aug. 11, 2026', html)
-        self.assertNotIn('days from now', html)
+        self.assertIn('since <strong>Aug. 11, 2025</strong>', html)  # the suspension date stays honest
+        self.assertIn('scheduled for deletion on Aug. 15, 2027', html)
+        self.assertIn('365 days from now', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_deliver__deletion_clock_runs_from_the_episodes_first_warning(self):
+        """The deletion clock runs from the episode's FIRST warning: the suspended
+        notice's ledger row is the durable warned-on record, so a deck warned days
+        ago keeps that original clock, and with no ledger row yet the deck counts
+        as warned today."""
+        from datetime import date
+        from unittest.mock import patch
+
+        from tenant import tasks
+        from tenant.notices import _deliver
+
+        inline_email = patch.object(
+            tasks.send_email_message, 'apply_async',
+            side_effect=lambda kwargs=None, queue=None: tasks.send_email_message.apply(kwargs=kwargs),
+        )
+
+        # suspended Aug 6 (paid through Jul 6 + 30-day grace), warned Aug 10
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=None, paid_until=TODAY - timedelta(days=40),
+            max_active_users=5, active_user_count=0,
+        )
+        self.tenant.refresh_from_db()
+        row = DeckNotice.objects.create(
+            tenant=self.tenant, kind=DeckNotice.KIND_SUSPENDED, threshold='suspended',
+            period_key=str(date(2026, 8, 5)),
+        )
+        # backdate past auto_now_add: the row records the warning sent on Aug 10
+        DeckNotice.objects.filter(pk=row.pk).update(sent_on=date(2026, 8, 10))
+
+        with inline_email:
+            _deliver(self.tenant, DeckNotice.KIND_SUSPENDED)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('scheduled for deletion on Aug. 10, 2027', html)
+
+        # no ledger row for the episode: treated as warned today (frozen Aug 15)
+        mail.outbox.clear()
+        DeckNotice.objects.all().delete()
+        with inline_email:
+            _deliver(self.tenant, DeckNotice.KIND_SUSPENDED)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('scheduled for deletion on Aug. 15, 2027', html)


### PR DESCRIPTION
### What?
Implements the clamp decided today: **a deck's 365-day deletion countdown never starts before the deck was actually warned.** The suspended email's deletion date is now `max(suspension start, first-warned date) + 365`, where the first-warned date is the episode's suspended notice ledger row (`DeckNotice.sent_on`, written moments before delivery; a missing row counts as warned today). The displayed suspension date itself stays honest (a legacy deck still reads "suspended since 2025").

### Why?
Rollout safety for production, where many decks lapsed long before the notice machinery existed. Unclamped, the derived deletion date for those decks is already in the past, so the first `DECK_NOTICES_ENABLED` cycle would email owners an absurd or already-elapsed deletion deadline. With the clamp, every legacy deck gets its full year measured from the day it is first told (in practice: the day notices go live in production). Decided with @tylerecouture 2026-07-31. **Not needed for the staging-to-production merge itself** (nothing sends while the flag is off), but must be in place before the flag flips.

### How?
* `tenant/notices.py` `_deliver`: the deletion-date computation looks up the episode's suspended `DeckNotice` row and clamps the clock start to its `sent_on` (fallback: today). One place; the emails, and later B3's real deletion criterion, both flow from the same warned-on record.
* No migration: `DeckNotice.sent_on` already exists.

### Testing?
* Full serial suite on this branch: **1552 tests, OK**, plus `ruff` clean.
* Updated the two suspended-email tests to the clamped dates, converted the old "overdue countdown" scenario into the legacy-deck case (suspended 400 days ago: email now grants the full year, honest suspension date pinned), and added a dedicated test that the clock honors an earlier warning via a backdated ledger row and treats a missing row as warned today.

### Screenshots (if front end is affected)
No page changes: email only (below).

### Email
Real send from the `hackerspace` dev deck (its trial genuinely lapsed June 20, so it IS the legacy case). Before this fix the same deck's email led with "scheduled for deletion on June 21, 2027 (326 days from now)". Now:

**HTML version rendered:**

![Clamped suspended email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/deletion-clock-clamp/suspended_email_clamped.png)

**Plain-text version verbatim (same send):**

```
Subject: Hackerspace: deck suspended warning

Hi owner,

Your deck [hackerspace](http://hackerspace.localhost:8000) is **scheduled for
deletion on July 30, 2027 (365 days from now)** , unless it gets a valid
subscription before then.

The deck has been **suspended** since **June 21, 2026** (its free trial ended
on June 20, 2026): only the deck owner can sign in until the deck has a valid
subscription. Nothing has been deleted yet: your content and student data are
intact until the deletion date above.

[Subscribe here](http://hackerspace.localhost:8000/decks/subscription/) to
restore access: any level works, including the low-cost _Maintenance_
subscription, which keeps the deck online with trial-level limits (max 5
current students) and stops the deletion countdown (ideal if you just want to
keep the deck for later).

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck

[\[Logo\]](/static/img/default_icon.png)
```

### Anything Else?
B3 of the suspension redesign (the real deletion criterion keyed to the suspension clock) will reuse the same ledger-row warned-on record, so admin-side deletability inherits the same fairness rule.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_