### PR TITLE
test: exclude import-time env/DEBUG-gated settings blocks from coverage

### DIFF
--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -35,7 +35,9 @@ DEBUG = env('DEBUG')
 ROOT_DOMAIN = env('ROOT_DOMAIN', default='localhost')
 
 ALLOWED_HOSTS = env('ALLOWED_HOSTS', default=[])
-if not ALLOWED_HOSTS:
+# ALLOWED_HOSTS is unset under the test harness, so the fallback always runs; the
+# "already provided via env" arc is only taken in real deployments.
+if not ALLOWED_HOSTS:  # pragma: no branch
     ALLOWED_HOSTS = [f".{ROOT_DOMAIN}"]
 
 CSRF_TRUSTED_ORIGINS = env('CSRF_TRUSTED_ORIGINS', default=[])
@@ -365,7 +367,7 @@ LOGGING = {
 # default). Augments the base LOGGING above rather than replacing it.
 DB_LOGS_ENABLED = env('DB_LOGS_ENABLED', default=False)
 
-if DB_LOGS_ENABLED:
+if DB_LOGS_ENABLED:  # pragma: no cover -- opt-in dev query tracer, disabled (env default) under the test harness
     MIDDLEWARE.insert(0, 'hackerspace_online.middleware.ForceDebugCursorMiddleware')
     LOGS_PATH = os.path.join(os.sep, 'tmp', 'bytedeck')
 
@@ -567,7 +569,7 @@ DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default=None)
 
 # SERVER ERRORS EMAIL
 admins_raw = env('ADMINS', default=[])
-if admins_raw:
+if admins_raw:  # pragma: no cover -- ADMINS env unset under the test harness
     # https://django-environ.readthedocs.io/en/latest/index.html?highlight=ADMINS#nested-lists
     ADMINS = [tuple(entry.split(':')) for entry in env.list('ADMINS')]
 SERVER_EMAIL = env('SERVER_EMAIL', default=None)
@@ -581,7 +583,7 @@ MEDIA_URL = '/media/'
 STATIC_URL = '/static/'
 
 USE_S3 = env('USE_S3', default='0') == '1'
-if USE_S3:
+if USE_S3:  # pragma: no cover -- production S3 storage config, disabled (env default) under the test harness
 
     # AWS settings
     AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID')
@@ -701,7 +703,7 @@ STRIPE_PRICE_ID = env('STRIPE_PRICE_ID', default=None)  # the recurring Price (p
 # RECAPTCHA #######################################################
 
 recaptcha_keys_available = env('RECAPTCHA_PRIVATE_KEY', default=None)
-if recaptcha_keys_available:
+if recaptcha_keys_available:  # pragma: no cover -- real reCAPTCHA keys env unset under the test harness (test keys used)
     RECAPTCHA_PUBLIC_KEY = env('RECAPTCHA_PUBLIC_KEY')
     RECAPTCHA_PRIVATE_KEY = env('RECAPTCHA_PRIVATE_KEY')
 else:
@@ -985,7 +987,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # TESTING ##################################################
 
 TESTING = 'test' in sys.argv
-if TESTING:
+if TESTING:  # pragma: no branch -- always true under the test runner ('test' in sys.argv)
     # Custom runner installs a model_bakery patch so baker.make(Prereq) builds
     # valid GenericForeignKey targets instead of random dangling ones (which
     # made the prerequisites signal tests intermittently crash). See
@@ -1014,7 +1016,7 @@ if TESTING:
 
 # DEBUG / DEVELOPMENT SPECIFIC SETTINGS #################################
 
-if DEBUG and not TESTING:
+if DEBUG and not TESTING:  # pragma: no cover -- dev-only debug toolbar setup, never runs under the test harness
 
     import socket
     INTERNAL_IPS = ['127.0.0.1', '0.0.0.0']


### PR DESCRIPTION
## What

Closes the coverage gaps in `hackerspace_online/settings.py` (was ~79%) by marking the import-time, environment/`DEBUG`-gated configuration blocks that never execute under the test harness. No behavior change (comments only).

## Why

Every remaining uncovered line in `settings.py` is an import-time config block whose execution depends on an environment variable or on `DEBUG`/`TESTING`, none of which are set the "other way" under the test runner. They can't be exercised without reloading `settings` under a different environment, which is fragile and has global side effects, so a documented pragma is the honest way to keep the reported percentage meaningful. This matches the existing production-security pragma already in this file.

Classification (all "must-pragma", none reasonably testable):

- **`# pragma: no cover`** on dev/production-only blocks that never run under tests:
  - `if DB_LOGS_ENABLED:` (opt-in DB query tracer, env default off)
  - `if USE_S3:` (production S3 storage config, env default off)
  - `if admins_raw:` (`ADMINS` env unset in tests)
  - `if recaptcha_keys_available:` (real reCAPTCHA keys unset in tests; test keys used)
  - `if DEBUG and not TESTING:` (dev-only debug-toolbar setup)
- **`# pragma: no branch`** where the condition is one-directional under tests:
  - `if not ALLOWED_HOSTS:` (unset in tests, so the fallback always runs)
  - `if TESTING:` (always true under the test runner, `'test' in sys.argv`)

## How

Inline pragma markers on the relevant `if` lines, each with a short comment naming why the branch/block isn't exercised under the test harness.

## Testing

- `coverage` confirms all previously-missing `settings.py` lines/branches are now excluded (the file's remaining coverage comes from the normally-executed import path).
- `manage.py check --deploy --fail-level WARNING` (the CI production-security step) still passes: this change is comments only.
- `ruff check` clean.

## Screenshots

N/A: coverage pragmas only; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaPtRRA32f6CW2ePFJyEeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code coverage tracking for deployment, logging, email, storage, reCAPTCHA, testing, and debugging configuration paths.
  * No changes to runtime behavior or available settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->