### PR TITLE
feat: semester archive confirmation page, POST-only state changes, status column (#2157 Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ target/
 
 # Claude Code hook runtime state (per-session mtime cache)
 .claude/.cache/
+
+# redis persistence file dropped by a locally-run redis-server
+dump.rdb

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -447,7 +447,7 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         draft_ann.refresh_from_db()
         self.assertFalse(draft_ann.archived)
 
-    def test_announcements_archived_after_semester_archive(self):
+    def test_announcements__archived_after_semester_archive(self):
         """ All unarchived (non-draft) announcements should be archived when a semester is
         archived with the archive_announcements box checked """
         announcements = [baker.make(Announcement, archived=False, draft=False) for _ in range(5)]

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -437,28 +437,27 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, oldest_announcement.title)
 
-    def test_announcement_draft__not_archived_after_semester_close(self):
-        """ Draft announcements should not be archived when a semester is closed """
+    def test_announcement_draft__not_archived_after_semester_archive(self):
+        """ Draft announcements should not be archived when a semester is archived """
         draft_ann = baker.make(Announcement, archived=False, draft=True)
 
         self.client.force_login(self.test_teacher)
-        self.client.get(reverse('courses:end_active_semester'))
+        self.client.post(reverse('courses:semester_archive'), data={'archive_announcements': 'on'})
 
         draft_ann.refresh_from_db()
         self.assertFalse(draft_ann.archived)
 
-    # TODO Fix this, announcements only archive if semester closing is successful, which its not here maybe?
-    # def test_announcements_archived_after_semester_close(self):
-    #     """ All unarchived (non-draft) announcements should be archived when a semester is closed"""
+    def test_announcements_archived_after_semester_archive(self):
+        """ All unarchived (non-draft) announcements should be archived when a semester is
+        archived with the archive_announcements box checked """
+        announcements = [baker.make(Announcement, archived=False, draft=False) for _ in range(5)]
 
-    #     announcements = [baker.make(Announcement, archived=False, draft=False) for _ in range(5)]
+        self.client.force_login(self.test_teacher)
+        self.client.post(reverse('courses:semester_archive'), data={'archive_announcements': 'on'})
 
-    #     self.client.force_login(self.test_teacher)
-    #     self.client.get(reverse('courses:end_active_semester'))
-
-    #     for announcement in announcements:
-    #         announcement.refresh_from_db()
-    #         self.assertTrue(announcement.archived)
+        for announcement in announcements:
+            announcement.refresh_from_db()
+            self.assertTrue(announcement.archived)
 
 
 class AnnouncementCreateUpdateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -304,6 +304,16 @@ class Semester(models.Model):
         # the current local date.  Use current local date with date.today()
         return self.first_day <= date.today() <= self.last_day
 
+    def has_ended(self):
+        """Whether the semester's last day is in the past (local date, consistent with
+        is_open()). Used by the semester list to flag an active semester that has run
+        past its end date and is probably due to be archived.
+
+        Returns:
+            bool: True when last_day is set and before today.
+        """
+        return self.last_day is not None and self.last_day < date.today()
+
     def num_days(self, upto_today=False):
         '''The number of classes in the semester (from start date to end date
         excluding weekends and ExcludedDates). '''

--- a/src/courses/templates/courses/semester_archive.html
+++ b/src/courses/templates/courses/semester_archive.html
@@ -1,0 +1,59 @@
+{% extends "courses/base.html" %}
+
+{% block head_title %}Semesters | {% endblock %}
+{% block head %}{% endblock %}
+
+{% block heading_inner %} Archive Semester {% endblock %}
+
+{% block content %}
+  <div class="well">
+    <p>Name: {{ semester }}</p>
+    <p>First Day: {{ semester.first_day }}</p>
+    <p>Last Day: {{ semester.last_day }}</p>
+  </div>
+
+  {% if semester.closed %}
+  <p class="text-danger"><b>This semester has already been archived.</b></p>
+  <a href="{% url 'courses:semester_list' %}" role="button" class="btn btn-info">Back to Semesters</a>
+  {% else %}
+
+  <p>Archiving a semester ends it permanently and records final marks. This is what will happen:</p>
+  <ul>
+    <li><b>{{ num_registrations }}</b> course registration{{ num_registrations|pluralize }} will have final XP recorded and be closed,
+      freeing up <b>{{ num_seats_freed }}</b> student seat{{ num_seats_freed|pluralize }} on your deck.</li>
+    <li>Student XP will be reset to 0, ready for the next semester.</li>
+    <li><b>{{ num_in_progress }}</b> in-progress quest submission{{ num_in_progress|pluralize }} will be permanently deleted.</li>
+    <li>All published announcements ({{ num_announcements }}) will be archived, unless you uncheck the box below.</li>
+  </ul>
+  <p class="text-danger"><b>Once a semester is archived it can't be re-opened</b>: changing or deleting quests,
+    submissions, or badges will no longer affect students' recorded marks.</p>
+
+  {% if blocked %}
+    <div class="alert alert-warning">
+      <p><b>This semester can't be archived yet:</b></p>
+      <ul>
+        {% if num_awaiting_approval %}
+        <li>{{ num_awaiting_approval }} quest submission{{ num_awaiting_approval|pluralize }} still awaiting approval:
+          <a href="{% url 'quests:approvals' %}">approve or return them</a> first.</li>
+        {% endif %}
+        {% for user in negative_xp_users %}
+        <li>{{ user.profile }} has negative XP ({{ user.profile.xp_cached }}); fix it before archiving.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <a href="{% url 'courses:semester_list' %}" role="button" class="btn btn-info">Back to Semesters</a>
+  {% else %}
+    <form action="" method="post">{% csrf_token %}
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" name="archive_announcements" checked> Also archive all published announcements
+        </label>
+      </div>
+
+      <a href="{% url 'courses:semester_list' %}" role="button" class="btn btn-info">Cancel</a>
+      <input type="submit" value="Archive Semester" class="btn btn-danger" />
+    </form>
+  {% endif %}
+
+  {% endif %}
+{% endblock %}

--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -50,7 +50,7 @@
         <span class="label label-default">Archived</span>
         {% elif object == config.active_semester %}
           {% if object.has_ended %}
-          <span class="label label-warning" title="This semester's last day has passed. Archive it to record final marks and free up student seats.">Active - ended {{ object.last_day }}</span>
+          <span class="label label-success" title="This semester's last day has passed. Archive it to record final marks and free up student seats.">Active - ended</span>
           {% else %}
           <span class="label label-success">Active</span>
           {% endif %}

--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -15,7 +15,8 @@
 
 <h3>Current Active Semester: {{ config.active_semester }}</h3>
 
-<p>When students join a course it will be connected to the active semester.</p>
+<p>When students join a course it will be connected to the active semester.
+  When a semester is over, archive it to record final marks and free up your students' seats.</p>
 <p>The first and last day of the semester are only relevant if you are using the
   <a href="{% url 'courses:my_marks' %}">mark calculations</a> page, activated
   with the "Use mark percentages" setting in your
@@ -31,8 +32,7 @@
       <th>Total Days</th>
       <th># Excluded Dates</th>
       <th># Students</th>
-      <th>Closed</th>
-      <!-- <th>Active</th> -->
+      <th>Status</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -45,24 +45,37 @@
       <td>{{ object.num_days }}</td>
       <td>{{ object.excludeddate_set.count }}</td>
       <td>{{ object.coursestudent_set.count }}</td>
-      <td>{{ object.closed }}</td>
-      <!-- <td>{% if object == config.active_semester %}True{% else %}False{% endif %}</td> -->
+      <td>
+        {% if object.closed %}
+        <span class="label label-default">Archived</span>
+        {% elif object == config.active_semester %}
+          {% if object.has_ended %}
+          <span class="label label-warning" title="This semester's last day has passed. Archive it to record final marks and free up student seats.">Active - ended {{ object.last_day }}</span>
+          {% else %}
+          <span class="label label-success">Active</span>
+          {% endif %}
+        {% else %}
+        <span class="label label-info" title="Students can't join this semester unless you activate it.">Inactive</span>
+        {% endif %}
+      </td>
       <td>
         {% if not object.closed %}
         <a class="btn btn-warning" href="{% url 'courses:semester_update' object.id %}" role="button" title="Edit this semester">
           <i class="fa fa-edit"></i>
         </a>
         {% endif %}
-        {% if not object.closed and object == config.active_semester%}
-        <a class="btn btn-danger" href="{% url 'courses:end_active_semester' %}" role="button" id="end-semester"
-          title="Close this semester. WARNING!  Once a semester is closed, it can't be re-opened. This will permanently record all student XP for the semester. Which means changing or deleting quests, submissions, or badges will no longer affect their marks.  It will also archive all announcements and delete any in-progress submissions.">
-          <i class="fa fa-calendar-times-o"></i>
+        {% if not object.closed and object == config.active_semester %}
+        <a class="btn btn-danger" href="{% url 'courses:semester_archive' %}" role="button"
+          title="Archive this semester: record all students' final XP and free up their seats.">
+          <i class="fa fa-archive"></i>
         </a>
         {% endif %}
         {% if not object.closed and object != config.active_semester %}
-        <a class="btn btn-success" href="{% url 'courses:semester_activate' object.id %}" role="button" title="Activate this semester">
-          <i class="fa fa-calendar-check-o"></i>
-        </a>
+        <form class="preview-action-form" action="{% url 'courses:semester_activate' object.id %}" method="post">{% csrf_token %}
+          <button type="submit" class="btn btn-success" title="Activate this semester">
+            <i class="fa fa-calendar-check-o"></i>
+          </button>
+        </form>
         <a class="btn btn-danger" href="{% url 'courses:semester_delete' object.id %}" role="button" title="Delete this semester">
           <i class="fa fa-trash-o"></i>
         </a>
@@ -73,16 +86,4 @@
   </tbody>
 </table>
 
-{% endblock %}
-
-{% block js %}
-
-<script>
-  $('body').on('click', '#end-semester', function(e) {
-      if(!confirm("WARNING!  Once a semester is closed, it can't be re-opened. It will archive all announcements and delete any in-progress submissions. Are you sure you want to do this?")) {
-          e.preventDefault();
-          return;
-      }
-  })
-</script>
 {% endblock %}

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -269,6 +269,18 @@ class SemesterModelTest(ByteDeckTenantTestCase):
 
         # Timezone problems?
 
+    def test_has_ended__only_after_last_day(self):
+        """has_ended() is True only once the last day is in the past, and False when the
+        semester has no last day at all."""
+        with freeze_time(self.semester_end, tz_offset=0):
+            self.assertFalse(self.semester.has_ended())
+
+        with freeze_time(self.semester_end + timedelta(days=1), tz_offset=0):
+            self.assertTrue(self.semester.has_ended())
+
+        dateless_semester = baker.make(Semester, name='dateless', first_day=None, last_day=None)
+        self.assertFalse(dateless_semester.has_ended())
+
     def test_active_by_date__true_inside_padded_window_false_outside(self):
         """active_by_date() is True from 20 days before the first day to 5 days after the last day,
         a padded window wider than is_open()."""

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -196,7 +196,7 @@ class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTest
         self.assertRedirectsLogin('courses:ranks')
         self.assertRedirectsLogin('courses:my_marks')
         self.assertRedirectsLogin('courses:marks', args=[1])
-        self.assertRedirectsLogin('courses:end_active_semester')
+        self.assertRedirectsLogin('courses:semester_archive')
 
         self.assertRedirectsLogin('courses:markranges')
         self.assertRedirectsLogin('courses:markrange_create')
@@ -233,7 +233,7 @@ class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTest
 
         # Staff access only
         self.assert403('courses:join', args=[self.test_student1.id])
-        self.assert403('courses:end_active_semester')
+        self.assert403('courses:semester_archive')
         self.assert403('courses:coursestudent_delete', args=[1])
 
         self.assert403('courses:markranges')
@@ -265,8 +265,7 @@ class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTest
         # Staff access only
         self.assert200('courses:join', args=[self.test_student1.id])
 
-        # Redirects, has own test
-        # self.assert200('courses:end_active_semester')
+        self.assert200('courses:semester_archive')
 
         self.assert200('courses:markranges')
         self.assert200('courses:markrange_create')
@@ -304,26 +303,97 @@ class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTest
         self.assert200('courses:update', args=[course_student.id])
         self.client.logout()
 
-    def test_end_active_semester__staff(self):
-        ''' End_active_semester view should redirect to semester list view '''
+    def test_SemesterArchive__staff_post_archives(self):
+        """POSTing the archive view closes the active semester and redirects to the semester list."""
         self.client.force_login(self.test_teacher)
         active_sem = SiteConfig.get().active_semester
         self.assertFalse(active_sem.closed)
         self.assertRedirects(
-            response=self.client.get(reverse('courses:end_active_semester')),
+            response=self.client.post(reverse('courses:semester_archive')),
             expected_url=reverse('courses:semester_list'),
         )
         active_sem.refresh_from_db()
         self.assertTrue(active_sem.closed)
 
+    def test_SemesterArchive__get_is_a_preview_and_does_not_archive(self):
+        """GET on the archive view renders the confirmation/preview page (with the counts of
+        what archiving will do) without changing anything."""
+        self.client.force_login(self.test_teacher)
+        active_sem = SiteConfig.get().active_semester
+        student = baker.make(User)
+        baker.make(CourseStudent, user=student, course=baker.make(Course), semester=active_sem)
+
+        response = self.client.get(reverse('courses:semester_archive'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['semester'], active_sem)
+        self.assertEqual(response.context['num_registrations'], 1)
+        self.assertEqual(response.context['num_seats_freed'], 1)
+        self.assertFalse(response.context['blocked'])
+        active_sem.refresh_from_db()
+        self.assertFalse(active_sem.closed)
+
+    def test_SemesterArchive__get_shows_blockers(self):
+        """The archive preview lists blockers: submissions awaiting approval and students
+        with negative XP, with the form replaced by a link back to the semester list."""
+        self.client.force_login(self.test_teacher)
+        active_sem = SiteConfig.get().active_semester
+        baker.make(QuestSubmission, is_completed=True, is_approved=False, semester=active_sem)
+        negative_student = baker.make(User)
+        baker.make(CourseStudent, user=negative_student, course=baker.make(Course),
+                   semester=active_sem, xp_adjustment=-10)
+
+        response = self.client.get(reverse('courses:semester_archive'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['blocked'])
+        self.assertEqual(response.context['num_awaiting_approval'], 1)
+        self.assertIn(negative_student, response.context['negative_xp_users'])
+
+    def test_SemesterArchive__already_archived(self):
+        """POSTing the archive view for an already-archived semester warns and takes no action."""
+        self.client.force_login(self.test_teacher)
+        active_sem = SiteConfig.get().active_semester
+        active_sem.closed = True
+        active_sem.save()
+
+        response = self.client.post(reverse('courses:semester_archive'))
+
+        self.assertRedirects(response, reverse('courses:semester_list'))
+        self.assertWarningMessage(response)
+
+    def test_SemesterArchive__announcements_opt_out(self):
+        """Archiving without the archive_announcements checkbox leaves announcements alone."""
+        from announcements.models import Announcement
+        announcement = baker.make(Announcement, archived=False, draft=False)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(reverse('courses:semester_archive'))  # no checkbox in POST data
+
+        self.assertRedirects(response, reverse('courses:semester_list'))
+        self.assertSuccessMessage(response)
+        announcement.refresh_from_db()
+        self.assertFalse(announcement.archived)
+
     def test_SemesterActivate__changes_active_semester(self):
-        """When this view is accessed, the siteconfig's active semester should be changed
-        and the view should redirect tot he semester_list """
+        """POSTing the activate view changes the siteconfig's active semester and
+        redirects to the semester_list."""
         self.client.force_login(self.test_teacher)
         new_semester = baker.make('courses.semester')
-        response = self.client.get(reverse('courses:semester_activate', args=[new_semester.pk]))
+        response = self.client.post(reverse('courses:semester_activate', args=[new_semester.pk]))
         self.assertRedirects(response, reverse('courses:semester_list'))
         self.assertEqual(SiteConfig.get().active_semester, Semester.objects.get(pk=new_semester.pk))
+
+    def test_SemesterActivate__get_not_allowed(self):
+        """GET must not change the active semester (deck-wide state changes are POST-only,
+        so they can't be triggered by link prefetching or a cross-site GET): it returns
+        405 Method Not Allowed and leaves the active semester untouched."""
+        self.client.force_login(self.test_teacher)
+        original_active = SiteConfig.get().active_semester
+        new_semester = baker.make('courses.semester')
+        response = self.client.get(reverse('courses:semester_activate', args=[new_semester.pk]))
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(SiteConfig.get().active_semester, original_active)
 
     def test_CourseList_view__staff_can_view(self):
         """ Admin should be able to view course list """
@@ -948,9 +1018,9 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(ExcludedDate.objects.exists())
 
     @patch('profile_manager.models.Profile.xp_per_course')
-    def test_SemesterDCloses__student_with_negative_xp__view(self, xp_per_course):
+    def test_SemesterArchive__student_with_negative_xp__view(self, xp_per_course):
         """
-            Test if SemesterClose returns a warning when there is a course student with
+            Test if SemesterArchive returns a warning when there is a course student with
             a negative xp.
         """
         xp_per_course.return_value = -10
@@ -969,7 +1039,7 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         course = baker.make(Course)
         baker.make(CourseStudent, user=student, course=course, semester=semester)
 
-        response = self.client.post(reverse('courses:end_active_semester'))
+        response = self.client.post(reverse('courses:semester_archive'))
         self.assertWarningMessage(response)
         self.assertRedirects(response, reverse('courses:semester_list'))
         message = self.get_message_list(response)[0]

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -350,6 +350,22 @@ class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTest
         self.assertEqual(response.context['num_awaiting_approval'], 1)
         self.assertIn(negative_student, response.context['negative_xp_users'])
 
+    def test_SemesterArchive__post_blocked_by_pending_approvals(self):
+        """POSTing the archive view while quest submissions still await approval warns
+        and leaves the semester open (the preview shows the blocker, but the POST must
+        also refuse in case the state changed after the preview was rendered)."""
+        self.client.force_login(self.test_teacher)
+        active_sem = SiteConfig.get().active_semester
+        baker.make(QuestSubmission, is_completed=True, is_approved=False, semester=active_sem)
+
+        response = self.client.post(reverse('courses:semester_archive'))
+
+        self.assertRedirects(response, reverse('courses:semester_list'))
+        self.assertWarningMessage(response)
+        self.assertIn('awaiting approval', str(self.get_message_list(response)[0]))
+        active_sem.refresh_from_db()
+        self.assertFalse(active_sem.closed)
+
     def test_SemesterArchive__already_archived(self):
         """POSTing the archive view for an already-archived semester warns and takes no action."""
         self.client.force_login(self.test_teacher)

--- a/src/courses/urls.py
+++ b/src/courses/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('semesters/add/', views.SemesterCreate.as_view(), name='semester_create'),
     path('semesters/<pk>/edit/', views.SemesterUpdate.as_view(), name='semester_update'),
     path('semesters/<pk>/delete/', views.SemesterDelete.as_view(), name='semester_delete'),
-    path('semesters/close/', views.end_active_semester, name='end_active_semester'),
+    path('semesters/archive/', views.SemesterArchive.as_view(), name='semester_archive'),
     path('semesters/<pk>/activate/', views.SemesterActivate.as_view(), name='semester_activate'),
 
     # Blocks

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -725,10 +725,11 @@ class SemesterArchive(NonPublicOnlyViewMixin, LoginRequiredMixin, TemplateView):
         # matches what QuestSubmission.objects.remove_in_progress() will delete
         context['num_in_progress'] = QuestSubmission.objects.all_not_completed(active_semester_only=False).count()
         context['num_awaiting_approval'] = QuestSubmission.objects.all_awaiting_approval().count()
-        # negative final XP comes from a negative xp_cached (final_xp = xp_cached / course count)
+        # negative final XP comes from a negative xp_cached (final_xp = xp_cached / course count);
+        # select_related the profile since the blockers list renders user.profile per row
         context['negative_xp_users'] = User.objects.filter(
             id__in=registrations.values_list('user', flat=True), profile__xp_cached__lt=0,
-        )
+        ).select_related('profile')
         context['num_announcements'] = Announcement.objects.get_queryset().not_archived().not_draft().count()
         context['blocked'] = bool(context['num_awaiting_approval'] or context['negative_xp_users'])
         return context

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -18,6 +18,7 @@ from django.http import JsonResponse
 from hackerspace_online.decorators import staff_member_required, xml_http_request_required
 
 from announcements.models import Announcement
+from quest_manager.models import QuestSubmission
 from siteconfig.models import SiteConfig
 from tags.models import get_user_tags_and_xp, get_quest_submission_by_tag, get_badge_assertion_by_tags
 from djcytoscape.models import CytoScape
@@ -617,9 +618,14 @@ class SemesterUpdate(SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, L
 @method_decorator(staff_member_required, name='dispatch')
 class SemesterActivate(NonPublicOnlyViewMixin, LoginRequiredMixin, View):
     """Staff-only endpoint that makes the given semester the deck's active semester
-    (the SiteConfig.active_semester pointer that registration, XP, and submissions run through)."""
+    (the SiteConfig.active_semester pointer that registration, XP, and submissions run through).
 
-    def get(self, request, *args, **kwargs):
+    POST only: a deck-wide state change must not be triggerable by a prefetched link or a
+    cross-site GET (Django's CSRF protection only covers unsafe methods), so GET returns 405.
+    """
+    http_method_names = ['post']
+
+    def post(self, request, *args, **kwargs):
         """Point SiteConfig.active_semester at the semester whose pk is in the URL.
 
         Returns:
@@ -630,6 +636,7 @@ class SemesterActivate(NonPublicOnlyViewMixin, LoginRequiredMixin, View):
         siteconfig = SiteConfig.get()
         siteconfig.active_semester = semester
         siteconfig.save()
+        messages.success(request, f'Semester {semester} is now the active semester.')
 
         return redirect('courses:semester_list')
 
@@ -689,28 +696,76 @@ class BlockDelete(NonPublicOnlyViewMixin, DeleteView):
         return context
 
 
-@non_public_only_view
-@staff_member_required
-def end_active_semester(request):
-    sem = Semester.objects.complete_active_semester()
-    semester_warnings = {
-        Semester.CLOSED: 'Semester is already closed, no action taken.',
-        Semester.QUEST_AWAITING_APPROVAL: "There are still quests awaiting approval. Can't close the Semester until they are approved or returned",
-        Semester.STUDENTS_WITH_NEGATIVE_XP: "There are some students with negative XP. Can't close the Semester until it is fixed.",
-        'success': f'Semester {sem} has been closed: student XP has been recorded and reset to 0, in-progress quests have been deleted, and \
-        announcements have been archived.',
-    }
+@method_decorator(staff_member_required, name='dispatch')
+class SemesterArchive(NonPublicOnlyViewMixin, LoginRequiredMixin, TemplateView):
+    """Staff-only two-step archive (close) of the active semester.
 
-    if sem not in (Semester.CLOSED, Semester.QUEST_AWAITING_APPROVAL,
-                   Semester.STUDENTS_WITH_NEGATIVE_XP):
+    GET renders a preview of everything archiving will do: how many course registrations
+    get their final XP recorded (freeing those students' deck seats), how many in-progress
+    quest submissions are deleted, and whether announcements will be archived, along with
+    any blockers (submissions still awaiting approval, students with negative XP). POST
+    performs the archive via Semester.objects.complete_active_semester().
+    """
+    template_name = 'courses/semester_archive.html'
+
+    def get_context_data(self, **kwargs):
+        """Assemble the preview counts and blockers for archiving the active semester.
+
+        Returns:
+            dict: template context with the active semester, the counts previewed above,
+            the negative-XP users queryset, and a `blocked` flag when archiving would be
+            refused (pending approvals or negative XP).
+        """
+        context = super().get_context_data(**kwargs)
+        semester = SiteConfig.get().active_semester
+        registrations = CourseStudent.objects.all_for_semester(semester)
+        context['semester'] = semester
+        context['num_registrations'] = registrations.count()
+        context['num_seats_freed'] = registrations.get_students_only().count()
+        # matches what QuestSubmission.objects.remove_in_progress() will delete
+        context['num_in_progress'] = QuestSubmission.objects.all_not_completed(active_semester_only=False).count()
+        context['num_awaiting_approval'] = QuestSubmission.objects.all_awaiting_approval().count()
+        # negative final XP comes from a negative xp_cached (final_xp = xp_cached / course count)
+        context['negative_xp_users'] = User.objects.filter(
+            id__in=registrations.values_list('user', flat=True), profile__xp_cached__lt=0,
+        )
+        context['num_announcements'] = Announcement.objects.get_queryset().not_archived().not_draft().count()
+        context['blocked'] = bool(context['num_awaiting_approval'] or context['negative_xp_users'])
+        return context
+
+    def post(self, request, *args, **kwargs):
+        """Archive the active semester: record final XP, deactivate registrations, delete
+        in-progress submissions, and (unless opted out via the archive_announcements
+        checkbox) archive announcements.
+
+        Returns:
+            HttpResponse: a redirect to the semester list with a success message, or a
+            warning message when archiving was refused (already archived, submissions
+            awaiting approval, or students with negative XP).
+        """
+        sem = Semester.objects.complete_active_semester()
+        semester_warnings = {
+            Semester.CLOSED: 'Semester is already archived, no action taken.',
+            Semester.QUEST_AWAITING_APPROVAL: "There are still quests awaiting approval. "
+                                              "Can't archive the semester until they are approved or returned.",
+            Semester.STUDENTS_WITH_NEGATIVE_XP: "There are some students with negative XP. Can't archive the semester until it is fixed.",
+        }
+        if sem in semester_warnings:
+            messages.warning(request, semester_warnings[sem])
+            return redirect('courses:semester_list')
+
         sem.reset_students_xp_cached()
-        Announcement.objects.archive_announcements()
-
-    messages.warning(
-        request,
-        semester_warnings.get(sem, semester_warnings['success']))
-
-    return redirect('courses:semester_list')
+        if request.POST.get('archive_announcements'):
+            Announcement.objects.archive_announcements()
+            announcements_note = ', and announcements have been archived'
+        else:
+            announcements_note = ''
+        messages.success(
+            request,
+            f'Semester {sem} has been archived: student XP has been recorded and reset to 0, '
+            f'in-progress quest submissions have been deleted{announcements_note}.'
+        )
+        return redirect('courses:semester_list')
 
 
 @xml_http_request_required


### PR DESCRIPTION
### What?
The first user-facing step of the semester workflow redesign (#2157): make the end-of-semester flow guided and safe instead of a one-click icon with a JS `confirm()`.

* **Archive confirmation page** (replaces the instant "end semester" GET): clicking Archive now opens a preview page showing exactly what will happen — how many course registrations get final XP recorded (and student seats freed), that student XP resets to 0, how many in-progress quest submissions will be deleted, and how many announcements will be archived (now an **opt-out checkbox** instead of an unconditional side effect). If archiving is blocked (submissions awaiting approval, students with negative XP), the blockers are listed **up front** with links/names, instead of today's try-then-error-message loop. POST performs the archive.
* **POST-only state changes**: `SemesterActivate` and the archive action now mutate on POST only (CSRF-protected); GET on activate returns 405 and changes nothing. This closes the cross-site/prefetch GET mutation CodeRabbit flagged on #2225, as promised there.
* **Status column** on the semester list replaces the bare `Closed: True/False`: green **Active** / **Active - ended** (the ended variant's tooltip nudges that it's time to archive; the end date itself stays in the Last Day column) / **Inactive** / **Archived**, and the vocabulary shifts from "close" to **"Archive"** throughout.
* New `Semester.has_ended()` model helper backing the ended label.

### Why?
Confusion points 2 and 5 in #2157: the end-of-term sequence was a cryptic unlabeled icon protected only by a JS confirm, with its consequences (XP finalization, submission deletion, announcement archiving) undocumented until after the fact, and nothing ever signaled that a long-finished semester was holding student seats. The archive preview + the "Active - ended" status label make the workflow self-explanatory.

### How?
* New `SemesterArchive` TemplateView (`GET` preview with counts/blockers from the same queries the archive itself uses, `POST` performs via the existing `Semester.objects.complete_active_semester()`), replacing the `end_active_semester` function view; URL renamed `semesters/close/` → `semesters/archive/` (`courses:semester_archive`).
* `SemesterActivate` gets `http_method_names = ['post']`; the semester list's activate button becomes a small POST form (reusing the existing `.preview-action-form` inline-form utility class — no new CSS).
* `semester_list.html`: Status column, Archive button links to the confirmation page (fa-archive icon), inline JS `confirm()` removed.
* Announcements archiving moved behind the `archive_announcements` checkbox (checked by default, so the default behavior is unchanged).
* The negative-XP blockers queryset uses `select_related('profile')` (per CodeRabbit review).

### Testing?
Full courses + announcements + profile_manager + quest_manager suites pass locally, plus `ruff check src`. New/updated tests:

* `test_SemesterArchive__staff_post_archives`, `__get_is_a_preview_and_does_not_archive`, `__get_shows_blockers`, `__post_blocked_by_pending_approvals`, `__already_archived`, `__announcements_opt_out`, `__student_with_negative_xp__view`
* `test_SemesterActivate__changes_active_semester` (now POST) and `__get_not_allowed` (GET → 405, active semester untouched)
* `test_has_ended__only_after_last_day` (model helper)
* Announcements: draft-not-archived and published-archived-after-archive tests updated to the new POST flow (the second was previously commented out as broken; it passes now)

### Screenshots (if front end is affected)
Captured from the running `hackerspace` dev deck seeded via `initdb` + `generate_content`, logged in as the deck admin. (The screenshot browser can't reach the FontAwesome CDN, so a local copy of the icon font was injected at capture time; everything else is exactly what the app renders.)

**Semester list — before:**
![before: semester list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2157/phase1-before-semester-list.png)

**Semester list — after** (Status column; activate is now a POST form; archive links to the confirmation page):
![after: semester list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2157/phase1-after-semester-list.png)

**New archive confirmation page** (preview of consequences + announcements opt-out):
![after: archive confirmation page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2157/phase1-archive-page.png)

### Anything Else?
Next in the #2157 Phase 1 sequence (separate PR): the staff reminder banners ("this semester ended on X, archive it to free N seats" and "no open semester, students can't join" per #1177).

The blocker preview on the archive page links to the approvals page and names the negative-XP students, so a teacher can resolve everything before committing.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCf7tPxvnsM34aMhk6fMHz

- Claude Code (`bytedeck - semester workflow redesign`)