### PR TITLE
test: cover ApproveView.form_invalid (ajax and non-ajax)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3663,6 +3663,29 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """ This view is only accessible via POST """
         self.assert404('quests:approve', args=[self.sub.id])
 
+    def test_approve__invalid_form_renders_submission_page(self):
+        """A non-ajax POST with an invalid awards value re-renders the submission page (form_invalid)."""
+        # An 'awards' value routes to SubmissionFormStaff, and an id that is not a
+        # manually-granted badge fails the ModelMultipleChoiceField validation.
+        response = self.client.post(
+            reverse('quests:approve', args=[self.sub.id]),
+            data={'awards': [999999], 'approve_button': True},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'quest_manager/submission.html')
+        self.sub.refresh_from_db()
+        self.assertFalse(self.sub.is_approved)  # the invalid submission did nothing
+
+    def test_approve__invalid_form_ajax_returns_400(self):
+        """An ajax POST with an invalid awards value returns a 400 JsonResponse (form_invalid)."""
+        response = self.client.post(
+            reverse('quests:approve', args=[self.sub.id]),
+            data={'awards': [999999], 'approve_button': True},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'error': 'Bad Request'})
+
     def test_approve__with_comment_quick_reply_form(self):
         """Approving via the quick reply form approves the submission, adds the comment, and notifies the student."""
         comment_text = "Lorum Ipsum"


### PR DESCRIPTION
## What

Covers `ApproveView.form_invalid()` and the `post()` fallthrough that calls it: the last untested branch cluster in the staff submission-approval flow.

## Why

`ApproveView.post()` ends with `return self.form_invalid()`, and `form_invalid()` splits into an ajax (400 `JsonResponse`) vs non-ajax (re-render) path. None of it was covered, because both candidate forms are otherwise all-optional (`SubmissionQuickReplyForm` and the base `SubmissionForm` have no required fields), so `form.is_valid()` was effectively always True in the existing tests.

The one field that *can* fail validation is `awards` on `SubmissionFormStaff` (a `ModelMultipleChoiceField` limited to manually-granted badges). Posting an `awards` value both routes `get_form()` to `SubmissionFormStaff` and (with an id that isn't a manually-granted badge) fails validation, so the request reaches `form_invalid()`.

## How

Two tests in `ApproveViewTest`:

- `test_approve__invalid_form_renders_submission_page`: a non-ajax POST with `awards=[999999]` re-renders `quest_manager/submission.html` (200) and leaves the submission unapproved.
- `test_approve__invalid_form_ajax_returns_400`: the same POST with the `XMLHttpRequest` header returns a 400 `JsonResponse` (`{'error': 'Bad Request'}`).

## Testing

- Both new tests pass; `ApproveViewTest` remains green.
- `coverage` confirms `quest_manager/views.py` lines 1222 to 1223 (ajax), 1229 to 1237 (non-ajax render), and 1454 (post fallthrough) are now covered.
- `ruff check` clean.

## Screenshots

N/A: test-only; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)