### PR TITLE
test: cover change_domain_urls guards and pragma its dead rewrite (#2258)

### DIFF
--- a/src/hackerspace_online/signals.py
+++ b/src/hackerspace_online/signals.py
@@ -30,16 +30,17 @@ def change_domain_urls(sender, *args, **kwargs):
         with transaction.atomic():
             all_tenants = Tenant.objects.exclude(schema_name='public')
             for tenant in all_tenants:
-                # domain_url is a removed field (always None); skip rather than
-                # crash on ``None.split(...)``. See the docstring above.
-                if not tenant.domain_url:
+                # domain_url is a removed field (always None); this always continues, so the
+                # rewrite below is dead until the handler is reimplemented against Domain (#2258).
+                if not tenant.domain_url:  # pragma: no branch -- domain_url is always None
                     continue
-                domain = tenant.domain_url.split(public_tenant.domain_url)[0]
-                tenant.domain_url = '{}{}'.format(domain, kwargs['instance'].domain)
-                tenant.save()
-            if public_tenant.domain_url:
-                public_tenant.domain_url = kwargs['instance'].domain
-                public_tenant.save()
+                domain = tenant.domain_url.split(public_tenant.domain_url)[0]  # pragma: no cover -- dead, see #2258
+                tenant.domain_url = '{}{}'.format(domain, kwargs['instance'].domain)  # pragma: no cover
+                tenant.save()  # pragma: no cover
+            # public_tenant.domain_url is likewise always None, so this block is dead (#2258).
+            if public_tenant.domain_url:  # pragma: no branch -- domain_url is always None
+                public_tenant.domain_url = kwargs['instance'].domain  # pragma: no cover
+                public_tenant.save()  # pragma: no cover
 
 
 def handle_tenant_site_domain_update(tenant, **kwargs):

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -52,10 +52,13 @@ class SignalTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def test_change_domain_urls__is_a_noop_on_create(self):
         """change_domain_urls only acts on Site updates; a create (created=True) returns
-        immediately without querying tenants."""
+        immediately, before even looking up the public tenant."""
         with schema_context(get_public_schema_name()):
             site = Site.objects.first()
-            self.assertIsNone(change_domain_urls(sender=Site, instance=site, created=True))
+            with patch.object(Tenant.objects, 'get') as mock_get:
+                self.assertIsNone(change_domain_urls(sender=Site, instance=site, created=True))
+            # The guard returns before the tenant lookup, so get() is never reached.
+            mock_get.assert_not_called()
 
     def test_change_domain_urls__returns_when_public_tenant_missing(self):
         """If the public tenant lookup fails, the handler returns quietly rather than raising."""

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 
 from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name, schema_context, tenant_context
 
+from hackerspace_online.signals import change_domain_urls
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
 from tenant.models import Tenant
 
@@ -46,3 +49,17 @@ class SignalTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertEqual(site.domain, full_domain)
             self.assertEqual(site.name, full_domain[:name_max])
             self.assertLessEqual(len(site.name), name_max)
+
+    def test_change_domain_urls__is_a_noop_on_create(self):
+        """change_domain_urls only acts on Site updates; a create (created=True) returns
+        immediately without querying tenants."""
+        with schema_context(get_public_schema_name()):
+            site = Site.objects.first()
+            self.assertIsNone(change_domain_urls(sender=Site, instance=site, created=True))
+
+    def test_change_domain_urls__returns_when_public_tenant_missing(self):
+        """If the public tenant lookup fails, the handler returns quietly rather than raising."""
+        with schema_context(get_public_schema_name()):
+            site = Site.objects.first()
+            with patch.object(Tenant.objects, 'get', side_effect=Tenant.DoesNotExist):
+                self.assertIsNone(change_domain_urls(sender=Site, instance=site, created=False))


### PR DESCRIPTION
## What

Closes the coverage gaps in `hackerspace_online/signals.py`'s `change_domain_urls` handler: test the reachable guards, and mark the dead domain-rewriting body as excluded. Opens #2258 to track fixing the handler itself.

## Why

`change_domain_urls` (a Sites `post_save` handler) is effectively inert. `domain_url` is no longer a field on the tenant model (django-tenants stores domains in the separate `Domain`/`TenantDomain` relation), so `tenant.domain_url` / `public_tenant.domain_url` is always `None` and the rewrite body can never run. The handler is kept only so that saving a `Site` while a non-public tenant exists doesn't crash.

The previously-uncovered parts were a mix of reachable guards and genuinely-dead code:

- **Reachable, so tested:**
  - the `created=True` early return (the handler only acts on Site *updates*)
  - the `except ObjectDoesNotExist: return` guard (missing public tenant)
- **Dead, so excluded** (`domain_url` is always `None`): the per-tenant and public-tenant rewrite blocks, plus the two `if ... domain_url:` branches whose "truthy" arc can never be taken.

## How

- `src/hackerspace_online/signals.py`: the dead rewrite lines are marked `# pragma: no cover` and the two always-one-way `if` checks `# pragma: no branch`, each with a comment pointing at #2258.
- `src/hackerspace_online/tests/test_signals.py`: `SignalTest.test_change_domain_urls__is_a_noop_on_create` and `test_change_domain_urls__returns_when_public_tenant_missing` (the latter patches `Tenant.objects.get` to raise `Tenant.DoesNotExist`).

## Related

- Opens #2258 (reimplement or remove the inert `change_domain_urls` handler). The pragmas point there so they're removed when the handler is fixed.

## Testing

- `hackerspace_online.tests.test_signals` green (3 tests).
- The dead lines/branches are excluded; the handler's reachable guards are covered by the new tests, and its loop remains covered by the full suite.
- `ruff check` clean.

## Screenshots

N/A: test coverage plus dead-code pragmas; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified domain handling behavior and documented currently unreachable rewrite paths.

* **Tests**
  * Added coverage confirming that creating a new site does not trigger domain changes.
  * Added coverage ensuring missing public tenant data is handled safely without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->