### PR TITLE
HOTFIX: fix: resolve legacy deck-owner emails without allauth bookkeeping

### DIFF
--- a/src/tenant/management/commands/backfill_owner_emails.py
+++ b/src/tenant/management/commands/backfill_owner_emails.py
@@ -41,7 +41,12 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser):
-        """Register the --apply flag (without it the command only reports)."""
+        """Register the --apply flag (without it the command only reports).
+
+        Args:
+            parser (argparse.ArgumentParser): The command's argument parser,
+                mutated in place. Returns nothing.
+        """
         parser.add_argument(
             '--apply', action='store_true',
             help="Write the EmailAddress fixes and refresh each fixed deck's cached fields. "
@@ -94,10 +99,20 @@ class Command(BaseCommand):
     def _process_deck(self, tenant, apply_changes):
         """Audit (and in apply mode normalize) one deck's owner email bookkeeping.
 
-        Must run inside the deck's tenant context. Returns
-        ``(status, owner_name, email, notes)`` where status is ``ok`` (nothing to
-        do), ``fixed`` (bookkeeping created or corrected), or ``no-email`` (needs
-        a human).
+        Must run inside the deck's tenant context.
+
+        Args:
+            tenant (Tenant): The deck being processed (its public-schema row).
+            apply_changes (bool): When True, write the EmailAddress fixes and
+                refresh the deck's cached fields; when False, only report.
+
+        Returns:
+            tuple: ``(status, owner_name, email, notes)`` where ``status`` is
+            ``ok`` (nothing to do), ``fixed`` (bookkeeping created or corrected;
+            in dry-run mode this means it WOULD be), or ``no-email`` (needs a
+            human); ``owner_name`` is the owner's username; ``email`` is the
+            owner's address or None; ``notes`` is the semicolon-joined audit
+            remarks for the report line.
         """
         from siteconfig.models import SiteConfig
 
@@ -116,7 +131,10 @@ class Command(BaseCommand):
         if not owner.email:
             return 'no-email', owner.username, None, '; '.join(notes)
 
-        email_address = EmailAddress.objects.filter(user=owner, email__iexact=owner.email).first()
+        # deterministic target row: prefer the exact-case match, else the oldest
+        # case-variant duplicate (legacy data can hold several case variants)
+        matches = list(EmailAddress.objects.filter(user=owner, email__iexact=owner.email).order_by('pk'))
+        email_address = next((row for row in matches if row.email == owner.email), matches[0] if matches else None)
         already_ok = (
             email_address is not None and email_address.verified and email_address.primary
             and not EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).exists()
@@ -126,13 +144,17 @@ class Command(BaseCommand):
 
         if apply_changes:
             # mirror TenantCreate.form_valid: the owner's address exists, verified
-            # and primary; plus demote any other primary rows so there is one
-            EmailAddress.objects.filter(user=owner, primary=True).exclude(email__iexact=owner.email).update(primary=False)
+            # and primary. Every OTHER primary row is demoted BEFORE the target
+            # saves: the DB allows at most one primary per user
+            # (unique_primary_email), so the demote must come first, and excluding
+            # by pk (a brand-new target has none, so nothing is spared) also
+            # demotes a case-variant duplicate of the owner's own address.
             if email_address is None:
                 email_address = EmailAddress(user=owner, email=owner.email, verified=True, primary=True)
             else:
                 email_address.verified = True
                 email_address.primary = True
+            EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).update(primary=False)
             email_address.full_clean()
             email_address.save()
             # land owner_email_cached now; the notice engine and the Stripe

--- a/src/tenant/management/commands/backfill_owner_emails.py
+++ b/src/tenant/management/commands/backfill_owner_emails.py
@@ -1,0 +1,141 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from allauth.account.models import EmailAddress
+from django_tenants.utils import get_public_schema_name, get_tenant_model, tenant_context
+
+from library.utils import get_library_schema_name
+
+
+class Command(BaseCommand):
+    """Backfill allauth EmailAddress bookkeeping for legacy deck owners (#1729 rollout).
+
+    Deck creation marks the owner's EmailAddress verified and primary
+    (TenantCreate.form_valid), but owners of decks created before that flow often
+    have a ``User.email`` with no allauth ``EmailAddress`` row at all. This
+    command brings every deck owner up to the same state deck creation produces
+    today: the ``EmailAddress`` row matching ``owner.email`` exists, is verified,
+    and is the owner's only primary address. Marking legacy addresses verified is
+    a deliberate maintainer decision (2026-08-01): they are long-standing
+    customer contact addresses, and verification gates nothing
+    security-sensitive here (sign-in and password reset already work
+    unverified).
+
+    Dry-run by default: pass ``--apply`` to write. In apply mode each fixed
+    deck's cached fields are refreshed immediately so ``owner_email_cached`` (the
+    address the notice engine and the Stripe backfill report use) is correct
+    without waiting for the nightly task.
+
+    Every run also audits the owners that need a human: owners with no email at
+    all, and owners still on the initial heuristic default account (the deck
+    never chose a real owner). Where the deprecated public-tenant
+    ``Tenant.owner_email`` disagrees with the owner's address, the line says so:
+    it is often the best clue to who the owner should be.
+    """
+
+    help = (
+        "Normalize every deck owner's allauth EmailAddress to verified+primary, matching "
+        "what deck creation sets up. Dry-run by default; pass --apply to write. Also "
+        "audits owners with no email and decks still on the heuristic default owner."
+    )
+
+    def add_arguments(self, parser):
+        """Register the --apply flag (without it the command only reports)."""
+        parser.add_argument(
+            '--apply', action='store_true',
+            help="Write the EmailAddress fixes and refresh each fixed deck's cached fields. "
+                 "Without this flag nothing is written.",
+        )
+
+    def handle(self, *args, **options):
+        """Iterate every billable tenant, print one audit line each, then a summary."""
+        apply_changes = options['apply']
+        tenants = get_tenant_model().objects.exclude(
+            schema_name__in=[get_public_schema_name(), get_library_schema_name()]
+        ).order_by('schema_name')
+
+        header = f"{'deck':<24} {'status':<10} {'owner':<20} {'email':<32} notes"
+        self.stdout.write(header)
+        self.stdout.write("-" * len(header))
+
+        counts = {'ok': 0, 'fixed': 0, 'no-email': 0, 'error': 0}
+        default_owner_decks = 0
+        for tenant in tenants:
+            try:
+                # atomic() makes each deck a savepoint, so one broken schema can't
+                # poison the connection (aborted transaction) for the remaining decks
+                with transaction.atomic(), tenant_context(tenant):
+                    status, owner_name, email, notes = self._process_deck(tenant, apply_changes)
+            except Exception as e:
+                counts['error'] += 1
+                self.stdout.write(f"{tenant.schema_name:<24} {'ERROR':<10} {'-':<20} {'-':<32} {type(e).__name__}: {e}")
+                continue
+            counts[status] += 1
+            if 'default owner account' in notes:
+                default_owner_decks += 1
+            label = status if (apply_changes or status != 'fixed') else 'would-fix'
+            self.stdout.write(f"{tenant.schema_name:<24} {label:<10} {owner_name:<20} {email or '-':<32} {notes}")
+
+        self.stdout.write("-" * len(header))
+        summary = (
+            f"{tenants.count()} deck(s): {counts['ok']} already ok, "
+            f"{counts['fixed']} {'fixed' if apply_changes else 'would be fixed'}, "
+            f"{counts['no-email']} with no owner email (fix by hand in the SiteConfig admin)"
+        )
+        if default_owner_decks:
+            summary += f"; {default_owner_decks} still on the default owner account"
+        if counts['error']:
+            summary += f"; {counts['error']} with errors"
+        self.stdout.write(f"{summary}.")
+        if not apply_changes:
+            self.stdout.write("Dry run: no changes were written. Re-run with --apply to write.")
+
+    def _process_deck(self, tenant, apply_changes):
+        """Audit (and in apply mode normalize) one deck's owner email bookkeeping.
+
+        Must run inside the deck's tenant context. Returns
+        ``(status, owner_name, email, notes)`` where status is ``ok`` (nothing to
+        do), ``fixed`` (bookkeeping created or corrected), or ``no-email`` (needs
+        a human).
+        """
+        from siteconfig.models import SiteConfig
+
+        owner = SiteConfig.get().deck_owner
+        notes = []
+        # the initial deck_owner default was a heuristic (oldest non-admin staff
+        # user, else a bare created account): flag decks that never chose for real
+        if owner.username == settings.TENANT_DEFAULT_OWNER_USERNAME:
+            notes.append("default owner account (heuristic guess, never chosen)")
+        # the deprecated hand-entered public-tenant address is often the best clue
+        # to who the owner SHOULD be when the schema's data is missing or wrong
+        legacy = (tenant.owner_email or '').strip()
+        if legacy and legacy.lower() != (owner.email or '').lower():
+            notes.append(f"public-tenant legacy owner_email differs: {legacy}")
+
+        if not owner.email:
+            return 'no-email', owner.username, None, '; '.join(notes)
+
+        email_address = EmailAddress.objects.filter(user=owner, email__iexact=owner.email).first()
+        already_ok = (
+            email_address is not None and email_address.verified and email_address.primary
+            and not EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).exists()
+        )
+        if already_ok:
+            return 'ok', owner.username, owner.email, '; '.join(notes)
+
+        if apply_changes:
+            # mirror TenantCreate.form_valid: the owner's address exists, verified
+            # and primary; plus demote any other primary rows so there is one
+            EmailAddress.objects.filter(user=owner, primary=True).exclude(email__iexact=owner.email).update(primary=False)
+            if email_address is None:
+                email_address = EmailAddress(user=owner, email=owner.email, verified=True, primary=True)
+            else:
+                email_address.verified = True
+                email_address.primary = True
+            email_address.full_clean()
+            email_address.save()
+            # land owner_email_cached now; the notice engine and the Stripe
+            # backfill report read the cache, not the schema
+            tenant.update_cached_fields()
+        return 'fixed', owner.username, owner.email, '; '.join(notes)

--- a/src/tenant/management/commands/backfill_owner_emails.py
+++ b/src/tenant/management/commands/backfill_owner_emails.py
@@ -28,16 +28,19 @@ class Command(BaseCommand):
     without waiting for the nightly task.
 
     Every run also audits the owners that need a human: owners with no email at
-    all, and owners still on the initial heuristic default account (the deck
-    never chose a real owner). Where the deprecated public-tenant
-    ``Tenant.owner_email`` disagrees with the owner's address, the line says so:
-    it is often the best clue to who the owner should be.
+    all, owners whose address is already verified by a different account on the
+    deck (the DB allows one verified row per address, so which account is really
+    the owner's is a human call), and owners still on the initial heuristic
+    default account (the deck never chose a real owner). Where the deprecated
+    public-tenant ``Tenant.owner_email`` disagrees with the owner's address, the
+    line says so: it is often the best clue to who the owner should be.
     """
 
     help = (
         "Normalize every deck owner's allauth EmailAddress to verified+primary, matching "
         "what deck creation sets up. Dry-run by default; pass --apply to write. Also "
-        "audits owners with no email and decks still on the heuristic default owner."
+        "audits owners with no email, addresses already verified by another account, "
+        "and decks still on the heuristic default owner."
     )
 
     def add_arguments(self, parser):
@@ -64,7 +67,7 @@ class Command(BaseCommand):
         self.stdout.write(header)
         self.stdout.write("-" * len(header))
 
-        counts = {'ok': 0, 'fixed': 0, 'no-email': 0, 'error': 0}
+        counts = {'ok': 0, 'fixed': 0, 'no-email': 0, 'skipped': 0, 'error': 0}
         default_owner_decks = 0
         for tenant in tenants:
             try:
@@ -88,6 +91,8 @@ class Command(BaseCommand):
             f"{counts['fixed']} {'fixed' if apply_changes else 'would be fixed'}, "
             f"{counts['no-email']} with no owner email (fix by hand in the SiteConfig admin)"
         )
+        if counts['skipped']:
+            summary += f"; {counts['skipped']} skipped (address verified by another account: fix by hand)"
         if default_owner_decks:
             summary += f"; {default_owner_decks} still on the default owner account"
         if counts['error']:
@@ -109,10 +114,11 @@ class Command(BaseCommand):
         Returns:
             tuple: ``(status, owner_name, email, notes)`` where ``status`` is
             ``ok`` (nothing to do), ``fixed`` (bookkeeping created or corrected;
-            in dry-run mode this means it WOULD be), or ``no-email`` (needs a
-            human); ``owner_name`` is the owner's username; ``email`` is the
-            owner's address or None; ``notes`` is the semicolon-joined audit
-            remarks for the report line.
+            in dry-run mode this means it WOULD be), ``no-email`` (needs a
+            human), or ``skipped`` (a different account already verified the
+            address, so no write can succeed: needs a human); ``owner_name`` is
+            the owner's username; ``email`` is the owner's address or None;
+            ``notes`` is the semicolon-joined audit remarks for the report line.
         """
         from siteconfig.models import SiteConfig
 
@@ -131,16 +137,32 @@ class Command(BaseCommand):
         if not owner.email:
             return 'no-email', owner.username, None, '; '.join(notes)
 
-        # deterministic target row: prefer the exact-case match, else the oldest
-        # case-variant duplicate (legacy data can hold several case variants)
+        # deterministic target row, preferring the form a save lands on:
+        # EmailAddress.clean() lowercases the address, so normalizing any other
+        # row rewrites it to the lowercase form; targeting the lowercase row
+        # first means that rewrite can never collide with a case-variant sibling
+        # under the unique (user, email) constraint. Fall back to the exact-case
+        # match, then the oldest case-variant duplicate.
+        canonical = owner.email.lower()
         matches = list(EmailAddress.objects.filter(user=owner, email__iexact=owner.email).order_by('pk'))
-        email_address = next((row for row in matches if row.email == owner.email), matches[0] if matches else None)
+        email_address = next(
+            (row for row in matches if row.email == canonical),
+            next((row for row in matches if row.email == owner.email), matches[0] if matches else None),
+        )
         already_ok = (
             email_address is not None and email_address.verified and email_address.primary
             and not EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).exists()
         )
         if already_ok:
             return 'ok', owner.username, owner.email, '; '.join(notes)
+
+        # the DB allows one VERIFIED row per address across the whole schema
+        # (unique_verified_email, from ACCOUNT_UNIQUE_EMAIL): if a different
+        # account already verified this address, no write can succeed, and which
+        # account is really the owner's is a human call. Report and leave it.
+        if EmailAddress.objects.exclude(user=owner).filter(email=canonical, verified=True).exists():
+            notes.append("address already verified by another account on this deck")
+            return 'skipped', owner.username, owner.email, '; '.join(notes)
 
         if apply_changes:
             # mirror TenantCreate.form_valid: the owner's address exists, verified

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -8,7 +8,6 @@ from django.utils.timezone import localdate, now, timedelta
 from django.contrib.auth import get_user_model
 
 from allauth.account.utils import user_email
-from allauth.account.models import EmailAddress
 from django_tenants.models import DomainMixin, TenantMixin
 
 from hackerspace_online import settings
@@ -362,18 +361,22 @@ class Tenant(TenantMixin):
 
     def get_owner_email_cached(self):
         """
-        Returns all known email addresses (verified or not) from SiteConfig().deck_owner object.
+        Returns the deck owner's email address (SiteConfig().deck_owner), or None
+        when the owner has no email set.
+
+        The owner's plain ``User.email`` is the operational contact address for
+        the deck: notice emails, checkout prefill, and the Stripe backfill
+        report's matching all ride on it. It is deliberately NOT gated on allauth
+        ``EmailAddress`` bookkeeping: owners of decks created before the current
+        sign-up flow often have a ``User.email`` but no ``EmailAddress`` row at
+        all, and requiring one silently disabled every owner email for exactly
+        the legacy decks that most need warning (maintainer decision,
+        2026-08-01; the ``backfill_owner_emails`` command normalizes the missing
+        rows so legacy owners match what deck creation sets up today).
         """
         SiteConfig = apps.get_model('siteconfig', 'SiteConfig')
         owner = SiteConfig.get().deck_owner
-
-        email = None
-        # get all known email addresses, verified or not
-        for email_address in EmailAddress.objects.filter(user=owner):
-            # make sure it's primary email for real
-            if email_address.email == user_email(owner):
-                email = owner.email
-        return email
+        return user_email(owner) or None
 
     def get_google_signon_enabled(self):
         """

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -361,8 +361,10 @@ class Tenant(TenantMixin):
 
     def get_owner_email_cached(self):
         """
-        Returns the deck owner's email address (SiteConfig().deck_owner), or None
-        when the owner has no email set.
+        Returns the deck owner's email address (SiteConfig().deck_owner) in
+        allauth's canonical lowercase form (``user_email`` lowercases, matching
+        how ``EmailAddress`` rows are stored), or None when the owner has no
+        email set.
 
         The owner's plain ``User.email`` is the operational contact address for
         the deck: notice emails, checkout prefill, and the Stripe backfill

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import SimpleTestCase
 
+from allauth.account.models import EmailAddress
 from django_tenants.utils import get_public_schema_name, schema_context
 from freezegun import freeze_time
 from model_bakery import baker
@@ -130,3 +131,76 @@ class BillingStatusLabelTest(SimpleTestCase):
             'suspended',
         )
         self.assertEqual(Command.billing_status(Tenant(trial_end_date=None, paid_until=None)), 'unmanaged')
+
+
+class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
+    """Tests for the `backfill_owner_emails` management command (#1729 rollout)."""
+
+    def run_command(self, *args):
+        """Run the command and return its full stdout."""
+        out = StringIO()
+        call_command('backfill_owner_emails', *args, stdout=out)
+        return out.getvalue()
+
+    def deck_line(self, output):
+        """Return this test deck's audit line, or fail if it's absent."""
+        matches = [line for line in output.splitlines() if line.startswith(self.tenant.schema_name)]
+        self.assertEqual(len(matches), 1, f"expected exactly one audit line for {self.tenant.schema_name}:\n{output}")
+        return matches[0]
+
+    def set_owner(self, **user_fields):
+        """Make a fresh staff user the deck owner and return it."""
+        owner = baker.make(User, is_staff=True, **user_fields)
+        config = SiteConfig.get()
+        config.deck_owner = owner
+        config.save()
+        return owner
+
+    def test_backfill__dry_run_reports_and_writes_nothing(self):
+        """Without --apply the command reports the fix it would make, but writes no
+        EmailAddress row and leaves the cached owner email untouched."""
+        owner = self.set_owner(email='legacy.owner@example.com')
+        output = self.run_command()
+        self.assertIn('would-fix', self.deck_line(output))
+        self.assertIn('Dry run: no changes were written', output)
+        self.assertFalse(EmailAddress.objects.filter(user=owner).exists())
+
+    def test_backfill__apply_normalizes_bookkeeping_and_refreshes_cache(self):
+        """--apply creates the owner's EmailAddress verified+primary, demotes any
+        other primary address, lands owner_email_cached immediately, and a second
+        run reports the deck as already ok (idempotent)."""
+        owner = self.set_owner(email='legacy.owner@example.com')
+        stale_primary = EmailAddress.objects.create(user=owner, email='old.address@example.com', verified=False, primary=True)
+
+        output = self.run_command('--apply')
+        self.assertIn(' fixed', self.deck_line(output))
+        address = EmailAddress.objects.get(user=owner, email='legacy.owner@example.com')
+        self.assertTrue(address.verified)
+        self.assertTrue(address.primary)
+        stale_primary.refresh_from_db()
+        self.assertFalse(stale_primary.primary)
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.owner_email_cached, 'legacy.owner@example.com')
+
+        self.assertIn(' ok', self.deck_line(self.run_command()))
+
+    def test_backfill__flags_owners_needing_a_human(self):
+        """An owner with no email is reported with nothing written, the deprecated
+        public-tenant owner_email is surfaced as a clue, and a deck still on the
+        heuristic default owner account is flagged."""
+        from django.conf import settings
+
+        # move the seeded default-owner username out of the way so the fresh owner
+        # can carry it (usernames are unique per schema)
+        User.objects.filter(username=settings.TENANT_DEFAULT_OWNER_USERNAME).update(username='renamed-for-test')
+        owner = self.set_owner(email='')
+        User.objects.filter(pk=owner.pk).update(username=settings.TENANT_DEFAULT_OWNER_USERNAME)
+        Tenant.objects.filter(pk=self.tenant.pk).update(owner_email='clue@example.com')
+
+        output = self.run_command('--apply')
+        line = self.deck_line(output)
+        self.assertIn('no-email', line)
+        self.assertIn('default owner account', line)
+        self.assertIn('clue@example.com', line)
+        self.assertFalse(EmailAddress.objects.filter(user=owner).exists())
+        self.assertIn('1 with no owner email', output)

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -240,6 +240,63 @@ class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
         self.assertTrue(rows[0].verified)
         self.assertTrue(rows[0].primary)
 
+    def test_backfill__mixed_case_owner_email_normalizes_the_lowercase_row(self):
+        """When the owner's User.email is mixed case and both the lowercase row and an
+        exact-case duplicate exist, --apply targets the lowercase row (the form
+        EmailAddress.clean() stores) and demotes the duplicate's primary, instead of
+        lowercasing the duplicate into a unique (user, email) collision with its
+        sibling. The cache lands allauth's canonical lowercase form."""
+        owner = self.set_owner(email='Mixed.Case@Example.com')
+        variant = EmailAddress.objects.create(user=owner, email='Mixed.Case@Example.com', verified=False, primary=True)
+        canonical = EmailAddress.objects.create(user=owner, email='mixed.case@example.com', verified=False, primary=False)
+
+        output = self.run_command('--apply')
+        self.assertIn(' fixed', self.deck_line(output))
+        canonical.refresh_from_db()
+        variant.refresh_from_db()
+        self.assertTrue(canonical.verified)
+        self.assertTrue(canonical.primary)
+        self.assertFalse(variant.primary)
+        self.assertEqual(EmailAddress.objects.filter(user=owner, primary=True).count(), 1)
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.owner_email_cached, 'mixed.case@example.com')
+
+    def test_backfill__mixed_case_owner_email_creates_lowercase_row_idempotently(self):
+        """With no existing rows and a mixed-case User.email, --apply stores the new row
+        lowercase (EmailAddress.clean() lowercases on save), the cache lands allauth's
+        canonical lowercase form, and a second run still reports the deck as ok."""
+        owner = self.set_owner(email='Mixed.Case@Example.com')
+
+        self.assertIn(' fixed', self.deck_line(self.run_command('--apply')))
+        row = EmailAddress.objects.get(user=owner)
+        self.assertEqual(row.email, 'mixed.case@example.com')
+        self.assertTrue(row.verified)
+        self.assertTrue(row.primary)
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.owner_email_cached, 'mixed.case@example.com')
+
+        self.assertIn(' ok', self.deck_line(self.run_command()))
+
+    def test_backfill__skips_when_another_account_verified_the_address(self):
+        """When a different account on the deck already holds the owner's address
+        verified (the DB allows one verified row per address), both dry run and
+        --apply report the deck as skipped for a human and write nothing: the
+        command must not guess which account is really the owner's."""
+        owner = self.set_owner(email='Shared@Example.com')
+        other_row = EmailAddress.objects.create(user=baker.make(User), email='shared@example.com', verified=True, primary=True)
+
+        dry_line = self.deck_line(self.run_command())
+        self.assertIn('skipped', dry_line)
+        self.assertIn('verified by another account', dry_line)
+
+        output = self.run_command('--apply')
+        self.assertIn('skipped', self.deck_line(output))
+        self.assertIn('1 skipped', output)
+        self.assertFalse(EmailAddress.objects.filter(user=owner).exists())
+        other_row.refresh_from_db()
+        self.assertTrue(other_row.verified)
+        self.assertTrue(other_row.primary)
+
     def test_backfill__broken_schema_reported_as_error_line(self):
         """A Tenant row whose schema doesn't exist is reported as an ERROR line (and
         counted in the summary) without aborting the run for the remaining decks."""

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -137,19 +137,41 @@ class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
     """Tests for the `backfill_owner_emails` management command (#1729 rollout)."""
 
     def run_command(self, *args):
-        """Run the command and return its full stdout."""
+        """Run backfill_owner_emails and capture its report.
+
+        Args:
+            *args: Extra command arguments (e.g. '--apply'); none means dry run.
+
+        Returns:
+            str: The command's full stdout.
+        """
         out = StringIO()
         call_command('backfill_owner_emails', *args, stdout=out)
         return out.getvalue()
 
     def deck_line(self, output):
-        """Return this test deck's audit line, or fail if it's absent."""
+        """Extract this test deck's audit line from a command report.
+
+        Args:
+            output (str): The command's full stdout.
+
+        Returns:
+            str: The single report line for this test's deck (fails the test if
+            the line is absent or duplicated).
+        """
         matches = [line for line in output.splitlines() if line.startswith(self.tenant.schema_name)]
         self.assertEqual(len(matches), 1, f"expected exactly one audit line for {self.tenant.schema_name}:\n{output}")
         return matches[0]
 
     def set_owner(self, **user_fields):
-        """Make a fresh staff user the deck owner and return it."""
+        """Make a fresh staff user the deck owner.
+
+        Args:
+            **user_fields: Field overrides forwarded to the User baker (e.g. email).
+
+        Returns:
+            User: The newly created owner now set as SiteConfig.deck_owner.
+        """
         owner = baker.make(User, is_staff=True, **user_fields)
         config = SiteConfig.get()
         config.deck_owner = owner
@@ -234,3 +256,21 @@ class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
         self.assertIn('1 with errors', output)
         # the healthy test deck was still processed after the broken one
         self.deck_line(output)
+
+    def test_backfill__case_variant_primary_demoted_in_favor_of_exact_match(self):
+        """When a case-variant duplicate of the owner's address holds primary, --apply
+        demotes it (by pk, before the promote saves: the DB's unique_primary_email
+        constraint allows only one primary per user) and promotes the exact-case
+        row, leaving exactly one verified primary."""
+        owner = self.set_owner(email='legacy.owner@example.com')
+        exact = EmailAddress.objects.create(user=owner, email='legacy.owner@example.com', verified=False, primary=False)
+        variant = EmailAddress.objects.create(user=owner, email='Legacy.Owner@example.com', verified=False, primary=True)
+
+        output = self.run_command('--apply')
+        self.assertIn(' fixed', self.deck_line(output))
+        exact.refresh_from_db()
+        variant.refresh_from_db()
+        self.assertTrue(exact.primary)
+        self.assertTrue(exact.verified)
+        self.assertFalse(variant.primary)
+        self.assertEqual(EmailAddress.objects.filter(user=owner, primary=True).count(), 1)

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -204,3 +204,33 @@ class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
         self.assertIn('clue@example.com', line)
         self.assertFalse(EmailAddress.objects.filter(user=owner).exists())
         self.assertIn('1 with no owner email', output)
+
+    def test_backfill__existing_unverified_row_is_marked_not_duplicated(self):
+        """--apply promotes an existing unverified, non-primary EmailAddress row for
+        the owner's address in place: no duplicate row is created."""
+        owner = self.set_owner(email='legacy.owner@example.com')
+        EmailAddress.objects.create(user=owner, email='legacy.owner@example.com', verified=False, primary=False)
+
+        output = self.run_command('--apply')
+        self.assertIn(' fixed', self.deck_line(output))
+        rows = EmailAddress.objects.filter(user=owner)
+        self.assertEqual(rows.count(), 1)
+        self.assertTrue(rows[0].verified)
+        self.assertTrue(rows[0].primary)
+
+    def test_backfill__broken_schema_reported_as_error_line(self):
+        """A Tenant row whose schema doesn't exist is reported as an ERROR line (and
+        counted in the summary) without aborting the run for the remaining decks."""
+        with schema_context(get_public_schema_name()):
+            broken = Tenant(name='brokendeck', schema_name='brokendeck')
+            broken.auto_create_schema = False
+            broken.full_clean()
+            broken.save()
+
+        output = self.run_command()
+        broken_line = [line for line in output.splitlines() if line.startswith('brokendeck')]
+        self.assertEqual(len(broken_line), 1)
+        self.assertIn('ERROR', broken_line[0])
+        self.assertIn('1 with errors', output)
+        # the healthy test deck was still processed after the broken one
+        self.deck_line(output)

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -370,6 +370,8 @@ class TenantCountingAndCachingTest(ByteDeckTenantTestCase):
         # subscribed deck uses its own (tier) cap, not the trial cap
         self.assertFalse(deck(paid_until=localdate(), max_active_users=40).is_over_user_limit)
         self.assertTrue(deck(paid_until=localdate(), max_active_users=live - 1).is_over_user_limit)
+
+
 class OwnerEmailResolutionTest(ByteDeckTenantTestCase):
     """Tests for Tenant.get_owner_email_cached() owner-email resolution (#1729 rollout).
 
@@ -400,6 +402,13 @@ class OwnerEmailResolutionTest(ByteDeckTenantTestCase):
         disable every owner email for a legacy deck."""
         self.set_owner(email='legacy.owner@example.com')
         self.assertEqual(self.tenant.get_owner_email_cached(), 'legacy.owner@example.com')
+
+    def test_get_owner_email_cached__returns_allauth_canonical_lowercase(self):
+        """A mixed-case User.email resolves to allauth's canonical lowercase form
+        (user_email lowercases), matching how EmailAddress rows are stored, so
+        every consumer of the cache sees one consistent spelling."""
+        self.set_owner(email='Mixed.Case@Example.com')
+        self.assertEqual(self.tenant.get_owner_email_cached(), 'mixed.case@example.com')
 
     def test_get_owner_email_cached__none_when_owner_has_no_email(self):
         """An owner with no email at all resolves to None: the notice engine then

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -370,6 +370,38 @@ class TenantCountingAndCachingTest(ByteDeckTenantTestCase):
         # subscribed deck uses its own (tier) cap, not the trial cap
         self.assertFalse(deck(paid_until=localdate(), max_active_users=40).is_over_user_limit)
         self.assertTrue(deck(paid_until=localdate(), max_active_users=live - 1).is_over_user_limit)
+class OwnerEmailResolutionTest(ByteDeckTenantTestCase):
+    """Tests for Tenant.get_owner_email_cached() owner-email resolution (#1729 rollout).
+
+    Legacy deck owners often predate the allauth sign-up flows, so they have a
+    User.email but no EmailAddress bookkeeping row; the resolver must still
+    surface their address, because the notice engine, checkout prefill, and the
+    Stripe backfill report's matching all ride on it.
+    """
+
+    def set_owner(self, **user_fields):
+        """Make a fresh staff user the deck owner and return it."""
+        owner = baker.make(User, is_staff=True, **user_fields)
+        config = SiteConfig.get()
+        config.deck_owner = owner
+        config.save()
+        return owner
+
+    def test_get_owner_email_cached__resolves_without_an_emailaddress_row(self):
+        """An owner with a plain User.email but no allauth EmailAddress row still
+        resolves to that address: a missing bookkeeping row must not silently
+        disable every owner email for a legacy deck."""
+        self.set_owner(email='legacy.owner@example.com')
+        self.assertEqual(self.tenant.get_owner_email_cached(), 'legacy.owner@example.com')
+
+    def test_get_owner_email_cached__none_when_owner_has_no_email(self):
+        """An owner with no email at all resolves to None: the notice engine then
+        skips the email leg, and the backfill command reports the deck for a
+        human to fix in the SiteConfig admin."""
+        self.set_owner(email='')
+        self.assertIsNone(self.tenant.get_owner_email_cached())
+
+
 class DefaultTrialEndDateTest(SimpleTestCase):
     """Tests for the default demo/trial expiry date on new tenants (Issue #1146).
 

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -380,7 +380,14 @@ class OwnerEmailResolutionTest(ByteDeckTenantTestCase):
     """
 
     def set_owner(self, **user_fields):
-        """Make a fresh staff user the deck owner and return it."""
+        """Make a fresh staff user the deck owner.
+
+        Args:
+            **user_fields: Field overrides forwarded to the User baker (e.g. email).
+
+        Returns:
+            User: The newly created owner now set as SiteConfig.deck_owner.
+        """
         owner = baker.make(User, is_staff=True, **user_fields)
         config = SiteConfig.get()
         config.deck_owner = owner

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -384,13 +384,13 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__owner_without_email_still_gets_in_app_notification(self):
-        """A deck whose owner has no known email skips the email channel but still
+        """A deck whose owner has no email at all skips the email channel but still
         records the notice and creates the in-app notification."""
-        from allauth.account.models import EmailAddress
+        from django.contrib.auth import get_user_model
         from siteconfig.models import SiteConfig
 
         owner = SiteConfig.get().deck_owner
-        EmailAddress.objects.filter(user=owner).delete()
+        get_user_model().objects.filter(pk=owner.pk).update(email='')
         self.assertIsNone(self.tenant.get_owner_email_cached())
 
         summary = self.run_engine_with_inline_email()


### PR DESCRIPTION
### What?
Fixes owner-email resolution for legacy decks, in two coordinated parts (investigation requested by the maintainer, 2026-08-01; hotfix per their call):

* **Resolver fix** (`Tenant.get_owner_email_cached`): the method required an allauth `EmailAddress` row matching the owner's `User.email` (verified or not, despite the field help text claiming verified). Owners of decks created before the current sign-up flow often have a `User.email` with no `EmailAddress` row at all, so every owner email was silently skipped for exactly the legacy decks that most need warning. The resolver now returns the owner's `User.email` directly: it is the operational contact address, and allauth bookkeeping no longer gates it. The address comes back in allauth's canonical lowercase form (`user_email()` lowercases, matching how `EmailAddress` rows are stored), so every consumer of the cache sees one consistent spelling.
* **`backfill_owner_emails` management command** (dry-run by default, `--apply` to write): brings every legacy owner up to the same state deck creation produces today (`EmailAddress` matching `owner.email` exists, verified, and the owner's only primary), refreshes each fixed deck's cached fields immediately, and audits the decks that need a human: owners with **no email at all**, addresses **already verified by a different account** on the deck (reported as `skipped`: the DB allows one verified row per address, so no write can succeed and which account is really the owner's is a human call), decks still on the **heuristic default owner account** (the initial `deck_owner` assignment guessed the oldest non-admin staff user, or created a bare `owner` account), and cases where the **deprecated public-tenant `owner_email` disagrees** with the schema's owner (often the best clue to who the owner should be).

Deliberately assuming legacy addresses are verified is the maintainer decision from the investigation: they are long-standing customer contact addresses, verification gates nothing security-sensitive in this app (sign-in and password reset already work unverified, `ACCOUNT_EMAIL_VERIFICATION = "optional"`), and the alternative is decks sailing into suspension without a single warning email.

### Why?
The suspension rollout's warning emails (deck status notices), the Stripe checkout prefill, and the #2043 backfill report's subscription matching all ride on `owner_email_cached`. With the old resolver, a legacy deck could reach suspension with the notice engine "working" while its owner never received one email, and the backfill report under-matched every such deck. Hotfixing to `staging` puts the fix in front of the production merge.

### How?
* The resolver reduces to `user_email(owner) or None`: the old loop's only effect was returning None when the bookkeeping row was missing, which was the bug. One behavioral test updated to match the new semantics (its "owner without email" precondition now requires an empty `User.email`, which is its actual intent).
* The command mirrors `TenantCreate.form_valid`'s EmailAddress handling (verified + primary), demotes any other primary rows by pk BEFORE the promote saves (the DB's `unique_primary_email` constraint allows one primary per user), reuses a case-insensitively matched existing row rather than duplicating it, and processes each deck in a savepoint so one broken schema cannot poison the run.
* **Apply-path hardening from the full-review pass** (maintainer request, 2026-08-01; commit c053e14), two fixes rooted in allauth model facts: (1) `EmailAddress.clean()` lowercases the address on save, so normalizing the exact-case row of a mixed-case `User.email` could rewrite it into a `unique (user, email)` collision with its own lowercase sibling; the target-row preference is now the lowercase (canonical) row first, then the exact-case match, then the oldest case variant, so the normalizing save can never collide. (2) `ACCOUNT_UNIQUE_EMAIL` enforces one VERIFIED row per address per schema (`unique_verified_email`), so an address already verified by a different account can never be written; that is now the first-class `skipped` audit status in both dry-run and apply (previously an ERROR crash-line in apply while the dry run claimed would-fix).
* **No model or migration changes**: the stale "verified" wording in the `owner_email_cached` help text is deferred to the develop cycle, keeping this hotfix migration-free (a migration here would collide with #2110's pending `0023` migration at the next staging/develop sync).

### Testing?
* Full serial suite on this branch (staging base): **1567 tests, OK**, plus `ruff` clean. The command is at **100% statement + branch coverage**.
* New tests: the resolver resolves without an `EmailAddress` row (**fails without the fix**), returns None for an email-less owner, and returns the canonical lowercase form for a mixed-case `User.email`; the command's dry run reports and writes nothing; `--apply` creates/normalizes the row (verified + primary, other primaries demoted) and lands `owner_email_cached` immediately; a second run reports the deck as already ok (idempotent); no-email owners are reported with nothing written, with the default-owner flag and the legacy public-tenant address surfaced; an existing unverified row is promoted in place with no duplicate created; a Tenant row with a broken schema is reported as an ERROR line and counted without aborting the run; a case-variant primary is demoted by pk before the exact row is promoted.
* Hardening regression tests (each **fails without its fix**): a mixed-case `User.email` with both case-variant rows normalizes the lowercase row instead of erroring on the `unique (user, email)` collision; a mixed-case `User.email` with no rows creates the row lowercase and stays idempotent; an address already verified by a different account is reported `skipped` in both dry-run and apply with nothing written.
* Real run against the dev database (`hackerspace` deck, whose owner had a `User.email` but no `EmailAddress` row):

```
$ python src/manage.py backfill_owner_emails
deck                     status     owner                email                            notes
-----------------------------------------------------------------------------------------------
hackerspace              would-fix  owner                owner@example.com                default owner account (heuristic guess, never chosen)
-----------------------------------------------------------------------------------------------
1 deck(s): 0 already ok, 1 would be fixed, 0 with no owner email (fix by hand in the SiteConfig admin); 1 still on the default owner account.
Dry run: no changes were written. Re-run with --apply to write.

$ python src/manage.py backfill_owner_emails --apply
hackerspace              fixed      owner                owner@example.com                default owner account (heuristic guess, never chosen)
1 deck(s): 0 already ok, 1 fixed, 0 with no owner email (fix by hand in the SiteConfig admin); 1 still on the default owner account.

$ python src/manage.py backfill_owner_emails
hackerspace              ok         owner                owner@example.com                default owner account (heuristic guess, never chosen)
```

### Screenshots (if front end is affected)
N/A (resolver + management command; the real command output above is the visible surface).

### Anything Else?
* **Ops after merge**: run `python src/manage.py backfill_owner_emails` on production (dry run), review the audit lines (especially no-email owners, `skipped` verified-elsewhere addresses, and default-owner decks: fix those by hand in each deck's SiteConfig admin, using the legacy public-tenant address as the clue where shown), then re-run with `--apply`.
* Deferred to the develop cycle: the `owner_email_cached` help-text correction (needs a migration) and any `deck_owner` picker validation. Note for the next staging/develop sync: `stripe_backfill_report` (#2110) should compare owner emails case-insensitively, since the resolver now returns the lowercase canonical form.

### Review request
@tylerecouture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

- Claude Code (`Bytedeck - payments integration`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an administrative tool to audit and optionally repair deck owner email records.
  - Supports safe preview mode before applying changes.
  - Repairs verified primary email records, resolves duplicate primary addresses, and refreshes cached owner emails.
  - Reports missing emails, conflicts, legacy mismatches, and processing errors.

- **Bug Fixes**
  - Owner email resolution now works even when a corresponding account email record is missing.
  - Email addresses are consistently normalized to lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->