### PR TITLE
fix: make nginx follow the web container's address instead of caching it (forward-port of #2299)

### DIFF
--- a/nginx/bytedeck.conf.template
+++ b/nginx/bytedeck.conf.template
@@ -8,11 +8,12 @@
 # source of truth instead of maintaining divergent copies. Do not edit the
 # generated /etc/nginx/sites-available/bytedeck.conf directly.
 
-# the upstream uwsgi component nginx needs to connect to
-upstream django {
-    # server unix:/bytedeck-volume/app.sock; # for a file socket
-    server web:8000; # for a web port socket (we'll use this first)
-}
+# Docker's embedded DNS, so nginx can look `web` up while it is serving rather
+# than only at config load. A hostname resolved at config load is cached for the
+# life of the worker process, and compose gives `web` a new IP every time it is
+# recreated, so without this nginx dials a dead address after each restart and
+# 502s until it is reloaded. `valid=10s` caps how long an answer is reused.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 server {
 
@@ -73,7 +74,11 @@ server {
 
 
     location / {
-        uwsgi_pass django;
+        # Keep the hostname in a variable. nginx uses the resolver above only
+        # when the passed address contains one; `uwsgi_pass web:8000` or an
+        # `upstream` block would go back to resolving once at startup.
+        set $web_upstream web;
+        uwsgi_pass $web_upstream:8000;
         include /etc/nginx/uwsgi_params;
         # Forward the original request scheme so Django's request.is_secure()
         # is correct behind this TLS-terminating proxy. Without it, is_secure()

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -111,9 +111,7 @@ git pull                      # master (prod) or staging (staging host)
    `vm.overcommit_memory=1` — the settings the dockerized Redis warns about).
 4. `systemctl daemon-reload`, enable + run `redis-host-setup`, then enable and
    **restart** `bytedeck.com.service` (which runs `docker compose ... up -d`).
-5. `nginx -s reload` inside the nginx container (works around nginx sometimes
-   not reconnecting to uwsgi after a restart).
-6. Tail the compose logs when run interactively; print a recent snapshot and
+5. Tail the compose logs when run interactively; print a recent snapshot and
    exit when run non-interactively (e.g. from the deploy runner).
 
 The app is managed by the **`bytedeck.com.service`** systemd unit
@@ -275,10 +273,27 @@ request, so it redirects every request forever).
 
 ## Troubleshooting
 
-- **502 / nginx not reaching the app after a deploy:** nginx sometimes doesn't
-  reconnect to uwsgi after `web` restarts. Re-run the reload:
-  `docker compose ... exec nginx nginx -s reload` (server-update.sh already does
-  this).
+- **502 right after a restart:** expected for a minute or two. The `web`
+  container runs `migrate_schemas` over every tenant schema and then
+  `collectstatic` before uwsgi binds :8000, and nginx has nothing to talk to
+  until it does. Watch for `spawned uWSGI master process` in
+  `docker compose ... logs web`.
+- **502 that does not clear:** check that nginx is dialling the address `web`
+  actually has:
+  ```bash
+  cd ~/bytedeck
+  C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
+  $C logs nginx | grep -o 'upstream: "uwsgi://[^"]*"' | tail -1   # who nginx calls
+  $C ps -q web | xargs docker inspect \
+      -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'  # where web is
+  ```
+  These must match. If they do not, nginx is holding a stale address: confirm
+  the site config still carries the `resolver` line and the `$web_upstream`
+  variable in `uwsgi_pass` (see `nginx/bytedeck.conf.template`), since dropping
+  either one restores the old resolve-once-at-startup behaviour.
+  `$C exec nginx nginx -s reload` clears it until the next recreation.
+- **Check nginx and web share a network:** `$C exec nginx getent hosts web`
+  should print the current web IP.
 - **Which user is each container running as:**
   `docker inspect $(docker ps -aq) --format '{{.Config.User}} {{.Name}}'`
 - **Logs:** `docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml logs -f`

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -273,27 +273,28 @@ request, so it redirects every request forever).
 
 ## Troubleshooting
 
-- **502 right after a restart:** expected for a minute or two. The `web`
-  container runs `migrate_schemas` over every tenant schema and then
-  `collectstatic` before uwsgi binds :8000, and nginx has nothing to talk to
-  until it does. Watch for `spawned uWSGI master process` in
-  `docker compose ... logs web`.
-- **502 that does not clear:** check that nginx is dialling the address `web`
-  actually has:
+- **502 right after a restart:** expected while the `web` container runs
+  `migrate_schemas` over every tenant schema and then `collectstatic`, since
+  uwsgi does not bind :8000 until those finish and nginx has nothing to talk to
+  before then. How long that takes grows with the number of tenants, so go by
+  the log rather than the clock: it is normal until `spawned uWSGI master
+  process` appears in `docker compose ... logs web`.
+- **502 that does not clear:** compare the address nginx dialled with the one it
+  resolves `web` to now. Ask nginx for both, rather than inspecting the
+  container: `web` is on `backend-network` and `frontend-network` while nginx
+  shares only `backend-network`, so listing web's addresses invites comparing
+  against the wrong one.
   ```bash
   cd ~/bytedeck
   C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
-  $C logs nginx | grep -o 'upstream: "uwsgi://[^"]*"' | tail -1   # who nginx calls
-  $C ps -q web | xargs docker inspect \
-      -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'  # where web is
+  $C logs nginx | grep -o 'upstream: "uwsgi://[^"]*"' | tail -1  # who nginx dialled
+  $C exec nginx getent hosts web                                 # where web is now
   ```
-  These must match. If they do not, nginx is holding a stale address: confirm
-  the site config still carries the `resolver` line and the `$web_upstream`
-  variable in `uwsgi_pass` (see `nginx/bytedeck.conf.template`), since dropping
-  either one restores the old resolve-once-at-startup behaviour.
+  A mismatch means nginx is holding a stale address: confirm the site config
+  still carries the `resolver` line and the `$web_upstream` variable in
+  `uwsgi_pass` (see `nginx/bytedeck.conf.template`), since dropping either one
+  restores the old resolve-once-at-startup behaviour.
   `$C exec nginx nginx -s reload` clears it until the next recreation.
-- **Check nginx and web share a network:** `$C exec nginx getent hosts web`
-  should print the current web IP.
 - **Which user is each container running as:**
   `docker inspect $(docker ps -aq) --format '{{.Config.User}} {{.Name}}'`
 - **Logs:** `docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml logs -f`

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -37,11 +37,6 @@ sudo systemctl restart redis-host-setup.service
 sudo systemctl enable bytedeck.com.service
 sudo systemctl restart bytedeck.com
 
-# Restart the nginx server: sometimes nginx doesn't reconnect to uwsgi after a
-# restart, and this helps when run manually. Best-effort: -T avoids needing a
-# TTY (so it works on the runner), and a failed reload shouldn't fail the deploy.
-$COMPOSE exec -T nginx nginx -s reload || echo "WARN: nginx reload failed; continuing."
-
 # Show logs. Follow them when run interactively; in an automated deploy (no TTY,
 # e.g. the CI runner) print a recent snapshot and exit so the job can finish.
 if [ -t 1 ]; then

--- a/production/systemd/bytedeck.com.service
+++ b/production/systemd/bytedeck.com.service
@@ -16,7 +16,7 @@ RemainAfterExit=yes
 WorkingDirectory=/home/ubuntu/bytedeck
 # WorkingDirectory=/usr/share/nginx/hackerspace
 ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml up -d
-ExecStop=/usr/bin/docker compose down
+ExecStop=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml down
 TimeoutStartSec=0
 
 [Install]


### PR DESCRIPTION
### What?

Forward-port of the hotfix merged to `staging` as #2299 (`d8ec1619`), so `develop` stops carrying the bug.

### Why?

#2299 went to `staging` because it was biting both live environments. `develop` still has the original `upstream django { server web:8000; }`, so every branch cut from `develop` inherits the 502 and the fix would be lost the next time `develop` becomes the basis for a release.

The bug: nginx resolved `web` once, at config load, and held that address for the life of the worker process. `systemctl restart bytedeck.com` recreates the `web` container on a fresh IP, so nginx kept dialling an address nothing was listening on and every request 502'd until nginx itself was reloaded:

```
connect() failed (111: Connection refused) while connecting to upstream,
upstream: "uwsgi://172.31.0.4:8000"
```

### How?

Straight cherry-pick of `d8ec1619`, applied cleanly apart from an automatic 3-way merge in `production/server-update.sh` (the surrounding context differs because #2298's image-prune step is on `staging` and not yet here). No content was changed during the port.

- `nginx/bytedeck.conf.template`: added `resolver 127.0.0.11 valid=10s ipv6=off;`, replaced `uwsgi_pass django;` with `set $web_upstream web;` + `uwsgi_pass $web_upstream:8000;`, and dropped the `upstream django` block. The variable is what makes nginx consult the resolver at request time instead of at config load.
- `production/systemd/bytedeck.com.service`: `ExecStop` now names the same file set as `ExecStart` (a bare `docker compose down` picks up `docker-compose.override.yml`, the development override present in the checkout on the server).
- `production/server-update.sh`: removed the `nginx -s reload` that existed only to paper over this.
- `production/SERVER-README.md`: troubleshooting now separates the expected startup 502 window from a stale address, with commands to tell them apart.

### Testing?

No Python changed. The behaviour was verified empirically on #2299 by building the real nginx image and moving the backend container's address underneath it: the old config stayed pinned to the dead IP and logged `Connection refused`, the new one followed to the new address, and repeating the move broke the `nginx -s reload` workaround again but not the fix. Full evidence is in #2299.

Re-checked on this branch's `develop` base:

- `docker build` of `nginx/` succeeds and `nginx -t` passes on the rendered config (with certs present for the built `DOMAIN`).
- The rendered config carries `resolver 127.0.0.11 valid=10s ipv6=off;` and `uwsgi_pass $web_upstream:8000;`, so envsubst leaves the variable alone.
- The `upstream django` block is gone, the reload workaround is gone, and #2298's staging-only prune lines were correctly not dragged along.

### Screenshots (if front end is affected)

N/A, deployment config.

### Deploy notes

The nginx image must be rebuilt for this to take effect, since the config is baked in at build time by `envsubst`. `production/server-update.sh` runs `docker compose build`, so a normal deploy covers it.

### Anything Else?

- No `CHANGELOG.md` entry: deploy plumbing, nothing a teacher or student sees on a deck.
- Still open as a separate follow-up: `web` runs `migrate_schemas` across every tenant schema and then `collectstatic` before uwsgi binds `:8000`, so there is a real (expected) multi-minute 502 window on every restart. Removing it means moving migrations out of the container's start command, which is a bigger change than this.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - infrastructure stack`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2eFCECQA6NsQqsugX8UYf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service routing during deployments so changing application container addresses are refreshed automatically.
  * Reduced stale upstream connection issues and clarified handling of temporary startup errors.

* **Documentation**
  * Updated deployment and troubleshooting guidance with improved log-monitoring steps and diagnostics for persistent gateway errors.

* **Chores**
  * Simplified deployment updates by removing an unnecessary configuration reload.
  * Improved service shutdown consistency with the production deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->