### PR TITLE
fix: add a re-send verification link to the verify-email reminder (#2233)

### DIFF
--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -14,6 +14,7 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 
 from django_resized import ResizedImageField
 from django_tenants.utils import get_public_schema_name
@@ -524,7 +525,20 @@ def user_logged_in_verify_email_reminder_handler(request, user, **kwargs):
     # Only send the email when they login again
     if not recently_signed_up_with_email:
         if email_address and email_address.verified is False:
-            messages.info(request, f"Please verify your email address: {user.email}.")
+            # Give the reminder an actionable link: clicking it re-sends the
+            # verification email (the same resend endpoint the profile form uses),
+            # since verifying requires the link inside that email. extra_tags='safe'
+            # lets the messages snippet render the anchor instead of escaping it.
+            resend_url = reverse('profiles:profile_resend_email_verification', args=[user.profile.pk])
+            messages.info(
+                request,
+                format_html(
+                    'Please verify your email address: {}. <a href="{}">Re-send verification link</a>.',
+                    user.email,
+                    resend_url,
+                ),
+                extra_tags='safe',
+            )
 
 
 def smart_list(value, delimiter=",", func=None):

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -582,7 +582,13 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             mock_messages_info.assert_called()
             message = mock_messages_info.call_args[0][1]
 
-        self.assertEqual(message, f"Please verify your email address: {self.test_student1.email}.")
+        # The reminder names the address and carries an actionable "Re-send verification link"
+        # pointing at the resend endpoint, flagged safe so the snippet renders the anchor (#2233).
+        resend_url = reverse('profiles:profile_resend_email_verification', args=[self.test_student1.profile.pk])
+        self.assertIn(f"Please verify your email address: {self.test_student1.email}", message)
+        self.assertIn(resend_url, message)
+        self.assertIn("Re-send verification link", message)
+        self.assertEqual(mock_messages_info.call_args.kwargs.get('extra_tags'), 'safe')
         self.client.logout()
         # end test of method: profile_manager.models.user_logged_in_verify_email_reminder_handler
 


### PR DESCRIPTION
### What?
The "Please verify your email address" reminder shown on login now carries an actionable **Re-send verification link** instead of being plain text.

### Why?
The reminder told the user to verify their email but gave them no way to do it: there was no link to click, so a user with an unverified address had to go hunting for the resend action on their profile edit page. Issue #2233.

### How?
- In `profile_manager.models.user_logged_in_verify_email_reminder_handler`, the message is now built with `format_html(...)` and includes an `<a>` pointing at the existing resend endpoint (`profiles:profile_resend_email_verification`), the same one the profile edit form's help text already links to. Clicking it re-sends the confirmation email, whose link is what actually verifies the address.
- The message is added with `extra_tags='safe'` so the shared messages snippet renders the anchor rather than escaping it.
- No new endpoint, model, or migration: it reuses the resend view that already exists.

### Testing?
- Updated the existing reminder test (`test_profile_update__email_confirmation_flow`) to assert the message names the address, contains the resend URL and the "Re-send verification link" text, and is flagged safe.
- `python src/manage.py test profile_manager` is green (111 tests). `ruff check` clean.

### Screenshots (if front end is affected)
**Before**: plain text, nothing to click:

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2233/before_reminder.png)

**After**: the reminder now offers a "Re-send verification link":

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2233/after_reminder.png)

Captured from the real running `hackerspace` dev deck, logged in as a student with an unverified email address.

### Anything Else?
The link re-sends the verification email (verification itself happens by clicking the link inside that email), matching the wording and behaviour of the existing resend link on the profile edit form.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_