### PR TITLE
HOTFIX: fix: make nginx follow the web container's address instead of caching it

### DIFF
--- a/nginx/bytedeck.conf.template
+++ b/nginx/bytedeck.conf.template
@@ -8,11 +8,24 @@
 # source of truth instead of maintaining divergent copies. Do not edit the
 # generated /etc/nginx/sites-available/bytedeck.conf directly.
 
-# the upstream uwsgi component nginx needs to connect to
-upstream django {
-    # server unix:/bytedeck-volume/app.sock; # for a file socket
-    server web:8000; # for a web port socket (we'll use this first)
-}
+# Resolve the `web` service name through Docker's embedded DNS (127.0.0.11) on
+# every request rather than once at startup, so nginx follows the app container
+# to whatever address it currently has.
+#
+# nginx caches a hostname it resolves at config-load time for the whole life of
+# the worker process. Compose gives the `web` container a fresh IP whenever it
+# is recreated (`systemctl restart bytedeck.com` does exactly that), so a cached
+# address goes stale on every restart and nginx keeps dialling the dead one:
+# `connect() failed (111: Connection refused) ... upstream: "uwsgi://<old-ip>:8000"`,
+# i.e. a 502 on every request until nginx itself is reloaded.
+#
+# `valid=10s` bounds how long a resolved address is reused. Docker's DNS returns
+# no TTL of its own, so without it nginx would cache indefinitely again.
+#
+# None of this applies to a unix socket (`uwsgi_pass unix:/bytedeck-volume/app.sock;`,
+# the alternative the commented-out socket_data mounts in the compose files are
+# for): a path cannot go stale, so it needs no resolver and no variable.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 server {
 
@@ -73,7 +86,15 @@ server {
 
 
     location / {
-        uwsgi_pass django;
+        # The variable is load-bearing: nginx only consults the resolver at
+        # request time when the passed address contains one. Inlining the name
+        # (`uwsgi_pass web:8000`) or naming an `upstream` block resolves it once
+        # at startup and caches the address for the life of the worker, which is
+        # the stale-address 502 described at the top of this file. envsubst in
+        # nginx/Dockerfile substitutes only the domain placeholder, so
+        # $web_upstream survives the build untouched.
+        set $web_upstream web;
+        uwsgi_pass $web_upstream:8000;
         include /etc/nginx/uwsgi_params;
         # Forward the original request scheme so Django's request.is_secure()
         # is correct behind this TLS-terminating proxy. Without it, is_secure()

--- a/nginx/bytedeck.conf.template
+++ b/nginx/bytedeck.conf.template
@@ -8,24 +8,11 @@
 # source of truth instead of maintaining divergent copies. Do not edit the
 # generated /etc/nginx/sites-available/bytedeck.conf directly.
 
-# Resolve the `web` service name through Docker's embedded DNS (127.0.0.11) at
-# request time rather than once at startup, so nginx follows the app container
-# to whatever address it currently has.
-#
-# nginx caches a hostname it resolves at config-load time for the whole life of
-# the worker process. Compose gives the `web` container a fresh IP whenever it
-# is recreated (`systemctl restart bytedeck.com` does exactly that), so a cached
-# address goes stale on every restart and nginx keeps dialling the dead one:
-# `connect() failed (111: Connection refused) ... upstream: "uwsgi://<old-ip>:8000"`,
-# i.e. a 502 on every request until nginx itself is reloaded.
-#
-# `valid=10s` bounds how long a resolved address is reused, so the lookup is not
-# literally once per request. Docker's DNS returns no TTL of its own, so without
-# it nginx would fall back to caching indefinitely again.
-#
-# None of this applies to a unix socket (`uwsgi_pass unix:/bytedeck-volume/app.sock;`,
-# the alternative the commented-out socket_data mounts in the compose files are
-# for): a path cannot go stale, so it needs no resolver and no variable.
+# Docker's embedded DNS, so nginx can look `web` up while it is serving rather
+# than only at config load. A hostname resolved at config load is cached for the
+# life of the worker process, and compose gives `web` a new IP every time it is
+# recreated, so without this nginx dials a dead address after each restart and
+# 502s until it is reloaded. `valid=10s` caps how long an answer is reused.
 resolver 127.0.0.11 valid=10s ipv6=off;
 
 server {
@@ -87,13 +74,9 @@ server {
 
 
     location / {
-        # The variable is load-bearing: nginx only consults the resolver at
-        # request time when the passed address contains one. Inlining the name
-        # (`uwsgi_pass web:8000`) or naming an `upstream` block resolves it once
-        # at startup and caches the address for the life of the worker, which is
-        # the stale-address 502 described at the top of this file. envsubst in
-        # nginx/Dockerfile substitutes only the domain placeholder, so
-        # $web_upstream survives the build untouched.
+        # Keep the hostname in a variable. nginx uses the resolver above only
+        # when the passed address contains one; `uwsgi_pass web:8000` or an
+        # `upstream` block would go back to resolving once at startup.
         set $web_upstream web;
         uwsgi_pass $web_upstream:8000;
         include /etc/nginx/uwsgi_params;

--- a/nginx/bytedeck.conf.template
+++ b/nginx/bytedeck.conf.template
@@ -8,8 +8,8 @@
 # source of truth instead of maintaining divergent copies. Do not edit the
 # generated /etc/nginx/sites-available/bytedeck.conf directly.
 
-# Resolve the `web` service name through Docker's embedded DNS (127.0.0.11) on
-# every request rather than once at startup, so nginx follows the app container
+# Resolve the `web` service name through Docker's embedded DNS (127.0.0.11) at
+# request time rather than once at startup, so nginx follows the app container
 # to whatever address it currently has.
 #
 # nginx caches a hostname it resolves at config-load time for the whole life of
@@ -19,8 +19,9 @@
 # `connect() failed (111: Connection refused) ... upstream: "uwsgi://<old-ip>:8000"`,
 # i.e. a 502 on every request until nginx itself is reloaded.
 #
-# `valid=10s` bounds how long a resolved address is reused. Docker's DNS returns
-# no TTL of its own, so without it nginx would cache indefinitely again.
+# `valid=10s` bounds how long a resolved address is reused, so the lookup is not
+# literally once per request. Docker's DNS returns no TTL of its own, so without
+# it nginx would fall back to caching indefinitely again.
 #
 # None of this applies to a unix socket (`uwsgi_pass unix:/bytedeck-volume/app.sock;`,
 # the alternative the commented-out socket_data mounts in the compose files are

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -111,9 +111,7 @@ git pull                      # master (prod) or staging (staging host)
    `vm.overcommit_memory=1` — the settings the dockerized Redis warns about).
 4. `systemctl daemon-reload`, enable + run `redis-host-setup`, then enable and
    **restart** `bytedeck.com.service` (which runs `docker compose ... up -d`).
-5. `nginx -s reload` inside the nginx container (works around nginx sometimes
-   not reconnecting to uwsgi after a restart).
-6. Tail the compose logs when run interactively; print a recent snapshot and
+5. Tail the compose logs when run interactively; print a recent snapshot and
    exit when run non-interactively (e.g. from the deploy runner).
 
 The app is managed by the **`bytedeck.com.service`** systemd unit
@@ -275,10 +273,27 @@ request, so it redirects every request forever).
 
 ## Troubleshooting
 
-- **502 / nginx not reaching the app after a deploy:** nginx sometimes doesn't
-  reconnect to uwsgi after `web` restarts. Re-run the reload:
-  `docker compose ... exec nginx nginx -s reload` (server-update.sh already does
-  this).
+- **502 right after a restart:** expected for a minute or two. The `web`
+  container runs `migrate_schemas` over every tenant schema and then
+  `collectstatic` before uwsgi binds :8000, and nginx has nothing to talk to
+  until it does. Watch for `spawned uWSGI master process` in
+  `docker compose ... logs web`.
+- **502 that does not clear:** check that nginx is dialling the address `web`
+  actually has:
+  ```bash
+  cd ~/bytedeck
+  C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
+  $C logs nginx | grep -o 'upstream: "uwsgi://[^"]*"' | tail -1   # who nginx calls
+  $C ps -q web | xargs docker inspect \
+      -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'  # where web is
+  ```
+  These must match. If they do not, nginx is holding a stale address: confirm
+  the site config still carries the `resolver` line and the `$web_upstream`
+  variable in `uwsgi_pass` (see `nginx/bytedeck.conf.template`), since dropping
+  either one restores the old resolve-once-at-startup behaviour.
+  `$C exec nginx nginx -s reload` clears it until the next recreation.
+- **Check nginx and web share a network:** `$C exec nginx getent hosts web`
+  should print the current web IP.
 - **Which user is each container running as:**
   `docker inspect $(docker ps -aq) --format '{{.Config.User}} {{.Name}}'`
 - **Logs:** `docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml logs -f`

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -45,11 +45,6 @@ sudo systemctl restart redis-host-setup.service
 sudo systemctl enable bytedeck.com.service
 sudo systemctl restart bytedeck.com
 
-# Restart the nginx server: sometimes nginx doesn't reconnect to uwsgi after a
-# restart, and this helps when run manually. Best-effort: -T avoids needing a
-# TTY (so it works on the runner), and a failed reload shouldn't fail the deploy.
-$COMPOSE exec -T nginx nginx -s reload || echo "WARN: nginx reload failed; continuing."
-
 # Show logs. Follow them when run interactively; in an automated deploy (no TTY,
 # e.g. the CI runner) print a recent snapshot and exit so the job can finish.
 if [ -t 1 ]; then

--- a/production/systemd/bytedeck.com.service
+++ b/production/systemd/bytedeck.com.service
@@ -15,10 +15,6 @@ Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/home/ubuntu/bytedeck
 # WorkingDirectory=/usr/share/nginx/hackerspace
-# Both lines name the same file set. A bare `docker compose down` would instead
-# pick up docker-compose.yml plus docker-compose.override.yml (the development
-# override, which is present in the checkout on the server), so teardown would
-# be reasoning about a different set of services than startup created.
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml up -d
 ExecStop=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml down
 TimeoutStartSec=0

--- a/production/systemd/bytedeck.com.service
+++ b/production/systemd/bytedeck.com.service
@@ -15,8 +15,12 @@ Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/home/ubuntu/bytedeck
 # WorkingDirectory=/usr/share/nginx/hackerspace
+# Both lines name the same file set. A bare `docker compose down` would instead
+# pick up docker-compose.yml plus docker-compose.override.yml (the development
+# override, which is present in the checkout on the server), so teardown would
+# be reasoning about a different set of services than startup created.
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml up -d
-ExecStop=/usr/bin/docker compose down
+ExecStop=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml down
 TimeoutStartSec=0
 
 [Install]


### PR DESCRIPTION
### What?

Stops nginx 502ing after every `systemctl restart bytedeck.com` on staging and production. nginx now resolves the `web` service name at request time rather than once at config load, so it follows the app container to whatever address it currently has.

Also removes the `nginx -s reload` workaround this bug forced into `server-update.sh`, and gives the systemd unit's `ExecStop` the same `-f` flags as its `ExecStart`.

### Why?

`systemctl restart bytedeck.com` recreates the `web` container, and compose hands it a fresh IP. nginx resolved `web` exactly once, when it parsed its config, and held that address for the life of the worker process. After a restart it kept dialling an address nothing was listening on:

```
connect() failed (111: Connection refused) while connecting to upstream,
upstream: "uwsgi://172.31.0.4:8000"
```

Every request 502'd until nginx itself was reloaded. This is a known-in-repo problem that had been papered over rather than fixed: `server-update.sh` carried an `nginx -s reload` commented "sometimes nginx doesn't reconnect to uwsgi after a restart", and the troubleshooting notes told you to re-run it by hand. That is also why deploys mostly looked fine while a bare `systemctl restart` did not: only the deploy path ran the reload.

The reload is a one-shot patch. It fixes the currently-cached address and then goes stale again the next time the container is recreated.

Worth separating out: there is also a legitimate 502 window on every restart while `web` runs `migrate_schemas` across every tenant schema and then `collectstatic` before uwsgi binds `:8000`. That window is expected and is not what this PR is about. It is now documented in the troubleshooting section, and removing it would mean moving migrations out of the container's start command (not attempted here).

### How?

In `nginx/bytedeck.conf.template`:

- Added `resolver 127.0.0.11 valid=10s ipv6=off;` (Docker's embedded DNS). `valid=10s` bounds how long a resolved address is reused, so the lookup is not literally once per request; the distinction that matters is request-time versus config-load-time. Docker's DNS returns no TTL of its own, so without `valid=` nginx would fall back to caching indefinitely.
- Replaced `uwsgi_pass django;` with `set $web_upstream web;` + `uwsgi_pass $web_upstream:8000;`, and dropped the `upstream django` block. **The variable is load-bearing:** nginx only consults the resolver at request time when the passed address contains one. Naming an `upstream` block, or inlining `uwsgi_pass web:8000`, both resolve once at startup. The removed group had a single static member and no balancing, failover or keepalive settings, so nothing else is lost. The commented-out unix-socket alternative that lived in it is preserved as a note, since a socket path cannot go stale and needs neither resolver nor variable.
- `envsubst` in `nginx/Dockerfile` is restricted to the domain placeholder, so `$web_upstream` survives the build untouched (verified below).

In `production/systemd/bytedeck.com.service`: `ExecStop` now names the same file set as `ExecStart`. A bare `docker compose down` picks up `docker-compose.yml` plus `docker-compose.override.yml`, the development override that is present in the checkout on the server, so teardown was reasoning about a different set of services than startup created. Independent of the 502, but it is right next door.

In `production/server-update.sh` and `production/SERVER-README.md`: dropped the reload workaround now that the root cause is gone, and rewrote the troubleshooting entry to distinguish the expected startup window from a stale address, with commands to tell them apart.

### Testing?

No Python changed, so the suite is untouched. This is nginx behaviour, which the Django tests cannot reach, so I verified it directly against the **real rendered config** by building the actual image from `nginx/` twice, once from `staging` and once from this branch, and moving the backend container's address underneath both.

Setup: a container named `web` on a compose-style network, both nginx variants pointed at it, then `web` destroyed and recreated so it landed on a different IP (`172.18.0.2` to `172.18.0.5`), with the nginx processes left untouched, exactly as a restart leaves them.

| | after 1st address change | after `nginx -s reload` | after 2nd address change |
| --- | --- | --- | --- |
| current config (`staging`) | **502**, `uwsgi://172.18.0.2:8000` refused | 200 | **502** again |
| this branch | **200**, no upstream errors | n/a | **200** |

The decisive evidence is from the new backend container's own access log, which shows the request arriving from `172.18.0.4`, the fixed nginx, carrying a raw uwsgi packet:

```
172.18.0.4 - - [09/Aug/2026:03:15:25 +0000] "\x00\xAE\x01\x00\x0C\x00QUERY_STRING\x00\x00\x0E\x00REQUEST_METHOD\x03\x00GET..."
```

The pre-fix nginx (`172.18.0.3`) never appears in that log at all: it was still dialling the dead `172.18.0.2`. Its error line reproduces the reported failure exactly, down to the wording.

Also checked, on this branch's tree:

- `docker build` of `nginx/` succeeds and `nginx -t` passes on the rendered config.
- The rendered `/etc/nginx/sites-available/bytedeck.conf` contains `resolver 127.0.0.11 valid=10s ipv6=off;` and `uwsgi_pass $web_upstream:8000;`, so envsubst left the variable alone.
- `ruff check src` clean.

(The test host has no IPv6, so the `listen [::]` lines were stripped for the test run only. Nothing else in the config was modified.)

### Screenshots (if front end is affected)

N/A, deployment config. No user-visible change beyond the site not 502ing after a restart.

### Deploy notes

- **The nginx image must be rebuilt**, since the config is baked in at build time by `envsubst`. `production/server-update.sh` runs `docker compose build`, so a normal deploy covers it. A restart without a rebuild will not pick this up.
- No new environment variables. `127.0.0.11` is Docker's built-in DNS, always present on a user-defined network.
- After deploying, the check is that these two agree:
  ```bash
  cd ~/bytedeck
  C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
  $C logs nginx | grep -o 'upstream: "uwsgi://[^"]*"' | tail -1
  $C ps -q web | xargs docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'
  ```

### Anything Else?

- Targeted at `staging` as a hotfix because it affects both live environments today. CodeRabbit does not auto-review PRs whose base is not `develop`, so it is being summoned manually.
- This wants to reach `develop` too, or the next `develop` release will reintroduce the cached-address behaviour. Happy to open the matching PR once this lands.
- No `CHANGELOG.md` entry: this is deploy plumbing with no effect on what a teacher or student sees on a deck.
- Follow-up worth considering separately: the migrations-and-collectstatic startup window is a real, if expected, 502 on every restart. Moving migrations to a step before `up -d` would remove it.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - infrastructure stack`)