### PR TITLE
test: finish quest_manager/views.py branch coverage (test reachable, pragma dead)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -17,7 +17,7 @@ from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
-from django.test import RequestFactory, SimpleTestCase
+from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.http import JsonResponse
@@ -3689,23 +3689,23 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """ This view is only accessible via POST """
         self.assert404('quests:approve', args=[self.sub.id])
 
-    def test_get_notification_kwargs__approver_already_a_teacher_not_re_added(self):
+    def test_approve__approver_who_is_a_teacher_not_re_added_to_affected_users(self):
         """When the approving staff member is already one of the student's current_teachers,
-        get_notification_kwargs leaves affected_users as just the student rather than re-adding
-        the teachers (the not-in-teachers_list branch is skipped)."""
-        from quest_manager.views import ApproveView
+        the approval notification's affected_users stays just the student rather than re-adding
+        the teachers (the not-in-teachers_list branch of get_notification_kwargs is skipped)."""
+        # current_teachers returns the approver, so the "extend affected_users" branch is skipped.
+        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.test_teacher]), \
+                patch('quest_manager.views.notify.send') as mock_notify:
+            response = self.client.post(
+                reverse('quests:approve', args=[self.sub.id]),
+                data={'comment_text': 'Nice work', 'approve_button': True},
+            )
+        self.assertEqual(response.status_code, 302)
 
-        view = ApproveView()
-        view.submission = self.sub
-        request = RequestFactory().post(reverse('quests:approve', args=[self.sub.id]))
-        request.user = self.test_teacher
-        view.request = request
-
-        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.test_teacher]):
-            kwargs = view.get_notification_kwargs()
-
-        # The approver is already a teacher, so affected_users is not extended with teachers_list.
-        self.assertEqual(kwargs['affected_users'], [self.sub.user])
+        # Isolate the approval notification (a badge grant could fire its own notify.send).
+        approval_calls = [c for c in mock_notify.call_args_list if c.kwargs.get('verb') == 'approved']
+        self.assertEqual(len(approval_calls), 1)
+        self.assertEqual(approval_calls[0].kwargs['affected_users'], [self.sub.user])
 
     def test_approve__invalid_form_renders_submission_page(self):
         """A non-ajax POST with an invalid awards value re-renders the submission page (form_invalid)."""

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -17,7 +17,7 @@ from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
-from django.test import SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.http import JsonResponse
@@ -3688,6 +3688,24 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def test_approve__get_returns_404(self):
         """ This view is only accessible via POST """
         self.assert404('quests:approve', args=[self.sub.id])
+
+    def test_get_notification_kwargs__approver_already_a_teacher_not_re_added(self):
+        """When the approving staff member is already one of the student's current_teachers,
+        get_notification_kwargs leaves affected_users as just the student rather than re-adding
+        the teachers (the not-in-teachers_list branch is skipped)."""
+        from quest_manager.views import ApproveView
+
+        view = ApproveView()
+        view.submission = self.sub
+        request = RequestFactory().post(reverse('quests:approve', args=[self.sub.id]))
+        request.user = self.test_teacher
+        view.request = request
+
+        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.test_teacher]):
+            kwargs = view.get_notification_kwargs()
+
+        # The approver is already a teacher, so affected_users is not extended with teachers_list.
+        self.assertEqual(kwargs['affected_users'], [self.sub.user])
 
     def test_approve__invalid_form_renders_submission_page(self):
         """A non-ajax POST with an invalid awards value re-renders the submission page (form_invalid)."""

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1280,7 +1280,10 @@ class ApproveView(NonPublicOnlyViewMixin, View):
             )
             blank_comment_text = f"<p>{SiteConfig.get().blank_return_text}</p>"
             self.submission.mark_returned()
-        elif "skip_button" in self.request.POST:
+        # dispatch() raises Http404 unless post_has_valid_button() is true, so one of the four
+        # buttons is always present by the time this runs; this elif always matches when the
+        # earlier ones did not, making the no-match fall-through unreachable.
+        elif "skip_button" in self.request.POST:  # pragma: no branch
             note_verb = "skipped"
             icon = (
                 "<span class='fa-stack text-muted'>"
@@ -1867,7 +1870,10 @@ def complete(request, submission_id):
         if not submission.quest.verification_required:
             submission.mark_approved()
 
-            if not submission.do_not_grant_xp:
+            # mark_approved() just set do_not_grant_xp to False (its transfer arg defaults to
+            # False), so this is always true on the auto-approve path; the skip-notify branch
+            # is unreachable here.
+            if not submission.do_not_grant_xp:  # pragma: no branch
                 # if not requesting xp, xp_requested will default to 0
                 # 0 or xp = xp
                 xp = xp_requested or submission.quest.xp
@@ -1878,7 +1884,10 @@ def complete(request, submission_id):
                     submission.user.profile.xp_cached,
                 )
 
-    elif "comment" in request.POST:
+    # The early-exit guard above raises Http404 unless "complete" or "comment" is in POST, so
+    # when the "complete" branch is not taken this elif always matches; the no-match
+    # fall-through (the redundant else noted below) is unreachable.
+    elif "comment" in request.POST:  # pragma: no branch
         note_verb = "commented on"
         msg_text = "Quest commented on."
         icon = (


### PR DESCRIPTION
## What

Closes the remaining flagged branches in `quest_manager/views.py`: one is genuinely reachable (now tested), three are guarded-unreachable defensive branches (now marked `# pragma: no branch` with explanations). Follows up on #2251, which covered the other two branches in this file.

## Why

A full-suite coverage run flagged these partial branches. Investigating each:

- **Reachable, so tested** — `ApproveView.get_notification_kwargs`: the approving staff member already being one of the student's `current_teachers()`, in which case `affected_users` is not re-extended with the teachers.
- **Unreachable, so excluded** (each cannot be hit because an earlier guard rules it out; a `# pragma: no branch` with a comment is the honest way to keep coverage meaningful):
  - `ApproveView` note/icon elif chain (`skip_button`): `dispatch()` raises `Http404` unless `post_has_valid_button()`, so one of the four buttons is always present and the chain always matches (the no-match fall-through can't happen).
  - `complete()` elif chain (`comment`): the early-exit guard raises `Http404` unless `"complete"` or `"comment"` is in POST.
  - `complete()` auto-approve rank-up guard (`if not submission.do_not_grant_xp`): `mark_approved()` on the immediately preceding line sets `do_not_grant_xp = False` (its `transfer` arg defaults to `False`), so the guard is always true here and the skip-notify arc is unreachable.

## How

- `src/quest_manager/views.py`: three `# pragma: no branch` markers, each with a comment naming the guard that makes the arc unreachable. No behavior change (comments only).
- `src/quest_manager/tests/test_views.py`: `ApproveViewTest.test_approve__approver_who_is_a_teacher_not_re_added_to_affected_users` drives an approval through the tenant-aware `self.client`, with `current_teachers` patched to return the approver, and asserts (via a `notify.send` mock) that the approval notification's `affected_users` stays `[student]`.

## Testing

- Full `quest_manager` suite green (356 tests); `ApproveViewTest` (17 tests) green.
- `coverage` confirms the reachable branch is now covered and the three pragma'd branches are no longer reported as partial. `quest_manager/views.py` has no remaining uncovered branches.
- `ruff check` clean.

## Screenshots

N/A: test coverage plus no-op-branch pragmas; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_