### PR TITLE
docs: bump 1.30.0 changelog date to cover its follow-up hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file chronologically records all notable changes to this website, including
 
 [Changelogs](http://keepachangelog.com/en/0.3.0/) | [Versioning](http://semver.org/) | [Branch model](https://nvie.com/posts/a-successful-git-branching-model/)
 
-### [1.30.0] 2026-07-23 Claude II
+### [1.30.0] 2026-08-01 Claude II
 * New Features:
   - **Repeatable quests now show when they'll be available again.** Completing a repeatable quest that has a cooldown used to make it silently vanish from the Available tab; it now appears in an "Available again soon" section at the top of that tab with a live countdown of when it returns (each entry links to the quest), and trying to start a quest you already have in progress now tells you to finish that one first [#57](https://github.com/bytedeck/bytedeck/issues/57)
   - **TAs can copy a quest after starting it.** A "Copy" button now appears on a quest's submission preview (the In Progress / Completed / Past Courses accordion) and on its full submission page, next to Drop and Continue. Previously a TA could only copy from the Available list, so once you started a quest and it became a submission you lost the option; copying creates a new draft quest using this one as a template, with the original set as its prerequisite [#141](https://github.com/bytedeck/bytedeck/issues/141)


### PR DESCRIPTION
### What?
Move the **[1.30.0]** CHANGELOG date from `2026-07-23` to `2026-08-01`. No other changes.

### Why?
~23 PRs merged to `staging`/`master` after the 1.30.0 entry was written. On review, **all of them are fixes/refinements to features 1.30.0 already describes** (no new headline feature), so folding them in as new bullets would just be "we also fixed X" noise on top of "we did X". The existing descriptions remain accurate:
- The largest group hardens the **billing / deck-lifecycle** rollout, which 1.30.0 describes as "mostly disabled by default while it's validated in report-only mode." That framing still holds: the engine is gated behind `DECK_NOTICES_ENABLED`, which **defaults off and runs report-only while off** (`tenant/notices.py`, `tenant/tasks.py`), so nothing about the user-facing description changed.
- The rest are UI polish for features already listed (Completion Statuses, grant-badge flow, quick-reply, submission-button tooltips), which don't change what those features do.

So the only thing that was stale was the **date**: 1.30.0's content reached its final state with the last of those changes (#2248, `2026-08-01`).

### How?
One-line date change on the `### [1.30.0] … Claude II` header.

### Testing?
Docs-only; no code paths affected.

### Screenshots (if front end is affected)
N/A — documentation only.

### Anything Else?
- **Date choice**: I used `2026-08-01` (the last substantive change, #2248). If you'd rather date it when the wave fully landed on `master`/production, that was the `2026-08-08` staging→master merge — easy to switch.
- One item I deliberately did **not** add per your "don't list fixes" steer, but will flag since it's security-relevant: #2113/#2123 sanitized comment HTML (instead of fully escaping it). It isn't tied to anything 1.30.0 describes, so there's no inaccuracy to fix, but if you want it surfaced to users I can add a one-line Bugfix. Your call.

### Review request
@tylerecouture

- Claude Code (Bytedeck - integrations and automations)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_