### PR TITLE
refactor: remove dead and broken Profile.chillax()

### DIFF
--- a/src/courses/templates/courses/chart_xp_progress.html
+++ b/src/courses/templates/courses/chart_xp_progress.html
@@ -12,7 +12,6 @@
   }
 
   var days = 85;
-  var chillax = 72.5;
 
   // XP DATA SET
   var XPData = {

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -377,14 +377,6 @@ class Profile(models.Model):
         else:
             return None
 
-    def chillax(self):
-        course = CourseStudent.objects.current_course(self.user)
-        if course:
-            semester = course.semester
-            if semester and semester.chillax_line_started():
-                return int(self.xp_per_course()) >= semester.chillax_line()
-        return False
-
     #################################
     #
     #   Ranks

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -60,36 +60,6 @@ class ProfileTestModel(ByteDeckTenantTestCase):
             f"{self.user.username}/customstyles/theme.css",
         )
 
-    # ---- chillax ------------------------------------------------------------
-
-    @patch("profile_manager.models.Profile.xp_per_course", return_value=50)
-    @patch("profile_manager.models.CourseStudent.objects.current_course")
-    def test_chillax__true_when_xp_reaches_started_chillax_line(self, mock_current_course, mock_xp):
-        """chillax() is True once the chillax line has started and the student's per-course XP reaches it."""
-        semester = Mock()
-        semester.chillax_line_started.return_value = True
-        semester.chillax_line.return_value = 50
-        mock_current_course.return_value = Mock(semester=semester)
-        self.assertTrue(self.profile.chillax())
-
-    @patch("profile_manager.models.Profile.xp_per_course", return_value=10)
-    @patch("profile_manager.models.CourseStudent.objects.current_course")
-    def test_chillax__false_when_xp_below_chillax_line(self, mock_current_course, mock_xp):
-        """chillax() is False when the student's per-course XP hasn't reached the (started) chillax line."""
-        semester = Mock()
-        semester.chillax_line_started.return_value = True
-        semester.chillax_line.return_value = 50
-        mock_current_course.return_value = Mock(semester=semester)
-        self.assertFalse(self.profile.chillax())
-
-    @patch("profile_manager.models.CourseStudent.objects.current_course")
-    def test_chillax__false_when_chillax_line_not_started(self, mock_current_course):
-        """chillax() is False while the semester's chillax line hasn't started, regardless of XP."""
-        semester = Mock()
-        semester.chillax_line_started.return_value = False
-        mock_current_course.return_value = Mock(semester=semester)
-        self.assertFalse(self.profile.chillax())
-
     # ---- num_hidden_quests / hide_quest / unhide_quest ----------------------
 
     def test_num_hidden_quests__available_only_false_counts_all_hidden(self):
@@ -519,7 +489,7 @@ class ProfileManagerAndQuerySetTest(ByteDeckTenantTestCase):
 
 
 class ProfileMiscMethodsTest(ByteDeckTenantTestCase):
-    """Covers gone_stale, xp_to_next_rank, xp_since_last_rank, and the no-course chillax path."""
+    """Covers gone_stale, xp_to_next_rank, and xp_since_last_rank."""
 
     def setUp(self):
         """A user whose auto-created profile we exercise."""
@@ -550,9 +520,5 @@ class ProfileMiscMethodsTest(ByteDeckTenantTestCase):
         """xp_since_last_rank swallows a failed rank lookup and returns 0."""
         with patch.object(Profile, 'rank', side_effect=Exception("boom")):
             self.assertEqual(self.profile.xp_since_last_rank(), 0)
-
-    def test_chillax__false_when_not_registered_in_a_course(self):
-        """chillax() is False for a user with no current course."""
-        self.assertFalse(self.profile.chillax())
 
 

--- a/src/siteconfig/models.py
+++ b/src/siteconfig/models.py
@@ -159,7 +159,6 @@ class SiteConfig(models.Model):
         help_text="Your currently active semester.  New semesters can be created from the admin menu."
     )
 
-    # hs_chillax_line_active
     color_headers_by_mark = models.BooleanField(
         verbose_name="Activate Header Colors by Mark", default=False,
         help_text="Set up at least one Mark Range in admin for this to do anything."


### PR DESCRIPTION
## What

Removes `Profile.chillax()`, its tests, and two leftover remnants of the same removed "chillax line" feature.

## Why

`Profile.chillax()` is both **unused and broken**:

- **No callers.** A codebase-wide search (`.py` + `.html`) finds no caller anywhere: no view, template, task, or other method invokes `profile.chillax()`. Only its tests referenced it.
- **Calls methods that don't exist.** Its body calls `semester.chillax_line_started()` and `semester.chillax_line()`, but neither exists on the `Semester` model (nor anywhere in the codebase). So for a student *with* a current course and active semester it would raise `AttributeError`. It's a remnant of a "chillax line" feature that was removed long ago.
- **The tests masked this.** The three `chillax` tests passed only because they mocked the `Semester` object (`semester.chillax_line_started.return_value = …`), substituting Mocks for the non-existent methods; the fourth used a real profile with no course and short-circuited before reaching them. They exercised the branching logic but never proved the code could run.

This mirrors the dead-and-broken `get_semester` removed in #2198.

## How

- Removed `Profile.chillax()` from `profile_manager/models.py`.
- Removed the four `chillax` tests from `profile_manager/tests/test_models.py` and the stale mention in the `ProfileMiscMethodsTest` docstring.
- Removed two other remnants of the feature: the orphaned `# hs_chillax_line_active` comment in `siteconfig/models.py`, and the unused `var chillax = 72.5` in `courses/templates/courses/chart_xp_progress.html` (declared, never referenced).

## Testing

- `python src/manage.py test profile_manager.tests.test_models` → 55 tests OK.
- `python src/manage.py makemigrations --check --dry-run` → no changes (no model fields touched).
- `ruff check` clean.

## Screenshots

N/A — dead-code removal. The removed template variable was never referenced, so the XP-progress chart renders identically.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused methods and obsolete code references across multiple modules to improve maintainability and simplify the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->