### PR TITLE
test: cover bulk-edit unrecognized-action and drop-without-draft branches

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -630,6 +630,18 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertFalse(Comment.objects.filter(id=draft_comment_id).exists())
         self.assertFalse(QuestSubmission.objects.filter(id=sub_id).exists())
 
+    def test_drop__deletes_submission_without_draft_comment(self):
+        """Dropping a submission that has no draft comment skips the comment-deletion branch
+        and still deletes the submission and redirects."""
+        self.client.force_login(self.test_student1)
+
+        sub = baker.make(QuestSubmission, user=self.test_student1)
+        self.assertIsNone(sub.draft_comment)
+
+        response = self.client.post(reverse('quests:drop', args=[sub.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(QuestSubmission.objects.filter(id=sub.id).exists())
+
     def test_all_submission_pages__teacher_access_codes(self):
         """Teachers can view, flag, unflag, and skip submissions, with 404s for nonexistent ones."""
         # log in a teacher
@@ -1394,6 +1406,20 @@ class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 302)
         messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertIn("No quests selected.", messages[0])
+
+    def test_bulk_edit__unrecognized_action_redirects_without_change(self):
+        """A POST with selected quests but an action matching none of the handled actions
+        falls through to a plain redirect: no message and no change to the quests."""
+        response = self.client.post(self.url, {
+            "selected_quests[]": [self.quest1.id],
+            "action": "not_a_real_action",
+        })
+        self.assertRedirects(response, reverse("quests:quests"), fetch_redirect_response=False)
+        # No branch matched, so no success/warning message was queued...
+        self.assertEqual([m.message for m in get_messages(response.wsgi_request)], [])
+        # ...and the unpublished quest was left untouched.
+        self.quest1.refresh_from_db()
+        self.assertFalse(self.quest1.published)
 
     def test_bulk_edit__publishes_unpublished_quests(self):
         """


### PR DESCRIPTION
## What

Covers two reachable, previously-untested branches in `quest_manager/views.py`. Test-only.

## Why

A full-suite coverage run flagged six partial branches in `quest_manager/views.py` (it sits at 99.5%). This PR closes the two that are cleanly reachable with robust tests:

- **`QuestBulkEditView.post`** (`656 -> 663`): a POST with selected quests but an `action` matching none of the handled actions (`delete`/`publish`/`unpublish`/`unarchive`) falls through the elif chain to the final `redirect("quests:quests")`. Only the recognized actions were tested.
- **`drop()`** (`2135 -> 2137`): dropping a submission that has **no** draft comment skips the `if sub.draft_comment: sub.draft_comment.delete()` branch. Only the with-draft-comment path was tested.

## How

In `src/quest_manager/tests/test_views.py`:

- `QuestBulkEditViewTests.test_bulk_edit__unrecognized_action_redirects_without_change`: posts an unhandled action and asserts a plain redirect, no queued message, and the quest left unchanged.
- `SubmissionViewTests.test_drop__deletes_submission_without_draft_comment`: drops a draft-comment-less submission and asserts it is deleted with a redirect.

## Remaining branches (deliberately not covered here)

For transparency, the other four flagged branches were assessed and left out; happy to follow up per your preference:

- **Guarded-unreachable (defensive) fall-throughs** (candidates for a `# pragma: no branch`, not a test):
  - `ApproveView` note/icon builder (`1283 -> 1295`): the "no button matched" exit of the `approve/comment/return/skip` elif chain, which cannot be reached because `post_has_valid_button()` guards the view.
  - `complete()` (`1881 -> 1914`): the "neither complete nor comment" exit, already noted redundant in a code comment ("this case is already covered at the top of the view").
- **Reachable but needs a specific/contrived scenario** (coverable in a follow-up):
  - `get_notification_kwargs` (`1324 -> 1327`): the approving staff user already being one of the student's `current_teachers()`.
  - `complete()` auto-approve path (`1870 -> 1914`): a submission with `do_not_grant_xp=True` completing a no-verification quest.

## Testing

- `QuestBulkEditViewTests` + `SubmissionViewTests` green (39 tests).
- `coverage` confirms branches `656->663` and `2135->2137` are now covered.
- `ruff check` clean.

## Screenshots

N/A: test-only; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_