### PR TITLE
refactor: key the checkout trial pass-through to the governing clock (#1734)

### DIFF
--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -52,10 +52,12 @@ def checkout_trial_end(deck):
     on. The deck's trial covers THROUGH ``trial_end_date``, so the Stripe trial
     runs to local midnight after that day (settings.TIME_ZONE).
 
-    None when the deck isn't on trial, or when the trial ends within
+    None when the TRIAL clock isn't the deck's governing (latest) clock
+    (#1734 B4: with both dates set the later one governs, and a tie speaks
+    subscription language), and None when the trial ends within
     CHECKOUT_TRIAL_END_MINIMUM (Stripe requires trial_end at least 48 hours in
-    the future, so a nearly-over trial just bills immediately: at most two days
-    of free time are forfeited, on a deck whose trial was ending anyway).
+    the future, so a nearly-over or lapsed-into-grace trial just bills
+    immediately: there is little or no free time left to preserve).
 
     Args:
         deck (Tenant): The current deck.
@@ -63,9 +65,9 @@ def checkout_trial_end(deck):
     Returns:
         datetime | None: The aware trial-end moment to send to Stripe, or None.
     """
-    if not deck.is_on_trial:
+    if not deck.governing_clock_is_trial:
         return None
-    end = timezone.make_aware(datetime.combine(deck.trial_end_date + timedelta(days=1), dt_time.min))
+    end = timezone.make_aware(datetime.combine(deck.governing_deadline + timedelta(days=1), dt_time.min))
     if end < timezone.now() + CHECKOUT_TRIAL_END_MINIMUM:
         return None
     return end

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -76,13 +76,27 @@ class CheckoutTrialEndTest(SimpleTestCase):
         end = checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14)))
         self.assertEqual(end, timezone.make_aware(datetime(2026, 9, 15, 0, 0)))
 
-    def test_checkout_trial_end__none_when_not_on_trial(self):
-        """Paid, lapsed-trial, and dateless decks have no trial time to keep,
-        so checkout bills immediately as usual."""
+    def test_checkout_trial_end__none_when_the_trial_clock_does_not_govern(self):
+        """Decks whose governing clock isn't the trial (paid-later, tied dates,
+        dateless) and lapsed trials have no trial time to keep, so checkout
+        bills immediately as usual."""
         self.assertIsNone(
             checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 12, 1))))
         self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 10))))  # trial lapsed
         self.assertIsNone(checkout_trial_end(self.deck()))  # managed manually
+
+    def test_checkout_trial_end__governing_clock_decides_with_both_dates(self):
+        """With BOTH dates set the governing (latest) clock decides (#1734 B4):
+        a trial outlasting an old paid date passes its end through, equal dates
+        speak subscription language (no pass-through), and a later paid date
+        bills immediately."""
+        self.assertEqual(
+            checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 8, 1))),
+            timezone.make_aware(datetime(2026, 9, 15, 0, 0)))
+        self.assertIsNone(
+            checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 9, 14))))
+        self.assertIsNone(
+            checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 12, 1))))
 
     def test_checkout_trial_end__none_when_the_trial_ends_too_soon(self):
         """Stripe requires trial_end at least 48 hours out, so a nearly-over

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -77,12 +77,10 @@ class CheckoutTrialEndTest(SimpleTestCase):
         self.assertEqual(end, timezone.make_aware(datetime(2026, 9, 15, 0, 0)))
 
     def test_checkout_trial_end__none_when_the_trial_clock_does_not_govern(self):
-        """Decks whose governing clock isn't the trial (paid-later, tied dates,
-        dateless) and lapsed trials have no trial time to keep, so checkout
-        bills immediately as usual."""
+        """Decks whose governing clock isn't the trial (a later paid date, or no
+        dates at all) have no trial to preserve, so checkout bills immediately."""
         self.assertIsNone(
             checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 12, 1))))
-        self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 10))))  # trial lapsed
         self.assertIsNone(checkout_trial_end(self.deck()))  # managed manually
 
     def test_checkout_trial_end__governing_clock_decides_with_both_dates(self):
@@ -99,8 +97,10 @@ class CheckoutTrialEndTest(SimpleTestCase):
             checkout_trial_end(self.deck(trial_end_date=date(2026, 9, 14), paid_until=date(2026, 12, 1))))
 
     def test_checkout_trial_end__none_when_the_trial_ends_too_soon(self):
-        """Stripe requires trial_end at least 48 hours out, so a nearly-over
-        trial gets a plain bill-now checkout instead of a doomed API call."""
+        """Stripe requires trial_end at least 48 hours out, so a trial-governed
+        deck whose trial is nearly over (or already lapsed into grace) gets a
+        plain bill-now checkout instead of a doomed API call."""
+        self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 10))))  # lapsed into grace
         self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 15))))  # ends today
         self.assertIsNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 16))))  # under the 49h floor
         self.assertIsNotNone(checkout_trial_end(self.deck(trial_end_date=date(2026, 8, 17))))  # clears it


### PR DESCRIPTION
## What

Follow-up to #2279 (merged): `checkout_trial_end` now decides eligibility with `governing_clock_is_trial` and measures from `governing_deadline`, the unified-lifecycle properties from #2277 (B4), rather than `is_on_trial`/`trial_end_date`.

With both dates set, the later clock decides, matching the rest of the lifecycle: a trial outlasting an old paid date passes its end through to Stripe, equal dates speak subscription language (no pass-through), and a later paid date bills immediately. A lapsed trial still bills immediately via the existing 48-hour Stripe floor.

## Why

CodeRabbit's review of #2279 asked for exactly this, but the properties only existed on #2277's unmerged branch at the time, so the thread was left open with this alignment promised once B4 merged. Both PRs have now merged, so this closes that thread. It also keeps CodeRabbit's recorded learning true: all trial/subscription lifecycle logic keys off the shared governing-clock properties.

## How

* `checkout_trial_end`: eligibility gate swapped to `governing_clock_is_trial`, end calculation to `governing_deadline`; docstring updated. No behavior change in states reachable today (whenever checkout is reachable and the trial governs, `is_on_trial` agreed), so this is alignment and future-proofing rather than a bug fix.
* Tests: the both-dates matrix (`test_checkout_trial_end__governing_clock_decides_with_both_dates`) covers trial-later (pass-through), equal (subscription language, none), and paid-later (none); the not-governing test renamed to match the new semantics.

## Testing

Full suite + `ruff check src` + `makemigrations --check` pass locally on top of the merged #2277 + #2279 develop.

## Screenshots

N/A: no user-visible change (the subscribe-button note's gating condition is unchanged in all reachable states; its copy is untouched).

- Claude Code (`Bytedeck - payments integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trial eligibility during checkout now follows the governing account clock.
  * Checkout no longer offers a trial when a paid period governs.
  * Trial end dates are now calculated consistently when trial and paid dates overlap or conflict.

* **Tests**
  * Expanded coverage for paid-later, equal-date, and competing-date scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->