### PR TITLE
test: cover quest_manager/models.py icon, repeat, and submission-manager gaps

### DIFF
--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -755,30 +755,54 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(qs.count(), 7)
 
     def test_get_queryset__include_related_false_skips_select_related(self):
-        """get_queryset(include_related=False) returns the same rows but without the
-        select_related/prefetch_related joins that the default (True) path adds."""
+        """get_queryset(include_related=False) returns the same rows but skips both related-loading
+        mechanisms (select_related and prefetch_related) that the default (True) path adds."""
         qs_with = QuestSubmission.objects.get_queryset(include_related=True)
         qs_without = QuestSubmission.objects.get_queryset(include_related=False)
 
         # Same rows either way.
         self.assertQuerySetEqual(qs_without, list(qs_with), ordered=False)
-        # The default path requests related objects; the include_related=False path does not.
+        # The default path requests select_related joins; the include_related=False path does not.
         self.assertTrue(qs_with.query.select_related)
         self.assertFalse(qs_without.query.select_related)
+        # ...and it requests a prefetch_related lookup (quest__tags) which the False path omits.
+        self.assertIn('quest__tags', qs_with._prefetch_related_lookups)
+        self.assertEqual(qs_without._prefetch_related_lookups, ())
 
     def test_all_completed__no_user_returns_all_students_completed(self):
-        """all_completed() with no user returns every completed submission in the active semester."""
-        self.sub1.mark_completed()
+        """all_completed() with no user returns completed submissions in the active semester and
+        excludes those still in progress."""
+        quest = baker.make(Quest, published=True, archived=False)
+        completed = baker.make(QuestSubmission, user=self.student, quest=quest, semester=self.active_semester)
+        completed.mark_completed()
+        # A different user's in-progress submission of the same quest must not appear.
+        in_progress = baker.make(QuestSubmission, user=self.teacher, quest=quest, semester=self.active_semester)
+
         qs = QuestSubmission.objects.all_completed()
-        self.assertIn(self.sub1, qs)
+        self.assertIn(completed, qs)
+        self.assertNotIn(in_progress, qs)
 
     def test_all_awaiting_approval__with_user_returns_that_users_unapproved_completions(self):
-        """all_awaiting_approval(user=...) returns the user's completed-but-not-yet-approved submissions."""
-        self.sub1.user = self.student
-        self.sub1.save()
-        self.sub1.mark_completed()
+        """all_awaiting_approval(user=...) returns that user's completed-but-not-yet-approved
+        submissions, excluding already-approved ones and other users' submissions."""
+        quest = baker.make(Quest, published=True, archived=False)
+        awaiting = baker.make(QuestSubmission, user=self.student, quest=quest, semester=self.active_semester)
+        awaiting.mark_completed()  # completed, not yet approved
+
+        # Already approved -> no longer awaiting approval.
+        approved = baker.make(QuestSubmission, user=self.student,
+                              quest=baker.make(Quest, published=True, archived=False), semester=self.active_semester)
+        approved.mark_completed()
+        approved.mark_approved()
+
+        # Belongs to a different user -> filtered out by get_user.
+        other_users = baker.make(QuestSubmission, user=self.teacher, quest=quest, semester=self.active_semester)
+        other_users.mark_completed()
+
         qs = QuestSubmission.objects.all_awaiting_approval(user=self.student)
-        self.assertIn(self.sub1, qs)
+        self.assertIn(awaiting, qs)
+        self.assertNotIn(approved, qs)
+        self.assertNotIn(other_users, qs)
 
     def test_all_for_user_quest__returns_active_semester_submissions(self):
         """

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -754,6 +754,32 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
             exclude_archived_quests=False, exclude_quests_not_published=False)
         self.assertEqual(qs.count(), 7)
 
+    def test_get_queryset__include_related_false_skips_select_related(self):
+        """get_queryset(include_related=False) returns the same rows but without the
+        select_related/prefetch_related joins that the default (True) path adds."""
+        qs_with = QuestSubmission.objects.get_queryset(include_related=True)
+        qs_without = QuestSubmission.objects.get_queryset(include_related=False)
+
+        # Same rows either way.
+        self.assertQuerySetEqual(qs_without, list(qs_with), ordered=False)
+        # The default path requests related objects; the include_related=False path does not.
+        self.assertTrue(qs_with.query.select_related)
+        self.assertFalse(qs_without.query.select_related)
+
+    def test_all_completed__no_user_returns_all_students_completed(self):
+        """all_completed() with no user returns every completed submission in the active semester."""
+        self.sub1.mark_completed()
+        qs = QuestSubmission.objects.all_completed()
+        self.assertIn(self.sub1, qs)
+
+    def test_all_awaiting_approval__with_user_returns_that_users_unapproved_completions(self):
+        """all_awaiting_approval(user=...) returns the user's completed-but-not-yet-approved submissions."""
+        self.sub1.user = self.student
+        self.sub1.save()
+        self.sub1.mark_completed()
+        qs = QuestSubmission.objects.all_awaiting_approval(user=self.student)
+        self.assertIn(self.sub1, qs)
+
     def test_all_for_user_quest__returns_active_semester_submissions(self):
         """
         QuestSubmissionManager.all_for_user_quest should return all published not archived quest submissions

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -34,6 +34,11 @@ class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
         self.assertIsInstance(self.category, Category)
         self.assertEqual(str(self.category), self.category.title)
 
+    def test_get_icon_url__returns_category_icon_when_set(self):
+        """Category.get_icon_url returns the campaign's own icon url when it has one."""
+        self.category.icon = 'icons/campaign.png'
+        self.assertEqual(self.category.get_icon_url(), self.category.icon.url)
+
     def test_condition_met_as_prerequisite__all_unique_quests_completed(self):
         """ Test that all unique quests in a campaign are completed before the campaign is considered completed
         for prerequisite purposes. Make sure multiple completions of repeatable quests don't count. """
@@ -171,6 +176,35 @@ class QuestTestModel(ByteDeckTenantTestCase):
         self.quest.icon = ''
         self.quest.campaign = baker.make('quest_manager.Category', icon='icons/campaign.png')
         self.assertEqual(self.quest.get_icon_url(), self.quest.campaign.icon.url)
+
+    def test_icon_url__returns_icon_url_when_set(self):
+        """XPItem.icon_url returns the quest's own icon url when it has one."""
+        self.quest.icon = 'icons/quest.png'
+        self.assertEqual(self.quest.icon_url(), self.quest.icon.url)
+
+    def test_icon_url__returns_none_when_no_icon(self):
+        """XPItem.icon_url returns None when the quest has no icon (used by templates via default_if_none)."""
+        self.quest.icon = ''
+        self.assertIsNone(self.quest.icon_url())
+
+    def test_is_repeatable__reflects_max_repeats(self):
+        """XPItem.is_repeatable is True when max_repeats is non-zero (a finite or unlimited cap), False when 0."""
+        self.quest.max_repeats = 0
+        self.assertFalse(self.quest.is_repeatable())
+        self.quest.max_repeats = 3
+        self.assertTrue(self.quest.is_repeatable())
+        self.quest.max_repeats = -1  # unlimited repeats
+        self.assertTrue(self.quest.is_repeatable())
+
+    def test_is_repeat_available__false_during_cooldown(self):
+        """is_repeat_available is False when a repeatable quest has been completed but its
+        hours_between_repeats cooldown has not yet elapsed (issue #57)."""
+        student = baker.make(User)
+        quest = baker.make(Quest, max_repeats=-1, hours_between_repeats=24)
+        sub = QuestSubmission.objects.create_submission(student, quest)
+        sub.mark_completed()
+        # Completed just now, so fewer than 24 hours have passed: still on cooldown.
+        self.assertFalse(quest.is_repeat_available(student))
 
     def test_active__false_for_unavailable_expired_or_hidden_quests(self):
         """


### PR DESCRIPTION
## What

Closes the remaining coverage gaps in `quest_manager/models.py` (icon helpers, repeatability, and three `QuestSubmissionManager` query paths). Test-only.

## Why

These were the last uncovered lines/branches in `quest_manager/models.py` per a full-suite coverage run:

- **`Category.get_icon_url`**: only the SiteConfig-default fallback was exercised; the branch returning the campaign's own icon url was uncovered.
- **`XPItem.icon_url`**: untested entirely (both the "has icon" and "no icon returns None" branches).
- **`XPItem.is_repeatable`**: the return was never exercised.
- **`Quest.is_repeat_available`**: the "still on cooldown" branch (completed, but `hours_between_repeats` not yet elapsed, so it returns False) was never hit. The existing large test only checked the in-progress and cooldown-elapsed cases.
- **`QuestSubmissionManager.get_queryset`**: the `include_related=False` branch (skipping the `select_related`/`prefetch_related` joins) was uncovered.
- **`QuestSubmissionManager.all_completed`**: the no-user path (all students' completed submissions) was uncovered.
- **`QuestSubmissionManager.all_awaiting_approval`**: the user-provided path was uncovered.

## How

In `src/quest_manager/tests/test_models.py`:

- `CategoryTestModel.test_get_icon_url__returns_category_icon_when_set`.
- `QuestTestModel.test_icon_url__returns_icon_url_when_set` / `__returns_none_when_no_icon`.
- `QuestTestModel.test_is_repeatable__reflects_max_repeats` (0 / finite / -1 unlimited).
- `QuestTestModel.test_is_repeat_available__false_during_cooldown`: completes a repeatable quest with a 24h cooldown and asserts it is not immediately repeat-available.

In `src/quest_manager/tests/test_managers.py` (added to `QuestSubmissionManagerTest`):

- `test_get_queryset__include_related_false_skips_select_related`: same rows as the default, but `query.select_related` is falsy.
- `test_all_completed__no_user_returns_all_students_completed`.
- `test_all_awaiting_approval__with_user_returns_that_users_unapproved_completions`.

## Testing

- New tests pass; `test_models` + `test_managers` modules green (81 tests).
- `coverage` confirms all seven previously-missing lines and seven missing branches in `quest_manager/models.py` are now covered.
- `ruff check` clean.

## Screenshots

N/A: test-only; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for quest submission filtering, completion status, and approval workflows.
  * Added tests for category and quest icon URL behavior.
  * Added coverage for repeatable quests, including repeat limits and cooldown enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->