### PR TITLE
feat: keep a mid-trial deck's remaining free time through Stripe checkout (#1729)

### DIFF
--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -102,9 +102,13 @@ def create_checkout_session(deck):
         success_url=deck.get_root_url() + reverse('decks:subscription_activating') + '?session_id={CHECKOUT_SESSION_ID}',
         cancel_url=_subscription_page_url(deck),
         # Stripe rejects a reused idempotency key whose parameters changed, so the
-        # trial variant carries its own marker (a same-day retry that crosses the
-        # trial-end cutoff would otherwise collide with the earlier key)
-        idempotency_key=f'deck-checkout-{deck.schema_name}-{localdate()}' + ('-trial' if trial_end else ''),
+        # trial variant carries the trial-end timestamp: a same-day retry after the
+        # cutoff passed, or after an admin moved trial_end_date, gets a fresh key
+        # while an identical retry still reuses the session
+        idempotency_key=(
+            f'deck-checkout-{deck.schema_name}-{localdate()}'
+            + (f'-trial-{int(trial_end.timestamp())}' if trial_end else '')
+        ),
     )
     return session.url
 

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -12,7 +12,7 @@ from Stripe and links/extends the deck itself. The webhook endpoint (plan PR 7)
 later takes over renewals and payment failures; this reconciliation stays as
 the never-assume-the-webhook-landed fallback (plan §5.4).
 """
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime, time as dt_time, timedelta, timezone as dt_timezone
 
 import stripe
 
@@ -20,6 +20,11 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import localdate
+
+# Stripe rejects a subscription trial_end closer than 48 hours out; the extra
+# hour absorbs clock skew and request latency so a boundary-day checkout can't
+# fail at Stripe after passing our check
+CHECKOUT_TRIAL_END_MINIMUM = timedelta(hours=49)
 
 
 def billing_configured():
@@ -36,14 +41,46 @@ def _subscription_page_url(deck):
     return deck.get_root_url() + reverse('decks:subscription')
 
 
+def checkout_trial_end(deck):
+    """When this deck subscribes mid-trial, the aware datetime its Stripe trial
+    should run until, or None when a plain (bill-now) checkout is right.
+
+    A mid-trial subscriber keeps their remaining free time (maintainer decision,
+    2026-08-06): checkout passes this as ``subscription_data.trial_end`` so the
+    subscription starts ``trialing``, the card is collected now, and the first
+    charge lands when the deck's existing trial ends, auto-renewing from then
+    on. The deck's trial covers THROUGH ``trial_end_date``, so the Stripe trial
+    runs to local midnight after that day (settings.TIME_ZONE).
+
+    None when the deck isn't on trial, or when the trial ends within
+    CHECKOUT_TRIAL_END_MINIMUM (Stripe requires trial_end at least 48 hours in
+    the future, so a nearly-over trial just bills immediately: at most two days
+    of free time are forfeited, on a deck whose trial was ending anyway).
+
+    Args:
+        deck (Tenant): The current deck.
+
+    Returns:
+        datetime | None: The aware trial-end moment to send to Stripe, or None.
+    """
+    if not deck.is_on_trial:
+        return None
+    end = timezone.make_aware(datetime.combine(deck.trial_end_date + timedelta(days=1), dt_time.min))
+    if end < timezone.now() + CHECKOUT_TRIAL_END_MINIMUM:
+        return None
+    return end
+
+
 def create_checkout_session(deck):
     """Create a subscription Checkout Session for an unlinked deck; return its URL.
 
     The deck is identified to Stripe three ways (client_reference_id, metadata,
     and the customer email), so the webhook (PR 7) and manual reconciliation can
-    always find their way back to the schema. The idempotency key means a
-    double-click or same-day retry with identical parameters reuses the same
-    session instead of minting duplicates.
+    always find their way back to the schema. A mid-trial deck's remaining free
+    time rides along as ``subscription_data.trial_end`` (see
+    :func:`checkout_trial_end`). The idempotency key means a double-click or
+    same-day retry with identical parameters reuses the same session instead of
+    minting duplicates.
 
     Args:
         deck (Tenant): The current deck; must not already have a stripe_customer_id.
@@ -51,6 +88,7 @@ def create_checkout_session(deck):
     Returns:
         str: The Stripe-hosted checkout URL to redirect the owner to.
     """
+    trial_end = checkout_trial_end(deck)
     session = stripe.checkout.Session.create(
         api_key=settings.STRIPE_SECRET_KEY,
         mode='subscription',
@@ -58,10 +96,15 @@ def create_checkout_session(deck):
         client_reference_id=deck.schema_name,
         customer_email=deck.get_owner_email_cached() or None,
         metadata={'schema_name': deck.schema_name},
+        # the subscription starts `trialing` until the deck's existing trial ends
+        **({'subscription_data': {'trial_end': int(trial_end.timestamp())}} if trial_end else {}),
         # Checkout substitutes the real session id into the literal placeholder
         success_url=deck.get_root_url() + reverse('decks:subscription_activating') + '?session_id={CHECKOUT_SESSION_ID}',
         cancel_url=_subscription_page_url(deck),
-        idempotency_key=f'deck-checkout-{deck.schema_name}-{localdate()}',
+        # Stripe rejects a reused idempotency key whose parameters changed, so the
+        # trial variant carries its own marker (a same-day retry that crosses the
+        # trial-end cutoff would otherwise collide with the earlier key)
+        idempotency_key=f'deck-checkout-{deck.schema_name}-{localdate()}' + ('-trial' if trial_end else ''),
     )
     return session.url
 

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -113,6 +113,11 @@
       Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.
     {% else %}
       Opens Stripe's secure checkout to start a subscription for this deck.
+      {% if checkout_trial_end %}
+        Subscribing now won't cut your free trial short: your card is charged for the first time
+        when the trial ends on <strong>{{ deck.trial_end_date }}</strong>, and the subscription
+        renews automatically from then on.
+      {% endif %}
     {% endif %}
   </p>
   {% endif %}

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -2,11 +2,15 @@ from datetime import date, datetime, timezone as dt_timezone
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
 
 from freezegun import freeze_time
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
-from tenant.billing import _subscription_period_end_date, billing_configured, reconcile_checkout_session
+from tenant.billing import (
+    _subscription_period_end_date, billing_configured, checkout_trial_end, create_checkout_session,
+    reconcile_checkout_session,
+)
 from tenant.models import Tenant
 
 
@@ -52,6 +56,74 @@ class SubscriptionPeriodEndDateTest(SimpleTestCase):
         """No period end in either shape (or no items at all) -> None."""
         self.assertIsNone(_subscription_period_end_date({}))
         self.assertIsNone(_subscription_period_end_date({'items': {'data': []}}))
+
+
+@freeze_time("2026-08-15 20:00:00")  # midday Pacific so localtime dates are stable
+class CheckoutTrialEndTest(SimpleTestCase):
+    """Tests for the mid-trial checkout trial_end pass-through (maintainer
+    decision, 2026-08-06): a mid-trial subscriber keeps their remaining free
+    time, so checkout starts the subscription `trialing` until the deck's
+    existing trial ends. Pure date logic on unsaved in-memory decks."""
+
+    def deck(self, trial_end_date=None, paid_until=None):
+        """Build an unsaved Tenant with explicit billing dates (overriding the
+        field default, which would give every bare deck a 60-day trial)."""
+        return Tenant(name='trialend', trial_end_date=trial_end_date, paid_until=paid_until)
+
+    def test_checkout_trial_end__runs_to_local_midnight_after_the_trials_last_day(self):
+        """A mid-trial deck's Stripe trial runs through local midnight AFTER
+        trial_end_date: the deck's own trial covers that whole day."""
+        end = checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14)))
+        self.assertEqual(end, timezone.make_aware(datetime(2026, 9, 15, 0, 0)))
+
+    def test_checkout_trial_end__none_when_not_on_trial(self):
+        """Paid, lapsed-trial, and dateless decks have no trial time to keep,
+        so checkout bills immediately as usual."""
+        self.assertIsNone(
+            checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 12, 1))))
+        self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 10))))  # trial lapsed
+        self.assertIsNone(checkout_trial_end(self.deck()))  # managed manually
+
+    def test_checkout_trial_end__none_when_the_trial_ends_too_soon(self):
+        """Stripe requires trial_end at least 48 hours out, so a nearly-over
+        trial gets a plain bill-now checkout instead of a doomed API call."""
+        self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 15))))  # ends today
+        self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 16))))  # under the 49h floor
+        self.assertIsNotNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 17))))  # clears it
+
+
+@override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+@freeze_time("2026-08-15 20:00:00")  # midday Pacific so localtime dates are stable
+class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
+    """create_checkout_session forwards the mid-trial trial_end to Stripe (with
+    a trial-marked idempotency key) exactly when checkout_trial_end applies."""
+
+    def create_session(self):
+        """Run create_checkout_session with Stripe mocked; return the call kwargs."""
+        with patch('tenant.billing.stripe.checkout.Session.create') as mock_create:
+            mock_create.return_value.url = 'https://stripe.example/session'
+            self.assertEqual(create_checkout_session(self.tenant), 'https://stripe.example/session')
+        return mock_create.call_args.kwargs
+
+    def test_create_checkout_session__mid_trial_passes_trial_end(self):
+        """A mid-trial deck's checkout carries subscription_data.trial_end (the
+        deck's remaining free time as a unix timestamp) and marks the
+        idempotency key, since the parameters differ from a bill-now session."""
+        Tenant.objects.filter(pk=self.tenant.pk).update(trial_end_date=date(2026, 9, 14), paid_until=None)
+        self.tenant.refresh_from_db()
+        kwargs = self.create_session()
+        expected = int(timezone.make_aware(datetime(2026, 9, 15, 0, 0)).timestamp())
+        self.assertEqual(kwargs['subscription_data'], {'trial_end': expected})
+        self.assertTrue(kwargs['idempotency_key'].endswith('-trial'))
+
+    def test_create_checkout_session__no_trial_end_when_not_applicable(self):
+        """A deck with no trial time to keep (here: trial lapsed) gets a plain
+        bill-now checkout: no subscription_data, unmarked idempotency key."""
+        Tenant.objects.filter(pk=self.tenant.pk).update(trial_end_date=date(2026, 8, 10), paid_until=None)
+        self.tenant.refresh_from_db()
+        kwargs = self.create_session()
+        self.assertNotIn('subscription_data', kwargs)
+        self.assertFalse(kwargs['idempotency_key'].endswith('-trial'))
 
 
 @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -107,14 +107,16 @@ class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
 
     def test_create_checkout_session__mid_trial_passes_trial_end(self):
         """A mid-trial deck's checkout carries subscription_data.trial_end (the
-        deck's remaining free time as a unix timestamp) and marks the
-        idempotency key, since the parameters differ from a bill-now session."""
+        deck's remaining free time as a unix timestamp) and stamps that same
+        timestamp into the idempotency key: the parameters differ from a
+        bill-now session, and from a session built for a different trial end,
+        so neither retry shape can collide with a stale key."""
         Tenant.objects.filter(pk=self.tenant.pk).update(trial_end_date=date(2026, 9, 14), paid_until=None)
         self.tenant.refresh_from_db()
         kwargs = self.create_session()
         expected = int(timezone.make_aware(datetime(2026, 9, 15, 0, 0)).timestamp())
         self.assertEqual(kwargs['subscription_data'], {'trial_end': expected})
-        self.assertTrue(kwargs['idempotency_key'].endswith('-trial'))
+        self.assertTrue(kwargs['idempotency_key'].endswith(f'-trial-{expected}'))
 
     def test_create_checkout_session__no_trial_end_when_not_applicable(self):
         """A deck with no trial time to keep (here: trial lapsed) gets a plain
@@ -123,7 +125,7 @@ class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
         self.tenant.refresh_from_db()
         kwargs = self.create_session()
         self.assertNotIn('subscription_data', kwargs)
-        self.assertFalse(kwargs['idempotency_key'].endswith('-trial'))
+        self.assertNotIn('-trial', kwargs['idempotency_key'])
 
 
 @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1013,6 +1013,26 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.set_deck(max_active_users=-1)
         self.assertContains(self.get_page(), 'Unlimited')
 
+    def test_page__mid_trial_checkout_note_promises_no_lost_trial_time(self):
+        """While the deck is on trial (with enough trial left for checkout to
+        preserve it), the subscribe button's help text says the card isn't
+        charged until the trial ends; a paid deck gets the plain portal/checkout
+        copy with no trial note (maintainer decision, 2026-08-06)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        with override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123'):
+            self.set_deck(trial_end_date=localdate() + timedelta(days=30), paid_until=None)
+            text = ' '.join(self.get_page().content.decode().split())
+            self.assertIn("won't cut your free trial short", text)
+            self.assertIn('renews automatically', text)
+
+            # subscribed deck: no trial note
+            self.set_deck(trial_end_date=None, paid_until=localdate() + timedelta(days=100))
+            text = ' '.join(self.get_page().content.decode().split())
+            self.assertNotIn("won't cut your free trial short", text)
+
     def test_page__not_configured_falls_back_to_public_subscribe_page(self):
         """Without Stripe keys the page says billing isn't configured and links the
         public subscribe page instead of rendering the checkout form."""

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -439,7 +439,7 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         """
         from datetime import timedelta
 
-        from .billing import billing_configured
+        from .billing import billing_configured, checkout_trial_end
         from .models import GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS
         from .utils import get_public_subscribe_url
 
@@ -474,6 +474,10 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             'manually_subscribed': bool(
                 deck.subscription_active and not deck.in_grace_period and not deck.stripe_customer_id
             ),
+            # set (the Stripe trial's end moment) when checkout would preserve the
+            # deck's remaining free trial; drives the "card isn't charged until
+            # your trial ends" note beside the subscribe button
+            'checkout_trial_end': checkout_trial_end(deck),
             'public_subscribe_url': get_public_subscribe_url(),
         })
         return context


### PR DESCRIPTION
## What

Subscribing while a deck is still on its free trial no longer bills immediately and forfeits the remaining free time. Checkout now passes the deck's trial end to Stripe as `subscription_data.trial_end`, so the subscription starts in Stripe's `trialing` status: the card is collected now, the first charge lands when the deck's existing trial ends, and the subscription renews automatically from then on. This is a Stripe-native free-trial subscription, entered whenever the owner chooses.

The subscribe button's help text says so: "Subscribing now won't cut your free trial short: your card is charged for the first time when the trial ends on [date], and the subscription renews automatically from then on."

## Why

Maintainer decision (2026-08-06): the trial should behave like a real Stripe trial subscription where possible. Deck signup stays Stripe-free (no card wall for teachers), but once an owner decides to subscribe mid-trial, they shouldn't have to choose between subscribing now and keeping the free time they were promised. This removes a perverse incentive to wait until the last day of the trial.

## How

* New `tenant.billing.checkout_trial_end(deck)`: the aware datetime the Stripe trial should run until, which is local midnight after `trial_end_date` (the deck's trial covers that whole day), or None when it doesn't apply. It applies only while the deck `is_on_trial` and the trial ends at least `CHECKOUT_TRIAL_END_MINIMUM` (49 hours) out: Stripe rejects a `trial_end` closer than 48 hours, so a nearly-over trial just bills immediately as before.
* `create_checkout_session` forwards it as `subscription_data.trial_end` and marks the idempotency key with a `-trial` suffix when it applies (Stripe rejects a reused idempotency key whose parameters changed, so a same-day retry that crosses the cutoff must not collide with the earlier key).
* The subscription page's context gets `checkout_trial_end`, which gates the new help-text note.
* No changes needed downstream: the checkout reconciler already links `trialing` subscriptions and lands `paid_until` on the subscription's period end (= the trial's end), and the webhook/sync engine in #2110 treats `trialing` as access-granting, so conversion and renewals flow through the existing plumbing.

## Testing

* Full suite + `ruff check src` + `makemigrations --check` pass locally.
* New coverage: `checkout_trial_end` boundaries (mid-trial midnight math, paid/lapsed/dateless decks, the 48-hour Stripe floor), `create_checkout_session` kwargs (trial_end present with marked idempotency key mid-trial; absent otherwise), and the subscription-page note (shown mid-trial, absent for paid decks).

## Screenshots

Captured from the real `hackerspace` dev deck (`http://hackerspace.localhost:8000`), signed in as the deck owner, deck mid-trial (ends Sept. 5, 30 days out), Stripe configured. The new note sits under the Subscribe now button:

![mid-trial subscribe note](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1729-trial-end/subscribe-note.png)

## Notes for review

* Coordination with #2110 (open): both PRs touch `create_checkout_session` (this one adds `subscription_data.trial_end`; #2110 adds `subscription_data.metadata.schema_name` stamping). Whichever merges second gets a small, mechanical conflict resolution: the two settings compose inside the same `subscription_data` dict. I'll handle the sync on whichever branch is still open.
* Also composes cleanly with #2277 (B4 unified grace, open): a lapsed trial in its grace window is not `is_on_trial`, so grace-period checkouts bill immediately, which is correct (no free time left to preserve).

Part of the #1729 payments epic.

- Claude Code (`Bytedeck - payments integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Starting a subscription during an active free trial now preserves the remaining trial period when eligible.
  - The first charge is delayed until the trial ends, followed by automatic renewal.

- **Improvements**
  - Checkout messaging now clearly explains trial timing and renewal details.
  - Subscriptions with little remaining trial time are charged immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->