### PR TITLE
chore: scope CodeRabbit's full_clean() rule to application code, not tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,7 +18,7 @@ reviews:
           - Ensure each method has a clear, detailed docstring explaining its purpose, parameters, and return values. Enhance existing docstrings for clarity and completeness.
           - Do not suggest adding type annotations.
           - Review Django querysets for potential performance improvements and suggest optimizations where applicable.
-          - Ensure that for every model.save() there is a model.full_clean() that precedes it.
+          - Ensure that for every model.save() in application (non-test) code there is a model.full_clean() that precedes it. Do not request model.full_clean() in test files (e.g. tests/, test_*.py, *_test.py, tests.py); tests intentionally build objects directly and are not required to call full_clean().
           - Avoid adding generic exception handling (e.g., `except Exception`) in test files. Each test failure should be addressed by the developer with specific exception handling or fixes.
           - Avoid adding comments relating to importing modules.
     - path: "tests/*.py"


### PR DESCRIPTION
### What?
Update `.coderabbit.yaml` so CodeRabbit stops requesting `model.full_clean()` before `model.save()` in **test** files. The rule now applies only to application (non-test) code.

### Why?
The `**/*.py` path instruction said "for every model.save() there is a model.full_clean() that precedes it" with no test-file exception, so CodeRabbit kept flagging tests. The project only wants `full_clean()` in application code (CLAUDE.md: "Prefer calling `model.full_clean()` before `model.save()` in new code … match the surrounding style"); tests intentionally build objects directly and don't need it. The noise was landing on every test that calls `.save()`.

### How?
Reworded the single bullet in the `**/*.py` `path_instructions` block to scope it to application code and explicitly exclude test files (`tests/`, `test_*.py`, `*_test.py`, `tests.py`). This mirrors the block's existing test-file carve-out (the "avoid generic exception handling in test files" bullet), so the instruction set stays internally consistent. No other instructions changed.

### Testing?
Config-only. Re-parsed `.coderabbit.yaml` as valid YAML (both `path_instructions` entries intact).

### Screenshots (if front end is affected)
N/A — CI/review configuration only.

### Anything Else?
Because this is an OSS repo, CodeRabbit applies the config from the **base** branch, so the change takes effect on the **next** PR after this merges (this PR is still reviewed under the current config). Separately: the second `path_instructions` entry uses `tests/*.py`, which likely doesn't match this repo's actual test paths (`src/<app>/tests/…`); I left it alone here since the fix above is self-contained, but it could be broadened to `**/tests/**/*.py` / `**/test_*.py` in a follow-up if you want the test-specific instructions to actually apply.

### Review request
@tylerecouture

- Claude Code (Bytedeck - integrations and automations)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_