### PR TITLE
test: cover utilities/fields.py GFK-choice and file-size validation gaps

### DIFF
--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -80,13 +80,13 @@ class QuerySetSequenceFieldMixin:
         content_type = ContentType.objects.get_for_id(content_type_id)
 
         for queryset in self.queryset.get_querysets():
-            if queryset.model.__name__ == 'QuerySequenceModel':
-                # django-queryset-sequence 0.7 support dynamically created
-                # QuerySequenceModel which replaces the original model when it
-                # patches the queryset since 6394e19
-                model = queryset.model.__bases__[0]
-            else:
-                model = queryset.model
+            model = queryset.model
+            # django-queryset-sequence <0.8 dynamically created a QuerySequenceModel that
+            # replaced the component model, so it had to be unwrapped to the real base model.
+            # The pinned version (>=0.18) never creates QuerySequenceModel, so this guard is a
+            # no-op safeguard for older library versions and cannot be exercised by the suite.
+            if model.__name__ == 'QuerySequenceModel':  # pragma: no cover
+                model = model.__bases__[0]
 
             if model == content_type.model_class():
                 return queryset

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
@@ -68,6 +70,44 @@ class GFKChoiceFieldTest(ByteDeckTenantTestCase):
         self.assertEqual(f.clean(self._ct_pk(self.user2)).get_full_name(), "Jane Doe")
         self.assertEqual(f.clean(self._ct_pk(self.group1)).name, "Editors")
 
+    def test_GFKChoiceField__empty_label_none_omits_blank_choice(self):
+        """With empty_label=None the iterator does not yield the leading blank ('', label) choice."""
+        f = GFKChoiceField(
+            queryset=QuerySetSequence(User.objects.filter(pk=self.user1.pk)),
+            empty_label=None,
+        )
+        choices = list(f.choices)
+        # No leading ('', ...) blank option; the first (and only) group is the users group.
+        self.assertNotIn('', [value for value, _ in choices])
+        self.assertEqual(choices[0][0], 'user')
+
+    def test_GFKChoiceField__clean_content_type_absent_from_queryset(self):
+        """A value whose content type is valid but absent from the field's queryset is rejected.
+
+        get_queryset_for_content_type finds no matching component queryset and returns None,
+        so to_python raises invalid_choice rather than resolving an out-of-scope object.
+        """
+        # Field only offers Users; a Group value is a real ct-pk pair but out of scope.
+        f = GFKChoiceField(queryset=QuerySetSequence(User.objects.filter(pk=self.user1.pk)))
+        with self.assertRaises(ValidationError):
+            f.clean(self._ct_pk(self.group1))
+
+    def test_GFKChoiceField__clean_nonexistent_object_pk(self):
+        """A value with an in-scope content type but a nonexistent object pk is rejected.
+
+        The queryset.get(pk=...) lookup raises DoesNotExist, which to_python catches and
+        re-raises as invalid_choice."""
+        f = GFKChoiceField(queryset=QuerySetSequence(User.objects.filter(pk=self.user1.pk)))
+        user_ct = ContentType.objects.get_for_model(User)
+        with self.assertRaises(ValidationError):
+            f.clean(f"{user_ct.pk}-9999999")
+
+    def test_GFKChoiceField__prepare_value_passes_through_strings(self):
+        """prepare_value returns a string value unchanged (Django passes both objects and
+        already-prepared 'ctpk-objpk' strings through this method)."""
+        f = GFKChoiceField(queryset=QuerySetSequence(User.objects.filter(pk=self.user1.pk)))
+        self.assertEqual(f.prepare_value('3-5'), '3-5')
+
 
 class RestrictedFileFieldTest(ByteDeckTenantTestCase):
     @classmethod
@@ -101,6 +141,13 @@ class RestrictedFileFormFieldTest(ByteDeckTenantTestCase):
 
         # ensure content type is set correctly
         self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])
+
+    def test_validate_file__raises_when_over_max_size(self):
+        """validate_file rejects an acceptable-type file whose size exceeds max_upload_size."""
+        field = RestrictedFileFormField(content_types=['image/png'], max_upload_size=10)
+        oversized = SimpleNamespace(content_type='image/png', size=11)
+        with self.assertRaises(ValidationError):
+            field.validate_file(oversized)
 
 
 class AllowedGFKChoiceFieldRebuildTest(ByteDeckTenantTestCase):


### PR DESCRIPTION
## What

Closes the remaining coverage gaps in `utilities/fields.py` (GFK choice field + restricted-file form field), and marks one unreachable compatibility branch as excluded.

## Why

Per a full-suite coverage run, these lines/branches in `utilities/fields.py` were uncovered:

- **`GFKChoiceIterator.__iter__`**: the `empty_label is None` branch (no leading blank choice) was never taken.
- **`GFKChoiceField.to_python`**: two invalid-choice **security** paths were untested: (1) a value whose content type is valid but not one of the field's querysets (`get_queryset_for_content_type` returns `None`), and (2) a value whose object pk does not exist (`queryset.get` raises `DoesNotExist`). Both must reject the value rather than resolve an out-of-scope object.
- **`GFKChoiceField.prepare_value`**: the `isinstance(value, str)` pass-through branch.
- **`RestrictedFileFormField.validate_file`**: the over-`max_upload_size` branch.
- **`get_queryset_for_content_type`**: the `QuerySequenceModel`-unwrapping branch is a compatibility shim for django-queryset-sequence `<0.8`. The pinned dependency (`>=0.18,<0.19`) never creates a `QuerySequenceModel` (the name does not exist anywhere in the installed package), so this branch is unreachable under the pin.

## How

In `src/utilities/tests/test_fields.py`:

- `GFKChoiceFieldTest.test_GFKChoiceField__empty_label_none_omits_blank_choice`.
- `GFKChoiceFieldTest.test_GFKChoiceField__clean_content_type_absent_from_queryset` (Group value against a User-only field).
- `GFKChoiceFieldTest.test_GFKChoiceField__clean_nonexistent_object_pk`.
- `GFKChoiceFieldTest.test_GFKChoiceField__prepare_value_passes_through_strings`.
- `RestrictedFileFormFieldTest.test_validate_file__raises_when_over_max_size` (a small `SimpleNamespace` file with an acceptable type but oversized `size`).

In `src/utilities/fields.py`:

- `get_queryset_for_content_type`: kept the `QuerySequenceModel` safeguard but restructured it so only the inert branch (not its `else`) is excluded, and marked that branch `# pragma: no cover` with a comment explaining it is unreachable under the pinned dependency. If preferred, this shim could be removed outright since the pin makes it dead; I left it in as a low-cost safeguard, happy to drop it instead.

## Testing

- `utilities` app suite green, plus `prerequisites.tests.test_fields` (which subclasses `GFKChoiceField`).
- `coverage` confirms the previously-missing lines/branches are now covered, and the excluded shim branch is no longer reported as missing.
- `ruff check` clean.

## Screenshots

N/A: test coverage plus a no-op-branch pragma; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when resolving querysets for content types.
  * Ensured empty labels, invalid querysets or content types, nonexistent objects, and string values are handled correctly.
  * Correctly rejects oversized files, even when their content type is allowed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->