### PR TITLE
feat: align remaining lifecycle copy with the unified grace period (#1734)

### DIFF
--- a/src/templates/deck_status_banner.html
+++ b/src/templates/deck_status_banner.html
@@ -9,7 +9,8 @@ Priority: suspended (everyone) > over-limit (staff) > expiring soon (staff) > tr
         <div class="alert alert-danger" id="deck-status-banner">
             <i class="fa fa-fw fa-ban"></i>
             {% if request.user.is_staff %}
-                <strong>This deck is suspended:</strong> its trial or subscription has ended. Only the deck
+                <strong>This deck is suspended:</strong> its trial or subscription ended and the grace
+                period has run out. Only the deck
                 owner can sign in, and a deck suspended for 365 days may be permanently deleted.
                 <a href="{{ deck_subscribe_url }}" class="alert-link">Subscribe</a> to restore access
                 (even the low-cost Maintenance subscription keeps the deck safe).

--- a/src/tenant/templates/tenant/email/limit_warning.html
+++ b/src/tenant/templates/tenant/email/limit_warning.html
@@ -3,10 +3,14 @@
 <p>Your deck <strong>{{ deck.name }}</strong> has <strong>{{ count }}</strong> current
   student{{ count|pluralize }} of <strong>{{ cap }}</strong> allowed{% if count >= cap %}: the limit has been reached, so no more students can register in a course.{% else %}: you're approaching the limit.{% endif %}</p>
 
-{% if deck.subscription_active %}
+{# the GOVERNING clock (the latest one) names the deadline, and grace decks are told their clock already ran out (#1734 B5) #}
+{% if deck.in_grace_period %}
+<p>Your deck's {% if deck.governing_clock_is_trial %}free trial ended{% else %}subscription expired{% endif %}
+  on <strong>{{ deck.governing_deadline }}</strong> and the deck is in its grace period.</p>
+{% elif deck.governing_clock_is_trial %}
+<p>Your deck's free trial ends on <strong>{{ deck.governing_deadline }}</strong>.</p>
+{% elif deck.subscription_active %}
 <p>Your deck's subscription is paid through <strong>{{ deck.paid_until }}</strong>.</p>
-{% elif deck.is_on_trial %}
-<p>Your deck's free trial ends on <strong>{{ deck.trial_end_date }}</strong>.</p>
 {% endif %}
 
 <p>Only <em>current</em> students (registered in a course in the active semester) count; staff and archived

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -9,7 +9,8 @@
 <h3>Status</h3>
 {% if deck.is_suspended %}
   <p><span class="label label-danger">Suspended</span>
-    This deck's trial and/or subscription period has ended: only the deck owner can sign in, and a deck
+    This deck's trial or subscription ended and the {{ grace_days }}-day grace period has run out:
+    only the deck owner can sign in, and a deck
     suspended for 365 days may be permanently deleted. Nothing has been deleted yet: subscribe
     (any level, including the low-cost Maintenance subscription) to restore access.</p>
 {% elif deck.in_grace_period %}

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -380,6 +380,29 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('alt="[Logo]"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
+    def test_deliver__limit_email_names_the_grace_state(self):
+        """The limit email on an in-grace deck says the governing clock already
+        ran out and the deck is in its grace period, rather than quoting a
+        pre-lapse deadline (#1734 B5)."""
+        from unittest.mock import patch
+
+        from tenant import tasks
+        from tenant.notices import _deliver
+
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            trial_end_date=TODAY - timedelta(days=5), paid_until=None,
+            max_active_users=5, active_user_count=5)
+        self.tenant.refresh_from_db()
+
+        with patch.object(
+            tasks.send_email_message, 'apply_async',
+            side_effect=lambda kwargs=None, queue=None: tasks.send_email_message.apply(kwargs=kwargs),
+        ):
+            _deliver(self.tenant, DeckNotice.KIND_LIMIT)
+        html = ' '.join(mail.outbox[0].alternatives[0][0].split())
+        self.assertIn('free trial ended on <strong>Aug. 10, 2026</strong> and the deck is in its grace period', html)
+
+    @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_states_when_and_why_with_logo(self):
         """The suspension email says when the suspension began, which clock ran
         out (trial or paid, plus the unified grace window, #1734 B4), current


### PR DESCRIPTION
## What

Step B5, the close-out of the #1734 suspension redesign: the last copy that predated the unified 30-day grace now speaks the governing-clock language.

* The **limit-warning email**'s date line keys off `governing_deadline`/`governing_clock_is_trial`, and a deck inside its grace window is told its clock already ran out ("Your deck's free trial ended on [date] and the deck is in its grace period."). Previously a grace deck got no date line at all (the template only knew "subscribed" and "on trial"), and a trial outlasting an old paid date could be labeled with the wrong clock.
* The **suspended banner** and the **subscription page's Suspended status** now say the grace period has run out, matching the lifecycle explainer: under the redesign a suspension always follows the grace window, and the old "its trial or subscription has ended" wording read as if lapsing alone suspended a deck.

## Why

B1 through B4 changed the machinery (owner-only sign-in, semester auto-close, the suspension-keyed deletion clock, the unified grace); B5 finishes the story by making every remaining user-facing sentence describe that lifecycle accurately. With this, the #1734 redesign is complete.

## How

Template-only changes plus one behavioral test (`test_deliver__limit_email_names_the_grace_state`) pinning the grace-state limit email wording. No logic changes; the governing-clock properties come from #2277.

## Testing

Full suite + `ruff check src` + `makemigrations --check` pass locally.

## Screenshots

All captured from the real `hackerspace` dev deck, signed in as the deck owner.

**Suspended banner** (trial ended June 20, grace ran out July 20, suspended since July 21):

![suspended banner](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b5/b5-suspended-banner.png)

**Subscription page, Suspended status** (same deck state; the Dates rows are from B4):

![suspended subscription page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b5/b5-suspended-subscription.png)

### Email

Real send captured from `_sent_mail/` (file email backend): the deck hit its 5-student cap while in its grace window (trial ended Aug 3).

**HTML rendered:**

![limit warning email in grace](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1734-b5/email-limit-grace.png)

**Plain-text part of the same send, verbatim:**

```
Hi owner,

Your deck **hackerspace** has **5** current students of **5** allowed: the
limit has been reached, so no more students can register in a course.

Your deck's free trial ended on **Aug. 3, 2026** and the deck is in its grace
period.

Only _current_ students (registered in a course in the active semester) count;
staff and archived students never do. You can [free up
seats](http://hackerspace.localhost:8000/courses/students/archive-help/) by
ending the semester or archiving past students, or [upgrade your
subscription](http://hackerspace.localhost:8000/decks/subscription/) for a
higher limit.

_Bytedeck is a non-profit Society. The board members are volunteers, and put
many hours into running and further developing Bytedeck. Our subscription
pricing is competitive, and funds are only utilized for maintaining systems
and development._

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck
```

## Notes for review

This is the final step of #1734 (B1 #2210, B2 #2224, B3 #2262, B4 #2277 all merged). Remaining epic work after this: the #2110 webhook/sync PR (open, approved) and the #1730 close-out.

- Claude Code (`Bytedeck - payments integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated suspended-deck notices to clearly distinguish expired trials from expired subscriptions.
  - Added the configured grace-period duration and deadline details to relevant status messages.
  - Improved limit-warning emails for decks in a trial or subscription grace period, including the governing expiration date.
  - Preserved paid-through messaging for active subscriptions.
- **Tests**
  - Added coverage confirming that grace-period trial limit emails show the correct expiration and grace-period information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->