### PR TITLE
HOTFIX: test: pin user ordering in the flaky GFK choice-field test

### DIFF
--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -28,9 +28,14 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
 
     def test_GFKChoiceField__choices_and_clean(self):
         """Field groups choices by content type and clean() validates and resolves GFK values."""
+        # order_by('pk') keeps the grouped-choices order deterministic: without
+        # an explicit ordering Postgres returns rows in arbitrary order, so the
+        # user sublist in the assertion below flaked intermittently in CI. The
+        # field respects the caller's queryset order, so the fix belongs on the
+        # queryset here rather than forcing an order inside the field.
         f = GFKChoiceField(
             queryset=QuerySetSequence(
-                User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]),
+                User.objects.filter(pk__in=[self.user1.pk, self.user2.pk]).order_by('pk'),
                 Group.objects.filter(pk__in=[self.group1.pk]),
             ),
         )


### PR DESCRIPTION
### What?
Ports develop's flake fix for `test_GFKChoiceField__choices_and_clean` (utilities app) to staging: the test's User queryset gains an explicit `order_by('pk')`, plus the rationale comment, byte-identical to develop's copy of the test.

### Why?
The test asserts the exact order of the user choices, but builds its queryset without an ordering, so Postgres returns the two users in arbitrary order. It flaked twice today on unmodified staging code: it failed the "Build and Test" CI run on #2227's docstring-only commit (4ed6f87), and one local full-suite run, while passing standalone and on reruns each time. develop's copy of the test already carries this fix; staging just predates it. With a staging release in motion, staging CI should not be a coin flip.

### How?
One-line queryset change plus the explanatory comment, taken verbatim from develop's copy so the next staging-into-develop sync merges without conflict. The `GFKChoiceField` itself is untouched: the field respects the caller's queryset order, so the fix belongs on the queryset in the test rather than forcing an ordering inside the field.

### Testing?
* Full suite on this branch: 1552 tests, OK, plus `ruff` clean.
* The utilities app also passes standalone before and after the change; the failure only reproduces when Postgres happens to return the rows reversed, which the explicit ordering now precludes.

### Screenshots (if front end is affected)
N/A (test-only change).

### Anything Else?
The flake predates every open PR: it exists in staging's own test suite and can red any staging-based PR at random, including hotfixes queued for the production merge. #2227's failed job has been queued for re-run separately; once this merges, staging CI stops rolling that die.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_