### PR TITLE
feat: raise short-answer limit to 255 and surface it in the teacher help text (#2235)

### DIFF
--- a/src/questions/forms.py
+++ b/src/questions/forms.py
@@ -14,6 +14,12 @@ from .models import Question, QuestionSubmission, QuestionType
 # 16 MiB, the maximum size of a student's file response.
 MAX_RESPONSE_FILE_SIZE = 16 * 1024 * 1024
 
+# Maximum length of a student's short-answer response. A short answer is a single line, so it's
+# capped; a Long Answer question is the option for a longer, formatted response. Enforced
+# server-side by the CharField below (not just the input's maxlength), and shown to teachers in
+# the add-question help text so they can choose the right question type.
+SHORT_ANSWER_MAX_LENGTH = 255
+
 
 class QuestionForm(forms.ModelForm):
     """Displayed to the teacher when they are creating or editing a Question.
@@ -60,7 +66,20 @@ class QuestionForm(forms.ModelForm):
         if question_type in (QuestionType.SHORT_ANSWER, QuestionType.LONG_ANSWER):
             del self.fields['solution_file']
             del self.fields['allowed_file_type']
-            solution_fields = Div('solution_text')
+            if question_type == QuestionType.SHORT_ANSWER:
+                # Tell the teacher a short answer is a single capped-length line, so they can pick
+                # a Long Answer question instead when they want a longer, formatted response.
+                solution_fields = Div(
+                    HTML(
+                        f'<p class="help-block"><i class="fa fa-info-circle"></i> '
+                        f'A short answer is a single line of plain text, limited to '
+                        f'{SHORT_ANSWER_MAX_LENGTH} characters. For a longer or formatted '
+                        f'response, use a Long Answer question instead.</p>'
+                    ),
+                    'solution_text',
+                )
+            else:
+                solution_fields = Div('solution_text')
         elif question_type == QuestionType.FILE_UPLOAD:
             del self.fields['solution_text']
 
@@ -148,8 +167,8 @@ class QuestionSubmissionForm(forms.ModelForm):
         form_fields = Div("response_text")
         if self.question.type == QuestionType.SHORT_ANSWER:
             del self.fields["response_file"]
-            # replace the model's TextField default with a CharField so the 200-character
-            # limit is enforced server-side, not just by the widget's maxlength attribute.
+            # replace the model's TextField default with a CharField so the character limit
+            # is enforced server-side, not just by the widget's maxlength attribute.
             # A short answer is a single line, so use a text input (not a textarea).
             # no visible label (the question's instructions directly above serve as the label,
             # matching the long answer field); a distinct aria-label per question keeps each
@@ -157,8 +176,8 @@ class QuestionSubmissionForm(forms.ModelForm):
             self.fields["response_text"] = forms.CharField(
                 label="",
                 required=self.question.required,
-                max_length=200,
-                widget=forms.TextInput(attrs={'maxlength': '200', 'aria-label': self._response_aria_label()}),
+                max_length=SHORT_ANSWER_MAX_LENGTH,
+                widget=forms.TextInput(attrs={'maxlength': str(SHORT_ANSWER_MAX_LENGTH), 'aria-label': self._response_aria_label()}),
             )
         elif self.question.type == QuestionType.LONG_ANSWER:
             del self.fields["response_file"]

--- a/src/questions/templates/questions/question_list.html
+++ b/src/questions/templates/questions/question_list.html
@@ -12,11 +12,11 @@
 
 {% block content %}
   <div class="help-block">
-    <p>Students answer these questions as part of submitting the quest — each question adds its own
+    <p>Students answer these questions as part of submitting the quest: each question adds its own
     answer field to the quest's submission form, shown in order above the usual comment box.
     Use the buttons above to add a question of each type:</p>
     <ul>
-      <li><strong>Short Answer</strong>: a single-line text response, up to 200 characters.</li>
+      <li><strong>Short Answer</strong>: a single-line text response, up to 255 characters.</li>
       <li><strong>Long Answer</strong>: a full rich-text response with formatting, images, and links.</li>
       <li><strong>File Upload</strong>: a file response; you can restrict the allowed file types
         (image, video, audio, image or video, or any file).</li>
@@ -24,7 +24,7 @@
     <p>Questions marked <strong>Required</strong> must be answered before the quest can be submitted;
     optional questions can be left blank. Text answers autosave with the student's draft as they
     work; file answers upload when the quest is submitted. Once submitted, answers appear with the
-    submission for marking — right beside each question's <strong>Solution</strong> and
+    submission for marking, right beside each question's <strong>Solution</strong> and
     <strong>Marker Notes</strong>, which only staff ever see.
     Deleting a question keeps any answers students have already submitted.</p>
   </div>

--- a/src/questions/tests/test_forms.py
+++ b/src/questions/tests/test_forms.py
@@ -4,7 +4,12 @@ from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
-from questions.forms import QuestionForm, QuestionSubmissionForm, QuestionSubmissionFormsetFactory
+from questions.forms import (
+    SHORT_ANSWER_MAX_LENGTH,
+    QuestionForm,
+    QuestionSubmissionForm,
+    QuestionSubmissionFormsetFactory,
+)
 from questions.models import Question, QuestionSubmission
 
 
@@ -34,6 +39,17 @@ class QuestionFormTest(ByteDeckTenantTestCase):
             QuestionForm(question_type="not_a_type")
         with self.assertRaises(ValueError):
             QuestionForm()  # question_type kwarg missing entirely
+
+    def test_init__short_answer_shows_character_limit_help(self):
+        """The add-Short-Answer form tells the teacher the response is a single line capped at
+        255 characters (so they can pick Long Answer for longer responses); Long Answer and
+        File Upload show no such note."""
+        from crispy_forms.utils import render_crispy_form
+        short_html = render_crispy_form(QuestionForm(question_type="short_answer"))
+        self.assertIn(f"{SHORT_ANSWER_MAX_LENGTH} characters", short_html)
+        for other_type in ("long_answer", "file_upload"):
+            other_html = render_crispy_form(QuestionForm(question_type=other_type))
+            self.assertNotIn(f"{SHORT_ANSWER_MAX_LENGTH} characters", other_html)
 
     def test_valid_data__creates_question(self):
         """The form validates and saves a well-formed short_answer question."""
@@ -86,11 +102,13 @@ class QuestionSubmissionFormTest(ByteDeckTenantTestCase):
         )
 
     def test_init__short_answer_field(self):
-        """Short answer forms get a 200-char text field and no file field."""
+        """Short answer forms get a length-capped text field (and matching widget maxlength) and
+        no file field."""
         form = QuestionSubmissionForm(instance=self.short_answer)
         self.assertIn("response_text", form.fields)
         self.assertNotIn("response_file", form.fields)
-        self.assertEqual(form.fields["response_text"].max_length, 200)
+        self.assertEqual(form.fields["response_text"].max_length, SHORT_ANSWER_MAX_LENGTH)
+        self.assertEqual(form.fields["response_text"].widget.attrs["maxlength"], str(SHORT_ANSWER_MAX_LENGTH))
         self.assertTrue(form.fields["response_text"].required)
 
     def test_init__long_answer_field(self):
@@ -152,10 +170,16 @@ class QuestionSubmissionFormTest(ByteDeckTenantTestCase):
         form = QuestionSubmissionForm(data={"response_text": "An answer"}, instance=self.short_answer)
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_clean__short_answer_over_200_chars_is_invalid(self):
-        """The 200-character short answer limit is enforced server-side, not just by the widget."""
-        form = QuestionSubmissionForm(data={"response_text": "x" * 201}, instance=self.short_answer)
-        self.assertFalse(form.is_valid())
+    def test_clean__short_answer_length_limit_enforced_server_side(self):
+        """The short answer character limit is enforced server-side, not just by the widget's
+        maxlength: exactly the limit is accepted, one character over is rejected."""
+        at_limit = QuestionSubmissionForm(
+            data={"response_text": "x" * SHORT_ANSWER_MAX_LENGTH}, instance=self.short_answer)
+        self.assertTrue(at_limit.is_valid(), at_limit.errors)
+
+        over_limit = QuestionSubmissionForm(
+            data={"response_text": "x" * (SHORT_ANSWER_MAX_LENGTH + 1)}, instance=self.short_answer)
+        self.assertFalse(over_limit.is_valid())
 
     def test_clean__required_file_missing_is_invalid(self):
         """A required file question rejects a POST with no file, and accepts an allowed one."""


### PR DESCRIPTION
### What?
Raise the short-answer response limit from 200 to **255** characters, and tell teachers about the limit when they add a Short Answer question.

### Why?
A student's short-answer response was capped at 200 characters (`QuestionSubmissionForm` built a `CharField(max_length=200)` with a matching input `maxlength`). Two problems (#2235):
1. 200 was an arbitrary value; a round 255 (a single line, the classic varchar length) is a better cap.
2. Nothing told the **teacher** about the limit. Adding a "Short Answer" question gave no hint that responses are capped, so a teacher couldn't decide between Short Answer and Long Answer on an informed basis.

### How?
- Introduced a `SHORT_ANSWER_MAX_LENGTH = 255` constant in `questions/forms.py` so the value lives in one place, and used it for both the `CharField` `max_length` and the input's `maxlength` (still enforced server-side, not just in the browser).
- Added a `help-block` note on the add-/edit-Short-Answer form: *"A short answer is a single line of plain text, limited to 255 characters. For a longer or formatted response, use a Long Answer question instead."* (Short Answer only; Long Answer and File Upload are unchanged.)
- Updated the "Short Answer" bullet in the question-list help block (`200` → `255`).
- Drive-by: the same help block contained two pre-existing em dashes (banned in this project); replaced them with a colon and a comma.

No migration: the response is stored in a `TextField`, so this is a form-level limit only (matching the existing behaviour).

### Testing?
`python src/manage.py test questions` (114 tests) and `ruff check src` pass locally on a Python 3.12 venv against Postgres 16. Tests updated/added:
- `test_init__short_answer_field` now asserts the field `max_length` and the widget `maxlength` both equal `SHORT_ANSWER_MAX_LENGTH`.
- `test_clean__short_answer_length_limit_enforced_server_side` checks the boundary: exactly 255 chars is accepted, 256 is rejected (server-side, not just the widget).
- `test_init__short_answer_shows_character_limit_help` renders the form and asserts the "255 characters" note appears for Short Answer and **not** for Long Answer / File Upload.

### Screenshots (if front end is affected)
Captured on a real `hackerspace` dev deck, logged in as staff.

**Add "Short Answer" question form** (the new help note appears under Instructions). The leading info-circle icon is Font-Awesome-CDN-served, which is blocked by this sandbox's proxy, so its glyph is blank in the shot; it renders in production:

![create form before/after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2235/form-before-after.png)

**Question-list help block** (200 → 255, em dashes cleaned up):

![list help block before/after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2235/list-before-after.png)

### Anything Else?
Follow-up polish to the submission-questions feature (#1304 / #2099). Sibling PR #2237 tightens the whitespace between questions on the submission form.

### Review request
@tylerecouture

Closes #2235

- Claude Code (`Bytedeck - multiple submission types`)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_