### PR TITLE
fix: render submission questions as a list-group so they flow without gaps (#2234)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -131,7 +131,7 @@
         {% if question_formset %}
           {# with per-question answer fields above, the general comment box needs its own heading #}
           {# so students know it's for anything beyond their answers #}
-          <p><strong>Additional Submission Comments</strong></p>
+          <p class="submission-comments-heading"><strong>Additional Submission Comments</strong></p>
         {% endif %}
         <div id="main-comment-form">
           {{ submission_form | crispy }}

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -106,10 +106,14 @@
           {% if question_formset.non_form_errors %}
             <div class="alert alert-danger">{{ question_formset.non_form_errors }}</div>
           {% endif %}
+          {% comment %} Each question is a list-group item, so the questions read as one connected
+             list (single hairline borders between them, no inter-item gaps) rather than a stack of
+             separate padded cards. {% endcomment %}
+          <div class="list-group question-submission-list">
           {# the loop variable must be named `form`: the crispy HTML() layout objects inside #}
           {# QuestionSubmissionForm reference {{ form.question... }} from the template context #}
           {% for form in question_formset %}
-            <div class="well well-sm question-submission-form">
+            <div class="list-group-item question-submission-form">
               {# question number and the teacher's instructions on one line to save space; unwrap_p strips #}
               {# summernote's wrapping <p> so a one-line prompt flows right after the "Question N:" label. #}
               {# A <div> (not <p>) wraps it because multi-paragraph instructions keep their <p> tags, which #}
@@ -121,6 +125,7 @@
               {% crispy form %}
             </div>
           {% endfor %}
+          </div>
           <hr>
         {% endif %}
         {% if question_formset %}

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -575,6 +575,13 @@ iframe.summernotewidget.form-control {
     margin-right: 15px;
 }
 
+/* The "Additional Submission Comments" heading sits directly inside the padding-less
+   .panel-summernote, so it needs the same 15px left inset as the summernote form fields to line
+   up with the question labels above it instead of jamming against the panel's left edge. */
+.submission-comments-heading {
+    margin-left: 15px;
+}
+
 .multifileinput {
     border: none;
     box-shadow: none !important;

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -1215,3 +1215,11 @@ table[data-toggle="table"].bt-reveal {
 .question-answers pre {
     white-space: pre-wrap;
 }
+
+/* Submission question blocks (quest_manager/submission.html) render as a Bootstrap list-group, so
+   the questions read as one connected list (single hairline borders between items, no inter-item
+   gaps) rather than separate padded .well cards. Trim the answer field's trailing form-group
+   margin so each item closes up right after the field instead of carrying a tall empty band. */
+.question-submission-form .form-group {
+    margin-bottom: 0;
+}

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -30,7 +30,7 @@
 {% else %}
 <link href="{{ STATIC_PREFIX }}css/custom.css?v=1.6" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=1.9" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.0" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -30,7 +30,7 @@
 {% else %}
 <link href="{{ STATIC_PREFIX }}css/custom.css?v=1.6" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.0" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.1" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->


### PR DESCRIPTION
### What?
Two front-end fixes to the quest submission form's question area:
1. Render the questions as a Bootstrap **list-group** so they flow as one connected list instead of a stack of separate cards with gaps.
2. Give the **"Additional Submission Comments" heading** its left inset back so it lines up with the question labels instead of jamming against the panel edge.

### Why?
1. Each question was a Bootstrap `.well`: a standalone card with a grey background, its own padding, and a 20px bottom margin meant to set it apart from surrounding content. Stacking one `.well` per question left a wide empty band between every question (#2234). A `.well` is the wrong component for a sequence of items; a `.list-group` is built for exactly this.
2. The `Additional Submission Comments` heading sits directly inside the padding-less `.panel-summernote`, so it rendered flush against the panel's left edge (measured left = 266) while the question labels above it are inset ~15px (left = 282). Reported in review.

### How?
- `submission.html`: wrap the question forms in a `.list-group` and render each as a `.list-group-item` (keeping the `question-submission-form` class that the draft-autosave JS and the CSS rely on). List-group items share single hairline borders and carry no inter-item margin, so the questions read as one connected list on a white background.
- `custom_common.css`: replaced the earlier `.well` spacing tweak with a rule that trims the answer field's trailing `.form-group` margin, and added a `.submission-comments-heading` rule giving that heading the same 15px left inset as the summernote fields.
- `submission.html`: added the `submission-comments-heading` class to the heading.
- Bumped the `custom_common.css` cache-buster (`1.9` → `2.1`). No inline CSS.

### Testing?
Template + CSS only (no Python touched). Verified on a real `hackerspace` dev deck (`initdb`-seeded, logged in as a student) on a quest with a short-answer, long-answer, and file-upload question:
- questions render as a connected list separated by single hairline borders, no inter-question gaps or grey card backgrounds;
- the `Additional Submission Comments` heading now aligns with the question labels (measured left 281 vs 282, was 266).

`ruff check src` is clean (no Python changes).

### Screenshots (if front end is affected)
Real `hackerspace` deck, logged in as a student.

Questions: before (`develop`, `.well` cards) vs after (list-group):

![before/after: submission questions as a list-group](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2234/before-after.png)

"Additional Submission Comments" heading: flush against the panel edge (before) vs inset/aligned (after):

![before/after: comments heading alignment](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2234/heading-before-after.png)

### Anything Else?
Follow-up polish to the submission-questions feature (#1304 / #2099). Revised from an initial "tighten the `.well` spacing" approach to a list-group after review feedback that a `.well` is the wrong component for stacked questions; the heading-alignment fix was added from a second review note (both are pre-existing #2099 layout issues in the same submission-form area).

### Review request
@tylerecouture

Closes #2234

- Claude Code (`Bytedeck - multiple submission types`)