### PR TITLE
HOTFIX: feat: label Stripe customers with their deck at link time

### DIFF
--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -165,8 +165,8 @@ def stamp_customer_description(deck, customer_id):
 
     Checkout creates the Customer with only the payer's email, so the dashboard's
     Customers list gives no hint which deck a customer belongs to (maintainer
-    request, 2026-08-09). Stamping the deck name/domain into the description and
-    the schema into searchable metadata fixes that at the moment a customer is
+    request, 2026-08-09). Stamping the deck name into the description and the
+    schema into searchable metadata fixes that at the moment a customer is
     first linked to a deck. Purely cosmetic, so a Stripe error is logged and
     swallowed: it must never fail the webhook or the post-checkout reconcile
     that calls it.
@@ -179,7 +179,7 @@ def stamp_customer_description(deck, customer_id):
         stripe.Customer.modify(
             customer_id,
             api_key=settings.STRIPE_SECRET_KEY,
-            description=f'Deck: {deck.name} ({deck.primary_domain_url})',
+            description=deck.name,
             metadata={'schema_name': deck.schema_name},
         )
     except stripe.StripeError as e:

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -187,8 +187,8 @@ def stamp_customer_description(deck, customer_id):
 
     Checkout creates the Customer with only the payer's email, so the dashboard's
     Customers list gives no hint which deck a customer belongs to (maintainer
-    request, 2026-08-09). Stamping the deck name into the description and the
-    schema into searchable metadata fixes that at the moment a customer is
+    request, 2026-08-09). Stamping the schema name into the description (and
+    searchable metadata) fixes that at the moment a customer is
     first linked to a deck. Purely cosmetic, so a Stripe error is logged and
     swallowed: it must never fail the webhook or the post-checkout reconcile
     that calls it.
@@ -201,7 +201,7 @@ def stamp_customer_description(deck, customer_id):
         stripe.Customer.modify(
             customer_id,
             api_key=settings.STRIPE_SECRET_KEY,
-            description=deck.name,
+            description=deck.schema_name,
             metadata={'schema_name': deck.schema_name},
         )
     except stripe.StripeError as e:

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -15,6 +15,7 @@ Two flows feed deck billing state, both defined here:
   handler is a thin translator that resolves the deck and funnels through
   ``Tenant.sync_from_stripe_subscription`` -- the single billing write path.
 """
+import logging
 from datetime import datetime, time as dt_time, timedelta, timezone as dt_timezone
 
 import stripe
@@ -23,6 +24,8 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import localdate
+
+logger = logging.getLogger(__name__)
 
 # Cap outbound Stripe HTTP time: webhook handlers retrieve subscriptions inside
 # the request's DB transaction (needed for the StripeEventLog dedupe + rollback
@@ -157,6 +160,32 @@ def create_portal_session(deck):
     return session.url
 
 
+def stamp_customer_description(deck, customer_id):
+    """Best-effort: label the Stripe Customer with the deck it pays for.
+
+    Checkout creates the Customer with only the payer's email, so the dashboard's
+    Customers list gives no hint which deck a customer belongs to (maintainer
+    request, 2026-08-09). Stamping the deck name/domain into the description and
+    the schema into searchable metadata fixes that at the moment a customer is
+    first linked to a deck. Purely cosmetic, so a Stripe error is logged and
+    swallowed: it must never fail the webhook or the post-checkout reconcile
+    that calls it.
+
+    Args:
+        deck (Tenant): The deck the customer was just linked to.
+        customer_id (str): The Stripe customer id (cus_...).
+    """
+    try:
+        stripe.Customer.modify(
+            customer_id,
+            api_key=settings.STRIPE_SECRET_KEY,
+            description=f'Deck: {deck.name} ({deck.primary_domain_url})',
+            metadata={'schema_name': deck.schema_name},
+        )
+    except stripe.StripeError as e:
+        logger.warning('could not stamp deck description on Stripe customer %s: %s', customer_id, e)
+
+
 def subscription_period_end_date(subscription):
     """The subscription's current period end as a local date, or None.
 
@@ -218,8 +247,13 @@ def reconcile_checkout_session(deck, session_id):
     paid_until = subscription_period_end_date(subscription)
     if paid_until is not None:
         updates['paid_until'] = paid_until
+    # stamp only on a fresh link, so repeat polls of the status endpoint don't
+    # re-write the customer on every poll
+    newly_linked = bool(updates['stripe_customer_id']) and deck.stripe_customer_id != updates['stripe_customer_id']
     Tenant.objects.filter(schema_name=deck.schema_name).update(**updates)
     invalidate_current_deck_cache(deck.schema_name)  # the banner should update immediately
+    if newly_linked:
+        stamp_customer_description(deck, updates['stripe_customer_id'])
     return True
 
 
@@ -347,6 +381,10 @@ def handle_webhook_event(event):
             if session_sub:
                 guard |= Q(stripe_subscription_id=session_sub)
             linked = Tenant.objects.filter(guard, pk=deck.pk).update(stripe_customer_id=obj['customer'])
+            if linked and deck.stripe_customer_id != obj['customer']:
+                # a fresh link (not a re-delivery rewriting the same id): label the
+                # customer with its deck so the dashboard's Customers list is legible
+                stamp_customer_description(deck, obj['customer'])
             parts.append('linked customer' if linked else 'customer link kept (session not for the linked subscription)')
         else:
             # a session without a customer must not CLEAR a stored link

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -213,7 +213,15 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.paid_until, original_paid_until)
 
     def _complete_session(self, customer='cus_9'):
-        """A completed session double for this deck, ready to reconcile."""
+        """A completed Checkout Session double for this deck, ready to reconcile.
+
+        Args:
+            customer (str): The Stripe customer id to place in the session.
+
+        Returns:
+            dict: A completed session payload bound to this deck, carrying the
+            given customer and an active subscription ('sub_9').
+        """
         return {
             'status': 'complete', 'client_reference_id': self.tenant.schema_name,
             'customer': customer, 'subscription': {'id': 'sub_9', 'status': 'active'},
@@ -254,7 +262,7 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
 
     def test_reconcile__customer_stamp_failure_never_breaks_the_link(self):
         """The description stamp is cosmetic: a Stripe error while writing it is
-        swallowed, and the deck still ends up linked and paid up."""
+        swallowed, and the deck still ends up fully linked."""
         import stripe as stripe_module
 
         Tenant.objects.filter(schema_name=self.tenant.schema_name).update(

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -220,8 +220,8 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         }
 
     def test_reconcile__fresh_link_stamps_the_deck_on_the_stripe_customer(self):
-        """A fresh customer link labels the Stripe Customer with the deck's name
-        and searchable schema metadata, so the dashboard's Customers list
+        """A fresh customer link labels the Stripe Customer with the deck's
+        schema name (description + searchable metadata), so the dashboard's Customers list
         shows which deck each customer pays for (maintainer request, 2026-08-09)."""
         Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
             stripe_customer_id='', stripe_subscription_id='')
@@ -234,9 +234,9 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         mock_modify.assert_called_once()
         args, kwargs = mock_modify.call_args
         self.assertEqual(args[0], 'cus_9')
-        # just the deck name (maintainer review on the PR): the Customers list's
-        # Description column stays short, and metadata carries the schema
-        self.assertEqual(kwargs['description'], self.tenant.name)
+        # the schema name (maintainer review on the PR): the operational deck
+        # identifier used everywhere else (admin, backfill report, logs)
+        self.assertEqual(kwargs['description'], self.tenant.schema_name)
         self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
 
     def test_reconcile__repeat_poll_does_not_restamp_the_customer(self):
@@ -386,7 +386,7 @@ class HandleWebhookEventTest(ByteDeckTenantTestCase):
 
     def test_checkout_completed__fresh_customer_link_stamps_the_deck_description(self):
         """A fresh customer link from the webhook labels the Stripe Customer with
-        the deck's name and searchable schema metadata, so the dashboard's
+        the deck's schema name (description + searchable metadata), so the dashboard's
         Customers list shows which deck each customer pays for (maintainer
         request, 2026-08-09); a re-delivered event that rewrites the same id does
         not re-stamp."""
@@ -402,7 +402,7 @@ class HandleWebhookEventTest(ByteDeckTenantTestCase):
         self.mock_customer_modify.assert_called_once()
         args, kwargs = self.mock_customer_modify.call_args
         self.assertEqual(args[0], 'cus_wh')
-        self.assertEqual(kwargs['description'], self.tenant.name)
+        self.assertEqual(kwargs['description'], self.tenant.schema_name)
         self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
 
         # duplicate delivery: the link UPDATE rewrites the same id; no re-stamp

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -184,6 +184,15 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
     endpoint in test_views; these pin the module-level edges.
     """
 
+    def setUp(self):
+        """Stub the cosmetic customer-description stamp so link tests that don't
+        care about it never attempt a real Stripe call; tests that DO assert on
+        it install their own mock over this stub."""
+        super().setUp()
+        patcher = patch('tenant.billing.stripe.Customer.modify')
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_reconcile__missing_period_end_links_ids_but_keeps_paid_until(self):
         """A completed session whose subscription carries no period end still links
         the deck to Stripe, but leaves paid_until alone rather than clearing it."""
@@ -202,6 +211,62 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.stripe_customer_id, 'cus_9')
         self.assertEqual(self.tenant.stripe_subscription_id, 'sub_9')
         self.assertEqual(self.tenant.paid_until, original_paid_until)
+
+    def _complete_session(self, customer='cus_9'):
+        """A completed session double for this deck, ready to reconcile."""
+        return {
+            'status': 'complete', 'client_reference_id': self.tenant.schema_name,
+            'customer': customer, 'subscription': {'id': 'sub_9', 'status': 'active'},
+        }
+
+    def test_reconcile__fresh_link_stamps_the_deck_on_the_stripe_customer(self):
+        """A fresh customer link labels the Stripe Customer with the deck's name,
+        domain, and searchable schema metadata, so the dashboard's Customers list
+        shows which deck each customer pays for (maintainer request, 2026-08-09)."""
+        Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
+            stripe_customer_id='', stripe_subscription_id='')
+        self.tenant.refresh_from_db()
+
+        with patch('tenant.billing.stripe.checkout.Session.retrieve', return_value=self._complete_session()):
+            with patch('tenant.billing.stripe.Customer.modify') as mock_modify:
+                self.assertTrue(reconcile_checkout_session(self.tenant, 'cs_9'))
+
+        mock_modify.assert_called_once()
+        args, kwargs = mock_modify.call_args
+        self.assertEqual(args[0], 'cus_9')
+        self.assertIn(self.tenant.name, kwargs['description'])
+        self.assertIn(self.tenant.primary_domain_url, kwargs['description'])
+        self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
+
+    def test_reconcile__repeat_poll_does_not_restamp_the_customer(self):
+        """Reconciling an already-linked deck (the status endpoint polls) leaves
+        the Stripe Customer untouched instead of re-writing it on every poll."""
+        Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
+            stripe_customer_id='cus_9', stripe_subscription_id='sub_9')
+        self.tenant.refresh_from_db()
+
+        with patch('tenant.billing.stripe.checkout.Session.retrieve', return_value=self._complete_session()):
+            with patch('tenant.billing.stripe.Customer.modify') as mock_modify:
+                self.assertTrue(reconcile_checkout_session(self.tenant, 'cs_9'))
+
+        mock_modify.assert_not_called()
+
+    def test_reconcile__customer_stamp_failure_never_breaks_the_link(self):
+        """The description stamp is cosmetic: a Stripe error while writing it is
+        swallowed, and the deck still ends up linked and paid up."""
+        import stripe as stripe_module
+
+        Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
+            stripe_customer_id='', stripe_subscription_id='')
+        self.tenant.refresh_from_db()
+
+        with patch('tenant.billing.stripe.checkout.Session.retrieve', return_value=self._complete_session()):
+            with patch('tenant.billing.stripe.Customer.modify',
+                       side_effect=stripe_module.StripeError('boom')):
+                self.assertTrue(reconcile_checkout_session(self.tenant, 'cs_9'))
+
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.stripe_customer_id, 'cus_9')
 
 
 class SubscriptionMaxActiveUsersTest(SimpleTestCase):
@@ -254,6 +319,14 @@ class HandleWebhookEventTest(ByteDeckTenantTestCase):
     PERIOD_END_TS = 1800014400  # 2027-01-15 12:00 UTC -> 2027-01-15 local
     PERIOD_END = date(2027, 1, 15)
 
+    def setUp(self):
+        """Stub the cosmetic customer-description stamp so linking tests never
+        attempt a real Stripe call; the stamping tests install their own mock."""
+        super().setUp()
+        patcher = patch('tenant.billing.stripe.Customer.modify')
+        self.mock_customer_modify = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def set_deck(self, **fields):
         """Persist billing fields on this deck's Tenant row and refresh the instance."""
         Tenant.objects.filter(pk=self.tenant.pk).update(**fields)
@@ -287,6 +360,34 @@ class HandleWebhookEventTest(ByteDeckTenantTestCase):
         self.tenant.refresh_from_db()
         self.assertEqual(self.tenant.stripe_customer_id, 'cus_wh')
         self.assertEqual(self.tenant.stripe_subscription_id, 'sub_wh')
+
+    def test_checkout_completed__fresh_customer_link_stamps_the_deck_description(self):
+        """A fresh customer link from the webhook labels the Stripe Customer with
+        the deck's name/domain and searchable schema metadata, so the dashboard's
+        Customers list shows which deck each customer pays for (maintainer
+        request, 2026-08-09); a re-delivered event that rewrites the same id does
+        not re-stamp."""
+        from tenant.billing import handle_webhook_event
+
+        self.set_deck(paid_until=None, stripe_customer_id='', stripe_subscription_id='')
+        event = self.make_event('checkout.session.completed', {
+            'client_reference_id': self.tenant.schema_name, 'customer': 'cus_wh', 'subscription': 'sub_wh',
+        })
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=self.stripe_subscription()):
+            handle_webhook_event(event)
+
+        self.mock_customer_modify.assert_called_once()
+        args, kwargs = self.mock_customer_modify.call_args
+        self.assertEqual(args[0], 'cus_wh')
+        self.assertIn(self.tenant.name, kwargs['description'])
+        self.assertIn(self.tenant.primary_domain_url, kwargs['description'])
+        self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
+
+        # duplicate delivery: the link UPDATE rewrites the same id; no re-stamp
+        self.tenant.refresh_from_db()
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=self.stripe_subscription()):
+            handle_webhook_event(event)
+        self.mock_customer_modify.assert_called_once()
         self.assertEqual(self.tenant.paid_until, self.PERIOD_END)
 
     def test_subscription_events__sync_through_the_single_write_path(self):

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -220,8 +220,8 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         }
 
     def test_reconcile__fresh_link_stamps_the_deck_on_the_stripe_customer(self):
-        """A fresh customer link labels the Stripe Customer with the deck's name,
-        domain, and searchable schema metadata, so the dashboard's Customers list
+        """A fresh customer link labels the Stripe Customer with the deck's name
+        and searchable schema metadata, so the dashboard's Customers list
         shows which deck each customer pays for (maintainer request, 2026-08-09)."""
         Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
             stripe_customer_id='', stripe_subscription_id='')
@@ -234,8 +234,9 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         mock_modify.assert_called_once()
         args, kwargs = mock_modify.call_args
         self.assertEqual(args[0], 'cus_9')
-        self.assertIn(self.tenant.name, kwargs['description'])
-        self.assertIn(self.tenant.primary_domain_url, kwargs['description'])
+        # just the deck name (maintainer review on the PR): the Customers list's
+        # Description column stays short, and metadata carries the schema
+        self.assertEqual(kwargs['description'], self.tenant.name)
         self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
 
     def test_reconcile__repeat_poll_does_not_restamp_the_customer(self):
@@ -363,7 +364,7 @@ class HandleWebhookEventTest(ByteDeckTenantTestCase):
 
     def test_checkout_completed__fresh_customer_link_stamps_the_deck_description(self):
         """A fresh customer link from the webhook labels the Stripe Customer with
-        the deck's name/domain and searchable schema metadata, so the dashboard's
+        the deck's name and searchable schema metadata, so the dashboard's
         Customers list shows which deck each customer pays for (maintainer
         request, 2026-08-09); a re-delivered event that rewrites the same id does
         not re-stamp."""
@@ -379,8 +380,7 @@ class HandleWebhookEventTest(ByteDeckTenantTestCase):
         self.mock_customer_modify.assert_called_once()
         args, kwargs = self.mock_customer_modify.call_args
         self.assertEqual(args[0], 'cus_wh')
-        self.assertIn(self.tenant.name, kwargs['description'])
-        self.assertIn(self.tenant.primary_domain_url, kwargs['description'])
+        self.assertEqual(kwargs['description'], self.tenant.name)
         self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
 
         # duplicate delivery: the link UPDATE rewrites the same id; no re-stamp

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1197,7 +1197,9 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Log in staff on an unlinked deck with billing configured via override in
-        each test (the deck's owner email resolution is exercised as-is)."""
+        each test (the deck's owner email resolution is exercised as-is). The
+        cosmetic customer-description stamp is stubbed so link-path tests never
+        attempt a real Stripe call."""
         from model_bakery import baker
 
         from tenant.utils import deck_cache_key
@@ -1206,6 +1208,9 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.client = TenantClient(self.tenant)
         self.staff = baker.make(User, is_staff=True)
         self.client.force_login(self.staff)
+        patcher = patch('tenant.billing.stripe.Customer.modify')
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def set_deck(self, **fields):
         """Persist billing fields on this deck's Tenant row and refresh the instance."""


### PR DESCRIPTION
### What

During the staging rehearsal the maintainer noticed the Stripe dashboard's Customers list shows only the payer's email, with no indication of which deck a customer pays for (2026-08-09). Checkout creates the Customer with just an email, and while our checkout stamps `schema_name` on the *subscription's* metadata, nothing labeled the Customer itself.

Now, at the moment a customer is first linked to a deck, the Stripe Customer gets:

- **Description**: the deck's `schema_name` (per maintainer review: the operational identifier used everywhere else, i.e. the tenant admin, backfill report rows, event log, and worker logs, so the Customers list shows exactly the string you'd cross-reference).
- **Metadata** `schema_name` (machine-readable, consistent with what checkout stamps on subscriptions).

The stamp fires from both linking paths: the `checkout.session.completed` webhook handler and the post-checkout polling reconciler. It fires only on a *fresh* link: re-delivered webhook events and repeat polls of the activating page never re-write the customer. It is deliberately best-effort: a Stripe error while stamping is logged and swallowed, so the cosmetic label can never fail the webhook or the reconcile.

Legacy customers hand-linked via the admin (#2043 backfill flow) are not stamped retroactively; their descriptions can be typed into the dashboard directly while hand-linking.

**HOTFIX to `staging`** (maintainer request on review). The branch carries `origin/staging` merged in, including the #2301 SDK plain-dict hotfix, with the overlap in `billing.py` resolved so both compose: the stamp reads from the already-converted plain dicts.

### Testing

New tests pin: the stamp on a fresh link via the reconciler and via the webhook handler (description equals the schema name, metadata carries it too), no re-stamp on repeat polls or duplicate webhook deliveries, and a StripeError during stamping leaving the deck fully linked. Existing link-path tests are shielded from real network calls with a setUp-level stub, which also covers #2301's SDK-object regression tests now that stamping fires on their fresh links. Full suite, ruff, and `makemigrations --check` pass locally on the merged tree.

### Screenshots

No app UI change; the visible effect is in the Stripe dashboard's Customers list, where the Description column now shows the deck's schema name for newly linked customers.

- Claude Code (`Bytedeck - payments integration`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stripe customer records now include the associated deck schema name in their description and metadata after checkout reconciliation or webhook completion.
  * Newly linked customers are updated only once, including when events are delivered repeatedly.

* **Bug Fixes**
  * Stripe update failures no longer prevent successful customer linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->