### PR TITLE
test: cover quest_manager/views.py approval-flow tail and drop dead skipped-view guard

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -4514,6 +4514,37 @@ class QuestArchiveViewTest(ByteDeckTenantTestCase):
         # Confirm redirect to archived quests page
         self.assertRedirects(response, reverse('quests:archived'))
 
+    def test_post__skips_submissions_whose_user_has_no_profile(self):
+        """Archiving still completes when an affected user has no Profile.
+
+        The XP-invalidation loop looks up each affected user's Profile. Every user
+        normally has one, but a rare data inconsistency (e.g. the profile-delete
+        signal's own user.delete() being swallowed on a TransactionManagementError,
+        leaving a user with no profile) would make the lookup raise
+        Profile.DoesNotExist. The loop catches that and moves on, so the archive
+        finishes and the quest's submissions are still deleted.
+
+        Profile.objects.get is patched to raise DoesNotExist because the orphaned
+        state cannot be produced directly: deleting a Profile fires a post_delete
+        signal that also deletes the User (and cascade-deletes the submission).
+        """
+        quest_to_archive = self.quest_b
+        user = baker.make(User)
+        submission = baker.make(QuestSubmission, quest=quest_to_archive, user=user)
+
+        url = reverse('quests:quest_archive', args=[quest_to_archive.id])
+        with patch('quest_manager.views.Profile.objects.get', side_effect=Profile.DoesNotExist):
+            response = self.client.post(url)
+
+        # The archive completed despite the affected user's missing Profile.
+        quest_to_archive.refresh_from_db()
+        self.assertTrue(quest_to_archive.archived)
+        self.assertRedirects(response, reverse('quests:archived'))
+        self.assertFalse(
+            QuestSubmission._base_manager.filter(id=submission.id).exists(),
+            "submission should still be deleted even though the user had no profile"
+        )
+
     def test_get__already_archived_quest_returns_404(self):
         """The archive confirmation page 404s for an already-archived quest (#1856).
 

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -4008,6 +4008,37 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class QuestSubmissionSummaryTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+    """Tests for the staff QuestSubmissionSummary metrics view (quests:summary)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a staff teacher and a quest to summarize."""
+        cls.teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.quest = baker.make(Quest, name="Summary Quest")
+
+    def setUp(self):
+        """Set up a tenant-aware test client and log in the teacher."""
+        self.client = TenantClient(self.tenant)
+        self.client.force_login(self.teacher)
+
+    def test_summary__with_approved_submission_computes_stats(self):
+        """With an approved submission, the summary reports the latest approval time and percent-returned.
+
+        Exercises the 'has approved submissions' and 'count_total > 0' branches that an
+        empty quest leaves uncovered.
+        """
+        baker.make(
+            QuestSubmission, quest=self.quest, is_approved=True, is_completed=True,
+            semester=SiteConfig.get().active_semester, time_approved=timezone.now(),
+        )
+        response = self.client.get(reverse('quests:summary', args=[self.quest.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context['latest_submission_time'])
+        self.assertEqual(response.context['count_total'], 1)
+        self.assertEqual(response.context['percent_returned'], 0)  # none returned -> 0%
+
+
 class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """ Tests for:
 
@@ -4189,6 +4220,14 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertTrue(response.context['current_teacher_only'])
         self.assertEqual(response.context['quest'], self.quest)
         self.assertURLEqual(response.context['tab_list'][2]['url'], reverse('quests:approved'))
+
+    def test_approvals__approved_for_quest_all(self):
+        """The 'all' variant shows approvals of this quest across all semesters (past_approvals_all=True)."""
+        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=[self.sub]):
+            response = self.client.get(reverse('quests:approved_for_quest_all', args=[self.quest.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['quest'], self.quest)
+        self.assertTrue(response.context['past_approvals_all'])
 
     def test_approvals__my_groups_all_button_rendered(self):
         """My groups/all button SHOULD NOT be rendered when there is only one user with assigned blocks AND that user is the current user"""

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2026,17 +2026,9 @@ def skipped(request, quest_id):
     regardless, and do_not_grant_xp = True
     """
     quest = get_object_or_404(Quest, pk=quest_id)
-    new_sub = QuestSubmission.objects.create_submission(request.user, quest)
-    if new_sub is None:  # might be because quest was already started
-        # so try to get the started Quest
-        submission = QuestSubmission.objects.all_for_user_quest(
-            request.user, quest, True
-        ).last()
-        if submission is None:
-            raise Http404
-    else:
-        submission = new_sub
-
+    # create_submission always returns a submission: a new in-progress one, or the
+    # existing in-progress submission when the quest was already started (issue #1345).
+    submission = QuestSubmission.objects.create_submission(request.user, quest)
     return skip(request, submission.id)
 
 


### PR DESCRIPTION
## What

Closes the remaining coverage gaps in the tail of `quest_manager/views.py` (staff approval / quest-lifecycle branches) and removes one dead branch.

## Why

- **`QuestSubmissionSummary.get_context_data`**: the "has approved submissions" branch (latest approval time) and the "count_total > 0" branch (percent returned) were only ever reached with a quest that had no approved submissions, so the stat-computing lines stayed uncovered.
- **`approvals()`**: the approved-for-quest "all" tab (the `approved_for_quest_all` URL) sets `active_sem_only = False` and `past_approvals_all = True`, but no test loaded that specific tab. The non-"all" `approved_for_quest` variant was already tested.
- **`QuestArchive.post`**: the XP-invalidation loop's `except Profile.DoesNotExist: continue` guard was uncovered. It handles the rare orphaned-submission state where an affected user has no Profile; the archive must still complete and delete submissions.
- **`skipped()`**: the `if new_sub is None:` block was dead. `create_submission` never returns None (it returns a new in-progress submission, or on the #1345 double-start race the existing one, re-raising if none matches), and the sibling `start()` view already calls it with no None-guard. The guard and its inner `Http404` were unreachable.

## How

In `src/quest_manager/tests/test_views.py`:

- `QuestSubmissionSummaryTest.test_summary__with_approved_submission_computes_stats`: creates an approved submission, loads `quests:summary` as staff, and asserts a non-null latest approval time, `count_total == 1`, and `percent_returned == 0`.
- `ApprovalsViewTest.test_approvals__approved_for_quest_all`: loads `quests:approved_for_quest_all` as staff and asserts `past_approvals_all` is True in context.
- `QuestArchiveViewTest.test_post__skips_submissions_whose_user_has_no_profile`: patches `Profile.objects.get` to raise `DoesNotExist` (the orphaned state can't be produced directly: deleting a Profile fires a post_delete signal that also deletes the User), then asserts the archive still completes and the submission is deleted.

In `src/quest_manager/views.py`:

- `skipped()`: drop the unreachable `if new_sub is None:` block; assign the submission from `create_submission` directly. The happy path stays fully covered by existing tests.

## Testing

- Full `quest_manager` suite green (345 tests).
- `coverage` confirms the previously-missing `quest_manager/views.py` lines are now covered (summary stats, approvals all-tab, archive `Profile.DoesNotExist` guard) and the simplified `skipped()` view has no uncovered lines.
- `ruff check` clean.

## Screenshots

N/A: test coverage plus a dead-code removal; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of skipped quests when an in-progress submission already exists.
  * Quest archiving now completes successfully even when an affected user lacks a profile.
  * Archiving continues to remove submissions and redirect correctly.
* **Tests**
  * Added coverage for quest summary metrics and approved submissions across all semesters.
  * Added tests for archiving quests with incomplete user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->