### PR TITLE
test: cover badges/models.py queryset, ratio, assertion, and icon gaps

### DIFF
--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -112,6 +112,24 @@ class BadgeTestModel(ByteDeckTenantTestCase):
         """The badge's absolute url is reachable and returns 200."""
         self.assertEqual(self.client.get(self.badge.get_absolute_url(), follow=True).status_code, 200)
 
+    def test_get_type__returns_only_badges_of_that_type(self):
+        """BadgeQuerySet.get_type filters the queryset to badges of the given badge type."""
+        badge_type = baker.make(BadgeType)
+        matching = baker.make(Badge, badge_type=badge_type)
+        other = baker.make(Badge, badge_type=baker.make(BadgeType))
+        qs = Badge.objects.all().get_type(badge_type)
+        self.assertIn(matching, qs)
+        self.assertNotIn(other, qs)
+
+    def test_fraction_of_active_users_granted_this__returns_zero_when_no_active_users(self):
+        """fraction_of_active_users_granted_this() returns 0 (no division by zero) when the
+        active-user count is zero."""
+        from django.core.cache import cache
+        from django.db import connection
+        # Prime the active-user-count cache to 0 so the guard short-circuits before dividing.
+        cache.set(f'{connection.schema_name}-active-user-count', 0, 60)
+        self.assertEqual(self.badge.fraction_of_active_users_granted_this(), 0)
+
     @mock.patch('badges.models.BadgeRarity.objects.get_rarity')
     def test_get_rarity_icon__without_rarity(self, mock_get_rarity):
         """get_rarity_icon() returns an empty string when the badge has no rarity."""
@@ -371,6 +389,23 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
             baker.make(Badge),
         )
         self.assertIsInstance(new_assertion, BadgeAssertion)
+
+    def test_create_assertion__uses_explicit_active_semester(self):
+        """create_assertion() honours a passed active_semester instead of the SiteConfig default."""
+        new_assertion = BadgeAssertion.objects.create_assertion(
+            self.student, baker.make(Badge), issued_by=self.teacher, active_semester=self.sem.id
+        )
+        self.assertEqual(new_assertion.semester_id, self.sem.id)
+
+    def test_post_save_receiver__uses_badge_type_fa_icon_when_set(self):
+        """The granted notification uses the badge type's own fa_icon when it has one, rather
+        than the default fa-certificate (the non-default branch of post_save_receiver)."""
+        badge_type = baker.make(BadgeType, fa_icon='fa-trophy')
+        badge = baker.make(Badge, badge_type=badge_type)
+        # Creating the assertion fires post_save_receiver, which builds the notification icon.
+        BadgeAssertion.objects.create_assertion(self.student, badge, issued_by=self.teacher)
+        notification = Notification.objects.all_for_user(self.student).last()
+        self.assertIn('fa-trophy', notification.font_icon)
 
     def test_calculate_xp_to_date__sums_granted_badge_xp(self):
         """calculate_xp_to_date() totals the XP of the badges granted to the user by a date."""

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -7,6 +7,7 @@ from model_bakery import baker
 from model_bakery.recipe import Recipe
 
 from badges.models import Badge, BadgeAssertion, BadgeRarity, BadgeSeries, BadgeType
+from courses.models import Semester
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
@@ -127,7 +128,10 @@ class BadgeTestModel(ByteDeckTenantTestCase):
         from django.core.cache import cache
         from django.db import connection
         # Prime the active-user-count cache to 0 so the guard short-circuits before dividing.
-        cache.set(f'{connection.schema_name}-active-user-count', 0, 60)
+        # Clean it up so the cached zero (60s TTL) can't leak into later tests in this process.
+        cache_key = f'{connection.schema_name}-active-user-count'
+        self.addCleanup(cache.delete, cache_key)
+        cache.set(cache_key, 0, 60)
         self.assertEqual(self.badge.fraction_of_active_users_granted_this(), 0)
 
     @mock.patch('badges.models.BadgeRarity.objects.get_rarity')
@@ -392,10 +396,13 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
 
     def test_create_assertion__uses_explicit_active_semester(self):
         """create_assertion() honours a passed active_semester instead of the SiteConfig default."""
+        # A semester distinct from the SiteConfig default (self.sem) so this proves the passed
+        # active_semester is used rather than the default (which would pass either way).
+        explicit_semester = baker.make(Semester)
         new_assertion = BadgeAssertion.objects.create_assertion(
-            self.student, baker.make(Badge), issued_by=self.teacher, active_semester=self.sem.id
+            self.student, baker.make(Badge), issued_by=self.teacher, active_semester=explicit_semester.id
         )
-        self.assertEqual(new_assertion.semester_id, self.sem.id)
+        self.assertEqual(new_assertion.semester_id, explicit_semester.id)
 
     def test_post_save_receiver__uses_badge_type_fa_icon_when_set(self):
         """The granted notification uses the badge type's own fa_icon when it has one, rather


### PR DESCRIPTION
## What

Closes the remaining coverage gaps in `badges/models.py`. Test-only.

## Why

Per a full-suite coverage run, these lines/branches were uncovered:

- **`BadgeQuerySet.get_type`**: never called in tests.
- **`Badge.fraction_of_active_users_granted_this`**: the zero-active-users guard (`if not num_users: return 0`, which prevents a division by zero) was never taken.
- **`BadgeAssertionManager.create_assertion`**: the branch where an explicit `active_semester` is passed (so the `SiteConfig` default is not looked up) was untested.
- **`post_save_receiver`**: the branch where the badge type has its own `fa_icon` (so the granted notification uses it instead of the default `fa-certificate`) was untested.

## How

In `src/badges/tests/test_models.py`:

- `BadgeTestModel.test_get_type__returns_only_badges_of_that_type`.
- `BadgeTestModel.test_fraction_of_active_users_granted_this__returns_zero_when_no_active_users`: primes the cached active-user count to 0 so the guard short-circuits before dividing.
- `BadgeAssertionTestModel.test_create_assertion__uses_explicit_active_semester`: asserts the new assertion's `semester_id` matches the passed semester.
- `BadgeAssertionTestModel.test_post_save_receiver__uses_badge_type_fa_icon_when_set`: grants a badge whose type has `fa_icon='fa-trophy'` and asserts the resulting notification's `font_icon` contains it.

## Testing

- `badges.tests.test_models` green (37 tests).
- `coverage` confirms the previously-missing lines/branches in `badges/models.py` are now covered.
- `ruff check` clean.

## Screenshots

N/A: test-only; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved badge filtering and grant calculations, including cases with no active users.
  * Badge notifications now use the selected badge type’s custom icon.
  * Improved validation for content selections, missing records, empty labels, and oversized file uploads.
  * Preserved support for legacy content references while improving queryset handling.

* **Tests**
  * Added regression coverage for badge behavior, content-selection fields, and file-size validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->