### PR TITLE
fix: show the ByteDeck wordmark in platform email sigblocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,11 @@ TENANT_DEFAULT_OWNER_PASSWORD=password
 # unset the page links the demo deck without printing a code.
 #DEMO_DECK_COURSE_CODE=
 
+# Sigblock logo for platform emails (deck-request verification/welcome).
+# Must be an absolute URL reachable from recipients' mail clients; defaults
+# to the production static host's wordmark.
+#PUBLIC_EMAIL_LOGO_URL=
+
 # DECK STATUS NOTICES (#1729/#1733) ###############################
 # When unset/False the nightly deck-status task runs REPORT-ONLY: it logs which
 # expiry/limit/suspension notices it would send, but sends and records nothing.

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -709,6 +709,16 @@ STRIPE_PRICE_ID = env('STRIPE_PRICE_ID', default=None)  # the recurring Price (p
 # unset, the page links the demo deck without printing a code.
 DEMO_DECK_COURSE_CODE = env('DEMO_DECK_COURSE_CODE', default='')
 
+# Logo for the sigblock of platform emails (the public-tenant sends: deck-request
+# verification and welcome). Must be an ABSOLUTE URL: mail clients resolve the
+# email body with no origin, so a schema-relative static path renders as a broken
+# image. The default is the production static host's copy of
+# static/public/images/wordmark-v2.png (maintainer request, 2026-08-08).
+PUBLIC_EMAIL_LOGO_URL = env(
+    'PUBLIC_EMAIL_LOGO_URL',
+    default='https://d10ge8y4vx8iud.cloudfront.net/static/public/images/wordmark-v2.png',
+)
+
 
 # RECAPTCHA #######################################################
 

--- a/src/tenant/templates/tenant/email/_email_footer.html
+++ b/src/tenant/templates/tenant/email/_email_footer.html
@@ -7,6 +7,8 @@
   only utilized for maintaining systems and development.</em></p>
 <p>If you have any questions, contact us at <a href="mailto:contact@bytedeck.com">contact@bytedeck.com</a>.</p>
 <p>Bytedeck</p>
-{# emails rendered on the PUBLIC schema (e.g. the deck-request verification) have no #}
-{# SiteConfig for site_logo_url to read, so they pass the platform logo's URL instead #}
-{% if logo_url %}<p><img alt="[Logo]" src="{{ logo_url }}"></p>{% else %}<p><img alt="[Logo]" src="{% site_logo_url %}"></p>{% endif %}
+{# platform emails (the deck-request sends) pass the wordmark's absolute URL as logo_url: #}
+{# there is no SiteConfig on the public schema, and mail clients can't resolve relative #}
+{# static paths anyway. width/height show the 510x128 wordmark at half size (maintainer #}
+{# request, 2026-08-08). Tenant lifecycle emails omit logo_url and get the deck's logo. #}
+{% if logo_url %}<p><img alt="[Logo]" src="{{ logo_url }}" width="255" height="64"></p>{% else %}<p><img alt="[Logo]" src="{% site_logo_url %}"></p>{% endif %}

--- a/src/tenant/tests/test_utils.py
+++ b/src/tenant/tests/test_utils.py
@@ -130,6 +130,29 @@ class WelcomeEmailTest(ByteDeckTenantTestCase):
         self.assertIn('change your password', message)
         self.assertIn('alt="[Logo]"', message)  # the standard sigblock, logo included
 
+    def test_send_welcome_email__sigblock_shows_the_wordmark_at_half_size(self):
+        """The welcome sigblock logo is the platform wordmark by ABSOLUTE URL at
+        half its natural size (maintainer request, 2026-08-08). A new deck's
+        SiteConfig only holds the seeded default logo as a schema-relative path,
+        which mail clients render as a broken image."""
+        from unittest.mock import patch
+
+        from django.contrib.auth import get_user_model
+        from django.test import override_settings
+
+        from model_bakery import baker
+
+        from tenant.utils import DeckRequestService
+
+        user = baker.make(get_user_model(), first_name='Jane', last_name='Doe', email='jane@example.com')
+        with override_settings(PUBLIC_EMAIL_LOGO_URL='https://cdn.example.com/wordmark.png'):
+            with patch('tenant.utils.send_email_message.apply_async') as mock_apply:
+                DeckRequestService.send_welcome_email(user, self.tenant, 'pw-secret-123')
+
+        _subject, message, _recipients = mock_apply.call_args.kwargs['args']
+        self.assertIn('src="https://cdn.example.com/wordmark.png" width="255" height="64"', message)
+        self.assertNotIn('src="/static/', message)  # no schema-relative logo path survives
+
     def test_send_welcome_email__uses_username_when_owner_name_is_blank(self):
         """An owner with no first/last name set is greeted by username instead of
         an empty "Hello ,": legacy and seeded owners often have no name."""

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -581,10 +581,10 @@ class DeckRequestServiceTest(TestCase):
         link = request.build_absolute_uri(reverse("decks:verify_deck_request", args=[nonce]))
         self.assertIn(f'<a href="{link}">', message)
         self.assertIn("1 hour", message)  # TOKEN_MAX_AGE = 3600, humanized
-        # the platform logo, absolute so it renders inside email clients
+        # the platform wordmark at half its 510x128 natural size, by absolute URL
+        # so it renders inside email clients (maintainer request, 2026-08-08)
         self.assertIn('alt="[Logo]"', message)
-        self.assertIn(request.build_absolute_uri("/"), message.split('alt="[Logo]"')[1])
-        self.assertIn("pixels-4-icon", message)
+        self.assertIn(f'src="{settings.PUBLIC_EMAIL_LOGO_URL}" width="255" height="64"', message)
 
     @patch("tenant.utils.send_email_message.apply_async")
     def test_send_verification_email__without_request_uses_relative_link(self, mock_apply_async):

--- a/src/tenant/utils.py
+++ b/src/tenant/utils.py
@@ -194,23 +194,22 @@ class DeckRequestService:
         Returns:
             None
         """
-        from django.templatetags.static import static
+        from django.conf import settings
 
         if request is not None:
             verification_link = DeckRequestService.build_verification_link(request, nonce)
-            logo_url = request.build_absolute_uri(static("public/images/pixels-4-icon.png"))
         else:
             verification_link = reverse("decks:verify_deck_request", args=[nonce])
-            logo_url = static("public/images/pixels-4-icon.png")
 
         # rendered as the email's HTML part (send_email_message derives the
         # plain-text part from it); this email goes out on the PUBLIC schema, so
-        # the footer gets the platform logo explicitly (no SiteConfig here)
+        # the footer gets the platform wordmark's absolute URL explicitly (no
+        # SiteConfig here, and mail clients can't resolve relative paths)
         message = get_template("tenant/email/verify_deck_request.html").render({
             "first_name": first_name,
             "verification_link": verification_link,
             "verification_validity": _humanize_seconds(DeckRequestService.TOKEN_MAX_AGE),
-            "logo_url": logo_url,
+            "logo_url": settings.PUBLIC_EMAIL_LOGO_URL,
         })
 
         # send in the background so the request doesn't block on SMTP
@@ -245,14 +244,19 @@ class DeckRequestService:
         })
         subject = "".join(subject.splitlines())
 
+        from django.conf import settings
+
         # rendered as the email's HTML part (send_email_message derives the
-        # plain-text part from it); runs inside the new deck's schema context,
-        # so the shared footer resolves the logo from its SiteConfig
+        # plain-text part from it). A platform email, so the sigblock shows the
+        # ByteDeck wordmark by absolute URL: a brand-new deck's SiteConfig only
+        # holds the seeded default logo as a schema-relative path, which mail
+        # clients render as a broken image.
         message = get_template("tenant/email/welcome_message.html").render({
             "config": SiteConfig.get(),
             "tenant": tenant,
             "user": user,
             "password": password,
+            "logo_url": settings.PUBLIC_EMAIL_LOGO_URL,
         })
 
         # send in the background so the request doesn't block on SMTP


### PR DESCRIPTION
### What

Follow-up to #2291 (maintainer request, 2026-08-08): the deck-request emails' sigblock logo now shows the ByteDeck wordmark at half size, and actually renders in mail clients.

The old sigblock logo was broken in two ways:

1. The **verification email** built its logo URL from the incoming request's host, so anywhere but production the URL pointed at an unserved host (e.g. `http://localhost/static/...`).
2. The **welcome email** emitted the new deck's seeded SiteConfig logo as a schema-relative path (`/static/img/default_icon.png`). Mail clients resolve the body with no origin, so a relative path is a broken image for every recipient, in every environment.

Both platform emails now use a new `PUBLIC_EMAIL_LOGO_URL` setting: env-overridable, defaulting to the production static host's copy of the repo's `wordmark-v2.png` (`https://d10ge8y4vx8iud.cloudfront.net/static/public/images/wordmark-v2.png`). The shared footer renders it with `width="255" height="64"`, half the image's natural 510x128, per the maintainer's sizing request. Tenant lifecycle emails (expiry / limit / suspended) are untouched: they omit `logo_url` and keep resolving the deck's own logo from its SiteConfig.

### Testing

Updated/new tests pin the wordmark by absolute URL and the half-size attributes in both emails, and assert no schema-relative `src="/static/` path survives in the welcome email. Full suite + ruff + `makemigrations --check` pass locally.

### Email

Real sends from `_sent_mail` (dev file backend). Capture note: this sandbox's proxy blocks CloudFront, so for the screenshots the browser was served the repo's own `src/static/public/images/wordmark-v2.png` for that URL (the CDN object is the same file); everything else is the real message.

**Verification email:**

![verify email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/email-sigblock-wordmark/email-verify.png)

**Welcome email:**

![welcome email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/email-sigblock-wordmark/email-welcome.png)

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_