### PR TITLE
test: cover initdb management command branches

### DIFF
--- a/src/hackerspace_online/management/commands/initdb.py
+++ b/src/hackerspace_online/management/commands/initdb.py
@@ -130,11 +130,15 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS('\n** Creating homepage...'))
             from django.contrib.flatpages.models import FlatPage
 
-            homepage = FlatPage.objects.create(
+            # get_or_create so re-running against an existing public tenant doesn't add a
+            # duplicate '/home/' flatpage (FlatPage.url isn't unique on its own).
+            homepage, _ = FlatPage.objects.get_or_create(
                 url='/home/',
-                title='Home',
-                content=get_homepage_content(),
-                template_name='public/flatpage-wide.html',
+                defaults={
+                    'title': 'Home',
+                    'content': get_homepage_content(),
+                    'template_name': 'public/flatpage-wide.html',
+                },
             )
             homepage.sites.add(site)
             absolute_url = reverse('django.contrib.flatpages.views.flatpage', args=['home'])

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -1,11 +1,14 @@
 from io import StringIO
 from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
 
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.models import Site
 from django.core.management import call_command
+from django.db.utils import OperationalError
 from django.test import TestCase
 from django_tenants.utils import tenant_context, get_public_schema_name, schema_context
 
@@ -71,6 +74,74 @@ class InitDbTest(TestCase, CommandMixin):
             self.assertTrue(Site.objects.exists())
 
             Tenant.objects.get(schema_name=apps.get_app_config('library').TENANT_NAME)  # no assert, but will throw exception if doesn't exist
+
+    def test_initdb__bails_when_database_is_unreachable(self):
+        """If the initial DB connectivity check raises OperationalError, initdb reports it and
+        bails without creating a superuser."""
+        # Replace the module-level ``connections`` in initdb so its ``connections['default'].cursor()``
+        # check raises; the surrounding @transaction.atomic still uses the real connection.
+        mock_connections = MagicMock()
+        mock_connections.__getitem__.return_value.cursor.side_effect = OperationalError
+
+        with patch('hackerspace_online.management.commands.initdb.connections', mock_connections):
+            out = self.call_command()
+
+        self.assertIn("can't connect to the database", out)
+        self.assertFalse(User.objects.filter(username=settings.DEFAULT_SUPERUSER_USERNAME).exists())
+
+    def test_initdb__bails_when_superuser_already_exists(self):
+        """Run twice: the second run finds the superuser from the first and bails without error,
+        keeping initdb idempotent-safe."""
+        self.call_command()
+        out = self.call_command()
+
+        self.assertIn(
+            f'A superuser with username `{settings.DEFAULT_SUPERUSER_USERNAME}` already exists', out
+        )
+        # still exactly one superuser (the second run did not create another)
+        self.assertEqual(User.objects.filter(username=settings.DEFAULT_SUPERUSER_USERNAME).count(), 1)
+
+    def test_initdb__setup_shared_library_backfills_missing_domain(self):
+        """setup_shared_library backfills the library tenant's domain when the tenant already
+        exists but its domain is missing (e.g. a re-run after the domain was removed), rather
+        than leaving the shared library unreachable."""
+        from hackerspace_online.management.commands.initdb import Command
+
+        self.call_command()
+        library_schema = apps.get_app_config('library').TENANT_NAME
+        library = Tenant.objects.get(schema_name=library_schema)
+        library.domains.all().delete()
+        self.assertFalse(library.domains.filter(domain='library.' + settings.ROOT_DOMAIN).exists())
+
+        # The domain backfill runs before the (non-idempotent) library quest re-labelling, which
+        # would re-prefix names and overflow Quest.name on a second run; patch it out so the test
+        # targets only the domain-backfill branch.
+        with patch('quest_manager.models.Quest'):
+            Command().setup_shared_library()
+
+        self.assertTrue(library.domains.filter(domain='library.' + settings.ROOT_DOMAIN).exists())
+
+    def test_initdb__notes_when_public_tenant_already_existed(self):
+        """When the public tenant already exists, initdb reports that (a not-created notice)
+        instead of failing.
+
+        The superuser guard is mocked to appear unset so the run proceeds to the public-tenant
+        step (deleting the real superuser isn't possible here: its cascade touches per-tenant
+        tables that don't exist in the public schema). The public domain is dropped first so the
+        unconditional domain re-create doesn't hit the domain uniqueness constraint.
+        """
+        self.call_command()
+        Tenant.objects.get(schema_name='public').domains.all().delete()
+
+        # Mock the superuser guard to appear unset (so the run reaches the public-tenant step) and
+        # skip setup_shared_library, whose non-idempotent quest re-labelling would overflow
+        # Quest.name on a re-run and is unrelated to the public-tenant notice under test.
+        with patch('hackerspace_online.management.commands.initdb.User') as MockUser, \
+                patch('hackerspace_online.management.commands.initdb.Command.setup_shared_library'):
+            MockUser.objects.filter.return_value.exists.return_value = False
+            out = self.call_command()
+
+        self.assertIn('A schema with the name `public` already existed', out)
 
 
 class GenerateContentTest(ByteDeckTenantTestCase, CommandMixin):

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -142,6 +142,10 @@ class InitDbTest(TestCase, CommandMixin):
             out = self.call_command()
 
         self.assertIn('A schema with the name `public` already existed', out)
+        # the re-run reuses the existing homepage instead of adding a duplicate
+        self.assertEqual(
+            FlatPage.objects.filter(url='/home/', sites__domain=settings.ROOT_DOMAIN).count(), 1
+        )
 
 
 class GenerateContentTest(ByteDeckTenantTestCase, CommandMixin):


### PR DESCRIPTION
## What

Brings the `initdb` management command (`hackerspace_online/management/commands/initdb.py`) to **100%** coverage by testing its previously-uncovered guard and re-entrant branches, and makes its homepage creation idempotent so a re-run doesn't duplicate the `/home/` flatpage.

## Why

`initdb` had a tail of uncovered defensive/re-entrant branches: the database-unreachable guard, the superuser-already-exists bail, the shared-library domain backfill, and the public-tenant-already-existed notice. These only run on a non-fresh or degraded database, which the single existing happy-path test never exercises. Covering the public-tenant re-entry path also surfaced a latent bug: the homepage was created unconditionally, so a re-run added a duplicate `/home/` page (`FlatPage.url` is not unique on its own).

## How

**Fix (`initdb.py`)**: homepage creation now uses `FlatPage.objects.get_or_create(url='/home/', defaults={...})`, so a re-run reuses the existing page instead of adding a duplicate.

**Tests** (four added to `InitDbTest` in `hackerspace_online/tests/test_management_commands.py`):

- **`test_initdb__bails_when_database_is_unreachable`**: swaps in a mock `connections` whose `['default'].cursor()` raises `OperationalError`, so initdb reports "can't connect to the database" and bails without creating a superuser (the surrounding `@transaction.atomic` still uses the real connection).
- **`test_initdb__bails_when_superuser_already_exists`**: runs initdb twice; the second run finds the first run's superuser and exits cleanly without creating a duplicate.
- **`test_initdb__setup_shared_library_backfills_missing_domain`**: after setup, drops the library tenant's domain and calls `setup_shared_library()` again to hit the domain-backfill branch. The (non-idempotent) library quest re-labelling that runs after the backfill is patched out so the test targets only that branch.
- **`test_initdb__notes_when_public_tenant_already_existed`**: mocks the superuser guard as unset so the run reaches the public-tenant step, drops the public domain first so the unconditional domain re-create doesn't hit the uniqueness constraint, and skips `setup_shared_library`. Asserts exactly one `/home/` page remains associated with the public site (the idempotency regression). The real superuser can't be deleted here because its cascade touches per-tenant tables that don't exist in the public schema.

`InitDbTest` deliberately inherits from plain `TestCase` (not `TenantTestCase`): `initdb` bootstraps the public schema and creates tenants from an empty DB, which a `TenantTestCase` (pre-creating a tenant and switching schema context in `setUpClass`) would collide with. The pre-existing `test_initdb__sets_up_public_tenant` uses `TestCase` for the same reason.

## Testing

- `python src/manage.py test hackerspace_online.tests.test_management_commands` green (7 tests).
- Coverage of `initdb.py` is **100%** (lines and branches).
- `ruff check` clean.

## Screenshots

N/A: test coverage plus a small idempotency fix; no user-facing or front-end change.

- Claude Code (`Bytedeck - test suite review`)