### PR TITLE
fix: close four missing access checks the tests were certifying as correct

### DIFF
--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -119,6 +119,59 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         notification.refresh_from_db()
         self.assertFalse(notification.unread)
 
+    def test_ajax_mark_read__another_users_notification_is_rejected(self):
+        """A student can't mark someone else's notification read: it 404s and stays unread."""
+        self.client.force_login(self.test_student1)
+
+        victims_notification = baker.make(
+            'notifications.Notification', recipient=self.test_student2,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+        self.assertTrue(victims_notification.unread)
+
+        response = self.client.post(
+            reverse('notifications:ajax_mark_read'),
+            data={'id': victims_notification.id},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
+        victims_notification.refresh_from_db()
+        self.assertTrue(victims_notification.unread)
+
+    def test_ajax_mark_read__unknown_id_returns_404(self):
+        """An id matching no notification is a 404, not an unhandled DoesNotExist (a 500)."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(
+            reverse('notifications:ajax_mark_read'),
+            data={'id': 999999},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_ajax_mark_read__non_numeric_id_returns_404(self):
+        """A non-numeric id is a 404, not the ValueError the pk lookup would raise (a 500)."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(
+            reverse('notifications:ajax_mark_read'),
+            data={'id': 'not-a-number'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_ajax_mark_read__missing_id_returns_404(self):
+        """A POST with no id at all is a 404 rather than a crash."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(
+            reverse('notifications:ajax_mark_read'),
+            data={},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_ajax__returns_200_for_logged_in_student(self):
         """A logged-in student's ajax POST to the notifications endpoint returns 200."""
         # log in student1

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import Http404, HttpResponseRedirect, redirect, render
+from django.shortcuts import Http404, HttpResponseRedirect, get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from tenant.views import non_public_only_view
@@ -125,10 +125,22 @@ def ajax(request):
 @non_public_only_view
 @login_required
 def ajax_mark_read(request):
+    """Mark one of the requesting user's own notifications as read.
+
+    Scoped to the recipient so a user can't mark (and so hide) another user's
+    notification, and so an id that doesn't exist is a 404 rather than an
+    unhandled DoesNotExist.
+    """
     if request.method == "POST":
 
-        id = request.POST.get('id', None)
-        n = Notification.objects.get(id=id)
+        # the id is client-supplied: a missing or non-numeric one would raise
+        # ValueError in the pk lookup below (a 500), so turn it away as a 404 first.
+        try:
+            id = int(request.POST.get('id', ''))
+        except (TypeError, ValueError):
+            raise Http404("No valid notification id provided.")
+
+        n = get_object_or_404(Notification, id=id, recipient=request.user)
         n.mark_read()
         return JsonResponse(data={})
     else:

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -12,6 +12,7 @@ or they could be moved into a `test_urls.py` module.
 
 import re
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
@@ -731,6 +732,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         quest = baker.make(Quest, name="TestSaveDrafts")
         draft_comment = baker.make(Comment, text="I am a test draft comment")
         sub = baker.make(QuestSubmission,
+                         user=self.test_student1,
                          quest=quest,
                          draft_comment=draft_comment)
         draft_text = "Test draft comment"
@@ -758,6 +760,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         quest = baker.make(Quest, name="TestSaveDrafts")
         # create a submission with no draft comment
         sub = baker.make(QuestSubmission, draft_comment=None,
+                         user=self.test_student1,
                          quest=quest)
 
         response = self.client.post(
@@ -777,6 +780,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         quest = baker.make(Quest, name="TestSaveDrafts")
         draft_comment = baker.make(Comment, text="I am a test draft comment")
         sub = baker.make(QuestSubmission,
+                         user=self.test_student1,
                          quest=quest,
                          draft_comment=draft_comment)
         draft_text = "I am a test draft comment"
@@ -804,6 +808,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         quest = baker.make(Quest, name="TestSaveDrafts")
         draft_comment = baker.make(Comment, text="I am a test draft comment")
         sub = baker.make(QuestSubmission,
+                         user=self.test_student1,
                          quest=quest,
                          draft_comment=draft_comment,
                          )
@@ -820,6 +825,56 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
             HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_ajax_save_draft__another_students_draft_is_not_overwritten(self):
+        """A student can't save over another student's draft: it 404s and the draft text is unchanged."""
+        self.client.force_login(self.test_student1)
+
+        original_text = "Student 2's work in progress"
+        quest = baker.make(Quest, name="TestSaveDrafts")
+        draft_comment = baker.make(Comment, text=original_text)
+        victims_sub = baker.make(QuestSubmission,
+                                 user=self.test_student2,
+                                 quest=quest,
+                                 draft_comment=draft_comment)
+
+        response = self.client.post(
+            reverse('quests:ajax_save_draft'),
+            data={
+                'comment': "Overwritten by student 1",
+                'submission_id': victims_sub.id,
+            },
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
+        draft_comment.refresh_from_db()
+        self.assertEqual(original_text, draft_comment.text)
+
+    def test_ajax_save_draft__staff_cannot_save_a_students_draft(self):
+        """A draft belongs to the student writing it; staff get the marking form, not the draft form."""
+        self.client.force_login(self.test_teacher)
+
+        original_text = "Student 1's work in progress"
+        quest = baker.make(Quest, name="TestSaveDrafts")
+        draft_comment = baker.make(Comment, text=original_text)
+        students_sub = baker.make(QuestSubmission,
+                                  user=self.test_student1,
+                                  quest=quest,
+                                  draft_comment=draft_comment)
+
+        response = self.client.post(
+            reverse('quests:ajax_save_draft'),
+            data={
+                'comment': "Overwritten by a teacher",
+                'submission_id': students_sub.id,
+            },
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
+        draft_comment.refresh_from_db()
+        self.assertEqual(original_text, draft_comment.text)
 
 
 class PaginateHelperTest(SimpleTestCase):
@@ -3360,25 +3415,33 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     url(r'^ajax_approval_info/(?P<submission_id>[0-9]+)/$', views.ajax_approval_info, name='ajax_approval_info'),
     """
 
+    INSTRUCTOR_NOTES = "Marking key: accept any answer mentioning recursion."
+
     @classmethod
     def setUpTestData(cls):
-        """Create a student, a quest, and a submission shared across the tests."""
+        """Create a teacher, two students, and a submission belonging to one of them.
+
+        The quest carries recognisable instructor notes so the tests can assert on the
+        staff-only content the rendered template exposes, not just on a status code.
+        """
+        cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
-        cls.quest = baker.make(Quest)
-        cls.submission = baker.make(QuestSubmission)
-        # cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.another_student = User.objects.create_user('another_student')
+        cls.quest = baker.make(Quest, instructor_notes=cls.INSTRUCTOR_NOTES)
+        cls.submission = baker.make(QuestSubmission, user=cls.test_student, quest=cls.quest)
 
     def setUp(self):
-        """Set up a tenant-aware test client and log in the student."""
+        """Set up a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
-        self.client.force_login(self.test_student)
 
     def test_ajax_approval_info__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
+        self.client.force_login(self.test_teacher)
         self.assert403('quests:ajax_approval_info', args=[self.submission.id])
 
     def test_ajax_approval_info__non_ajax_post_returns_403(self):
         """ This view is only accessible by an ajax POST request """
+        self.client.force_login(self.test_teacher)
         response = self.client.post(
             reverse('quests:ajax_approval_info', args=[self.submission.id])
         )
@@ -3386,6 +3449,7 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def test_ajax_approval_info__ajax_get_returns_404(self):
         """ This view is only accessible by an ajax POST request """
+        self.client.force_login(self.test_teacher)
         response = self.client.get(
             reverse('quests:ajax_approval_info', args=[self.submission.id]),
             content_type='application/json',
@@ -3394,7 +3458,8 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_ajax_approval_info__returns_json(self):
-        """An ajax POST returns a JsonResponse with the submission in context; missing id 404s."""
+        """A teacher's ajax POST returns a JsonResponse with the submission in context; missing id 404s."""
+        self.client.force_login(self.test_teacher)
         response = self.client.post(
             reverse('quests:ajax_approval_info', args=[self.submission.id]),
             content_type='application/json',
@@ -3407,6 +3472,9 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # includes the submission in context as s
         self.assertEqual(response.context['s'], self.submission)
 
+        # the approval view is where a teacher reads the staff-only instructor notes
+        self.assertIn(self.INSTRUCTOR_NOTES, response.json()['quest_info_html'])
+
         # Without a submission ID fails, 404:
         response = self.client.post(
             reverse('quests:ajax_approval_root'),  # what the heck is this used for?!
@@ -3414,6 +3482,41 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_ajax_approval_info__student_is_denied_their_own_submission(self):
+        """This is the teachers' approval view: a student can't read it even for their own work.
+
+        The template it renders includes the quest's Instructor Notes, which are staff-only.
+        """
+        self.client.force_login(self.test_student)
+        response = self.client.post(
+            reverse('quests:ajax_approval_info', args=[self.submission.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertNotContains(response, self.INSTRUCTOR_NOTES, status_code=403)
+
+    def test_ajax_approval_info__student_is_denied_another_students_submission(self):
+        """A student can't read another student's submission, which would leak their marking thread."""
+        self.client.force_login(self.another_student)
+        response = self.client.post(
+            reverse('quests:ajax_approval_info', args=[self.submission.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertNotContains(response, self.INSTRUCTOR_NOTES, status_code=403)
+
+    def test_ajax_approval_info__anonymous_is_redirected_to_login(self):
+        """An anonymous ajax POST is sent to the login page rather than served the submission."""
+        response = self.client.post(
+            reverse('quests:ajax_approval_info', args=[self.submission.id]),
+            content_type='application/json',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse(settings.LOGIN_URL), response.url)
 
 
 class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -826,6 +826,28 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_ajax_save_draft__non_numeric_submission_id_returns_404(self):
+        """A non-numeric submission id is a 404, not the ValueError the pk lookup would raise (a 500)."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(
+            reverse('quests:ajax_save_draft'),
+            data={'comment': "I am a test", 'submission_id': 'not-a-number'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_ajax_save_draft__missing_submission_id_returns_404(self):
+        """A POST with no submission id at all is a 404 rather than a crash."""
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(
+            reverse('quests:ajax_save_draft'),
+            data={'comment': "I am a test"},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_ajax_save_draft__another_students_draft_is_not_overwritten(self):
         """A student can't save over another student's draft: it 404s and the draft text is unchanged."""
         self.client.force_login(self.test_student1)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2063,7 +2063,12 @@ def ajax_save_draft(request):
         }
 
         submission_comment = request.POST.get("comment")
-        submission_id = request.POST.get("submission_id")
+        # the id is client-supplied: a missing or non-numeric one would raise ValueError
+        # in the pk lookup below (a 500), so turn it away as a 404 first.
+        try:
+            submission_id = int(request.POST.get("submission_id", ""))
+        except (TypeError, ValueError):
+            raise Http404("No valid submission id provided.")
         # xp_requested = request.POST.get('xp_requested')
 
         sub = get_object_or_404(QuestSubmission, pk=submission_id, user=request.user)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -959,8 +959,14 @@ def ajax_quest_info(request, quest_id=None):
 
 @xml_http_request_required
 @non_public_only_view
-@login_required
+@staff_member_required
 def ajax_approval_info(request, submission_id=None):
+    """Render one submission's row content for the teachers' approvals page.
+
+    Staff-only: the template it renders includes the quest's Instructor Notes and the
+    submitting student's details, and its only caller is the approvals page, which is
+    itself staff-only.
+    """
     if request.method == "POST":
         qs = QuestSubmission.objects.get_queryset(exclude_archived_quests=False, exclude_quests_not_published=False)
 
@@ -2045,6 +2051,12 @@ def skipped(request, quest_id):
 @non_public_only_view
 @login_required
 def ajax_save_draft(request):
+    """Autosave the requesting student's own draft comment and draft question answers.
+
+    Scoped to the submission's owner: a draft is the student's own work in progress, and
+    the draft form is only ever rendered for them (staff get the marking form instead), so
+    any other user's submission id is a 404.
+    """
     if request.POST:
         response_data = {
             "result": "No changes",
@@ -2054,7 +2066,7 @@ def ajax_save_draft(request):
         submission_id = request.POST.get("submission_id")
         # xp_requested = request.POST.get('xp_requested')
 
-        sub = get_object_or_404(QuestSubmission, pk=submission_id)
+        sub = get_object_or_404(QuestSubmission, pk=submission_id, user=request.user)
         # if there is no draft comment, then the quest is not in progress
         if not sub.draft_comment:
             raise Http404("No draft comment found. The quest is not in progress.")
@@ -2071,7 +2083,7 @@ def ajax_save_draft(request):
         # upload when the quest is submitted). Sent as a JSON object of the formset's field
         # names, pairing each row's hidden id with its response_text.
         answers_json = request.POST.get("answers")
-        if answers_json and sub.user == request.user and sub.quest.question_set.exists():
+        if answers_json and sub.quest.question_set.exists():
             try:
                 answers = json.loads(answers_json)
             except ValueError:

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -556,6 +556,12 @@ class VideosViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertFalse(VideoResource.objects.filter(title='Anonymous Clip').exists())
 
+    def test_videos__student_get_is_forbidden(self):
+        """A logged-in student can't even read the page: it is the staff upload form."""
+        self.client.force_login(self.test_student)
+        response = self.client.get(reverse('utilities:videos'))
+        self.assertEqual(response.status_code, 403)
+
     def test_videos__student_post_does_not_upload(self):
         """A logged-in student gets a 403 and their upload is not saved."""
         self.client.force_login(self.test_student)

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -511,7 +511,7 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
 
 class VideosViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
-    """The Video Resources page (utilities:videos) — lists videos and accepts uploads."""
+    """The Video Resources page (utilities:videos): lists videos and accepts uploads from staff."""
 
     @classmethod
     def setUpClass(cls):
@@ -532,12 +532,44 @@ class VideosViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.addClassCleanup(shutil.rmtree, cls._temp_media, ignore_errors=True)
         super().setUpClass()
 
+    @classmethod
+    def setUpTestData(cls):
+        """Create a teacher (who may manage videos) and a student (who may not)."""
+        cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.test_student = User.objects.create_user('test_student')
+
     def setUp(self):
         """Build a tenant-aware test client."""
         self.client = TenantClient(self.tenant)
 
+    def test_videos__anonymous_is_redirected_to_login(self):
+        """An anonymous visitor can't reach the page: the upload form writes to the deck's storage."""
+        self.assertRedirectsLogin('utilities:videos')
+
+    def test_videos__anonymous_post_does_not_upload(self):
+        """An anonymous POST is turned away at the login redirect without saving the file."""
+        upload = SimpleUploadedFile("anon.mp4", b"fake video bytes", content_type="video/mp4")
+        response = self.client.post(
+            reverse('utilities:videos'),
+            data={'title': 'Anonymous Clip', 'video_file': upload},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(VideoResource.objects.filter(title='Anonymous Clip').exists())
+
+    def test_videos__student_post_does_not_upload(self):
+        """A logged-in student gets a 403 and their upload is not saved."""
+        self.client.force_login(self.test_student)
+        upload = SimpleUploadedFile("student.mp4", b"fake video bytes", content_type="video/mp4")
+        response = self.client.post(
+            reverse('utilities:videos'),
+            data={'title': 'Student Clip', 'video_file': upload},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(VideoResource.objects.filter(title='Student Clip').exists())
+
     def test_videos__get_lists_existing_video_resources(self):
-        """GET renders the videos page and includes existing VideoResources in the context."""
+        """A teacher's GET renders the videos page and includes existing VideoResources in the context."""
+        self.client.force_login(self.test_teacher)
         video = VideoResource.objects.create(
             title="Intro Video",
             video_file=SimpleUploadedFile("intro.mp4", b"fake video bytes", content_type="video/mp4"),
@@ -548,7 +580,8 @@ class VideosViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn(video, list(response.context['videos']))
 
     def test_videos__post_valid_form_creates_video_resource(self):
-        """POST with a title and an uploaded file saves a new VideoResource and re-renders the page."""
+        """A teacher's POST with a title and an uploaded file saves a new VideoResource and re-renders the page."""
+        self.client.force_login(self.test_teacher)
         upload = SimpleUploadedFile("clip.mp4", b"fake video bytes", content_type="video/mp4")
         response = self.client.post(
             reverse('utilities:videos'),

--- a/src/utilities/views.py
+++ b/src/utilities/views.py
@@ -130,7 +130,13 @@ class QuerySetSequenceAutoResponseView(AutoResponseView):
 
 
 @non_public_only_view
+@staff_member_required
 def videos(request):
+    """List the deck's video resources and let staff upload a new one.
+
+    Staff-only because the page is an upload form: its POST writes a file into the
+    deck's media storage, which no student (or anonymous visitor) should be able to do.
+    """
     videos = VideoResource.objects.all()
     form = VideoForm(request.POST or None, request.FILES or None)
     if form.is_valid():


### PR DESCRIPTION
### What?

Adds the missing access checks on four endpoints, and repairs the tests that were describing the holes as correct behaviour:

| Endpoint | Today | After |
| --- | --- | --- |
| `utilities.videos()` | any anonymous visitor can upload a file into the deck's media storage | staff only |
| `notifications.ajax_mark_read` | any user can mark any other user's notification read | scoped to the recipient |
| `quest_manager.ajax_approval_info` | any student can read any submission's Instructor Notes, submitter details and marking thread | staff only |
| `quest_manager.ajax_save_draft` | any student can overwrite any other student's draft | scoped to the submission's owner |

Also turns four 500s into 404s: `ajax_mark_read` and `ajax_save_draft` both passed a client-supplied id straight into an integer pk lookup, so a missing or non-numeric one raised before the query could return.

No new issue number: these came out of the test-suite review this session rather than a bug report. Happy to file one if you want an anchor for the changelog.

### Why?

All four were found by asking what the existing tests would still pass if the view's guard were deleted. The answer in each case was "all of them", and the mechanism was the same: a fixture built without naming its owner.

Three `ajax_save_draft` tests call `baker.make(QuestSubmission, quest=quest, draft_comment=...)` with no `user=`. `QuestSubmission.user` is non-nullable, so baker invents an unrelated owner. The tests then log in as `test_student1`, post a draft, and assert it saved. They were green, and what they actually proved is that a student can overwrite another student's draft. `AjaxApprovalInfoTest` had the same shape: `cls.submission = baker.make(QuestSubmission)` with a student logged in, asserting a 200.

The video page was simpler: its tests confirmed the upload worked and never asked who did it, because they ran anonymously and passed.

Each of these was confirmed against a running database before the fix, not inferred from reading:

```
FAIL: test_videos__student_post_does_not_upload            AssertionError: 200 != 403
FAIL: test_videos__anonymous_post_does_not_upload          AssertionError: 200 != 302
FAIL: test_ajax_mark_read__another_users_notification...   AssertionError: 200 != 404
ERROR: test_ajax_mark_read__unknown_id_returns_404         Notification.DoesNotExist (a 500)
FAIL: test_ajax_approval_info__student_is_denied_another_students_submission  AssertionError: 200 != 403
FAIL: test_ajax_save_draft__another_students_draft_is_not_overwritten         AssertionError: 200 != 404
ERROR: test_ajax_save_draft__non_numeric_submission_id_returns_404  ValueError: Field 'id' expected a number
```

### How?

Four commits, grouped by app.

**`utilities.videos()`** gains `@staff_member_required`. The page is an upload form whose POST writes into the deck's media storage, and nothing in the app links to it. The project's `staff_member_required` already redirects anonymous users to login, so no separate `@login_required` is needed.

**`ajax_mark_read`** looks the notification up with `get_object_or_404(Notification, id=id, recipient=request.user)`, and coerces the client-supplied id first so a missing or non-numeric one is a 404 rather than a `ValueError` in the pk lookup.

**`ajax_approval_info`** swaps `@login_required` for `@staff_member_required`, matching `ajax_flag` next to it. Its only caller is the approvals page (`views.approvals`), which is itself `@staff_member_required`, so no student flow reaches it.

**`ajax_save_draft`** scopes the lookup with `user=request.user`, and coerces its posted `submission_id` the same way. Scoping makes the `sub.user == request.user` term in the answers branch below unreachable-as-False, so it is removed rather than left as a permanently-true condition. Staff never reach this endpoint: `views.submission` renders the marking form for staff and the draft form only for the submitting student.

On the test side, the four `baker.make(QuestSubmission, ...)` fixtures now name their owner, so the existing tests exercise the path their docstrings claim. `test_ajax_save_draft__no_submission_draft_comment` needed this too, or it would have kept passing on the new ownership 404 instead of the missing-draft one it is meant to test. The approval tests now assert on the Instructor Notes text itself, so they fail if the content leaks even when the status code is right.

### Testing?

Full suite against a local Postgres 16 + Redis:

```
Ran 1962 tests in 338.495s
OK (skipped=5)
```

Plus the rest of CI's checks: `ruff check src` clean, `manage.py check` clean, `makemigrations --check --dry-run` reports no changes.

Coverage on the changed modules: `notifications/views.py` and `utilities/views.py` at 100% (statements and branches). `quest_manager/views.py`'s draft-answers block is covered by `src/questions/tests/test_integration.py`, so it reads 95% when `quest_manager` is run alone and is covered in a full run.

14 new tests; each was confirmed to fail before its fix (output above).

### Screenshots (if front end is affected)

The one page a user can navigate to that changes is `/utilities/videos/`. Captured from a seeded `hackerspace` deck at `http://hackerspace.localhost:8000` (`initdb` + `generate_content hackerspace`).

**Before: not signed in at all, and the upload form is right there.** Note "Sign Up" in the top right: this is an anonymous visitor.

![Before, anonymous visitor sees the upload form](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2304/before_anonymous.png)

**Before: a student sees the same upload form.**

![Before, a logged-in student sees the upload form](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2304/before_student.png)

**After: the student gets the deck's 403 page.**

![After, a logged-in student gets 403 Permission Denied](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2304/after_student.png)

**After: a teacher (the deck owner) still gets the page and can upload, unchanged.**

![After, the deck owner still sees the video resources page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2304/after_teacher.png)

The other three endpoints are ajax-only and have no page of their own, so there is nothing to show for them beyond the tests.

### Anything Else?

This is the first PR from the test-suite review. The next one is the structural change that puts `ViewTestUtilsMixin` on `ByteDeckTenantTestCase` and deletes the ~59 `setUp` methods that only build a `TenantClient`.

Worth noting for review: nothing in the app links to `utilities:videos`, so making it staff-only should be invisible in practice. If it is actually meant to be a student-facing video library, the right shape would be a staff-only upload with a student-readable list, and I will split it that way instead.

CodeRabbit's first pass found the `ajax_save_draft` malformed-id 500 (a real one, same shape as the `ajax_mark_read` case already in the PR) and a missing student-GET test; both are fixed in `e34ed90`. I declined its docstring nitpick asking for parameter/return sections, since none of the surrounding view functions in these modules carry them.

### Review request
@tylerecouture

- Claude Code (`bytedeck - test suite review`)