### PR TITLE
ci: auto-post changelog releases to GitHub Discussions

### DIFF
--- a/.github/scripts/changelog_new_sections.py
+++ b/.github/scripts/changelog_new_sections.py
@@ -11,12 +11,17 @@ re-posted on later pushes.
 
 Outputs (for the workflow):
   * ``discussion_body.md`` : the post body (new sections, oldest first), if any.
-  * ``$GITHUB_OUTPUT`` gets ``has_new`` (true/false) and, when true, ``title``.
+  * ``$GITHUB_OUTPUT`` gets ``has_new`` (true/false) and, when true, ``title``
+    plus ``versions`` (the announced version numbers, comma-separated, ascending)
+    for the workflow's per-version duplicate guard.
 
 Env:
-  * ``BEFORE_SHA``   : the ``github.event.before`` commit (may be all-zeros for a
-                       brand-new branch, in which case the "old" changelog is
-                       treated as empty so every version reads as new).
+  * ``BEFORE_SHA``   : the ``github.event.before`` commit to diff against. An
+                       all-zeros SHA (a force-push / rewritten history) or an
+                       unreachable commit means there is no reliable baseline; in
+                       that case only the single newest changelog section is
+                       announced (never the whole history), and the workflow's
+                       per-version duplicate guard prevents a repost.
   * ``CHANGELOG``    : path to the changelog (default ``CHANGELOG.md``).
   * ``GITHUB_OUTPUT``: set by Actions; if absent (local testing) it is skipped.
 """
@@ -163,6 +168,7 @@ def main():
     title = format_title(versions)
     write_output("has_new", "true")
     write_output("title", title)
+    write_output("versions", ",".join(versions))
     print(f"New version(s) detected: {', '.join(versions)}")
     print(f"Discussion title: {title}")
 

--- a/.github/scripts/changelog_new_sections.py
+++ b/.github/scripts/changelog_new_sections.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Detect newly-added CHANGELOG version sections and build a discussion post.
+
+Run by the ``announce-changelog`` workflow when ``CHANGELOG.md`` changes on the
+``master`` branch. It compares the current ``CHANGELOG.md`` against its state at
+the commit before the push (``BEFORE_SHA``) and, for every ``### [x.y.z]`` version
+heading that is present now but was not present then, extracts that whole section
+verbatim. Those sections become the body of a single GitHub Discussion
+announcement, so a release that reaches production is posted once and never
+re-posted on later pushes.
+
+Outputs (for the workflow):
+  * ``discussion_body.md`` : the post body (new sections, oldest first), if any.
+  * ``$GITHUB_OUTPUT`` gets ``has_new`` (true/false) and, when true, ``title``.
+
+Env:
+  * ``BEFORE_SHA``   : the ``github.event.before`` commit (may be all-zeros for a
+                       brand-new branch, in which case the "old" changelog is
+                       treated as empty so every version reads as new).
+  * ``CHANGELOG``    : path to the changelog (default ``CHANGELOG.md``).
+  * ``GITHUB_OUTPUT``: set by Actions; if absent (local testing) it is skipped.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+# Matches a version heading like "### [1.30.0] 2026-08-01 Claude II" and
+# captures the semantic version. Only headings of this exact shape delimit a
+# release section; anything else in the file is section content.
+HEADER_RE = re.compile(r"^### \[(\d+\.\d+\.\d+)\]")
+
+CHANGELOG = os.environ.get("CHANGELOG", "CHANGELOG.md")
+
+
+def read_current(path):
+    """Return the working-tree changelog text, or '' if it can't be read."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def read_old(before_sha, path):
+    """Return ``(available, text)`` for the changelog at ``before_sha``.
+
+    ``available`` is False when there is no reliable baseline to diff against:
+    an all-zero SHA (GitHub's sentinel for "no previous commit", e.g. a
+    force-push that rewrites history or a freshly created ref) or a git error
+    (the commit is unreachable, or the file did not exist there). The caller
+    must not treat an unavailable baseline as "empty old changelog": doing so
+    would mark every historical version as new and flood the discussion. When
+    True, ``text`` is the changelog exactly as it was at that commit.
+    """
+    if not before_sha or set(before_sha) == {"0"}:
+        return False, ""
+    try:
+        text = subprocess.check_output(
+            ["git", "show", f"{before_sha}:{path}"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return True, text
+    except subprocess.CalledProcessError:
+        return False, ""
+
+
+def parse_sections(text):
+    """Split changelog text into an ordered list of (version, section_text).
+
+    ``section_text`` runs from a version heading up to (but not including) the
+    next version heading, with trailing blank lines stripped. Content before the
+    first heading (the file's intro) is ignored.
+    """
+    lines = text.splitlines()
+    sections = []
+    current_version = None
+    current_lines = []
+
+    def flush():
+        if current_version is not None:
+            # Drop trailing blank lines so joined sections space evenly.
+            body = "\n".join(current_lines).rstrip("\n")
+            sections.append((current_version, body))
+
+    for line in lines:
+        match = HEADER_RE.match(line)
+        if match:
+            flush()
+            current_version = match.group(1)
+            current_lines = [line]
+        elif current_version is not None:
+            current_lines.append(line)
+    flush()
+    return sections
+
+
+def version_key(version):
+    """Sort key turning '1.30.0' into (1, 30, 0) for chronological ordering."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def format_title(versions):
+    """Build the announcement title from the new version numbers (ascending).
+
+    One version -> "(1.30.0)"; two -> "(1.30.0 and 1.31.0)"; three or more ->
+    "(1.30.0, 1.31.0, and 1.32.0)". Mirrors the wording of past announcements.
+    """
+    ordered = sorted(versions, key=version_key)
+    if len(ordered) == 1:
+        joined = ordered[0]
+    elif len(ordered) == 2:
+        joined = f"{ordered[0]} and {ordered[1]}"
+    else:
+        joined = ", ".join(ordered[:-1]) + f", and {ordered[-1]}"
+    return f"Bytedeck App Updates ({joined})"
+
+
+def write_output(name, value):
+    """Append a ``name=value`` line to $GITHUB_OUTPUT if the runner set it."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def main():
+    before_sha = os.environ.get("BEFORE_SHA", "")
+    new_text = read_current(CHANGELOG)
+    available, old_text = read_old(before_sha, CHANGELOG)
+    new_sections = parse_sections(new_text)
+
+    if available:
+        # Normal path: announce every version present now but not at BEFORE_SHA,
+        # ordered oldest-first so a multi-version catch-up post reads
+        # chronologically.
+        old_versions = {version for version, _ in parse_sections(old_text)}
+        added = [(v, body) for v, body in new_sections if v not in old_versions]
+    elif new_sections:
+        # No reliable baseline (force-push / rewritten history): fall back to
+        # announcing only the single newest release section rather than the whole
+        # changelog. The workflow's duplicate-title guard still prevents a repost
+        # if that version was already announced.
+        added = [max(new_sections, key=lambda item: version_key(item[0]))]
+        print("No reliable baseline; falling back to newest section only.")
+    else:
+        added = []
+    added.sort(key=lambda item: version_key(item[0]))
+
+    if not added:
+        write_output("has_new", "false")
+        print("No new changelog version sections detected.")
+        return
+
+    versions = [v for v, _ in added]
+    body = "\n\n\n".join(section for _, section in added).rstrip("\n") + "\n"
+    with open("discussion_body.md", "w", encoding="utf-8") as fh:
+        fh.write(body)
+
+    title = format_title(versions)
+    write_output("has_new", "true")
+    write_output("title", title)
+    print(f"New version(s) detected: {', '.join(versions)}")
+    print(f"Discussion title: {title}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/announce-changelog.yml
+++ b/.github/workflows/announce-changelog.yml
@@ -53,11 +53,15 @@ jobs:
         uses: actions/github-script@v7
         env:
           DISCUSSION_TITLE: ${{ steps.extract.outputs.title }}
+          DISCUSSION_VERSIONS: ${{ steps.extract.outputs.versions }}
         with:
           github-token: ${{ secrets.DISCUSSIONS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const title = process.env.DISCUSSION_TITLE;
+            const versions = (process.env.DISCUSSION_VERSIONS || '')
+              .split(',')
+              .filter(Boolean);
             const body = fs.readFileSync('discussion_body.md', 'utf8');
             const { owner, repo } = context.repo;
 
@@ -87,19 +91,32 @@ jobs:
               return;
             }
 
-            // Best-effort duplicate guard: if a discussion with this exact title
-            // already exists (e.g. a re-run or a force-push), don't post again.
-            const found = await github.graphql(
-              `query($q: String!) {
-                 search(query: $q, type: DISCUSSION, first: 20) {
-                   nodes { ... on Discussion { title url } }
-                 }
-               }`,
-              { q: `repo:${owner}/${repo} in:title ${JSON.stringify(title)}` }
-            );
-            const duplicate = found.search.nodes.find((n) => n && n.title === title);
-            if (duplicate) {
-              core.info(`Discussion already exists, skipping: ${duplicate.url}`);
+            // Best-effort duplicate guard, keyed on the version number(s) rather
+            // than the exact title. A version number is the stable identity of an
+            // announcement and always appears in the discussion title, so this
+            // still recognizes a version a previous post announced alongside
+            // others under a different aggregate title (e.g. a later force-push
+            // fallback re-announcing just the newest). If every version in this
+            // post is already announced, skip; otherwise post.
+            const titleHasVersion = (discussionTitle, version) => {
+              // Bounded match so "1.3.0" doesn't match "1.30.0" or "11.3.0".
+              const escaped = version.replace(/\./g, '\\.');
+              return new RegExp(`(^|[^0-9.])${escaped}([^0-9.]|$)`).test(discussionTitle);
+            };
+            const versionAnnounced = async (version) => {
+              const res = await github.graphql(
+                `query($q: String!) {
+                   search(query: $q, type: DISCUSSION, first: 20) {
+                     nodes { ... on Discussion { title } }
+                   }
+                 }`,
+                { q: `repo:${owner}/${repo} in:title ${JSON.stringify(version)}` }
+              );
+              return res.search.nodes.some((n) => n && titleHasVersion(n.title, version));
+            };
+            const announced = await Promise.all(versions.map(versionAnnounced));
+            if (versions.length && announced.every(Boolean)) {
+              core.info(`Version(s) already announced, skipping: ${versions.join(', ')}`);
               return;
             }
 

--- a/.github/workflows/announce-changelog.yml
+++ b/.github/workflows/announce-changelog.yml
@@ -1,0 +1,114 @@
+name: Announce Changelog
+
+# Posts a release announcement to GitHub Discussions when a new changelog
+# version reaches production. The branch model is develop -> staging -> master;
+# master is production, so this fires only on pushes to master that touch
+# CHANGELOG.md. The extract step diffs CHANGELOG.md against the commit before the
+# push (github.event.before) and emits only the version sections that are newly
+# added, so a release is announced exactly once and later edits to an already
+# released section (typo fixes, etc.) don't re-post. If nothing new was added,
+# the post step is skipped.
+#
+# Auth: the post uses GITHUB_TOKEN (granted discussions:write below), which can
+# create discussions via GraphQL and posts as github-actions[bot]. To have the
+# announcement authored by a real account instead, add a DISCUSSIONS_TOKEN
+# repository secret (a PAT with discussions write access) and it's used in
+# preference to GITHUB_TOKEN.
+on:
+  push:
+    branches: [master]
+    paths:
+      - CHANGELOG.md
+
+# Least-privilege: this workflow only reads the repo and writes a discussion.
+permissions:
+  contents: read
+  discussions: write
+
+# Never run two announcement jobs at once; if two pushes land close together,
+# let the first finish so the duplicate-title guard sees its discussion.
+concurrency:
+  group: announce-changelog
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    name: Announce changelog to Discussions
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history so the extract step can `git show` CHANGELOG.md at
+          # github.event.before to diff against. This job doesn't push, so don't
+          # leave GITHUB_TOKEN persisted in .git/config for later steps to read.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Extract newly-added changelog sections
+        id: extract
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: python3 .github/scripts/changelog_new_sections.py
+      - name: Post announcement to Discussions
+        if: steps.extract.outputs.has_new == 'true'
+        uses: actions/github-script@v7
+        env:
+          DISCUSSION_TITLE: ${{ steps.extract.outputs.title }}
+        with:
+          github-token: ${{ secrets.DISCUSSIONS_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const title = process.env.DISCUSSION_TITLE;
+            const body = fs.readFileSync('discussion_body.md', 'utf8');
+            const { owner, repo } = context.repo;
+
+            // Look up the repository node id and its discussion categories so we
+            // can post into the "Announcements" category (the changelog home).
+            const repoData = await github.graphql(
+              `query($owner: String!, $repo: String!) {
+                 repository(owner: $owner, name: $repo) {
+                   id
+                   discussionCategories(first: 25) { nodes { id name } }
+                 }
+               }`,
+              { owner, repo }
+            );
+            const repositoryId = repoData.repository.id;
+            const categories = repoData.repository.discussionCategories.nodes;
+            // Match "Announcements" exactly, then fall back to any category whose
+            // name contains "announcement" (in case it's renamed or emoji-tagged).
+            const category =
+              categories.find((c) => c.name.toLowerCase() === 'announcements') ||
+              categories.find((c) => c.name.toLowerCase().includes('announcement'));
+            if (!category) {
+              core.setFailed(
+                `No "Announcements" discussion category found. Available: ` +
+                  categories.map((c) => c.name).join(', ')
+              );
+              return;
+            }
+
+            // Best-effort duplicate guard: if a discussion with this exact title
+            // already exists (e.g. a re-run or a force-push), don't post again.
+            const found = await github.graphql(
+              `query($q: String!) {
+                 search(query: $q, type: DISCUSSION, first: 20) {
+                   nodes { ... on Discussion { title url } }
+                 }
+               }`,
+              { q: `repo:${owner}/${repo} in:title ${JSON.stringify(title)}` }
+            );
+            const duplicate = found.search.nodes.find((n) => n && n.title === title);
+            if (duplicate) {
+              core.info(`Discussion already exists, skipping: ${duplicate.url}`);
+              return;
+            }
+
+            const created = await github.graphql(
+              `mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+                 createDiscussion(input: {
+                   repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body
+                 }) { discussion { url } }
+               }`,
+              { repositoryId, categoryId: category.id, title, body }
+            );
+            core.info(`Created discussion: ${created.createDiscussion.discussion.url}`);


### PR DESCRIPTION
### What?
Adds a GitHub Action that automatically posts a release announcement to [GitHub Discussions](https://github.com/bytedeck/bytedeck/discussions) whenever a new changelog version reaches **production** (the `master` branch). This is the step we currently do by hand: e.g. [discussion #2150](https://github.com/bytedeck/bytedeck/discussions/2150) ("Bytedeck App Updates (1.29.0 and 1.30.0)").

Two files:
- `.github/workflows/announce-changelog.yml`: the workflow.
- `.github/scripts/changelog_new_sections.py`: extracts the newly-added changelog section(s) and builds the post title/body.

### Why?
The branch model is `develop -> staging -> master`, and `master` is production. When a release lands on `master`, its changelog section should be announced to teachers/students in Discussions. Doing it manually is easy to forget and easy to get wrong (wrong version, stale copy). This makes it happen automatically, once, at the exact moment the release goes live.

### How?
- **Trigger (production only):** `on: push` to `master`, filtered to `paths: [CHANGELOG.md]`. It never fires for `develop`/`staging`, so a version is only announced when it actually reaches production.
- **Announce exactly once:** the extract step diffs the current `CHANGELOG.md` against its state at `github.event.before` (the commit the push replaced) and emits only version sections (`### [x.y.z] ...`) that are newly added. Consequences:
  - A later push that edits an already-released section (typo fix, etc.) adds no new version, so nothing is re-posted.
  - If a `master` push batches more than one new version, all of them are announced together (oldest-first), titled like `Bytedeck App Updates (1.30.0 and 1.31.0)`.
- **Post:** an `actions/github-script` step looks up the repo's **Announcements** discussion category and creates a discussion whose body is the changelog section(s) verbatim (issue links preserved). It's skipped entirely when the extract step finds nothing new.
- **Safety:**
  - If no reliable baseline exists (force-push / rewritten history so `github.event.before` is unreachable or all-zeros), it falls back to announcing only the single newest section rather than flooding Discussions with the entire changelog history.
  - **Per-version duplicate guard:** before posting, the workflow checks each version being announced against existing Announcement discussion titles (bounded match, so `1.3.0` can't match `1.30.0`/`11.3.0`) and skips if they're all already announced. Keying on the version number rather than the exact title means a version a prior post announced alongside others (or under a different aggregate title) is still recognized, so re-runs and force-push fallbacks don't create duplicates.
  - `concurrency` serializes announcement runs so two near-simultaneous pushes can't both post.
- **Auth:** uses `GITHUB_TOKEN` with `permissions: discussions: write` by default (posts as `github-actions[bot]`). Optionally set a `DISCUSSIONS_TOKEN` repository secret (a PAT with discussions write access) to author the post as a real account instead; the workflow prefers it when present.

**Activation note:** because the workflow triggers on push to `master`, it only starts working once this change itself has propagated `develop -> staging -> master`. The first real announcement will be the next release that reaches `master` after that. Already-announced versions (1.29.0 / 1.30.0) are never re-posted, because they're already in the changelog at whatever `master` commit precedes that release push.

### Testing?
The extraction script was exercised locally against this repo's real git history and CHANGELOG.md:
- **No changelog change** (`BEFORE_SHA` = HEAD): `has_new=false`, post step skipped.
- **Real release diff** (`BEFORE_SHA` = the commit before `1.30.0` was added): detects exactly `1.30.0`, extracts its full section verbatim, title `Bytedeck App Updates (1.30.0)`, `versions=1.30.0`.
- **No reliable baseline** (all-zero and unreachable `BEFORE_SHA`): falls back to the newest section only (`1.30.0`), not the whole 80+ version history.
- **Title formatting** for one / two / three+ versions matches the existing convention (`(1.30.0)`, `(1.29.0 and 1.30.0)`, `(1.29.0, 1.30.0, and 1.31.0)`).
- **Per-version match** (the duplicate guard's bounded regex): verified it matches a version inside single- and multi-version titles and does not false-match `1.3.0` against `1.30.0`/`11.3.0`.

Also: `ruff check` clean on the script, workflow YAML parses, and the embedded `github-script` JS passes `node --check` (async-wrapped, as `actions/github-script` runs it). No em dashes (per house style).

### Screenshots (if front end is affected)
N/A (CI / automation only; no front-end or user-visible app change).

### Anything Else?
- The posted body is the changelog section verbatim, so it reads exactly like the hand-written announcements do today; it is intentionally not signed by a Claude session (it's an automated maintainer-style post).
- If `GITHUB_TOKEN` is ever blocked from creating discussions in this org, add the `DISCUSSIONS_TOKEN` PAT secret described above and no code change is needed.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - integrations and automations`)