### PR TITLE
HOTFIX: fix: prune stale docker images/cache before the deploy build

### DIFF
--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -10,6 +10,14 @@ cd "$(dirname "$0")/.."
 
 COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
 
+# Reclaim disk before building so image layers and BuildKit cache left by earlier
+# deploys can't fill the host and fail the build mid-`pip install` ([Errno 28] No
+# space left on device). Only unused data is removed: dangling images (a previous
+# deploy's now-superseded image) and build cache. Named volumes (the Postgres
+# data) are never touched. Best-effort: a prune hiccup shouldn't fail the deploy.
+docker image prune -f || echo "WARN: docker image prune failed; continuing."
+docker builder prune -f || echo "WARN: docker builder prune failed; continuing."
+
 $COMPOSE build
 
 # Update the web app's systemd unit file


### PR DESCRIPTION
### What?
Add two best-effort prune commands to `production/server-update.sh`, right before `docker compose build`, so each deploy reclaims disk from earlier deploys:

```sh
docker image prune -f    # dangling images (a previous deploy's superseded image)
docker builder prune -f  # BuildKit cache
```

### Why?
The **staging** deploy failed ([Deploy run #41](https://github.com/bytedeck/bytedeck/actions/runs/31287699932/job/93179422217)) at the `celery` image's `RUN python3 -m pip install -r requirements.txt` with:

```
ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device
```

`server-update.sh` runs `docker compose build` on every deploy but never reclaims space, so image layers and BuildKit cache from earlier deploys accumulate on the self-hosted host until a build can't write. This was the **first failure after a long run of green deploys** (deploy #40, ~5h earlier, was fine), which is the signature of disk creeping to full rather than a code regression. It is unrelated to any application change.

### How?
Prune **before** `$COMPOSE build` so a near-full host self-heals on its next deploy (the pruned build cache is usually the bulk of the growth). Safety:
- Only **unused** data is removed: dangling (untagged) images and build cache. **Named volumes (the Postgres data) are never touched** (no `--volumes`, no `docker system prune`).
- Both prunes are **best-effort** (`|| echo "WARN: ..."`), matching the script's existing pattern for non-critical steps (nginx reload, runner setup), so a prune hiccup can't fail an otherwise-good deploy.
- Trade-off: clearing the BuildKit cache each deploy makes the build re-download/rebuild layers (a little slower), in exchange for a deploy that can't run the host out of disk.

### Testing?
Deploy-infra shell script; no application code paths. Validated `sh -n production/server-update.sh` (syntax OK). The prune commands run as part of the next staging deploy of this branch, so merging this exercises the new path directly.

### Screenshots (if front end is affected)
N/A (deploy script only; no front-end or user-visible change).

### Anything Else?
- **A host already full still needs a one-time manual cleanup**, since the very build that would run this new prune can only start once there's room. On the `bytedeck-staging` host: `docker system prune -af` (keeps named volumes) and `docker builder prune -af`, then re-run the failed `deploy-staging` job (the `workflow_run` payload is preserved) or push to `staging` again. After that, this change keeps it from recurring.
- Targeted at `staging` as a `HOTFIX:` per the branch model, since it's the staging deploy path that's broken and it should reach the hosts without waiting on the normal `develop` release cycle. The same prune benefits production, so it rides `staging -> master` with the rest.
- CodeRabbit doesn't auto-review PRs to `staging`, so I'll request a review by comment.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - integrations and automations`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_