### PR TITLE
HOTFIX: fix: close sign-up on suspended decks (#1734)

### DIFF
--- a/src/hackerspace_online/adapter.py
+++ b/src/hackerspace_online/adapter.py
@@ -27,6 +27,13 @@ class CustomAccountAdapter(DefaultAccountAdapter):
 
         get_current_deck() is None outside deck schemas (public/library), where
         sign-up stays governed by the default behavior.
+
+        Args:
+            request: The current HTTP request.
+
+        Returns:
+            bool: False while the current deck is suspended; otherwise the
+            default allauth decision.
         """
         deck = get_current_deck()
         if deck is not None and deck.is_suspended:

--- a/src/hackerspace_online/adapter.py
+++ b/src/hackerspace_online/adapter.py
@@ -16,6 +16,8 @@ User = get_user_model()
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):
+    """Customizes allauth account behavior for the current deck: sign-up gating,
+    lowercase usernames, and tenant-aware email confirmation URLs."""
 
     def is_open_for_signup(self, request):
         """No new sign-ups on a suspended deck (#1734 redesign): a suspended deck is

--- a/src/hackerspace_online/adapter.py
+++ b/src/hackerspace_online/adapter.py
@@ -10,10 +10,28 @@ from allauth.utils import build_absolute_uri
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django_tenants.utils import get_tenant_model
 
+from tenant.utils import get_current_deck
+
 User = get_user_model()
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):
+
+    def is_open_for_signup(self, request):
+        """No new sign-ups on a suspended deck (#1734 redesign): a suspended deck is
+        owner-only, so a brand-new account registering (and landing in a signed-in
+        session) contradicts the suspension. allauth renders
+        account/signup_closed.html when this returns False, and the social-account
+        adapter delegates its own is_open_for_signup here, so this single guard
+        covers both the sign-up form and Google sign-ups.
+
+        get_current_deck() is None outside deck schemas (public/library), where
+        sign-up stays governed by the default behavior.
+        """
+        deck = get_current_deck()
+        if deck is not None and deck.is_suspended:
+            return False
+        return super().is_open_for_signup(request)
 
     def clean_username(self, username, shallow=False):
         username = super().clean_username(username, shallow)

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -63,6 +63,60 @@ class NonPublicOnlyAuthViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('account_reset_password_from_key_done')  # ok
 
 
+class SuspendedDeckSignupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+    """Sign-up is closed on a suspended deck (#1734 redesign): a suspended deck is
+    owner-only, so brand-new accounts must not be able to register and land in a
+    signed-in session (maintainer find on staging, 2026-07-31)."""
+
+    def setUp(self):
+        """Use a tenant-aware client and start from an unsuspended
+        (far-future-trial) deck with a clean deck cache."""
+        from django.core.cache import cache
+
+        from tenant.models import Tenant
+        from tenant.utils import deck_cache_key
+
+        self.client = TenantClient(self.tenant)
+        cache.delete(deck_cache_key(self.tenant.schema_name))
+        self.set_deck = lambda **fields: (
+            Tenant.objects.filter(pk=self.tenant.pk).update(**fields),
+            cache.delete(deck_cache_key(self.tenant.schema_name)),
+        )
+
+    def suspend_deck(self):
+        """Lapse the deck's trial far past the grace window."""
+        from datetime import date
+
+        self.set_deck(trial_end_date=date(2020, 1, 1), paid_until=None)
+
+    def test_signup__closed_on_suspended_deck(self):
+        """On a suspended deck the sign-up page renders the closed notice (with the
+        owner-only explanation) instead of the form, and a POST creates no user."""
+        self.suspend_deck()
+
+        response = self.client.get(reverse('account_signup'))
+        self.assertTemplateUsed(response, 'account/signup_closed.html')
+        self.assertContains(response, 'Sign-up is currently closed')
+        self.assertContains(response, 'only the deck owner can sign in')
+
+        form_data = {
+            'username': "sneakysignup",
+            'first_name': "Sneaky",
+            'last_name': "Signup",
+            'access_code': "314159",
+            'password1': "password",
+            'password2': "password",
+        }
+        self.client.post(reverse('account_signup'), form_data)
+        self.assertFalse(User.objects.filter(username='sneakysignup').exists())
+
+    def test_signup__open_on_unsuspended_deck(self):
+        """An unsuspended deck's sign-up page still renders the normal form."""
+        response = self.client.get(reverse('account_signup'))
+        self.assertTemplateUsed(response, 'account/signup.html')
+        self.assertNotContains(response, 'Sign-up is currently closed')
+
+
 class ResetPasswordViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     @classmethod

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -66,7 +66,7 @@ class NonPublicOnlyAuthViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 class SuspendedDeckSignupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """Sign-up is closed on a suspended deck (#1734 redesign): a suspended deck is
     owner-only, so brand-new accounts must not be able to register and land in a
-    signed-in session (maintainer find on staging, 2026-07-31)."""
+    signed-in session."""
 
     def setUp(self):
         """Use a tenant-aware client and start from an unsuspended

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -107,8 +107,22 @@ class SuspendedDeckSignupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             'password1': "password",
             'password2': "password",
         }
-        self.client.post(reverse('account_signup'), form_data)
+        response = self.client.post(reverse('account_signup'), form_data)
+        # the guard, not form validation, must be what blocked the valid payload:
+        # the closed notice renders and no account exists
+        self.assertContains(response, 'Sign-up is currently closed')
+        self.assertContains(response, 'only the deck owner can sign in')
         self.assertFalse(User.objects.filter(username='sneakysignup').exists())
+
+    def test_signup__adapter_defers_to_default_outside_deck_schemas(self):
+        """Where there is no current deck (the public and shared-library schemas),
+        the adapter leaves sign-up governed by the default allauth behavior."""
+        from unittest.mock import patch as mock_patch
+
+        from hackerspace_online.adapter import CustomAccountAdapter
+
+        with mock_patch('hackerspace_online.adapter.get_current_deck', return_value=None):
+            self.assertTrue(CustomAccountAdapter().is_open_for_signup(request=None))
 
     def test_signup__open_on_unsuspended_deck(self):
         """An unsuspended deck's sign-up page still renders the normal form."""

--- a/src/templates/account/signup_closed.html
+++ b/src/templates/account/signup_closed.html
@@ -1,0 +1,15 @@
+{% extends "base_no_sidebar.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Sign Up Closed" %} | {% endblock %}
+
+{% block heading %}{% trans "Sign Up Closed" %}<i class="pull-right fa fa-ban"></i>{% endblock %}
+
+{% block content %}
+  <p><strong>Sign-up is currently closed on this deck.</strong></p>
+  {% if current_deck.is_suspended %}
+    {# the only closed-signup case today: keep this conditional so future closed states don't inherit suspension copy #}
+    <p>This deck is suspended: only the deck owner can sign in until the deck has a valid subscription.</p>
+  {% endif %}
+{% endblock %}

--- a/src/templates/account/signup_closed.html
+++ b/src/templates/account/signup_closed.html
@@ -7,9 +7,9 @@
 {% block heading %}{% trans "Sign Up Closed" %}<i class="pull-right fa fa-ban"></i>{% endblock %}
 
 {% block content %}
-  <p><strong>Sign-up is currently closed on this deck.</strong></p>
+  <p><strong>{% trans "Sign-up is currently closed on this deck." %}</strong></p>
   {% if current_deck.is_suspended %}
     {# the only closed-signup case today: keep this conditional so future closed states don't inherit suspension copy #}
-    <p>This deck is suspended: only the deck owner can sign in until the deck has a valid subscription.</p>
+    <p>{% trans "This deck is suspended: only the deck owner can sign in until the deck has a valid subscription." %}</p>
   {% endif %}
 {% endblock %}

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -28,9 +28,14 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
 
     def test_GFKChoiceField__choices_and_clean(self):
         """Field groups choices by content type and clean() validates and resolves GFK values."""
+        # order_by('pk') keeps the grouped-choices order deterministic: without
+        # an explicit ordering Postgres returns rows in arbitrary order, so the
+        # user sublist in the assertion below flaked intermittently in CI. The
+        # field respects the caller's queryset order, so the fix belongs on the
+        # queryset here rather than forcing an order inside the field.
         f = GFKChoiceField(
             queryset=QuerySetSequence(
-                User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]),
+                User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]).order_by('pk'),
                 Group.objects.filter(pk__in=[self.group1.pk]),
             ),
         )


### PR DESCRIPTION
### What?
On a suspended deck the sign-up page now renders a "Sign Up Closed" notice (with the owner-only explanation) instead of the registration form, and POSTs create no account. Implemented at the allauth adapter level: `CustomAccountAdapter.is_open_for_signup` returns False while the current deck is suspended, which also covers **Google sign-ups** (the social-account adapter delegates its `is_open_for_signup` to the account adapter). Public and library schemas are unaffected.

This is the develop PR #2222 re-targeted to `staging` as a hotfix at the maintainer's request (2026-07-31): its two commits cherry-picked onto `staging` unchanged, including all the CodeRabbit review fixes already confirmed there (docstring Args/Returns, guard-proving POST test, i18n on the template copy, no-current-deck unit test). #2222 is closed as superseded by this PR. Follow-up commits from review and CI: 4ed6f87 takes CodeRabbit's two docstring nitpicks from this PR's own review, and fbbf034 carries the `test_GFKChoiceField__choices_and_clean` ordering fix (same change as #2230 and develop's copy of the test) because that pre-existing staging flake redded this PR's CI twice; whichever of this PR or #2230 merges first makes the other's copy a clean no-op.

### Why?
Maintainer find on staging: with a deck suspended, a brand-new user could still register and land in a signed-in session. The suspension copy live in production says "only the deck owner can sign in", so the open sign-up front door contradicts it; this closes it now rather than waiting for the develop release cycle.

### How?
* `hackerspace_online/adapter.py`: the `is_open_for_signup` override (one guard for form + social sign-ups), on a class that now carries its required docstring.
* `templates/account/signup_closed.html` (new): rendered by allauth when signup is closed; extends the site's `base_no_sidebar.html` like the other account pages, with translatable copy and the suspension explanation kept conditional.
* `utilities/tests/test_fields.py`: the carried flake fix (an explicit `order_by('pk')` so the choice-order assertion stops depending on Postgres row order).
* No migrations, no settings changes. Re-gated on the `staging` base.

### Testing?
* Full serial suite on this branch (staging base): **1555 tests, OK**, plus `ruff` clean, re-run green after each follow-up commit.
* Tests: suspended deck renders `signup_closed.html` with the owner-only copy and a valid signup POST renders the closed notice and creates no user; unsuspended deck still renders the normal form; the adapter defers to the default outside deck schemas.

### Screenshots (if front end is affected)
Real `hackerspace` dev deck, suspended, visiting `/accounts/signup/` anonymously (before: the full registration form, as in the maintainer's staging screenshot):

![Sign-up closed on a suspended deck](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/suspension-signup-block/signup_closed.png)

### Anything Else?
The rest of the #1734 enforcement stays on the develop cycle per the maintainer's choice: B1 owner-only middleware is already merged into `develop` (#2210) and B2 semester auto-close is open as #2224. After this hotfix merges, the next staging-to-develop sync will meet the same changes already present on develop-based branches; I'll resolve any overlap at sync time.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_



## Summary by CodeRabbit

* **New Features**
  * Signups are now blocked for suspended decks, including social signups.
  * Active decks and non-deck contexts continue to support normal signup behavior.
  * Added a dedicated signup-closed page with suspension details when applicable.

* **Bug Fixes**
  * Prevented account creation while a deck is suspended.
