### PR TITLE
feat: give lapsed trials the same 30-day grace period as subscriptions (#1734)

### DIFF
--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -32,7 +32,8 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
             <div class="alert {% if current_deck.days_until_expiry < 0 %}alert-danger{% else %}alert-warning{% endif %}" id="deck-status-banner">
                 <i class="fa fa-fw fa-exclamation-triangle"></i>
                 {% if current_deck.days_until_expiry < 0 %}
-                    <strong>Subscription expired:</strong> this deck is in its grace period, which ends in
+                    <strong>{% if current_deck.paid_until %}Subscription expired:{% else %}Trial ended:{% endif %}</strong>
+                    this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
                     the deck will then be suspended (only the deck owner will be able to sign in).
                 {% elif current_deck.is_on_trial %}

--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -32,11 +32,12 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
             <div class="alert {% if current_deck.days_until_expiry < 0 %}alert-danger{% else %}alert-warning{% endif %}" id="deck-status-banner">
                 <i class="fa fa-fw fa-exclamation-triangle"></i>
                 {% if current_deck.days_until_expiry < 0 %}
-                    <strong>{% if current_deck.paid_until %}Subscription expired:{% else %}Trial ended:{% endif %}</strong>
+                    {# the GOVERNING clock picks the wording: an admin-extended trial can outlast an old paid date (#1734 B4) #}
+                    <strong>{% if current_deck.governing_clock_is_trial %}Trial ended:{% else %}Subscription expired:{% endif %}</strong>
                     this deck is in its grace period, which ends in
                     {{ current_deck.grace_days_remaining }} day{{ current_deck.grace_days_remaining|pluralize }};
                     the deck will then be suspended (only the deck owner will be able to sign in).
-                {% elif current_deck.is_on_trial %}
+                {% elif current_deck.governing_clock_is_trial %}
                     <strong>Trial ending soon:</strong> this deck's free trial ends in
                     {{ current_deck.days_until_expiry }} day{{ current_deck.days_until_expiry|pluralize }}.
                 {% else %}

--- a/src/tenant/management/commands/deck_status_report.py
+++ b/src/tenant/management/commands/deck_status_report.py
@@ -82,6 +82,9 @@ class Command(BaseCommand):
             return 'grace' if tenant.in_grace_period else 'subscribed'
         if tenant.is_on_trial:
             return 'trial'
+        if tenant.in_grace_period:
+            # a lapsed trial inside the unified grace window (#1734 B4)
+            return 'grace'
         if tenant.is_suspended:
             return 'suspended'
         return 'unmanaged'

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -209,14 +209,38 @@ class Tenant(TenantMixin):
         return self.paid_until is not None and localdate() <= self.paid_until + timedelta(days=GRACE_PERIOD_DAYS)
 
     @property
-    def in_grace_period(self):
-        """Whether the deck is past its latest deadline (trial end or `paid_until`)
-        but still within the unified grace window (access retained, expiry
-        warnings due). Trial and paid clocks get the same grace (#1734 B4)."""
+    def governing_deadline(self):
+        """The single deadline the deck's lifecycle runs on: the LATEST of its set
+        clocks (trial end and/or `paid_until`), or None for a comped/managed-manually
+        deck with both dates blank. Expiry, the unified grace window, and suspension
+        are all measured from this one date (#1734 B4: a trial is just another kind
+        of subscription)."""
         clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
-        if not clocks:
+        return max(clocks) if clocks else None
+
+    @property
+    def governing_clock_is_trial(self):
+        """Whether the governing deadline comes from the TRIAL clock, so status
+        copy should say "trial ended" rather than "subscription expired". False
+        when the paid clock governs, when the dates tie (subscription language
+        wins), and when the deck has no dates at all. Presentation must key off
+        this rather than `paid_until` existing: trial_end_date is never cleared,
+        and an admin can extend a trial past an old lapsed paid date, making the
+        trial the clock the lifecycle actually runs on."""
+        return (
+            self.trial_end_date is not None
+            and (self.paid_until is None or self.trial_end_date > self.paid_until)
+        )
+
+    @property
+    def in_grace_period(self):
+        """Whether the deck is past its governing deadline but still within the
+        unified grace window (access retained, expiry warnings due). Trial and
+        paid clocks get the same grace (#1734 B4)."""
+        deadline = self.governing_deadline
+        if deadline is None:
             return False
-        return max(clocks) < localdate() <= max(clocks) + timedelta(days=GRACE_PERIOD_DAYS)
+        return deadline < localdate() <= deadline + timedelta(days=GRACE_PERIOD_DAYS)
 
     @property
     def grace_days_remaining(self):
@@ -253,10 +277,10 @@ class Tenant(TenantMixin):
         comped/legacy decks managed outside the subscription lifecycle, reached by
         clearing both date fields on the deck in the public-tenant admin.
         """
-        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
-        if not clocks:
+        deadline = self.governing_deadline
+        if deadline is None:
             return False
-        return localdate() > max(clocks) + timedelta(days=GRACE_PERIOD_DAYS)
+        return localdate() > deadline + timedelta(days=GRACE_PERIOD_DAYS)
 
     @property
     def effective_max_active_users(self):
@@ -303,10 +327,10 @@ class Tenant(TenantMixin):
         through the grace window); None when the deck has no dates at all
         (comped/legacy decks).
         """
-        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
-        if not clocks:
+        deadline = self.governing_deadline
+        if deadline is None:
             return None
-        return (max(clocks) - localdate()).days
+        return (deadline - localdate()).days
 
     @property
     def is_over_user_limit(self):
@@ -349,8 +373,7 @@ class Tenant(TenantMixin):
         """
         if not self.is_suspended:
             return None
-        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
-        return max(clocks) + timedelta(days=GRACE_PERIOD_DAYS + 1)
+        return self.governing_deadline + timedelta(days=GRACE_PERIOD_DAYS + 1)
 
     @property
     def deletion_date(self):
@@ -371,12 +394,11 @@ class Tenant(TenantMixin):
         since = self.suspended_since
         if since is None:
             return None
-        # the episode key mirrors the suspended notice's period_key (the latest
-        # lapsed deadline), so this finds exactly this episode's first warning
-        lapsed_clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
+        # the episode key mirrors the suspended notice's period_key (the lapsed
+        # governing deadline), so this finds exactly this episode's first warning
         first_warned_row = DeckNotice.objects.filter(
             tenant=self, kind=DeckNotice.KIND_SUSPENDED, threshold='suspended',
-            period_key=str(max(lapsed_clocks)),
+            period_key=str(self.governing_deadline),
         ).order_by('sent_on').first()
         warned_on = first_warned_row.sent_on if first_warned_row else localdate()
         return max(since, warned_on) + timedelta(days=INACTIVE_DELETE_DAYS)

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -46,9 +46,11 @@ def default_trial_end_date():
 # authoritative (see effective_max_active_users).
 TRIAL_MAX_ACTIVE_USERS = 5
 
-# Days of continued paid access after `paid_until` before a deck counts as lapsed.
-# Codifies the 0-30-day "gold band" the tenant admin changelist has always shown
-# for recently expired decks (#1494).
+# Days of continued access after the deck's LATEST deadline (trial end or
+# `paid_until`) before it counts as lapsed: every deck, trial or paid, falls back
+# on the same grace window before suspension (#1734 B4: a trial is treated as
+# just another kind of subscription). Codifies the 0-30-day "gold band" the
+# tenant admin changelist has always shown for recently expired decks (#1494).
 GRACE_PERIOD_DAYS = 30
 
 # The status banner starts warning staff when the governing deadline (trial end or
@@ -208,13 +210,17 @@ class Tenant(TenantMixin):
 
     @property
     def in_grace_period(self):
-        """Whether the deck is past `paid_until` but still within the grace period
-        (access retained, expiry warnings due)."""
-        return self.subscription_active and localdate() > self.paid_until
+        """Whether the deck is past its latest deadline (trial end or `paid_until`)
+        but still within the unified grace window (access retained, expiry
+        warnings due). Trial and paid clocks get the same grace (#1734 B4)."""
+        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
+        if not clocks:
+            return False
+        return max(clocks) < localdate() <= max(clocks) + timedelta(days=GRACE_PERIOD_DAYS)
 
     @property
     def grace_days_remaining(self):
-        """Days of paid grace left after `paid_until`; None when not in the grace
+        """Days of grace left after the latest deadline; None when not in the grace
         period. 0 on the final day (the grace period ends today). Drives the
         expired banner's "grace period ends in N days" copy.
 
@@ -237,15 +243,20 @@ class Tenant(TenantMixin):
 
     @property
     def is_suspended(self):
-        """Whether every clock this deck was ever given (trial and/or paid) has lapsed.
+        """Whether every clock this deck was ever given (trial and/or paid) has
+        lapsed AND the unified grace window after the LATEST one has closed: every
+        deck, trial or paid, keeps access for GRACE_PERIOD_DAYS past its latest
+        deadline before suspension (#1734 B4: a trial is treated as just another
+        kind of subscription, with a single latest-clock deadline).
 
         A deck with BOTH dates blank is never suspended: that is the escape hatch for
         comped/legacy decks managed outside the subscription lifecycle, reached by
         clearing both date fields on the deck in the public-tenant admin.
         """
-        if self.subscription_active or self.is_on_trial:
+        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
+        if not clocks:
             return False
-        return self.paid_until is not None or self.trial_end_date is not None
+        return localdate() > max(clocks) + timedelta(days=GRACE_PERIOD_DAYS)
 
     @property
     def effective_max_active_users(self):
@@ -281,9 +292,9 @@ class Tenant(TenantMixin):
 
     @property
     def days_until_expiry(self):
-        """Days until the governing deadline: `paid_until` while a subscription is
-        active, `trial_end_date` while on trial, otherwise (suspended) the LATEST
-        lapsed clock.
+        """Days until the deck's governing deadline: the LATEST of its set clocks
+        (trial end and/or `paid_until`), the single deadline the unified grace
+        window and suspension are measured from (#1734 B4).
 
         The latest-clock rule matters because trial_end_date is set at creation and
         never cleared when a deck subscribes: a lapsed subscriber should read as
@@ -292,16 +303,10 @@ class Tenant(TenantMixin):
         through the grace window); None when the deck has no dates at all
         (comped/legacy decks).
         """
-        if self.subscription_active:
-            deadline = self.paid_until
-        elif self.is_on_trial:
-            deadline = self.trial_end_date
-        else:
-            lapsed_clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
-            deadline = max(lapsed_clocks) if lapsed_clocks else None
-        if deadline is None:
+        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
+        if not clocks:
             return None
-        return (deadline - localdate()).days
+        return (max(clocks) - localdate()).days
 
     @property
     def is_over_user_limit(self):
@@ -336,20 +341,16 @@ class Tenant(TenantMixin):
     @property
     def suspended_since(self):
         """The first day of the current suspension episode: the day after the deck's
-        LAST covered day (a trial covers through `trial_end_date`; paid access covers
-        through `paid_until` plus the grace window). None while the deck is not
+        LAST covered day. A trial and a paid period alike cover through their
+        deadline plus the unified grace window (#1734 B4), so this is the day
+        after the latest clock's grace closes. None while the deck is not
         suspended. is_suspended requires at least one date field, so a suspended
         deck always has at least one covered day to count from.
         """
         if not self.is_suspended:
             return None
-        last_covered_days = [
-            d for d in (
-                self.trial_end_date,
-                self.paid_until + timedelta(days=GRACE_PERIOD_DAYS) if self.paid_until else None,
-            ) if d is not None
-        ]
-        return max(last_covered_days) + timedelta(days=1)
+        clocks = [d for d in (self.trial_end_date, self.paid_until) if d is not None]
+        return max(clocks) + timedelta(days=GRACE_PERIOD_DAYS + 1)
 
     @property
     def deletion_date(self):

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -112,8 +112,10 @@ def evaluate_deck_notices(deck):
         # --- expiry cadence (not for suspended decks; their deadline is history) --
         days = deck.days_until_expiry
         if days is not None and days <= EXPIRY_THRESHOLDS[-1][1]:
-            deadline = deck.paid_until if deck.subscription_active else deck.trial_end_date
-            period_key = str(deadline)
+            # keyed to the GOVERNING deadline (the one days_until_expiry counts to
+            # and the email reports), so a stale paid key can never suppress
+            # reminders for a later governing trial date (#1734 B4)
+            period_key = str(deck.governing_deadline)
             # the first (most specific) milestone whose window we're inside governs --
             # broader milestones are superseded, never fired late. The guard above
             # guarantees at least the broadest window matches.

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -207,7 +207,12 @@ def _deliver(deck, kind):
         # paid period ended/ends, how long ago, when the grace window closes, and --
         # for suspended decks -- the day the suspension began. None when not applicable.
         'grace_days': GRACE_PERIOD_DAYS,
-        'grace_end_date': deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS) if deck.paid_until else None,
+        # the unified grace window closes GRACE_PERIOD_DAYS after the deck's
+        # LATEST deadline, trial and paid clocks alike (#1734 B4)
+        'grace_end_date': (
+            max(d for d in (deck.trial_end_date, deck.paid_until) if d is not None) + timedelta(days=GRACE_PERIOD_DAYS)
+            if (deck.trial_end_date or deck.paid_until) else None
+        ),
         'grace_days_left': deck.grace_days_remaining,
         'expired_days_ago': -days if days is not None and days < 0 else None,
         'suspended_since': suspended_since,

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -69,8 +69,7 @@ def close_semester_on_new_suspension(deck):
     if not deck.is_suspended:
         return 'not suspended'
 
-    lapsed_clocks = [d for d in (deck.trial_end_date, deck.paid_until) if d is not None]
-    period_key = str(max(lapsed_clocks))
+    period_key = str(deck.governing_deadline)
     with transaction.atomic():
         _, created = DeckNotice.objects.get_or_create(
             tenant=deck, kind=DeckNotice.KIND_SUSPENDED, threshold='semester-close', period_key=period_key,
@@ -106,8 +105,7 @@ def evaluate_deck_notices(deck):
 
     # --- suspension: once per suspension episode ---------------------------------
     if deck.is_suspended:
-        lapsed_clocks = [d for d in (deck.trial_end_date, deck.paid_until) if d is not None]
-        period_key = str(max(lapsed_clocks))
+        period_key = str(deck.governing_deadline)
         if _unfired(deck, DeckNotice.KIND_SUSPENDED, 'suspended', period_key):
             due.append((DeckNotice.KIND_SUSPENDED, 'suspended', period_key))
     else:
@@ -208,10 +206,12 @@ def _deliver(deck, kind):
         # for suspended decks -- the day the suspension began. None when not applicable.
         'grace_days': GRACE_PERIOD_DAYS,
         # the unified grace window closes GRACE_PERIOD_DAYS after the deck's
-        # LATEST deadline, trial and paid clocks alike (#1734 B4)
+        # governing (latest) deadline, trial and paid clocks alike (#1734 B4);
+        # templates read the deadline and its origin from the deck itself
+        # (governing_deadline / governing_clock_is_trial)
         'grace_end_date': (
-            max(d for d in (deck.trial_end_date, deck.paid_until) if d is not None) + timedelta(days=GRACE_PERIOD_DAYS)
-            if (deck.trial_end_date or deck.paid_until) else None
+            deck.governing_deadline + timedelta(days=GRACE_PERIOD_DAYS)
+            if deck.governing_deadline else None
         ),
         'grace_days_left': deck.grace_days_remaining,
         'expired_days_ago': -days if days is not None and days < 0 else None,

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -5,13 +5,14 @@
   {% if deck.is_on_trial %}free trial ends{% else %}subscription expires{% endif %}
   on <strong>{% if deck.is_on_trial %}{{ deck.trial_end_date }}{% else %}{{ deck.paid_until }}{% endif %}</strong>
   (<strong>{{ days }} day{{ days|pluralize }}</strong> from now).
-  {% if deck.is_on_trial %}When the trial ends, the deck is suspended: only the deck owner can sign in,
-  and the 365-day countdown to deck deletion begins.{% else %}After that, a {{ grace_days }}-day grace
-  period keeps full access until <strong>{{ grace_end_date }}</strong>; the deck is then suspended:
-  only the deck owner can sign in, and the 365-day countdown to deck deletion begins.{% endif %}</p>
+  After that, a {{ grace_days }}-day grace period keeps full access until
+  <strong>{{ grace_end_date }}</strong>; the deck is then suspended:
+  only the deck owner can sign in, and the 365-day countdown to deck deletion begins.</p>
 {% else %}
-<p>Your deck <strong>{{ deck.name }}</strong>'s subscription expired on
-  <strong>{{ deck.paid_until }}</strong> ({{ expired_days_ago }} day{{ expired_days_ago|pluralize }} ago)
+<p>Your deck <strong>{{ deck.name }}</strong>'s
+  {% if deck.paid_until %}subscription expired on <strong>{{ deck.paid_until }}</strong>{% else %}free
+  trial ended on <strong>{{ deck.trial_end_date }}</strong>{% endif %}
+  ({{ expired_days_ago }} day{{ expired_days_ago|pluralize }} ago)
   and is in its {{ grace_days }}-day grace period, which ends on <strong>{{ grace_end_date }}</strong>
   ({{ grace_days_left }} day{{ grace_days_left|pluralize }} left). When the grace period ends, the deck
   will be suspended: only the deck owner will be able to sign in, and the 365-day countdown to deck

--- a/src/tenant/templates/tenant/email/expiry_reminder.html
+++ b/src/tenant/templates/tenant/email/expiry_reminder.html
@@ -1,17 +1,22 @@
 <p>Hi {{ config.deck_owner.get_full_name|default:config.deck_owner.username }},</p>
 
+{% comment %}
+The GOVERNING deadline (the deck's latest clock) picks both the date shown and the
+trial-vs-subscription wording: trial_end_date is never cleared, so an admin-extended
+trial can outlast an old paid date (#1734 B4).
+{% endcomment %}
 {% if days >= 0 %}
 <p>Your deck <strong>{{ deck.name }}</strong>'s
-  {% if deck.is_on_trial %}free trial ends{% else %}subscription expires{% endif %}
-  on <strong>{% if deck.is_on_trial %}{{ deck.trial_end_date }}{% else %}{{ deck.paid_until }}{% endif %}</strong>
+  {% if deck.governing_clock_is_trial %}free trial ends{% else %}subscription expires{% endif %}
+  on <strong>{{ deck.governing_deadline }}</strong>
   (<strong>{{ days }} day{{ days|pluralize }}</strong> from now).
   After that, a {{ grace_days }}-day grace period keeps full access until
   <strong>{{ grace_end_date }}</strong>; the deck is then suspended:
   only the deck owner can sign in, and the 365-day countdown to deck deletion begins.</p>
 {% else %}
 <p>Your deck <strong>{{ deck.name }}</strong>'s
-  {% if deck.paid_until %}subscription expired on <strong>{{ deck.paid_until }}</strong>{% else %}free
-  trial ended on <strong>{{ deck.trial_end_date }}</strong>{% endif %}
+  {% if deck.governing_clock_is_trial %}free trial ended{% else %}subscription expired{% endif %}
+  on <strong>{{ deck.governing_deadline }}</strong>
   ({{ expired_days_ago }} day{{ expired_days_ago|pluralize }} ago)
   and is in its {{ grace_days }}-day grace period, which ends on <strong>{{ grace_end_date }}</strong>
   ({{ grace_days_left }} day{{ grace_days_left|pluralize }} left). When the grace period ends, the deck

--- a/src/tenant/templates/tenant/email/suspended_notice.html
+++ b/src/tenant/templates/tenant/email/suspended_notice.html
@@ -6,12 +6,13 @@
   ({{ deletion_days_left }} day{{ deletion_days_left|pluralize }} from now){% endif %}</strong>,
   unless it gets a valid subscription before then.</p>
 
+{# the GOVERNING clock (the latest one) picks the explanation: an admin-extended trial can outlast an old paid date (#1734 B4) #}
 <p>The deck has been <strong>suspended</strong>{% if suspended_since %}
   since <strong>{{ suspended_since }}</strong>{% endif %}
-  {% if deck.paid_until %}(its subscription was paid through {{ deck.paid_until }}, and the
-  {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.trial_end_date %}(its
-  free trial ended on {{ deck.trial_end_date }}, and the {{ grace_days }}-day grace period ended on
-  {{ grace_end_date }}){% endif %}: only the deck owner can sign in until the
+  {% if deck.governing_clock_is_trial %}(its free trial ended on {{ deck.governing_deadline }}, and the
+  {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.governing_deadline %}(its
+  subscription was paid through {{ deck.governing_deadline }}, and the {{ grace_days }}-day grace period
+  ended on {{ grace_end_date }}){% endif %}: only the deck owner can sign in until the
   deck has a valid subscription. Nothing has been deleted yet: your content and student data
   are intact until the deletion date above.</p>
 

--- a/src/tenant/templates/tenant/email/suspended_notice.html
+++ b/src/tenant/templates/tenant/email/suspended_notice.html
@@ -10,7 +10,8 @@
   since <strong>{{ suspended_since }}</strong>{% endif %}
   {% if deck.paid_until %}(its subscription was paid through {{ deck.paid_until }}, and the
   {{ grace_days }}-day grace period ended on {{ grace_end_date }}){% elif deck.trial_end_date %}(its
-  free trial ended on {{ deck.trial_end_date }}){% endif %}: only the deck owner can sign in until the
+  free trial ended on {{ deck.trial_end_date }}, and the {{ grace_days }}-day grace period ended on
+  {{ grace_end_date }}){% endif %}: only the deck owner can sign in until the
   deck has a valid subscription. Nothing has been deleted yet: your content and student data
   are intact until the deletion date above.</p>
 

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -15,8 +15,10 @@
 {% elif deck.in_grace_period %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
   <p><span class="label label-danger">Grace period</span>
-    The paid period ended on <strong>{{ deck.paid_until }}</strong> and the deck is in its
-    {{ grace_days }}-day grace period: renew to keep full access; otherwise the deck will be
+    {% if deck.paid_until %}The paid period ended on <strong>{{ deck.paid_until }}</strong>{% else %}The
+    free trial ended on <strong>{{ deck.trial_end_date }}</strong>{% endif %} and the deck is in its
+    {{ grace_days }}-day grace period: {% if deck.paid_until %}renew{% else %}subscribe{% endif %} to
+    keep full access; otherwise the deck will be
     suspended (only the deck owner will be able to sign in, and the 365-day countdown to deck
     deletion begins).</p>
 {% elif deck.is_on_maintenance %}
@@ -48,6 +50,7 @@
     <tr><th>Grace period</th><td>extends {{ grace_days }} days after your subscription ends ({{ grace_end_phrase }})</td></tr>
   {% elif deck.trial_end_date %}
     <tr><th>Trial ends</th><td>{{ deck.trial_end_date }} ({{ trial_end_phrase }})</td></tr>
+    <tr><th>Grace period</th><td>extends {{ grace_days }} days after your trial ends ({{ grace_end_phrase }})</td></tr>
   {% else %}
     <tr><th>Expires</th><td>Never (this deck is managed manually)</td></tr>
   {% endif %}
@@ -82,9 +85,9 @@
 {# the full lifecycle, so an owner always knows what happens next (maintainer request, 2026-07-30) #}
 <ol>
   <li><strong>Valid subscription:</strong> full use of the deck at your subscription level.</li>
-  <li><strong>Grace period:</strong> when a subscription expires, everything keeps working as
-    before for {{ grace_days }} more days while you renew.</li>
-  <li><strong>Suspension:</strong> after the grace period (or when a free trial ends), the deck
+  <li><strong>Grace period:</strong> when a trial or subscription expires, everything keeps working as
+    before for {{ grace_days }} more days while you subscribe or renew.</li>
+  <li><strong>Suspension:</strong> after the grace period, the deck
     is suspended. Only the deck owner can sign in, and the 365-day countdown to deck deletion begins.
     Content and student data stay intact.</li>
   <li><strong>Deletion:</strong> a deck with no valid subscription for 365 days may be

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -14,24 +14,27 @@
     (any level, including the low-cost Maintenance subscription) to restore access.</p>
 {% elif deck.in_grace_period %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
+  {# the GOVERNING clock (the latest one) picks the wording: an admin-extended trial can outlast an old paid date (#1734 B4) #}
   <p><span class="label label-danger">Grace period</span>
-    {% if deck.paid_until %}The paid period ended on <strong>{{ deck.paid_until }}</strong>{% else %}The
-    free trial ended on <strong>{{ deck.trial_end_date }}</strong>{% endif %} and the deck is in its
-    {{ grace_days }}-day grace period: {% if deck.paid_until %}renew{% else %}subscribe{% endif %} to
+    {% if deck.governing_clock_is_trial %}The free trial ended on
+    <strong>{{ deck.governing_deadline }}</strong>{% else %}The paid period ended on
+    <strong>{{ deck.governing_deadline }}</strong>{% endif %} and the deck is in its
+    {{ grace_days }}-day grace period: {% if deck.governing_clock_is_trial %}subscribe{% else %}renew{% endif %} to
     keep full access; otherwise the deck will be
     suspended (only the deck owner will be able to sign in, and the 365-day countdown to deck
     deletion begins).</p>
 {% elif deck.is_on_maintenance %}
+  {# the countdown pairs with the PAID date it sits beside (days_until_expiry can track a longer leftover trial clock) #}
   <p><span class="label label-primary">Maintenance</span>
     This deck is on a maintenance subscription through <strong>{{ deck.paid_until }}</strong>
-    ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining): it won't expire,
+    ({{ paid_until_phrase }}): it won't expire,
     be suspended, or time out for deletion, but registration stays capped at the trial limit
     (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}).
     Upgrade any time to raise the cap.</p>
 {% elif deck.subscription_active %}
   <p><span class="label label-success">Subscribed</span>
     Paid through <strong>{{ deck.paid_until }}</strong>
-    ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining).</p>
+    ({{ paid_until_phrase }}).</p>
 {% elif deck.is_on_trial %}
   <p><span class="label label-info">Free trial</span>
     Ends <strong>{{ deck.trial_end_date }}</strong>
@@ -43,14 +46,14 @@
 {% endif %}
 
 <h3>Dates</h3>
-{# one governing deadline row, not both: a paid date (even lapsed) supersedes the trial date #}
+{# one governing deadline row, not both: the LATEST clock governs the lifecycle (#1734 B4), so only its row shows #}
 <table class="table" style="max-width: 30em;">
-  {% if deck.paid_until %}
-    <tr><th>Paid until</th><td>{{ deck.paid_until }} ({{ paid_until_phrase }})</td></tr>
-    <tr><th>Grace period</th><td>extends {{ grace_days }} days after your subscription ends ({{ grace_end_phrase }})</td></tr>
-  {% elif deck.trial_end_date %}
+  {% if deck.governing_clock_is_trial %}
     <tr><th>Trial ends</th><td>{{ deck.trial_end_date }} ({{ trial_end_phrase }})</td></tr>
     <tr><th>Grace period</th><td>extends {{ grace_days }} days after your trial ends ({{ grace_end_phrase }})</td></tr>
+  {% elif deck.paid_until %}
+    <tr><th>Paid until</th><td>{{ deck.paid_until }} ({{ paid_until_phrase }})</td></tr>
+    <tr><th>Grace period</th><td>extends {{ grace_days }} days after your subscription ends ({{ grace_end_phrase }})</td></tr>
   {% else %}
     <tr><th>Expires</th><td>Never (this deck is managed manually)</td></tr>
   {% endif %}

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -123,9 +123,14 @@ class BillingStatusLabelTest(SimpleTestCase):
         self.assertEqual(Command.billing_status(Tenant(paid_until=today)), 'subscribed')
         self.assertEqual(Command.billing_status(Tenant(paid_until=today - timedelta(days=5), trial_end_date=None)), 'grace')
         self.assertEqual(Command.billing_status(Tenant(trial_end_date=today, paid_until=None)), 'trial')
+        # a lapsed trial in its unified grace window also reads as grace (#1734 B4)
+        self.assertEqual(Command.billing_status(Tenant(trial_end_date=today - timedelta(days=5), paid_until=None)), 'grace')
         self.assertEqual(
             Command.billing_status(
-                Tenant(trial_end_date=today - timedelta(days=1), paid_until=today - timedelta(days=GRACE_PERIOD_DAYS + 1))
+                Tenant(
+                    trial_end_date=today - timedelta(days=GRACE_PERIOD_DAYS + 40),
+                    paid_until=today - timedelta(days=GRACE_PERIOD_DAYS + 1),
+                )
             ),
             'suspended',
         )

--- a/src/tenant/tests/test_middleware.py
+++ b/src/tenant/tests/test_middleware.py
@@ -80,11 +80,14 @@ class OwnerOnlyWhenSuspendedMiddlewareTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'This deck is suspended')
 
     def test_bounce__nobody_bounced_while_not_suspended(self):
-        """On a live deck (trial running, or paid, or in grace) nobody is bounced."""
+        """On a live deck (trial running, or paid, or in grace) nobody is bounced.
+        A lapsed trial's grace window counts (#1734 B4): students keep access for
+        the full grace period before the owner-only bounce begins."""
         for fields in (
             {'trial_end_date': localdate() + timedelta(days=30), 'paid_until': None},  # on trial
             {'trial_end_date': None, 'paid_until': localdate() + timedelta(days=30)},  # subscribed
-            {'trial_end_date': None, 'paid_until': localdate() - timedelta(days=5)},   # in grace
+            {'trial_end_date': None, 'paid_until': localdate() - timedelta(days=5)},   # in paid grace
+            {'trial_end_date': localdate() - timedelta(days=5), 'paid_until': None},   # in trial grace (#1734 B4)
         ):
             self.set_deck(**fields)
             for user in (self.staff, self.student, self.owner):

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -179,15 +179,31 @@ class TenantBillingStatusTest(SimpleTestCase):
         self.assertIsNone(self.make_tenant().grace_days_remaining)  # unmanaged
 
     def test_in_grace_period__only_between_paid_until_and_grace_end(self):
-        """in_grace_period is True strictly after paid_until and only while subscription_active."""
+        """in_grace_period is True strictly after paid_until and only until the grace window closes."""
         self.assertFalse(self.make_tenant(paid_until=FROZEN_TODAY).in_grace_period)
         self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=1)).in_grace_period)
         self.assertFalse(self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).in_grace_period)
 
+    def test_in_grace_period__lapsed_trial_gets_the_same_grace(self):
+        """A lapsed trial enters the SAME grace window a lapsed subscription gets
+        (#1734 B4: a trial is just another kind of subscription): grace starts the
+        day after trial_end_date, runs GRACE_PERIOD_DAYS, then closes."""
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY).in_grace_period)  # still on trial
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).in_grace_period)
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS)).in_grace_period)
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).in_grace_period)
+
+    def test_grace_days_remaining__lapsed_trial_counts_down_too(self):
+        """The grace countdown works identically for a lapsed trial (#1734 B4)."""
+        self.assertEqual(
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=10)).grace_days_remaining, GRACE_PERIOD_DAYS - 10)
+        self.assertEqual(
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS)).grace_days_remaining, 0)
+
     def test_suspended_since__day_after_the_last_covered_day(self):
-        """suspended_since is the day after the deck's last covered day: the trial's
-        end for a trial-only deck, the grace window's close for a paid deck, and
-        the LATER of the two when both dates exist; None while not suspended."""
+        """suspended_since is the day after the deck's last covered day: the close of
+        the unified grace window after the LATEST clock, trial or paid alike
+        (#1734 B4); None while not suspended."""
         lapsed_trial = FROZEN_TODAY - timedelta(days=100)
         lapsed_paid = FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 10)
 
@@ -195,7 +211,9 @@ class TenantBillingStatusTest(SimpleTestCase):
         self.assertIsNone(self.make_tenant(trial_end_date=FROZEN_TODAY).suspended_since)  # on trial
         self.assertIsNone(self.make_tenant().suspended_since)  # managed manually
 
-        self.assertEqual(self.make_tenant(trial_end_date=lapsed_trial).suspended_since, lapsed_trial + timedelta(days=1))
+        self.assertEqual(
+            self.make_tenant(trial_end_date=lapsed_trial).suspended_since,
+            lapsed_trial + timedelta(days=GRACE_PERIOD_DAYS + 1))
         self.assertEqual(
             self.make_tenant(paid_until=lapsed_paid).suspended_since,
             lapsed_paid + timedelta(days=GRACE_PERIOD_DAYS + 1))
@@ -216,8 +234,12 @@ class TenantBillingStatusTest(SimpleTestCase):
         self.assertFalse(self.make_tenant().is_on_trial)
 
     def test_is_suspended__true_when_all_given_clocks_lapsed(self):
-        """A deck whose trial and/or paid clocks have all run out (past grace) is suspended."""
-        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).is_suspended)
+        """A deck whose trial and/or paid clocks have all run out past the unified
+        grace window is suspended; a just-lapsed trial is still in grace (#1734 B4)."""
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).is_suspended)
+        # a lapsed trial inside its grace window is NOT yet suspended
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).is_suspended)
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS)).is_suspended)
         # trial date cleared by an admin, paid_until lapsed beyond grace: still suspended
         self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).is_suspended)
         self.assertTrue(
@@ -243,13 +265,17 @@ class TenantBillingStatusTest(SimpleTestCase):
         owner-only sign-in instead); the admin's value, higher or lower, always
         wins (maintainer decision on #2178: a suspended deck's cap lowered to 1
         was silently overridden back to 5)."""
-        # suspended (trial lapsed): the field, untouched -- both above and below
-        # the trial default
+        # suspended (trial lapsed past grace): the field, untouched -- both above
+        # and below the trial default
         self.assertEqual(
-            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=80).effective_max_active_users, 80,
+            self.make_tenant(
+                trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), max_active_users=80,
+            ).effective_max_active_users, 80,
         )
         self.assertEqual(
-            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=1).effective_max_active_users, 1,
+            self.make_tenant(
+                trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), max_active_users=1,
+            ).effective_max_active_users, 1,
         )
         # on trial with an admin-raised cap: the admin grant is honored
         self.assertEqual(
@@ -271,8 +297,8 @@ class TenantBillingStatusTest(SimpleTestCase):
         self.assertFalse(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=-1).is_on_maintenance)
         self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY, max_active_users=5).is_on_maintenance)  # trial
         self.assertFalse(self.make_tenant(max_active_users=5).is_on_maintenance)  # managed manually
-        self.assertFalse(  # suspended
-            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1), max_active_users=5).is_on_maintenance
+        self.assertFalse(  # suspended (trial lapsed past grace)
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), max_active_users=5).is_on_maintenance
         )
 
     def test_effective_max_active_users__unlimited_passthrough(self):
@@ -537,17 +563,19 @@ class TenantBannerStatusTest(SimpleTestCase):
 
     def test_is_expiring_soon__within_warning_window_or_grace(self):
         """Warns within EXPIRY_WARNING_DAYS of the governing deadline, and through the
-        paid grace window (negative days); quiet before the window."""
+        grace window (negative days), paid or trial alike; quiet before the window."""
         self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=EXPIRY_WARNING_DAYS)).is_expiring_soon)
         self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY + timedelta(days=EXPIRY_WARNING_DAYS + 1)).is_expiring_soon)
         self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY + timedelta(days=3)).is_expiring_soon)
-        # in the paid grace window: expired but still subscription_active
+        # in the grace window: expired but not yet suspended (#1734 B4 gives
+        # trials the same window)
         self.assertTrue(self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=5)).is_expiring_soon)
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=5)).is_expiring_soon)
 
     def test_is_expiring_soon__false_for_suspended_and_unmanaged_decks(self):
         """Suspended decks get the suspension banner instead, and dateless (comped)
         decks have no deadline to warn about."""
-        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).is_expiring_soon)
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).is_expiring_soon)
         self.assertFalse(self.make_tenant().is_expiring_soon)
 
 

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -223,6 +223,29 @@ class TenantBillingStatusTest(SimpleTestCase):
             self.make_tenant(trial_end_date=lapsed_trial, paid_until=lapsed_paid).suspended_since,
             lapsed_paid + timedelta(days=GRACE_PERIOD_DAYS + 1))
 
+    def test_governing_deadline_and_origin__latest_clock_wins(self):
+        """governing_deadline is the LATEST set clock (None for dateless decks) and
+        governing_clock_is_trial says which clock it is, preferring subscription
+        language on a tie: presentation keys its trial-vs-paid wording off these
+        rather than off paid_until existing (#1734 B4 review find: an
+        admin-extended trial can outlast an old lapsed paid date)."""
+        trial_later = self.make_tenant(
+            trial_end_date=FROZEN_TODAY - timedelta(days=5), paid_until=FROZEN_TODAY - timedelta(days=100))
+        self.assertEqual(trial_later.governing_deadline, FROZEN_TODAY - timedelta(days=5))
+        self.assertTrue(trial_later.governing_clock_is_trial)
+
+        paid_later = self.make_tenant(
+            trial_end_date=FROZEN_TODAY - timedelta(days=100), paid_until=FROZEN_TODAY + timedelta(days=5))
+        self.assertEqual(paid_later.governing_deadline, FROZEN_TODAY + timedelta(days=5))
+        self.assertFalse(paid_later.governing_clock_is_trial)
+
+        # a tie speaks subscription language
+        self.assertFalse(self.make_tenant(trial_end_date=FROZEN_TODAY, paid_until=FROZEN_TODAY).governing_clock_is_trial)
+
+        self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY).governing_clock_is_trial)  # trial-only
+        self.assertIsNone(self.make_tenant().governing_deadline)  # managed manually
+        self.assertFalse(self.make_tenant().governing_clock_is_trial)
+
     def test_is_on_trial__true_through_trial_end_date(self):
         """A deck with no subscription is on trial through its trial_end_date."""
         self.assertTrue(self.make_tenant(trial_end_date=FROZEN_TODAY).is_on_trial)

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -112,6 +112,20 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         self.set_deck(max_active_users=-1, paid_until=TODAY + timedelta(days=90), active_user_count=999)
         self.assertEqual(self.due(), [])
 
+    def test_evaluate__expiry_key_uses_the_governing_trial_deadline(self):
+        """With an in-grace paid date and a LATER governing trial date, the expiry
+        notice is keyed to the governing trial deadline (the one the email
+        reports), so milestones recorded under the stale paid key can never
+        suppress reminders for the clock that actually governs (#1734 B4
+        review find)."""
+        trial = TODAY + timedelta(days=20)
+        self.set_deck(trial_end_date=trial, paid_until=TODAY - timedelta(days=10))
+        self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'd30', str(trial))])
+        process_deck_notices(self.tenant)
+        self.assertTrue(DeckNotice.objects.filter(
+            tenant=self.tenant, kind=DeckNotice.KIND_EXPIRY, threshold='d30', period_key=str(trial)).exists())
+        self.assertEqual(self.due(), [])  # recorded under the governing key: nothing more due
+
     def test_evaluate__suspension_notice_once_per_episode(self):
         """A suspended deck gets exactly one suspension notice (keyed to the lapsed deadline),
         and no expiry cadence. The trial must be lapsed past the unified grace

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -406,6 +406,55 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('alt="[Logo]"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_process__suspended_email_follows_the_governing_trial_clock(self):
+        """With BOTH dates set and the trial the LATER clock (an admin-extended
+        trial on a deck whose paid period lapsed earlier), the suspension email
+        explains the TRIAL clock: the governing deadline picks the wording, not
+        whether a paid date exists (#1734 B4 review find)."""
+        from datetime import date
+
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            # paid lapsed May 1; trial extended to Jul 1 -> grace ended Jul 31 -> suspended Aug 1
+            trial_end_date=date(2026, 7, 1), paid_until=date(2026, 5, 1),
+            max_active_users=5, active_user_count=0,
+        )
+        self.tenant.refresh_from_db()
+
+        summary = self.run_engine_with_inline_email()
+        self.assertEqual(len(mail.outbox), 1, summary)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('since <strong>Aug. 1, 2026</strong>', html)
+        self.assertIn('free trial ended on July 1, 2026', html)
+        self.assertIn('grace period ended on July 31, 2026', html)
+        self.assertNotIn('paid through', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_deliver__expiry_email_follows_the_governing_trial_clock(self):
+        """With BOTH dates set and the trial the LATER clock, the expiry
+        reminder's grace-window variant reports the TRIAL date and wording
+        (#1734 B4 review find)."""
+        from unittest.mock import patch
+
+        from tenant import tasks
+        from tenant.notices import _deliver
+
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=TODAY - timedelta(days=5), paid_until=TODAY - timedelta(days=100),
+            max_active_users=5, active_user_count=0,
+        )
+        self.tenant.refresh_from_db()
+
+        with patch.object(
+            tasks.send_email_message, 'apply_async',
+            side_effect=lambda kwargs=None, queue=None: tasks.send_email_message.apply(kwargs=kwargs),
+        ):
+            _deliver(self.tenant, DeckNotice.KIND_EXPIRY)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('free trial ended on <strong>Aug. 10, 2026</strong>', html)
+        self.assertIn('(5 days ago)', html)
+        self.assertNotIn('subscription expired', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_paid_clock_and_legacy_full_year(self):
         """A deck suspended after a PAID subscription lapsed explains the paid
         clock (paid-through and grace-end dates) in its suspension email, with the

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from notifications.models import Notification
-from tenant.models import DeckNotice, Tenant
+from tenant.models import GRACE_PERIOD_DAYS, DeckNotice, Tenant
 from tenant.notices import evaluate_deck_notices, process_deck_notices
 from tenant.utils import deck_cache_key
 
@@ -114,13 +114,26 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
 
     def test_evaluate__suspension_notice_once_per_episode(self):
         """A suspended deck gets exactly one suspension notice (keyed to the lapsed deadline),
-        and no expiry cadence."""
-        self.set_deck(trial_end_date=TODAY - timedelta(days=1), paid_until=None)
-        self.assertEqual(self.due(), [(DeckNotice.KIND_SUSPENDED, 'suspended', str(TODAY - timedelta(days=1)))])
+        and no expiry cadence. The trial must be lapsed past the unified grace
+        window (#1734 B4) to be suspended at all."""
+        lapsed = TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)
+        self.set_deck(trial_end_date=lapsed, paid_until=None)
+        self.assertEqual(self.due(), [(DeckNotice.KIND_SUSPENDED, 'suspended', str(lapsed))])
         process_deck_notices(self.tenant)
         self.assertEqual(self.due(), [])
         with freeze_time("2026-09-15 20:00:00"):
             self.assertEqual(self.due(), [])  # still just the one
+
+    def test_evaluate__lapsed_trial_stays_on_expiry_cadence_through_grace(self):
+        """A lapsed trial inside its grace window is NOT suspended: it stays on the
+        expiry-reminder cadence (daily after the milestone), exactly like a lapsed
+        paid deck (#1734 B4)."""
+        lapsed = TODAY - timedelta(days=10)
+        self.set_deck(trial_end_date=lapsed, paid_until=None)
+        self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'd7', str(lapsed))])  # no suspension notice
+        process_deck_notices(self.tenant)
+        with freeze_time("2026-08-16 20:00:00"):
+            self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'daily-2026-08-16', str(lapsed))])
 
 
 @freeze_time(NOW)
@@ -355,11 +368,13 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_states_when_and_why_with_logo(self):
         """The suspension email says when the suspension began, which clock ran
-        out (trial vs paid + grace), current seat usage, and carries the logo."""
+        out (trial or paid, plus the unified grace window, #1734 B4), current
+        seat usage, and carries the logo."""
         from datetime import date
 
         Tenant.objects.filter(pk=self.tenant.pk).update(
-            trial_end_date=date(2026, 8, 1), paid_until=None,  # trial lapsed -> suspended Aug 2
+            # trial ended Jul 1 + 30-day grace ended Jul 31 -> suspended Aug 1
+            trial_end_date=date(2026, 7, 1), paid_until=None,
             max_active_users=5, active_user_count=0,
         )
         self.tenant.refresh_from_db()
@@ -376,8 +391,9 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('scheduled for deletion on Aug. 15, 2027', html)
         self.assertIn('365 days from now', html)
         self.assertIn(f'<a href="{self.tenant.get_root_url()}">', html)
-        self.assertIn('since <strong>Aug. 2, 2026</strong>', html)
-        self.assertIn('free trial ended on Aug. 1, 2026', html)
+        self.assertIn('since <strong>Aug. 1, 2026</strong>', html)
+        self.assertIn('free trial ended on July 1, 2026', html)
+        self.assertIn('grace period ended on July 31, 2026', html)
         # the new suspension rules (redesign, 2026-07-30): owner-only sign-in,
         # data intact, and the Maintenance escape hatch
         self.assertIn('only the deck owner can sign in', html)
@@ -517,7 +533,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         )
         self.assertGreater(self.tenant.get_active_user_count(), 0)
 
-        self.set_deck(trial_end_date=TODAY - timedelta(days=1), paid_until=None)
+        self.set_deck(trial_end_date=TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None)
         summary = self.close()
         self.assertIn('closed semester', summary)
         self.assertIn('returned 1 awaiting-approval submission(s)', summary)
@@ -542,7 +558,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         sem = SiteConfig.get().active_semester
         sem.closed = True
         sem.save()
-        self.set_deck(trial_end_date=TODAY - timedelta(days=1))
+        self.set_deck(trial_end_date=TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1))
         self.assertEqual(self.close(), 'semester was already closed')
         self.assertEqual(self.close(), 'semester close already handled this episode')
 
@@ -561,7 +577,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         student = baker.make(User)
         registration = baker.make(CourseStudent, user=student, semester=SiteConfig.get().active_semester)
 
-        self.set_deck(trial_end_date=TODAY - timedelta(days=1), paid_until=None)
+        self.set_deck(trial_end_date=TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None)
         with patch('profile_manager.models.Profile.xp_per_course', return_value=-50):
             summary = self.close()
         self.assertIn('closed semester', summary)
@@ -577,7 +593,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
 
         from courses.models import Semester
 
-        self.set_deck(trial_end_date=TODAY - timedelta(days=1), paid_until=None)
+        self.set_deck(trial_end_date=TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None)
         with patch.object(Semester.objects, 'complete_active_semester', return_value=Semester.QUEST_AWAITING_APPROVAL):
             with self.assertRaises(RuntimeError):
                 self.close()

--- a/src/tenant/tests/test_tasks.py
+++ b/src/tenant/tests/test_tasks.py
@@ -132,10 +132,10 @@ class DeckStatusCheckTaskTests(ByteDeckTenantTestCase):
 
         from django.utils.timezone import localdate
 
-        from tenant.models import Tenant
+        from tenant.models import GRACE_PERIOD_DAYS, Tenant
 
         Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
-            trial_end_date=localdate() - timedelta(days=1), paid_until=None, max_active_users=80,
+            trial_end_date=localdate() - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None, max_active_users=80,
         )
 
         self.assertTrue(tasks.deck_status_check.apply().successful())
@@ -153,14 +153,14 @@ class DeckStatusCheckTaskTests(ByteDeckTenantTestCase):
         from django.utils.timezone import localdate
         from model_bakery import baker
         from siteconfig.models import SiteConfig
-        from tenant.models import Tenant
+        from tenant.models import GRACE_PERIOD_DAYS, Tenant
 
         User = get_user_model()
         baker.make(User, is_staff=True)  # a teacher must exist before students
         student = baker.make(User)
         baker.make('courses.CourseStudent', user=student, semester=SiteConfig.get().active_semester)
         Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
-            trial_end_date=localdate() - timedelta(days=1), paid_until=None,
+            trial_end_date=localdate() - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None,
         )
 
         result = tasks.deck_status_check.apply()

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -779,6 +779,22 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         # whole object, so clear the paid date or it leaks into later tests
         self.set_deck(paid_until=None)
 
+    def test_banner__extended_trial_outlasting_an_old_paid_date_reads_as_trial(self):
+        """With BOTH dates set and the trial the LATER clock (an admin-extended
+        trial on a deck whose paid period lapsed long ago), the expired-into-grace
+        banner speaks about the TRIAL: the governing clock picks the wording
+        (#1734 B4 review find), not whether a paid date exists."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=localdate() - timedelta(days=5), paid_until=localdate() - timedelta(days=100))
+        response = self.get_quests_page(self.staff)
+        self.assertContains(response, 'Trial ended')
+        self.assertNotContains(response, 'Subscription expired')
+        # clear the paid date so it doesn't leak into later tests (shared instance)
+        self.set_deck(paid_until=None)
+
 
 class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """Access and rendering tests for the staff-facing Subscription details page
@@ -878,14 +894,15 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn('(ends today)', ' '.join(self.get_page().content.decode().split()))
 
     def test_page__dates_show_only_the_governing_deadline(self):
-        """The Dates table shows ONE deadline row -- Paid until when a paid date
-        exists (it supersedes the trial date, even while lapsed), Trial ends on a
-        trial-only deck, and a never-expires row on a managed-manually deck."""
+        """The Dates table shows ONE deadline row -- the governing (LATEST) clock's
+        (#1734 B4): Paid until when the paid clock governs, Trial ends when the
+        trial clock governs (even with both dates set), and a never-expires row
+        on a managed-manually deck."""
         from datetime import timedelta
 
         from django.utils.timezone import localdate
 
-        # subscribed decks keep their old trial date; only the paid row shows
+        # subscribed decks keep their old trial date; the paid clock governs
         self.set_deck(trial_end_date=localdate() - timedelta(days=300))
         response = self.get_page()
         self.assertContains(response, 'Paid until')
@@ -900,6 +917,25 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         response = self.get_page()
         self.assertContains(response, 'Never')
         self.assertNotContains(response, 'Trial ends')
+        self.assertNotContains(response, 'Paid until')
+
+    def test_page__extended_trial_outlasting_an_old_paid_date_reads_as_trial(self):
+        """With BOTH dates set and the trial the LATER clock (an admin-extended
+        trial on a deck whose paid period lapsed earlier), the grace status and
+        the Dates table follow the governing trial clock: trial wording,
+        subscribe (not renew), the Trial ends row, and no Paid until row
+        (#1734 B4 review find)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=localdate() - timedelta(days=5), paid_until=localdate() - timedelta(days=100))
+        response = self.get_page()
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('free trial ended on', text)
+        self.assertIn('subscribe to keep full access', text)
+        self.assertIn('extends 30 days after your trial ends (ends in 25 days)', text)
+        self.assertContains(response, 'Trial ends')
         self.assertNotContains(response, 'Paid until')
 
     def test_page__remaining_seats_counts_down_and_clamps_at_zero(self):

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -939,6 +939,24 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn('otherwise the deck will be suspended (only the deck owner will be able to sign in, '
                       'and the 365-day countdown to deck deletion begins)', text)
 
+    def test_page__lapsed_trial_gets_the_same_grace_status(self):
+        """A lapsed trial lands in the SAME grace state (#1734 B4): the danger
+        "Grace period" label, trial-specific wording ("free trial ended",
+        subscribe rather than renew), and the trial Dates rows with the grace
+        row's countdown."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=localdate() - timedelta(days=5), paid_until=None)
+        response = self.get_page()
+        self.assertContains(response, 'Grace period</span>')
+        self.assertContains(response, 'label-danger')
+        text = ' '.join(response.content.decode().split())
+        self.assertIn('free trial ended on', text)
+        self.assertIn('subscribe to keep full access', text)
+        self.assertIn('extends 30 days after your trial ends (ends in 25 days)', text)
+
     def test_page__suspended_deck_states_owner_only_and_deletion_countdown(self):
         """A suspended deck's status copy states the suspension rules -- only
         the deck owner can sign in, and the 365-day deletion countdown -- while

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -452,9 +452,14 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             # "(expired 24 days ago)"); None when the corresponding date is unset
             'paid_until_phrase': _relative_date_phrase(deck.paid_until, 'remaining') if deck.paid_until else None,
             'trial_end_phrase': _relative_date_phrase(deck.trial_end_date, 'remaining') if deck.trial_end_date else None,
+            # the unified grace window closes after the LATEST deadline, trial and
+            # paid clocks alike (#1734 B4)
             'grace_end_phrase': (
-                _relative_date_phrase(deck.paid_until + timedelta(days=GRACE_PERIOD_DAYS), 'ends')
-                if deck.paid_until else None
+                _relative_date_phrase(
+                    max(d for d in (deck.trial_end_date, deck.paid_until) if d is not None) + timedelta(days=GRACE_PERIOD_DAYS),
+                    'ends',
+                )
+                if (deck.trial_end_date or deck.paid_until) else None
             ),
         })
         context.update({


### PR DESCRIPTION
## What

Step B4 of the suspension-model redesign (#1734): a free trial is now treated as just another kind of subscription. One unified deadline (the **latest** of `trial_end_date` and `paid_until`) governs expiry, and **every** deck keeps full access for the 30-day grace window past that deadline before suspension.

Previously a trial deck was suspended the day after `trial_end_date`, with no grace at all: the trial banner said "trial ends in N days" and the very next day students were signed out and the semester auto-closed.

## Why

Maintainer decision on the redesign plan (2026-07-30): the cliff-edge trial ending was hostile to new decks (a teacher mid-evaluation lost student access overnight), and having two different lifecycles (trial vs paid) doubled the copy, the notices logic, and the number of states owners had to understand. With B4, the lifecycle explained on the subscription page is the whole truth: valid period, then 30 days grace, then suspension, then (a year later) deletion, no matter which clock a deck is on.

## How

* New `Tenant.governing_deadline` (the latest set clock) and `Tenant.governing_clock_is_trial` (its origin; a tie speaks subscription language) are the single source of truth: the lifecycle properties (`in_grace_period`, `is_suspended`, `days_until_expiry`, `suspended_since`, the notice period keys) and every presentation path read them, so a lapsed trial enters grace instead of suspending immediately, and an admin-extended trial that outlasts an old paid date shows trial wording and dates everywhere (CodeRabbit review find). `subscription_active`, `is_on_trial`, `deletion_date` and `is_deletable` are unchanged in meaning.
* The status banner's expired-into-grace and approaching-deadline branches say "Trial ended:"/"Trial ending soon:" or "Subscription expired:"/"Subscription expiring:" per the governing clock; the grace copy (days left, suspension ahead) is shared.
* The subscription page gets a trial-aware Grace period status ("The free trial ended on ... subscribe to keep full access"), a Grace period row in the Dates table, a deadline row chosen by the governing clock, and a lifecycle explainer that no longer special-cases trials. The Subscribed/Maintenance status countdown pairs with the paid date it sits beside.
* The expiry-reminder email's countdown and expired variants both report the governing deadline with matching trial/paid wording; the suspended-notice email's explanation names the governing clock and when its grace period ended.
* `deck_status_report` labels a lapsed trial inside its window `grace` (it previously fell through to `suspended`).
* Tests: existing suspension tests move their trial fixtures past the grace window (a just-lapsed trial no longer counts as suspended); new tests prove a lapsed trial stays in grace (model properties, middleware access, notices cadence, report label, banner/subscription rendering) and suspends only after the window closes; regression tests pin the trial-later-than-an-old-paid-date corner across the model, banner, both emails, and the subscription page.

## Testing

* Full suite + `ruff check src` + `makemigrations --check` pass locally (re-run green after the review round; `Ran 278 tests` in `tenant` alone).
* New coverage: trial grace window boundaries (`in_grace_period`, `grace_days_remaining`, `is_suspended`), `suspended_since` for trial-only decks, `governing_deadline`/`governing_clock_is_trial` origins (latest clock wins, tie prefers subscription language), expiry cadence continuing through trial grace, middleware admitting everyone during trial grace, `grace`/`suspended` report labels, subscription-page trial-grace rendering, and the trial-later-than-paid wording regressions.

## Screenshots

All captured from the real `hackerspace` dev deck (`http://hackerspace.localhost:8000`), signed in as the deck owner, with the trial ended 5 days ago (Aug 1, "today" Aug 6).

### Banner: before (deck suspended the day the trial ends) vs after (30-day grace)

**Before:**

![before banner](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b4/before-trial-lapsed-banner.png)

**After:**

![after banner](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b4/after-trial-grace-banner.png)

### Subscription page: before vs after (same deck state)

**Before:**

![before subscription](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b4/before-trial-lapsed-subscription.png)

**After:**

![after subscription](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b4/after-trial-grace-subscription.png)

### Email

Both messages below are real sends captured from `_sent_mail/` on the dev deck (file email backend), HTML part rendered in the browser, plain-text part verbatim from the same message.

**Expiry reminder, trial in grace (HTML):**

![expiry reminder email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b4/email-expiry-grace.png)

Plain-text part of the same send:

```
Hi owner,

Your deck **hackerspace** 's free trial ended on **Aug. 1, 2026** (5 days ago)
and is in its 30-day grace period, which ends on **Aug. 31, 2026** (25 days
left). When the grace period ends, the deck will be suspended: only the deck
owner will be able to sign in, and the 365-day countdown to deck deletion
begins.

You are currently using **3** of **5** current student seats.

[Subscribe or renew
here](http://hackerspace.localhost:8000/decks/subscription/) to keep full
access. Questions about which students count? Only _current_ students (those
registered in a course this semester) count toward your limit; see [freeing up
student seats](http://hackerspace.localhost:8000/courses/students/archive-
help/).

Not planning to use the deck for a while? The low-cost _Maintenance_
subscription keeps it online with trial-level limits (max 5 current students)
and stops it from ever being deleted.

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck
```

**Suspended notice, trial past grace (HTML):** the trial branch now names the grace window's end ("its free trial ended on June 20, 2026, and the 30-day grace period ended on July 20, 2026"), matching the paid branch.

![suspended notice email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b4/email-suspended-trial.png)

Plain-text part of the same send:

```
Hi owner,

Your deck [hackerspace](http://hackerspace.localhost:8000) is **scheduled for
deletion on July 30, 2027 (358 days from now)** , unless it gets a valid
subscription before then.

The deck has been **suspended** since **July 21, 2026** (its free trial ended
on June 20, 2026, and the 30-day grace period ended on July 20, 2026): only
the deck owner can sign in until the deck has a valid subscription. Nothing
has been deleted yet: your content and student data are intact until the
deletion date above.

[Subscribe here](http://hackerspace.localhost:8000/decks/subscription/) to
restore access: any level works, including the low-cost _Maintenance_
subscription, which keeps the deck online with trial-level limits (max 5
current students) and stops the deletion countdown (ideal if you just want to
keep the deck for later).

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck
```

(The screenshots above predate the review-round commit 3f2ca97, which changed no copy in the states shown: the trial-only deck's wording is identical through the governing-deadline refactor.)

## Notes for review

* A deck with **both** dates blank (comped / managed manually) still never expires or suspends; that escape hatch is untouched.
* A lapsed ex-subscriber that still carries its ancient never-cleared trial date keeps suspending relative to its recent `paid_until` (the latest-clock rule), so nothing backdates.
* The semester auto-close (B2) and deletion clock (B3) key off `is_suspended`/`suspended_since`, so they inherit the new timing automatically: the close now happens at grace end, not trial end.
* Next (B5, last step): a copy-alignment sweep across remaining templates/admin for the unified lifecycle language.

Part of the #1729 payments epic; step B4 of #1734.

- Claude Code (`Bytedeck - payments integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trial expirations now follow the same grace-period, access, and suspension behavior as expired subscriptions.
  * Statuses and countdowns consistently use the later trial or subscription deadline.
  * Notifications and banners now accurately distinguish ended trials from expired subscriptions.

* **User Experience**
  * Subscription details, reminders, and suspension notices show the correct deadlines, grace-period dates, and next steps.
  * Trial grace periods are clearly reflected in billing status and lifecycle messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->