### PR TITLE
ci: post only unannounced changelog sections; sharpen server-doc diagnostics

### DIFF
--- a/.github/scripts/changelog_new_sections.py
+++ b/.github/scripts/changelog_new_sections.py
@@ -85,6 +85,7 @@ def parse_sections(text):
     current_lines = []
 
     def flush():
+        """Append the section collected so far, if any, to ``sections``."""
         if current_version is not None:
             # Drop trailing blank lines so joined sections space evenly.
             body = "\n".join(current_lines).rstrip("\n")
@@ -133,6 +134,11 @@ def write_output(name, value):
 
 
 def main():
+    """Diff the changelog against ``BEFORE_SHA`` and emit the workflow outputs.
+
+    Writes ``discussion_body.md`` plus the ``has_new``/``title``/``versions``
+    outputs described in the module docstring.
+    """
     before_sha = os.environ.get("BEFORE_SHA", "")
     new_text = read_current(CHANGELOG)
     available, old_text = read_old(before_sha, CHANGELOG)

--- a/.github/workflows/announce-changelog.yml
+++ b/.github/workflows/announce-changelog.yml
@@ -58,11 +58,10 @@ jobs:
           github-token: ${{ secrets.DISCUSSIONS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const title = process.env.DISCUSSION_TITLE;
             const versions = (process.env.DISCUSSION_VERSIONS || '')
               .split(',')
               .filter(Boolean);
-            const body = fs.readFileSync('discussion_body.md', 'utf8');
+            const fullBody = fs.readFileSync('discussion_body.md', 'utf8');
             const { owner, repo } = context.repo;
 
             // Look up the repository node id and its discussion categories so we
@@ -96,8 +95,9 @@ jobs:
             // announcement and always appears in the discussion title, so this
             // still recognizes a version a previous post announced alongside
             // others under a different aggregate title (e.g. a later force-push
-            // fallback re-announcing just the newest). If every version in this
-            // post is already announced, skip; otherwise post.
+            // fallback re-announcing just the newest). Versions that were already
+            // announced are dropped from this post; if none are left, the post
+            // is skipped entirely.
             const titleHasVersion = (discussionTitle, version) => {
               // Bounded match so "1.3.0" doesn't match "1.30.0" or "11.3.0".
               const escaped = version.replace(/\./g, '\\.');
@@ -115,9 +115,35 @@ jobs:
               return res.search.nodes.some((n) => n && titleHasVersion(n.title, version));
             };
             const announced = await Promise.all(versions.map(versionAnnounced));
-            if (versions.length && announced.every(Boolean)) {
+            const newVersions = versions.filter((v, i) => !announced[i]);
+            if (versions.length && newVersions.length === 0) {
               core.info(`Version(s) already announced, skipping: ${versions.join(', ')}`);
               return;
+            }
+
+            // Mixed batch: part of this push was announced before (e.g. a section
+            // restored by a history rewrite landing alongside a genuinely new
+            // release). Keep only the unannounced sections in the body and
+            // rebuild the title to name just those versions. newVersions
+            // preserves the extract script's ascending order, and the title
+            // wording mirrors its format_title().
+            let title = process.env.DISCUSSION_TITLE;
+            let body = fullBody;
+            if (newVersions.length < versions.length) {
+              const dropped = versions.filter((v, i) => announced[i]);
+              core.info(`Already announced, dropped from this post: ${dropped.join(', ')}`);
+              const sections = fullBody.split(/^(?=### \[\d+\.\d+\.\d+\])/m);
+              const kept = sections.filter((section) => {
+                const match = section.match(/^### \[(\d+\.\d+\.\d+)\]/);
+                return match && newVersions.includes(match[1]);
+              });
+              body = kept.map((s) => s.replace(/\s+$/, '')).join('\n\n\n') + '\n';
+              const last = newVersions[newVersions.length - 1];
+              const joined =
+                newVersions.length === 1 ? last
+                : newVersions.length === 2 ? `${newVersions[0]} and ${last}`
+                : `${newVersions.slice(0, -1).join(', ')}, and ${last}`;
+              title = `Bytedeck App Updates (${joined})`;
             }
 
             const created = await github.graphql(

--- a/nginx/bytedeck.conf.template
+++ b/nginx/bytedeck.conf.template
@@ -110,8 +110,8 @@ server {
     # OCSP responders in 2025 (in favour of CRLs), so its certificates carry no
     # OCSP URL and "ssl_stapling on" only produced a startup warning
     # ('"ssl_stapling" ignored, no OCSP responder URL in the certificate').
-    # The `resolver` directive that existed solely for OCSP fetching was
-    # removed along with it.
+    # The resolver at the top of this file is for Docker DNS resolution of the
+    # `web` upstream and plays no part in OCSP.
 
     # GZIP SETTINGS: https://www.nginx.com/blog/help-the-world-by-healing-your-nginx-configuration/#Enabling-Gzip-Compression-for-HTML-CSS-and-JavaScript-Files
     gzip on;

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -273,11 +273,18 @@ request, so it redirects every request forever).
 
 ## Troubleshooting
 
-- **502 right after a restart:** expected for a minute or two. The `web`
-  container runs `migrate_schemas` over every tenant schema and then
-  `collectstatic` before uwsgi binds :8000, and nginx has nothing to talk to
-  until it does. Watch for `spawned uWSGI master process` in
-  `docker compose ... logs web`.
+- **502 right after a restart:** expected while `web` is still starting, and it
+  lasts as long as startup does rather than any fixed time: the `web` container
+  runs `migrate_schemas` over every tenant schema and then `collectstatic`
+  before uwsgi binds :8000 (the more tenants, the longer it takes; the
+  container healthcheck allows up to 10 minutes), and nginx has nothing to talk
+  to until it does. The 502s clear once `spawned uWSGI master process` appears
+  in the web logs:
+  ```bash
+  cd ~/bytedeck
+  C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
+  $C logs -f web
+  ```
 - **502 that does not clear:** check that nginx is dialling the address `web`
   actually has:
   ```bash
@@ -285,9 +292,11 @@ request, so it redirects every request forever).
   C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
   $C logs nginx | grep -o 'upstream: "uwsgi://[^"]*"' | tail -1   # who nginx calls
   $C ps -q web | xargs docker inspect \
-      -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'  # where web is
+      -f '{{range $name, $net := .NetworkSettings.Networks}}{{$name}}={{$net.IPAddress}} {{end}}'  # web's IP per network
   ```
-  These must match. If they do not, nginx is holding a stale address: confirm
+  The upstream address must match web's IP on the network it shares with nginx
+  (`backend-network`; web also sits on `frontend-network`, and that IP is not
+  the one nginx dials). If they do not match, nginx is holding a stale address: confirm
   the site config still carries the `resolver` line and the `$web_upstream`
   variable in `uwsgi_pass` (see `nginx/bytedeck.conf.template`), since dropping
   either one restores the old resolve-once-at-startup behaviour.


### PR DESCRIPTION
### What

Carries forward the CodeRabbit review fixes from #2303 (commit 60854b4 there). That PR was closed when `staging` was merged into `develop` directly, which achieved the convergence but left these follow-up fixes stranded on the closed branch. This PR cherry-picks them onto the current `develop`; the diff is identical to what CodeRabbit already reviewed and approved on #2303.

- `announce-changelog.yml`: a push whose new changelog sections mix an already-announced version with a genuinely new one now drops the announced sections and rebuilds the discussion title/body to cover only the new versions, instead of reposting everything unfiltered.
- `SERVER-README.md` troubleshooting: the post-restart 502 note no longer claims a fixed "minute or two" (startup scales with tenant count; the healthcheck allows 10 minutes) and now includes a runnable compose command; the `docker inspect` diagnostic labels web's IP per network so it can be compared against the nginx upstream on their shared `backend-network`.
- Docstrings on `changelog_new_sections.py`'s `main()` and `flush()`.
- nginx template: the OCSP-stapling comment now describes the current resolver's Docker DNS role rather than referring to a removed one.

### Testing

Full suite, ruff, and `makemigrations --check` pass locally on this branch (no `src/` code is touched). The announcement workflow's mixed-batch filter logic was exercised with a standalone assertion script covering all-new, all-announced, and mixed batches, single-survivor titles, and heading-boundary edge cases (a bracketed version string inside section content is not treated as a section boundary).

### Screenshots

N/A (CI workflow, docs, and comment changes only).

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_