### PR TITLE
hotfix: convert Stripe SDK objects to plain dicts at every boundary

### DIFF
--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -314,6 +314,13 @@ def _sync_deck_from_subscription_id(deck, subscription_id):
     configured with only the webhook secret can still absorb events that sync
     straight from their payloads, but it cannot retrieve, and an exception here
     would turn into a 500 that Stripe retries for days (review find on #2110).
+
+    Args:
+        deck (Tenant): The deck whose billing state the subscription drives.
+        subscription_id (str): The Stripe subscription id (sub_...) to retrieve.
+
+    Returns:
+        str: A short human-readable summary for the caller's log/audit trail.
     """
     if not settings.STRIPE_SECRET_KEY:
         return 'STRIPE_SECRET_KEY unset; retrieve skipped'
@@ -329,6 +336,10 @@ def handle_webhook_event(event):
     changes billing state, the notices machinery for payment failures. Unhandled
     event types are logged and acknowledged. Idempotence (duplicate delivery)
     is enforced by the caller via StripeEventLog before this runs.
+
+    Args:
+        event: The verified Stripe Event, as the SDK's Event object or an
+            equivalent plain dict (converted internally via to_plain_dict).
 
     Returns:
         tuple[str, str]: ``(schema_name, summary)`` -- the resolved deck's schema

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -15,6 +15,7 @@ Two flows feed deck billing state, both defined here:
   handler is a thin translator that resolves the deck and funnels through
   ``Tenant.sync_from_stripe_subscription`` -- the single billing write path.
 """
+import json
 from datetime import datetime, time as dt_time, timedelta, timezone as dt_timezone
 
 import stripe
@@ -41,6 +42,27 @@ except (ImportError, AttributeError):  # pragma: no cover -- requires a differen
 # hour absorbs clock skew and request latency so a boundary-day checkout can't
 # fail at Stripe after passing our check
 CHECKOUT_TRIAL_END_MINIMUM = timedelta(hours=49)
+
+
+def to_plain_dict(stripe_obj):
+    """A stripe-python object (or a dict) as plain nested dicts/lists.
+
+    stripe-python 15.x objects support indexing but are NOT dicts: ``.get()``
+    raises AttributeError. The handlers and sync code are written dict-style,
+    which every test exercised with plain-dict doubles, so the mismatch only
+    surfaced on staging's first real webhook delivery (500 on every event,
+    2026-08-09). Converting at each SDK boundary keeps the dict-style code and
+    the test doubles honest; ``str()`` of a Stripe object is its full JSON.
+
+    Args:
+        stripe_obj: A stripe-python object, or an already-plain dict.
+
+    Returns:
+        dict: The same data as plain nested dicts/lists.
+    """
+    if isinstance(stripe_obj, dict):
+        return stripe_obj
+    return json.loads(str(stripe_obj))
 
 
 def billing_configured():
@@ -193,9 +215,9 @@ def reconcile_checkout_session(deck, session_id):
     from tenant.models import Tenant
     from tenant.utils import invalidate_current_deck_cache
 
-    session = stripe.checkout.Session.retrieve(
+    session = to_plain_dict(stripe.checkout.Session.retrieve(
         session_id, api_key=settings.STRIPE_SECRET_KEY, expand=['subscription'],
-    )
+    ))
     # The session id arrives via the success-URL query string, so never trust it
     # blindly: the session must be one THIS deck's checkout created (bound via
     # client_reference_id/metadata), or a session id from some other deck's
@@ -295,7 +317,7 @@ def _sync_deck_from_subscription_id(deck, subscription_id):
     """
     if not settings.STRIPE_SECRET_KEY:
         return 'STRIPE_SECRET_KEY unset; retrieve skipped'
-    subscription = stripe.Subscription.retrieve(subscription_id, api_key=settings.STRIPE_SECRET_KEY)
+    subscription = to_plain_dict(stripe.Subscription.retrieve(subscription_id, api_key=settings.STRIPE_SECRET_KEY))
     return deck.sync_from_stripe_subscription(subscription)
 
 
@@ -315,6 +337,9 @@ def handle_webhook_event(event):
     """
     from django_tenants.utils import tenant_context
 
+    # accept the SDK's Event object as well as a plain dict: everything below
+    # (and every handler) speaks dict
+    event = to_plain_dict(event)
     event_type = event.get('type', '')
     obj = (event.get('data') or {}).get('object') or {}
     metadata = obj.get('metadata') or {}

--- a/src/tenant/management/commands/stripe_backfill_report.py
+++ b/src/tenant/management/commands/stripe_backfill_report.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from tenant.billing import to_plain_dict
 from tenant.models import Tenant
 
 
@@ -32,6 +33,9 @@ class Command(BaseCommand):
 
         matched, ambiguous, unmatched = [], [], []
         for subscription in subscriptions:
+            # the SDK yields Subscription objects, which are not dicts on
+            # stripe-python 15.x; the reads below all speak dict
+            subscription = to_plain_dict(subscription)
             customer = subscription.get('customer') or {}
             email = (customer.get('email') or '').strip().lower()
             label = f"sub {subscription.get('id')} / customer {customer.get('id')} <{email or 'no email'}>"

--- a/src/tenant/management/commands/stripe_backfill_report.py
+++ b/src/tenant/management/commands/stripe_backfill_report.py
@@ -20,7 +20,15 @@ class Command(BaseCommand):
             "'Sync from Stripe' admin action.")
 
     def handle(self, *args, **options):
-        """Fetch active subscriptions and print matched / ambiguous / unmatched sections."""
+        """Fetch active subscriptions and print matched / ambiguous / unmatched sections.
+
+        Args:
+            *args: Unused positional arguments (BaseCommand signature).
+            **options: Unused parsed options (the command takes no arguments).
+
+        Returns:
+            None: The report is written to stdout; nothing is ever modified.
+        """
         import stripe
 
         if not settings.STRIPE_SECRET_KEY:

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -203,6 +203,29 @@ class ReconcileCheckoutSessionTest(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.stripe_subscription_id, 'sub_9')
         self.assertEqual(self.tenant.paid_until, original_paid_until)
 
+    def test_reconcile__handles_the_sdks_real_session_object(self):
+        """Session.retrieve returns the SDK's object, which is NOT a dict on
+        stripe-python 15.x (.get() raises): the reconciler's dict-style reads only
+        worked in tests because the doubles were plain dicts (the same drift that
+        500ed staging's webhook, 2026-08-09). Pins the seam with the real type."""
+        import stripe as stripe_lib
+
+        Tenant.objects.filter(schema_name=self.tenant.schema_name).update(
+            stripe_customer_id='', stripe_subscription_id='')
+        self.tenant.refresh_from_db()
+        sdk_session = stripe_lib.checkout.Session.construct_from({
+            'status': 'complete', 'client_reference_id': self.tenant.schema_name,
+            'customer': 'cus_sdk', 'subscription': {'id': 'sub_sdk', 'status': 'active'},
+        }, 'sk_test_x')
+        self.assertFalse(hasattr(sdk_session, 'get'))  # the very property that broke staging
+
+        with patch('tenant.billing.stripe.checkout.Session.retrieve', return_value=sdk_session):
+            self.assertTrue(reconcile_checkout_session(self.tenant, 'cs_sdk'))
+
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.stripe_customer_id, 'cus_sdk')
+        self.assertEqual(self.tenant.stripe_subscription_id, 'sub_sdk')
+
 
 class SubscriptionMaxActiveUsersTest(SimpleTestCase):
     """Tests for reading the tier cap off a Stripe subscription (epic #1729 PR 7)."""

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -199,6 +199,33 @@ class StripeBackfillReportTest(ByteDeckTenantTestCase):
         # read-only: the matched deck was NOT linked
         self.assertEqual(Tenant.objects.get(pk=self.tenant.pk).stripe_subscription_id, '')
 
+    def test_report__handles_the_sdks_real_subscription_objects(self):
+        """The listing yields the SDK's Subscription objects, which are NOT dicts
+        on stripe-python 15.x (.get() raises): the report's dict-style reads only
+        worked in tests because the doubles were plain dicts (the same drift that
+        500ed staging's webhook, 2026-08-09). Pins the seam with the real type."""
+        from unittest.mock import MagicMock, patch
+
+        import stripe as stripe_lib
+
+        from django.test import override_settings
+
+        from tenant.models import Tenant
+
+        Tenant.objects.filter(pk=self.tenant.pk).update(owner_email_cached='owner@example.com')
+        sdk_sub = stripe_lib.Subscription.construct_from(
+            {'id': 'sub_sdk', 'customer': {'id': 'cus_sdk', 'email': 'OWNER@example.com'}}, 'sk_test_x')
+        self.assertFalse(hasattr(sdk_sub, 'get'))  # the very property that broke staging
+
+        listing = MagicMock()
+        listing.auto_paging_iter.return_value = [sdk_sub]
+        with override_settings(STRIPE_SECRET_KEY='sk_test_123'):
+            with patch('stripe.Subscription.list', return_value=listing):
+                output = self.call()
+
+        self.assertIn('sub_sdk', output)
+        self.assertIn(f"deck '{self.tenant.schema_name}'", output)
+
     def test_report__skips_already_linked_subscriptions(self):
         """A subscription some deck already carries doesn't reappear in the report."""
         from unittest.mock import MagicMock, patch

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1460,6 +1460,31 @@ class StripeWebhookViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(StripeEventLog.objects.count(), 1)
 
     @override_settings(STRIPE_WEBHOOK_SECRET='whsec_123')
+    def test_webhook__handles_the_sdks_real_event_object(self):
+        """construct_event returns the SDK's Event object, which is NOT a dict on
+        stripe-python 15.x (.get() raises AttributeError): the first real staging
+        delivery 500ed on every event while tests passed with plain-dict doubles
+        (2026-08-09). This pins the seam with the SDK's actual object type."""
+        import stripe as stripe_lib
+
+        from tenant.models import StripeEventLog
+
+        payload = {'id': 'evt_sdk', 'type': 'customer.subscription.updated',
+                   'data': {'object': {'id': 'sub_sdk', 'status': 'active', 'customer': 'cus_sdk',
+                                       'metadata': {'schema_name': self.tenant.schema_name},
+                                       'items': {'data': [{'price': {'id': 'price_x', 'metadata': {}}}]}}}}
+        sdk_event = stripe_lib.Event.construct_from(payload, 'sk_test_x')
+        self.assertFalse(hasattr(sdk_event, 'get'))  # the very property that broke staging
+
+        with patch('stripe.Webhook.construct_event', return_value=sdk_event):
+            response = self.post_webhook()
+
+        self.assertEqual(response.status_code, 200)
+        log = StripeEventLog.objects.get(event_id='evt_sdk')
+        self.assertEqual(log.event_type, 'customer.subscription.updated')
+        self.assertEqual(log.schema_name, self.tenant.schema_name)
+
+    @override_settings(STRIPE_WEBHOOK_SECRET='whsec_123')
     def test_webhook__404_on_tenant_schemas(self):
         """The endpoint only exists on the public schema (public_only_view)."""
         tenant_client = TenantClient(self.tenant)  # requests on the deck's own domain

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -611,7 +611,7 @@ def stripe_webhook(request):
 
     from django.db import transaction
 
-    from .billing import handle_webhook_event
+    from .billing import handle_webhook_event, to_plain_dict
     from .models import StripeEventLog
 
     if not settings.STRIPE_WEBHOOK_SECRET:
@@ -622,6 +622,10 @@ def stripe_webhook(request):
         )
     except (ValueError, stripe_lib.SignatureVerificationError):
         return HttpResponse('invalid payload or signature', status=400, content_type='text/plain')
+    # construct_event returns the SDK's Event object, which is not a dict
+    # (.get() raises on stripe-python 15.x, caught live on staging 2026-08-09);
+    # everything below speaks dict, so convert once at the boundary
+    event = to_plain_dict(event)
 
     with transaction.atomic():
         _, created = StripeEventLog.objects.get_or_create(


### PR DESCRIPTION
### What

Fixes the webhook 500s caught live during the staging rehearsal (2026-08-09): every Stripe delivery to `/decks/stripe/webhook/` failed with `AttributeError: get` at `event.get('type', '')`.

**Root cause:** stripe-python 15.x objects support `event['id']`-style indexing but are NOT dicts: `.get()` raises `AttributeError`. The webhook view, all event handlers, `sync_from_stripe_subscription`, the checkout reconciler (the "Activating your subscription" poller, also silently affected), and `stripe_backfill_report` are written dict-style, and every test fed plain-dict doubles through the mocked `tenant.billing.stripe` seam, so the mismatch never surfaced until the first real delivery. The failure was uniform across all event types because `event.get('type')` runs before any handler.

**Fix:** a `to_plain_dict()` helper (JSON round-trip via the SDK object's `str()`; passes real dicts through unchanged) converts at every SDK boundary:

- the webhook view, right after signature verification
- `handle_webhook_event`'s entry (defensive, so any caller is safe)
- the subscription retrieve behind the admin "Sync from Stripe" action and the nightly reconcile
- the checkout-session retrieve behind the post-checkout poller
- the backfill report's subscription listing

### Testing

Three new regression tests pin the seams with the SDK's **actual object types** built via `construct_from` (each asserts `hasattr(obj, 'get')` is False, the exact property that broke staging): the webhook view end-to-end with a real `stripe.Event`, the reconciler with a real `checkout.Session`, and the backfill report with a real `Subscription`. All three fail without the fix. Full suite (1900+), ruff, and `makemigrations --check` pass locally; `billing.py` coverage unchanged at 100%.

### Screenshots

N/A (no user-facing change; the visible effect is webhook deliveries returning 200 instead of 500).

### Anything else

After merging, merge `develop` into `staging` to redeploy the rehearsal environment, then Resend one failed delivery from the Stripe dashboard to confirm a 200 plus a `StripeEventLog` row. Stripe's automatic retries will re-deliver the rest.

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe billing, subscription reporting, checkout reconciliation, and webhook processing compatibility with newer Stripe SDK response objects.
  * Preserved handling for existing dictionary-based responses.
  * Ensured valid webhook events are correctly processed, logged, and associated with the appropriate tenant.
* **Tests**
  * Added regression coverage for real Stripe SDK objects, including case-insensitive owner matching and read-only report behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->