### PR TITLE
test: give every tenant test the view helpers and a tenant client by default

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -7,19 +7,18 @@ from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
 from announcements.forms import AnnouncementForm
 from announcements.models import Announcement
 from comments.models import Comment
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
 
 User = get_user_model()
 
 
-class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AnnouncementViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -31,10 +30,6 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         cls.test_announcement = baker.make(Announcement, draft=False)
         cls.ann_pk = cls.test_announcement.pk
-
-    def setUp(self):
-        """Set up a tenant test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_announcement_form__has_unsaved_changes_guard(self):
         """The announcement create and edit forms opt into the unsaved-changes warning, and the guard script is loaded (#192)."""
@@ -389,7 +384,7 @@ class AnnouncementViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, "CustomAnnouncement commented on")
 
 
-class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AnnouncementArchivedViewTests(ByteDeckTenantTestCase):
     """ Tests for archived announcements view and other archived processes
 
     Mostly this one:
@@ -403,10 +398,6 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_teacher = baker.make(User, is_staff=True)
         cls.test_student = baker.make(User)
         cls.test_announcement = baker.make(Announcement, draft=False)
-
-    def setUp(self):
-        """Set up a tenant test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_archived_announcement__hidden_from_list(self):
         """ Archived announcements should not appear in announcements list"""
@@ -492,7 +483,7 @@ class AnnouncementArchivedViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertTrue(announcement.archived)
 
 
-class AnnouncementCreateUpdateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AnnouncementCreateUpdateViewTests(ByteDeckTenantTestCase):
     """Covers the Create/Update CBV form_valid + success-message branches and EmptyPage paging."""
 
     @classmethod
@@ -500,10 +491,6 @@ class AnnouncementCreateUpdateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCa
         """Create a staff author and one existing published announcement to edit."""
         cls.teacher = User.objects.create_user('cu_teacher', is_staff=True)
         cls.announcement = baker.make(Announcement, draft=False)
-
-    def setUp(self):
-        """Set up a tenant test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def _form_data(self, **overrides):
         """Return valid AnnouncementForm POST data (title/content/release), with overrides applied."""

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -2,7 +2,6 @@ from unittest import mock
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 from model_bakery.recipe import Recipe
 
@@ -87,10 +86,6 @@ class BadgeTestModel(ByteDeckTenantTestCase):
     def setUpTestData(cls):
         """Create a Badge for the class tests."""
         cls.badge = baker.make(Badge)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_badge__creation(self):
         """A Badge is created and its str is its name."""
@@ -209,10 +204,6 @@ class BadgeAssertionManagerTest(ByteDeckTenantTestCase):
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
 
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
-
     def test_user_badge_assertion_count__annotates_count_per_user(self):
         """Test that BadgeAssertion.objects.user_assertion_count_of_badge() returns a User queryset with
         the correct number of assertions for each user as an "assertion_count" annotation on the queryset"""
@@ -297,10 +288,6 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         cls.badge = Recipe(Badge, xp=20).make()
 
         cls.badge_assertion_recipe = Recipe(BadgeAssertion, user=cls.student, badge=cls.badge, semester=cls.sem)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_badge_assertion__creation(self):
         """A BadgeAssertion is created and its str is its badge's name."""

--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -6,11 +6,10 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
 from badges.models import Badge, BadgeAssertion, BadgeType
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from prerequisites.models import Prereq
 from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
@@ -23,7 +22,7 @@ import json
 User = get_user_model()
 
 
-class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class BadgeViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -40,10 +39,6 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_badge.tags.add('tag')
         cls.test_badge_type = baker.make(BadgeType)
         cls.test_assertion = baker.make(BadgeAssertion)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_badge_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to home  '''
@@ -544,7 +539,7 @@ class BadgeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(request, "CustomBadge Type")
 
 
-class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class BadgeTypeViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -554,10 +549,6 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_student1 = User.objects.create_user('test_student')
 
         cls.badge_type = baker.make(BadgeType)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to login page '''
@@ -667,7 +658,7 @@ class BadgeTypeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(request, 'Delete CustomBadge Type')
 
 
-class BadgeAjaxTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class BadgeAjaxTests(ByteDeckTenantTestCase):
     """ test case for
     + ajax/on_show_badge_popup/
     + ajax/on_close_badge_popup/
@@ -702,10 +693,6 @@ class BadgeAjaxTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.badge_type2 = baker.make(BadgeType)
         cls.badge_single = baker.make(Badge, badge_type=cls.badge_type2)
         cls.create_assertion_notification(cls.badge_single)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_status_codes__badge_popup_endpoints(self):
         ''' tests correct status codes for `on_show_badge_popup` and `on_close_badge_popup`

--- a/src/bytedeck_summernote/tests/test_views.py
+++ b/src/bytedeck_summernote/tests/test_views.py
@@ -1,15 +1,10 @@
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 
 class TestByteDeckSummernoteView(ByteDeckTenantTestCase):
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
-
     def test_url__editor_view_responds(self):
         """Customized view class is configured and respond"""
         url = reverse("bytedeck_summernote-editor", kwargs={"id": "foobar"})

--- a/src/comments/tests/test_views.py
+++ b/src/comments/tests/test_views.py
@@ -1,18 +1,17 @@
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from unittest.mock import patch
 from model_bakery import baker
 from comments.models import Comment
 from bs4 import BeautifulSoup
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 User = get_user_model()
 
 
-class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CommentViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -30,10 +29,6 @@ class CommentViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             target_content_type=None,
         )
         cls.comment_decoy = baker.make('comments.Comment', target_content_type=None)
-
-    def setUp(self):
-        """Set up a tenant test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     @patch('comments.models.Comment.unflag')
     def test_unflag__staff_only_calls_unflag(self, mock_unflag):

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -15,7 +15,7 @@ from courses.models import Block, Course, CourseStudent, MarkRange, Semester, Ra
 from quest_manager.models import Quest, QuestSubmission
 from badges.models import Badge, BadgeAssertion
 from notifications.models import Notification, notify_rank_up
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin, generate_form_data, model_to_form_data, generate_formset_data
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase, generate_form_data, model_to_form_data, generate_formset_data
 from siteconfig.models import SiteConfig
 from djcytoscape.models import CytoScape
 
@@ -27,7 +27,7 @@ import json
 User = get_user_model()
 
 
-class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class RankViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -37,10 +37,6 @@ class RankViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_rank_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to login page '''
@@ -186,7 +182,7 @@ class CourseViewTestData:
         self.client = TenantClient(self.tenant)
 
 
-class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
 
     def test_all_page_status_codes__anonymous_redirected(self):
         ''' If not logged in then all views should redirect to home page '''
@@ -482,7 +478,7 @@ class CourseViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTest
         self.assertContains(response, dt_well_ptag)
 
 
-class CourseStudentViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
 
     def test_CourseStudentUpdate_view__staff_can_update(self):
         """ Staff can update a student's course """
@@ -783,7 +779,7 @@ class CourseStudentViewTests(CourseViewTestData, ViewTestUtilsMixin, ByteDeckTen
         self.assertFalse(any('added to' in m for m in messages))
 
 
-class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class MarkRangeViewTests(ByteDeckTenantTestCase):
     """Test module for the MarkRange model's view classes"""
 
     @classmethod
@@ -801,10 +797,6 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             'color_dark': '#337AB7',
             'days': '1,2,3,4,5,6,7',
         }
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_MarkRangeList_view__lists_all(self):
         """The MarkRange list view's object list should contain all MarkRange objects"""
@@ -859,7 +851,7 @@ class MarkRangeViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(MarkRange.objects.filter(id=1).exists())
 
 
-class SemesterStatusBannerTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SemesterStatusBannerTests(ByteDeckTenantTestCase):
     """The staff-only semester status banner rendered on every page via base.html
     (semester_status_banner.html): nudges archiving an ended active semester (#2157)
     and warns when no semester is open for students to join (#1177)."""
@@ -871,10 +863,6 @@ class SemesterStatusBannerTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """A teacher and a student for checking who sees the banner."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_semester_status_banner__hidden_while_active_semester_is_running(self):
         """No banner renders while the active semester is open and within its dates."""
@@ -937,7 +925,7 @@ class SemesterStatusBannerTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotIn(self.BANNER_ID, html)
 
 
-class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SemesterViewTests(ByteDeckTenantTestCase):
 
     def generate_dates(quantity, dates=None):
         """
@@ -963,10 +951,6 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUpTestData(cls):
         """Create a teacher for the class tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_SemesterList_view__lists_semesters(self):
         """The semester list view renders each semester with its day counts and excluded-date counts."""
@@ -1230,16 +1214,12 @@ class SemesterViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn(registration, response.context['registrations'])
 
 
-class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class BlockViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
         """Create a teacher for the class tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_BlockList_view__staff_can_view(self):
         """ Admin should be able to view block list """
@@ -1323,7 +1303,7 @@ class BlockViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(form['current_teacher'].value(), SiteConfig.get().deck_owner.pk)
 
 
-class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class TestAjax_MarkDistributionChart(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1334,10 +1314,6 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase)
         cls.course = baker.make(Course)
         cls.semester = SiteConfig.get().active_semester
         cls.inactive_semester = baker.make(Semester)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def create_student_course(self, xp):
         """
@@ -1453,7 +1429,7 @@ class TestAjax_MarkDistributionChart(ViewTestUtilsMixin, ByteDeckTenantTestCase)
         self.assertEqual(total_students, len(active_sem_students))
 
 
-class TestAjax_TagChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class TestAjax_TagChart(ByteDeckTenantTestCase):
     """Tests for the Ajax_TagChart view (courses:ajax_tag_progress_chart), which returns
     per-tag quest/badge XP datasets for chart.js."""
 
@@ -1462,10 +1438,6 @@ class TestAjax_TagChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """Create the target user whose tag chart is requested, and cache the active semester."""
         cls.user = baker.make(User)
         cls.semester = SiteConfig.get().active_semester
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def _tagged_quest_with_submissions(self, tag, xp, max_xp, quantity):
         """Make a tagged quest and `quantity` approved, active-semester submissions for self.user.
@@ -1568,7 +1540,7 @@ class TestAjax_TagChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertTrue(all('(' not in name for name in badge_names), badge_names)
 
 
-class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class TestAjax_ProgressChart(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1596,10 +1568,6 @@ class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # (UTC-8) for datetime.date(2024, 1, 1)
         cls.tz = timezone.get_default_timezone()
         cls.base_xp = 1
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def create_quest_and_submissions(self, xp, quest_submission_date, quest_submission_quantity=1):
         """
@@ -1792,7 +1760,7 @@ class TestAjax_ProgressChart(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertEqual(valid_days, 10)
 
 
-class MarkCalculationsViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class MarkCalculationsViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1812,8 +1780,6 @@ class MarkCalculationsViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
-
         # to show mark calculation page without 404 you need to turn this on
         # (stays in setUp: SiteConfig writes populate cross-test caches)
         siteconfig = SiteConfig.get()
@@ -1893,7 +1859,7 @@ class MarkCalculationsViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, '1068')  # 1250 * 0.855 = 1068.75
 
 
-class AjaxRankPopupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AjaxRankPopupTests(ByteDeckTenantTestCase):
     """ test case for
     + ajax/on_show_ranked_popup/
     + ajax/on_close_ranked_popup/
@@ -1903,10 +1869,6 @@ class AjaxRankPopupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUpTestData(cls):
         """Create a student for the rank popup tests."""
         cls.student = baker.make(User)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_status_codes__ranked_popup_endpoints(self):
         ''' tests correct status codes for `on_show_ranked_popup` and `on_close_ranked_popup`
@@ -2043,7 +2005,7 @@ class AjaxRankPopupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(Notification.objects.all_unread(self.student).count(), 1)
 
 
-class DeckCapacityEnforcementTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class DeckCapacityEnforcementTests(ByteDeckTenantTestCase):
     """Enforcement of the deck's current-student cap at the registration choke points
     (#1729 PR 4; closes the 'trial mode (max 5 users)' checkbox of #1730)."""
 
@@ -2062,7 +2024,6 @@ class DeckCapacityEnforcementTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.tenant.max_active_users = 1
         self.tenant.save()
 
-        self.client = TenantClient(self.tenant)
         self.occupant = baker.make(User)
         baker.make('courses.CourseStudent', user=self.occupant, active=True, semester=SiteConfig.get().active_semester)
         self.newcomer = baker.make(User)

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -9,12 +9,12 @@ from unittest.mock import patch
 from djcytoscape.models import CytoScape
 
 from profile_manager.models import Profile
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin, generate_form_data
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase, generate_form_data
 
 User = get_user_model()
 
 
-class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class ViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -42,10 +42,6 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             initial_content_type=cls.quest_ct,
             initial_object_id=cls.map_initial_quest.id,
         )
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to home page  '''
@@ -185,7 +181,7 @@ class ViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         mock_regenerate.assert_called_once()
 
 
-class QuestMapAccessAndInterlinkTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestMapAccessAndInterlinkTests(ByteDeckTenantTestCase):
     """Access-control and interlink/generate branches of the map views."""
 
     @classmethod
@@ -207,10 +203,6 @@ class QuestMapAccessAndInterlinkTests(ViewTestUtilsMixin, ByteDeckTenantTestCase
             initial_content_type=cls.quest_ct,
             initial_object_id=cls.map_quest.id,
         )
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_quest_map_personalized__student_cannot_view_another_students_map(self):
         """A non-staff user requesting another user's personalized map gets a 404."""
@@ -254,7 +246,7 @@ class QuestMapAccessAndInterlinkTests(ViewTestUtilsMixin, ByteDeckTenantTestCase
         self.assertTemplateUsed(response, 'djcytoscape/generate_new_form.html')
 
 
-class UpdateMapMessageMixinTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class UpdateMapMessageMixinTests(ByteDeckTenantTestCase):
     """UpdateMapMessageMixin adds a 'maps are being updated' message after editing/deleting a
     model that maps depend on (ranks/quests/badges). Its map-auto-update-off path is exercised
     here through a rank delete (RankDelete mixes it in); the message-emitting path is covered by
@@ -262,7 +254,6 @@ class UpdateMapMessageMixinTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Log in a staff user (the mixin's consumer views require staff)."""
-        self.client = TenantClient(self.tenant)
         self.staff = User.objects.create_user('mixin_staff', is_staff=True)
         self.client.force_login(self.staff)
 
@@ -287,7 +278,7 @@ class UpdateMapMessageMixinTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         )
 
 
-class PrimaryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class PrimaryViewTests(ByteDeckTenantTestCase):
 
     def test_primary__generates_initial_map_on_first_view(self):
         """Viewing the primary map for the first time generates the 'Main' map."""
@@ -307,7 +298,7 @@ class PrimaryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertTrue(CytoScape.objects.filter(name="Main").exists())
 
 
-class RegenerateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class RegenerateViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -320,7 +311,6 @@ class RegenerateViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant client logged in as the staff user."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.staff_user)
 
     def test_regenerate__redirects_to_quest_map(self):

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -5,22 +5,17 @@ from django.contrib.auth import get_user_model
 from django.core import mail
 from django.shortcuts import reverse
 
-from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 User = get_user_model()
 
 
-class NonPublicOnlyAuthViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class NonPublicOnlyAuthViewTests(ByteDeckTenantTestCase):
     """
     Custom `non_public_only_view` decorator was applied on every `allauth` views.
     """
-
-    def setUp(self):
-        """Use a tenant-aware client for each test."""
-        self.client = TenantClient(self.tenant)
 
     @patch('hackerspace_online.views.connection', schema_name=get_public_schema_name())
     @patch('tenant.views.connection', schema_name=get_public_schema_name())
@@ -63,7 +58,7 @@ class NonPublicOnlyAuthViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert200('account_reset_password_from_key_done')  # ok
 
 
-class SuspendedDeckSignupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SuspendedDeckSignupTests(ByteDeckTenantTestCase):
     """Sign-up is closed on a suspended deck (#1734 redesign): a suspended deck is
     owner-only, so brand-new accounts must not be able to register and land in a
     signed-in session."""
@@ -76,7 +71,6 @@ class SuspendedDeckSignupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         from tenant.models import Tenant
         from tenant.utils import deck_cache_key
 
-        self.client = TenantClient(self.tenant)
         cache.delete(deck_cache_key(self.tenant.schema_name))
         self.set_deck = lambda **fields: (
             Tenant.objects.filter(pk=self.tenant.pk).update(**fields),
@@ -131,7 +125,7 @@ class SuspendedDeckSignupTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotContains(response, 'Sign-up is currently closed')
 
 
-class ResetPasswordViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class ResetPasswordViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -139,10 +133,6 @@ class ResetPasswordViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_email = 'test_email@bytedeck.com'
         cls.test_password = 'password'
         cls.test_student1 = User.objects.create_user('test_student', email=cls.test_email, password=cls.test_password)
-
-    def setUp(self):
-        """Use a tenant-aware client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_request_password_reset__fails_for_unassigned_email(self):
         """ User should not be able to request password reset if they registered without an email """

--- a/src/hackerspace_online/tests/test_middleware.py
+++ b/src/hackerspace_online/tests/test_middleware.py
@@ -7,7 +7,6 @@ from django.contrib.messages import get_messages
 from django.test import override_settings, RequestFactory, SimpleTestCase
 from django.http import HttpResponse
 
-from django_tenants.test.client import TenantClient
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
@@ -51,8 +50,6 @@ class RequestDataTooBigMiddlewareTestCase(ByteDeckTenantTestCase):
 
     def setUp(self):
         """Use a tenant client and ensure RequestDataTooBigMiddleware is enabled."""
-        self.client = TenantClient(self.tenant)
-
         # make sure RequestDataTooBig middleware is enabled for a testing purpose
         self.old_MIDDLEWARE = settings.MIDDLEWARE
         middleware_class = "hackerspace_online.middleware.RequestDataTooBigMiddleware"

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -3,11 +3,10 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 
-from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name, schema_context, tenant_context
 
 from hackerspace_online.signals import change_domain_urls
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from tenant.models import Tenant
 
 # from django.shortcuts import reverse
@@ -17,11 +16,7 @@ from tenant.models import Tenant
 User = get_user_model()
 
 
-class SignalTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
-    def setUp(self):
-        """Use a tenant-aware client for each test."""
-        self.client = TenantClient(self.tenant)
-
+class SignalTest(ByteDeckTenantTestCase):
     def test_handle_tenant_site_domain_update__long_domain_truncates_site_name(self):
         """A tenant whose full domain exceeds Site.name's 50-char limit is still
         created successfully.

--- a/src/hackerspace_online/tests/test_utils.py
+++ b/src/hackerspace_online/tests/test_utils.py
@@ -3,7 +3,6 @@ from django.contrib.auth import get_user_model
 from django.db import connection
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 
 from model_bakery import baker
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase, generate_form_data
@@ -21,10 +20,6 @@ class Utils_generate_form_data_Test(ByteDeckTenantTestCase):
     def setUpTestData(cls):
         """Create a teacher used to authenticate the form-submission requests."""
         cls.teacher = get_user_model().objects.create(username="teacher", is_staff=True,)
-
-    def setUp(self):
-        """Use a tenant-aware client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_generate_form_data__valid_SiteConfig_model(self):
         """

--- a/src/hackerspace_online/tests/test_views.py
+++ b/src/hackerspace_online/tests/test_views.py
@@ -5,24 +5,16 @@ from django.contrib.sites.models import Site
 from django.shortcuts import reverse
 from django.templatetags.static import static
 
-from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name, schema_context
 from unittest.mock import patch
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
 
 User = get_user_model()
 
 
-class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
-    def setUp(self):
-        """Use a tenant-aware client for each test."""
-        # Every test needs access to the request factory.
-        # https://docs.djangoproject.com/en/5.2/topics/testing/advanced/#the-request-factory
-        # self.factory = RequestFactory()
-        self.client = TenantClient(self.tenant)
-
+class ViewsTest(ByteDeckTenantTestCase):
     def test_secret_view__returns_200(self):
         """The 'simple' secret view responds with 200."""
         self.assert200('simple')
@@ -93,11 +85,7 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertRedirects(self.client.get('/achievements/1/delete/'), reverse('badges:badge_delete', args=[1]))
 
 
-class GoogleSigninViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
-
-    def setUp(self):
-        """Use a tenant-aware client for each test."""
-        self.client = TenantClient(self.tenant)
+class GoogleSigninViewTest(ByteDeckTenantTestCase):
 
     def test_enable_google_signin__False_hides_button(self):
         """

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -8,6 +8,7 @@ from django.shortcuts import reverse
 from django.test import RequestFactory
 
 from django_tenants.test.cases import TenantTestCase
+from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_tenant_model, get_tenant_domain_model
 
 from model_bakery import baker
@@ -17,10 +18,191 @@ import re
 import warnings
 
 
-class ByteDeckTenantTestCase(TenantTestCase):
+class ViewTestUtilsMixin():
+    """
+    Utility methods to make cleaner tests for common response assertions.  The base class must
+    be a django TestCase.
+
+    ``ByteDeckTenantTestCase`` already inherits this, so tenant tests get these helpers
+    for free and must **not** list the mixin themselves. Naming a class ahead of its own
+    base is an unresolvable MRO, so doing it raises ``TypeError`` at import time rather
+    than being silently redundant. Only a test case built on some other base needs it.
+    """
+
+    def assertRedirectsAdmin(self, url_name, *args, **kwargs):
+        """
+        Redirection to django admin is now deprecated.
+        Use assertRedirectsLogin(self, url_name, *args, **kwargs) instead.
+
+        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the admin login page.
+        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
+
+        """
+        warnings.warn("Redirection to django admin is now deprecated.\nUse assertRedirectsLogin(self, url_name, *args, **kwargs) instead...",
+                      stacklevel=2)
+        self.assertRedirects(
+            response=self.client.get(reverse(url_name, *args, **kwargs)),
+            expected_url='{}?next={}'.format('/admin/login/', reverse(url_name, *args, **kwargs)),
+        )
+
+    def assertRedirectsHome(self, url_name, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the home page
+        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
+        """
+        self.assertRedirects(
+            response=self.client.get(reverse(url_name, *args, **kwargs)),
+            expected_url='{}?next={}'.format(reverse('home'), reverse(url_name, *args, **kwargs)),
+        )
+
+    def assertRedirectsLogin(self, url_name, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the login page
+        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
+        """
+        self.assertRedirects(
+            response=self.client.get(reverse(url_name, *args, **kwargs)),
+            expected_url=f'{reverse(settings.LOGIN_URL)}?next={reverse(url_name, *args, **kwargs)}'
+        )
+
+    def assertRedirectsLoginURL(self, url_name):
+        """
+            assertRedirectsLogin function without reverse() hard coded inside it
+
+            Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the login page
+            with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
+        """
+        self.assertRedirects(
+            response=self.client.get(url_name),
+            expected_url=f'{reverse(settings.LOGIN_URL)}?next={url_name}'
+        )
+
+    def assertRedirectsQuests(self, url_name, follow=False, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the available quests page.
+        Provide any url and path parameters as args or kwargs.
+
+        Returns the response object.
+        """
+        response = self.client.get(reverse(url_name, *args, **kwargs), follow=follow)
+        self.assertRedirects(
+            response=response,
+            expected_url=reverse('quest_manager:quests'),
+        )
+        return response
+
+    def assert200(self, url_name, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) succeeded with a status code of 200.
+        Provide any url and path parameters as args or kwargs.
+
+        Returns the response object.
+        """
+        response = self.client.get(reverse(url_name, *args, **kwargs))
+        self.assertEqual(
+            response.status_code,
+            200
+        )
+        return response
+
+    def assert200URL(self, url):
+        """ Assert that a GET response succeeded with a status code of 200.
+        """
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code,
+            200
+        )
+
+    def assert302(self, url_name, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) gives a 302 Redirect.
+        For example, when an unauthenticated user attempts to access a view with the LoginRequiredMixin
+        Provide any url and path parameters as args or kwargs.
+        """
+        response = self.client.get(reverse(url_name, *args, **kwargs))
+        self.assertEqual(
+            response.status_code,
+            302
+        )
+        return response
+
+    def assert404(self, url_name, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) fails with a status code of 404.
+        Provide any url and path parameters as args or kwargs.
+
+        Returns the response object.
+        """
+        response = self.client.get(reverse(url_name, *args, **kwargs))
+        self.assertEqual(
+            response.status_code,
+            404
+        )
+        return response
+
+    def assert404URL(self, url):
+        """Assert that a GET response fails with a status code of 404."""
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code,
+            404
+        )
+
+    def assert403(self, url_name, *args, **kwargs):
+        """
+        Assert that a response to reverse(url_name, *args, **kwargs) is permission denied: 403
+        Provide any url and path parameters as args or kwargs.
+
+        Returns the response object.
+        """
+        response = self.client.get(reverse(url_name, *args, **kwargs))
+        self.assertEqual(
+            response.status_code,
+            403
+        )
+        return response
+
+    def get_message_list(self, response):
+        """ Django messages missing from context of redirected views, so get another way
+        https://stackoverflow.com/questions/2897609/how-can-i-unit-test-django-messages
+        https://docs.djangoproject.com/en/5.2/ref/contrib/messages/
+        """
+        return list(response.wsgi_request._messages)
+
+    def assertSuccessMessage(self, response):
+        """ Assert that a response, including redirects, provides a single success message
+        """
+        message_list = self.get_message_list(response)
+        self.assertEqual(len(message_list), 1)
+        self.assertEqual(message_list[0].level, messages.SUCCESS)
+
+    def assertWarningMessage(self, response):
+        """ Assert that a response, including redirects, provides a single warning message
+        """
+        message_list = self.get_message_list(response)
+        self.assertEqual(len(message_list), 1)
+        self.assertEqual(message_list[0].level, messages.WARNING)
+
+    def assertErrorMessage(self, response):
+        """ Assert that a response, including redirects, provides a single error message
+        """
+        message_list = self.get_message_list(response)
+        self.assertEqual(len(message_list), 1)
+        self.assertEqual(message_list[0].level, messages.ERROR)
+
+    def assertInfoMessage(self, response):
+        """ Assert that a response, including redirects, provides a single info message
+        """
+        message_list = self.get_message_list(response)
+        self.assertEqual(len(message_list), 1)
+        self.assertEqual(message_list[0].level, messages.INFO)
+
+
+class ByteDeckTenantTestCase(ViewTestUtilsMixin, TenantTestCase):
     """A TenantTestCase that reuses one test schema across classes and runs ``setUpTestData``.
 
-    Two problems with django-tenants' ``TenantTestCase`` are fixed here:
+    Three problems with django-tenants' ``TenantTestCase`` are fixed here:
 
     1. **``setUpTestData`` never runs.** ``TenantTestCase.setUpClass`` doesn't call
        ``super().setUpClass()``, so Django ``TestCase``'s class-level setup — the
@@ -30,9 +212,16 @@ class ByteDeckTenantTestCase(TenantTestCase):
 
     2. **The schema is rebuilt for every test class.** ``TenantTestCase`` creates a
        fresh schema, replays *all* tenant-app migrations, and re-seeds the tenant's
-       initial data in ``setUpClass``, then drops it in ``tearDownClass`` — once per
+       initial data in ``setUpClass``, then drops it in ``tearDownClass``: once per
        test class. With ~160 tenant test classes that migrate/seed cost dominates
        the suite's runtime.
+
+    3. **Every test class had to build its own tenant client.** Django's
+       ``_pre_setup`` hands each test a plain ``Client``, which can't reach a
+       tenant's subdomain, so each class needed a ``setUp`` that replaced it with a
+       ``TenantClient``. ``_pre_setup`` below does that instead, and the class
+       inherits ``ViewTestUtilsMixin``, so a subclass gets both without declaring
+       anything.
 
     This class instead creates the ``test`` schema **once per process** (the first
     test class to run migrates and seeds it, committed outside any transaction so it
@@ -60,9 +249,10 @@ class ByteDeckTenantTestCase(TenantTestCase):
       seed so it is rebuilt. A normal (non-``--keepdb``) run always starts fresh.
 
     Use this as the base class for all tenant tests. Fixtures that no test mutates
-    beyond its own rolled-back transaction belong in ``setUpTestData``;
-    ``self.client = TenantClient(self.tenant)`` and ``force_login`` calls stay in
-    ``setUp``.
+    beyond its own rolled-back transaction belong in ``setUpTestData``. ``self.client``
+    is already a ``TenantClient`` for this tenant, so a subclass only needs a ``setUp``
+    when it has other per-test work to do; ``force_login`` belongs in the test that
+    needs it (or in ``setUp`` when every test in the class logs in as the same user).
 
     **Opting out of reuse.** A few kinds of test are incompatible with a shared,
     long-lived schema and must set ``reuse_schema = False`` to get the original
@@ -76,11 +266,21 @@ class ByteDeckTenantTestCase(TenantTestCase):
     * Tests that ``freeze_time`` at the class level *and* depend on the tenant's
       seed data being created at that frozen time (the shared seed is created once,
       at whatever the first class's clock was).
+
+    **Opting out of the tenant client.** A test that drives the *public* schema (the
+    Django admin for tenants lives there) must set ``tenant_client = False`` and keep
+    Django's plain ``Client``: a ``TenantClient`` addresses this tenant's own domain,
+    so its requests switch the connection to this tenant's schema and a public-schema
+    user then can't be found.
     """
 
     # Set to False on a subclass to force the stock per-class fresh schema instead
     # of the shared, reused one. See the class docstring for when that's required.
     reuse_schema = True
+
+    # Set to False on a subclass whose requests must not be addressed to this tenant's
+    # domain. See the class docstring for when that's required.
+    tenant_client = True
 
     @classmethod
     def get_test_schema_name(cls):
@@ -150,6 +350,27 @@ class ByteDeckTenantTestCase(TenantTestCase):
         # and calls setUpTestData with the tenant schema active. super(TenantTestCase,
         # cls) skips django-tenants' override (which would rebuild the schema).
         super(TenantTestCase, cls).setUpClass()
+
+    @classmethod
+    def _pre_setup(cls):
+        """Give every test a client that talks to this tenant's domain.
+
+        Django's ``SimpleTestCase._pre_setup`` builds a plain ``Client`` from
+        ``client_class``, which sends requests without the tenant's host header and so
+        lands on the public schema. ``TenantClient`` takes the tenant as a constructor
+        argument, so it can't simply be set as ``client_class``; it is built here
+        instead, after ``super()`` (which would otherwise overwrite it).
+
+        Like Django's own ``_pre_setup``, this is a ``classmethod`` that runs once per
+        test method, so each test still gets its own client and no login session
+        leaks from one test into the next.
+
+        A class that drives the public schema sets ``tenant_client = False`` and keeps
+        the plain client ``super()`` just built.
+        """
+        super()._pre_setup()
+        if cls.tenant_client:
+            cls.client = TenantClient(cls.tenant)
 
     @classmethod
     def _fixture_setup(cls):
@@ -358,179 +579,3 @@ def generate_formset_data(model_formset, prefix='form', quantity=1, **kwargs):
     }
     [formset_data.update(form_data) for form_data in json_data]
     return formset_data
-
-
-class ViewTestUtilsMixin():
-    """
-    Utility methods to make cleaner tests for common response assertions.  The base class must
-    be a django TestCase.
-    """
-
-    def assertRedirectsAdmin(self, url_name, *args, **kwargs):
-        """
-        Redirection to django admin is now deprecated.
-        Use assertRedirectsLogin(self, url_name, *args, **kwargs) instead.
-
-        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the admin login page.
-        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
-
-        """
-        warnings.warn("Redirection to django admin is now deprecated.\nUse assertRedirectsLogin(self, url_name, *args, **kwargs) instead...",
-                      stacklevel=2)
-        self.assertRedirects(
-            response=self.client.get(reverse(url_name, *args, **kwargs)),
-            expected_url='{}?next={}'.format('/admin/login/', reverse(url_name, *args, **kwargs)),
-        )
-
-    def assertRedirectsHome(self, url_name, *args, **kwargs):
-        """
-        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the home page
-        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
-        """
-        self.assertRedirects(
-            response=self.client.get(reverse(url_name, *args, **kwargs)),
-            expected_url='{}?next={}'.format(reverse('home'), reverse(url_name, *args, **kwargs)),
-        )
-
-    def assertRedirectsLogin(self, url_name, *args, **kwargs):
-        """
-        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the login page
-        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
-        """
-        self.assertRedirects(
-            response=self.client.get(reverse(url_name, *args, **kwargs)),
-            expected_url=f'{reverse(settings.LOGIN_URL)}?next={reverse(url_name, *args, **kwargs)}'
-        )
-
-    def assertRedirectsLoginURL(self, url_name):
-        """
-            assertRedirectsLogin function without reverse() hard coded inside it
-
-            Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the login page
-            with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
-        """
-        self.assertRedirects(
-            response=self.client.get(url_name),
-            expected_url=f'{reverse(settings.LOGIN_URL)}?next={url_name}'
-        )
-
-    def assertRedirectsQuests(self, url_name, follow=False, *args, **kwargs):
-        """
-        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the available quests page.
-        Provide any url and path parameters as args or kwargs.
-
-        Returns the response object.
-        """
-        response = self.client.get(reverse(url_name, *args, **kwargs), follow=follow)
-        self.assertRedirects(
-            response=response,
-            expected_url=reverse('quest_manager:quests'),
-        )
-        return response
-
-    def assert200(self, url_name, *args, **kwargs):
-        """
-        Assert that a GET response to reverse(url_name, *args, **kwargs) succeeded with a status code of 200.
-        Provide any url and path parameters as args or kwargs.
-
-        Returns the response object.
-        """
-        response = self.client.get(reverse(url_name, *args, **kwargs))
-        self.assertEqual(
-            response.status_code,
-            200
-        )
-        return response
-
-    def assert200URL(self, url):
-        """ Assert that a GET response succeeded with a status code of 200.
-        """
-        response = self.client.get(url)
-        self.assertEqual(
-            response.status_code,
-            200
-        )
-
-    def assert302(self, url_name, *args, **kwargs):
-        """
-        Assert that a GET response to reverse(url_name, *args, **kwargs) gives a 302 Redirect.
-        For example, when an unauthenticated user attempts to access a view with the LoginRequiredMixin
-        Provide any url and path parameters as args or kwargs.
-        """
-        response = self.client.get(reverse(url_name, *args, **kwargs))
-        self.assertEqual(
-            response.status_code,
-            302
-        )
-        return response
-
-    def assert404(self, url_name, *args, **kwargs):
-        """
-        Assert that a GET response to reverse(url_name, *args, **kwargs) fails with a status code of 404.
-        Provide any url and path parameters as args or kwargs.
-
-        Returns the response object.
-        """
-        response = self.client.get(reverse(url_name, *args, **kwargs))
-        self.assertEqual(
-            response.status_code,
-            404
-        )
-        return response
-
-    def assert404URL(self, url):
-        """Assert that a GET response fails with a status code of 404."""
-        response = self.client.get(url)
-        self.assertEqual(
-            response.status_code,
-            404
-        )
-
-    def assert403(self, url_name, *args, **kwargs):
-        """
-        Assert that a response to reverse(url_name, *args, **kwargs) is permission denied: 403
-        Provide any url and path parameters as args or kwargs.
-
-        Returns the response object.
-        """
-        response = self.client.get(reverse(url_name, *args, **kwargs))
-        self.assertEqual(
-            response.status_code,
-            403
-        )
-        return response
-
-    def get_message_list(self, response):
-        """ Django messages missing from context of redirected views, so get another way
-        https://stackoverflow.com/questions/2897609/how-can-i-unit-test-django-messages
-        https://docs.djangoproject.com/en/5.2/ref/contrib/messages/
-        """
-        return list(response.wsgi_request._messages)
-
-    def assertSuccessMessage(self, response):
-        """ Assert that a response, including redirects, provides a single success message
-        """
-        message_list = self.get_message_list(response)
-        self.assertEqual(len(message_list), 1)
-        self.assertEqual(message_list[0].level, messages.SUCCESS)
-
-    def assertWarningMessage(self, response):
-        """ Assert that a response, including redirects, provides a single warning message
-        """
-        message_list = self.get_message_list(response)
-        self.assertEqual(len(message_list), 1)
-        self.assertEqual(message_list[0].level, messages.WARNING)
-
-    def assertErrorMessage(self, response):
-        """ Assert that a response, including redirects, provides a single error message
-        """
-        message_list = self.get_message_list(response)
-        self.assertEqual(len(message_list), 1)
-        self.assertEqual(message_list[0].level, messages.ERROR)
-
-    def assertInfoMessage(self, response):
-        """ Assert that a response, including redirects, provides a single info message
-        """
-        message_list = self.get_message_list(response)
-        self.assertEqual(len(message_list), 1)
-        self.assertEqual(message_list[0].level, messages.INFO)

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -6,9 +6,8 @@ from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection
 from django.urls import reverse
-from django_tenants.test.client import TenantClient
 from django_tenants.utils import schema_exists
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.utils import get_library_schema_name, library_schema_context
 from library.importer import import_quest_to, import_campaign_to
 from library.exporter import export_campaign_and_copy_quests, export_campaign_to_library, export_quest_to_library
@@ -23,7 +22,7 @@ from tenant.models import TenantDomain
 User = get_user_model()
 
 
-class LibraryTenantTestCaseMixin(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class LibraryTenantTestCaseMixin(ByteDeckTenantTestCase):
     library_tenant = None
     library_domain = None
 
@@ -77,7 +76,6 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
 
     def setUp(self):
         """Set up a tenant client, site config, and active semester."""
-        self.client = TenantClient(self.tenant)
         self.config = SiteConfig.get()
         self.sem = SiteConfig.get().active_semester
 
@@ -502,7 +500,6 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
 
     def setUp(self):
         """Set up a tenant client, active semester, site config, and deck owner."""
-        self.client = TenantClient(self.tenant)
         self.sem = SiteConfig.get().active_semester
 
         self.config = SiteConfig.get()
@@ -1119,10 +1116,6 @@ class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):
         # Need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student', is_staff=False)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_library_overview__redirects_anonymous(self):
         """

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -4,17 +4,16 @@ from django.db import connection
 from django.shortcuts import reverse
 from django.test.utils import CaptureQueriesContext
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from notifications.models import Notification
 from notifications.signals import notify
 
 User = get_user_model()
 
 
-class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class NotificationViewTests(ByteDeckTenantTestCase):
 
     # includes some basic model data
     # fixtures = ['initial_data.json']
@@ -26,10 +25,6 @@ class NotificationViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
         cls.test_student2 = baker.make(User)
-
-    def setUp(self):
-        """Set up a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_notification_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to home page '''

--- a/src/portfolios/tests/test_views.py
+++ b/src/portfolios/tests/test_views.py
@@ -1,13 +1,12 @@
 from django.utils import timezone
 from io import BytesIO
 from django.urls import reverse
-from django_tenants.test.client import TenantClient
 from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedFile
 from django.contrib.auth import get_user_model
 
 from model_bakery import baker
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from portfolios.models import Artwork, Portfolio
 from portfolios.views import is_acceptable_vid_type
 
@@ -35,7 +34,7 @@ def generate_test_png_file():
     return uploaded_file
 
 
-class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class PortfolioViewTests(ByteDeckTenantTestCase):
     """ url(r'^$', views.PortfolioList.as_view(), name='list'),
         url(r'^public/$', views.public_list, name='public_list'),
         url(r'^create/$', views.PortfolioCreate.as_view(), name='create'),
@@ -82,10 +81,6 @@ class PortfolioViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.portfolio = baker.make('portfolios.Portfolio', user=cls.test_student)
         cls.art = baker.make('portfolios.Artwork', image_file=generate_test_png_file(), portfolio=cls.portfolio)
         cls.doc = baker.make('comments.Document', docfile=generate_test_png_file(), comment=baker.make('comments.Comment', user=cls.test_student))
-
-    def setUp(self):
-        """Create a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_portfolio_view_status_codes__for_anonymous(self):
         ''' If not logged in then all views should redirect to login, EXCEPT the public list and public urls '''

--- a/src/prerequisites/tests/test_forms.py
+++ b/src/prerequisites/tests/test_forms.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
@@ -19,7 +18,6 @@ class PrereqFormInlineMediaTest(ByteDeckTenantTestCase):
 
     def setUp(self):
         """Create a tenant client and a teacher user for the tests."""
-        self.client = TenantClient(self.tenant)
         self.teacher = baker.make(User, is_staff=True)
 
     def test_media__includes_prereq_css(self):

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 
 from django.contrib.contenttypes.models import ContentType
-from django_tenants.test.client import TenantClient
 from freezegun import freeze_time
 from unittest.mock import patch
 from model_bakery import baker
@@ -40,10 +39,6 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         cls.course_student = baker.make(CourseStudent,
                                         user=cls.student,
                                         active=False)
-
-    def setUp(self):
-        """Create a tenant client for each test."""
-        self.client = TenantClient(self.tenant)
 
     @patch('prerequisites.signals.update_quest_conditions_for_user.apply_async')
     def test_update_conditions_met_for_user__triggered_by_badge_assertion_on_create(self, task):

--- a/src/prerequisites/tests/test_tasks.py
+++ b/src/prerequisites/tests/test_tasks.py
@@ -6,7 +6,6 @@ from django.core.cache import cache
 from django.db.utils import OperationalError
 from django.test import override_settings
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 from tenant_schemas_celery.task import TenantTask
 
@@ -35,7 +34,6 @@ class GrantBadgeAssertionsForBadgeTest(ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a teacher, a current-semester student who has completed a quest, and a badge."""
-        self.client = TenantClient(self.tenant)
         self.teacher = baker.make(User, is_staff=True)
         self.student = baker.make(User)
         baker.make('courses.CourseStudent', user=self.student,

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -8,12 +8,11 @@ from django.core import mail
 from django.core.cache import cache
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name, schema_context
 from model_bakery import baker
 
 from courses.models import Block, CourseStudent
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
 
 from profile_manager.forms import ProfileForm, UserForm
@@ -22,7 +21,7 @@ from profile_manager.models import Profile
 from hackerspace_online.tests.utils import generate_form_data
 
 
-class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class ProfileViewTests(ByteDeckTenantTestCase):
 
     # includes some basic model data
     # fixtures = ['initial_data.json']
@@ -44,10 +43,6 @@ class ProfileViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # create semester with pk of default semester
         # this seems backward, but no semesters should exist yet in the test, so their shouldn't be any conflicts.
         cls.active_sem = SiteConfig.get().active_semester
-
-    def setUp(self):
-        """Create a tenant-aware test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def tearDown(self):
         """Clear the cache after each test."""
@@ -739,10 +734,6 @@ class ProfileDeleteTests(ByteDeckTenantTestCase):
         # URL for deleting the student's profile
         cls.delete_url = reverse("profiles:profile_delete", kwargs={"pk": cls.student.profile.pk})
 
-    def setUp(self):
-        """Create a tenant-aware test client for each test."""
-        self.client = TenantClient(self.tenant)
-
     def test_profile_delete__teacher_can_delete(self):
         """Ensure that teacher (staff) users can delete a profile and its associated user."""
         self.client.force_login(self.teacher)
@@ -797,10 +788,6 @@ class ProfileArchiveTests(ByteDeckTenantTestCase):
         cls.restore_url = reverse("profiles:profile_restore", args=[cls.student.profile.pk])
         cls.detail_url = reverse("profiles:profile_detail", args=[cls.student.profile.pk])
         cls.delete_url = reverse("profiles:profile_delete", args=[cls.student.profile.pk])
-
-    def setUp(self):
-        """Create a tenant-aware test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def test_profile_archive__staff_deactivates_student(self):
         """A staff request to profile_archive deactivates the student (is_active=False) and redirects."""
@@ -880,7 +867,6 @@ class OAuthMergeAccountViewTests(ByteDeckTenantTestCase):
     def setUp(self):
         """Create a teacher (required before other users, as profile creation notifies staff),
         a local user with an unverified email, the Google SocialApp, and a tenant client."""
-        self.client = TenantClient(self.tenant)
         self.User = get_user_model()
         self.teacher = self.User.objects.create_user('test_teacher', is_staff=True)
         self.user = self.User.objects.create_user('existing_student', email='student@example.com')

--- a/src/quest_manager/tests/test_cooldown.py
+++ b/src/quest_manager/tests/test_cooldown.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from model_bakery import baker
 
 from courses.models import CourseStudent
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
 
@@ -135,7 +135,7 @@ class GetInCooldownManagerTests(CooldownTestMixin, ByteDeckTenantTestCase):
         self.assertNotIn(one_off, Quest.objects.get_in_cooldown(self.test_student))
 
 
-class CooldownViewTests(CooldownTestMixin, ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CooldownViewTests(CooldownTestMixin, ByteDeckTenantTestCase):
 
     def test_quest_list__available_tab_lists_cooldown_quest(self):
         """The Available tab shows a completed-in-cooldown quest with its countdown."""

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from django_tenants.test.client import TenantClient
 from freezegun import freeze_time
 from model_bakery import baker
 from model_bakery.recipe import Recipe
@@ -24,10 +23,6 @@ class CategoryTestModel(ByteDeckTenantTestCase):  # aka Campaigns
     def setUpTestData(cls):
         """Create a test campaign (Category) shared across the tests."""
         cls.category = baker.make(Category, title="Test Campaign")
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_category__creation_and_str(self):
         """Creating a Category yields a Category instance whose str is its title."""
@@ -152,10 +147,6 @@ class QuestTestModel(ByteDeckTenantTestCase):
     def setUpTestData(cls):
         """Create a Quest shared across the tests."""
         cls.quest = baker.make(Quest)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_quest__creation_and_str(self):
         """Creating a Quest yields a Quest instance whose str is its name."""
@@ -457,10 +448,6 @@ class SubmissionManagerTest(ByteDeckTenantTestCase):
         """Capture the active semester shared across the tests."""
         cls.active_semester = SiteConfig.get().active_semester
 
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
-
     def test_all_approved__filters_by_semester_quest_and_user(self):
         """ Tests of QuestSubmissionManager.all_approved()
         def all_approved(self, user=None, quest=None, up_to_date=None, active_semester_only=True):
@@ -581,10 +568,6 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
         cls.submission = baker.make(QuestSubmission, quest__name="Test")
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_submission__creation_and_quest_name(self):
         """Creating a QuestSubmission yields a QuestSubmission linked to its quest."""
@@ -753,10 +736,6 @@ class QuestExpiredAnnotationTest(ByteDeckTenantTestCase):
     it reuses an ``is_expired`` annotation from the queryset when one is present
     instead of issuing a query per call."""
 
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
-
     def test_expired__prefers_is_expired_annotation(self):
         """When the instance carries an is_expired annotation, expired() returns
         it without issuing a query."""
@@ -789,10 +768,6 @@ class QuestManagerPrefetchTest(ByteDeckTenantTestCase):
         # a teacher is needed both as staff caller and as each quest's editor
         cls.teacher = User.objects.create_user('teacher', is_staff=True)
         cls.campaign = baker.make(Category, title="Test Campaign")
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def _make_quests(self, **kwargs):
         """Create three quests with a campaign, editor and tags set, so the

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -25,12 +25,11 @@ from django.http import JsonResponse
 from django.utils import timezone
 
 
-from django_tenants.test.client import TenantClient
 from unittest.mock import patch
 from model_bakery import baker, recipe
 
 from courses.models import Block, Rank
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin, generate_form_data
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase, generate_form_data
 from notifications.models import Notification
 from quest_manager.models import Category, CommonData, Quest, QuestSubmission, XPItem
 from prerequisites.models import Prereq
@@ -61,7 +60,7 @@ def create_two_test_files():
     return [test_file1, test_file2]
 
 
-class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestViewQuickTests(ByteDeckTenantTestCase):
 
     # includes some basic model data
     # fixtures = ['initial_data.json']
@@ -85,10 +84,6 @@ class QuestViewQuickTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         # cls.sub1 = baker.make(QuestSubmission, user=cls.test_student1, quest=cls.quest1)
         # cls.sub2 = baker.make(QuestSubmission, quest=cls.quest1)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_quest_pages__anonymous_redirected_to_login(self):
         """ If not logged in then all views should redirect to home page  """
@@ -383,10 +378,6 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
             is_completed=True,
             semester=SiteConfig.get().active_semester
         )
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_submission_pages__student_access_codes(self):
         """Students can reach their own submission pages but are forbidden or 404 on others' and staff-only actions."""
@@ -910,7 +901,7 @@ class PaginateHelperTest(SimpleTestCase):
         self.assertEqual(page.number, page.paginator.num_pages)
 
 
-class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
     """ Tests for view.py :
 
         def complete(request, submission_id)
@@ -935,8 +926,6 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the student for all tests."""
-        self.client = TenantClient(self.tenant)
-
         # log in the student for all tests here
         self.client.force_login(self.test_student)
 
@@ -1431,7 +1420,7 @@ class SubmissionCompleteViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestBulkEditViewTests(ByteDeckTenantTestCase):
     @classmethod
     def setUpTestData(cls):
         """Create a teacher and an unpublished and a published quest shared across the tests."""
@@ -1444,7 +1433,6 @@ class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the teacher."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_teacher)
 
     def test_bulk_edit__get_renders_with_bulk_edit_mode(self):
@@ -1611,7 +1599,7 @@ class QuestBulkEditViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, "Delete All Selected")
 
 
-class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestUserStatusViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1631,7 +1619,6 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the staff user."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.staff_user)
 
     def test_quest_user_status__displays_users_and_statuses(self):
@@ -1841,7 +1828,7 @@ class QuestUserStatusViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.context['scope'], 'active')
 
 
-class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestCRUDViewsTest(ByteDeckTenantTestCase):
     """ Tests for:
 
         class QuestCreate(NonPublicOnlyViewMixin, UserPassesTestMixin, CreateView)
@@ -1866,10 +1853,6 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             'date_available': "2006-10-25",
             'time_available': "14:30:59",
         }
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_quest_form__quick_reply_field_below_tags(self):
         """The Quick Reply Text field renders below the Tags field on the quest form (#2114)."""
@@ -2117,7 +2100,7 @@ class QuestCRUDViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
 
 # Can't test any forms with this DAL widget because content_types isn't available yet.
-class QuestPrereqsUpdate(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestPrereqsUpdate(ByteDeckTenantTestCase):
     """ These tests are mostly of the prerequisites app's ObjectPrereqsFormView and PrereqFormInline,
     However, the QuestPrereqsUpdate view is where those are both used.
 
@@ -2138,10 +2121,6 @@ class QuestPrereqsUpdate(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # parent_quest.pk on a fresh schema (aligned sequences); on a reused
         # schema the two diverge, so capture the real value here.
         cls.existing_prereq = cls.parent_quest.prereqs().first()
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def build_formset_form_data(self, form_prefix, form_number, **data):
         """ https://stackoverflow.com/a/62744916/2700631
@@ -2337,7 +2316,7 @@ class QuestPrereqsUpdate(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # self.assertEqual(Prereq.objects.count(), old_num_prereqs + 2)
 
 
-class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestCopyViewTest(ByteDeckTenantTestCase):
     """ Tests for:
 
             def quest_copy(request, quest_id):
@@ -2374,10 +2353,6 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             # validation error
             'date_available': '2006-10-25',
         })
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_quest_copy__teacher_get_initial_values(self):
         """ initial values in form GET is the same as the self.quest (quest that is being copied)  """
@@ -2579,7 +2554,7 @@ class QuestCopyViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(Quest.objects.count(), quests_before)
 
 
-class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestListViewTest(ByteDeckTenantTestCase):
     """ Tests for:
 
         def quest_list(request, quest_id=None, submission_id=None, template="quest_manager/quests.html"):
@@ -2592,10 +2567,6 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_student = User.objects.create_user('test_student')
 
         cls.quest1 = baker.make(Quest)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_quest_list__quest_id_provided_to_view(self):
         """
@@ -2802,7 +2773,7 @@ class QuestListViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertListEqual(intended_order, displayed_order)
 
 
-class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CategoryViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -2812,10 +2783,6 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_student1 = User.objects.create_user('test_student')
 
         # cls.category = baker.make('quests_manager.category', name="testcat")
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_category_pages__anonymous_redirected_to_login(self):
         ''' If not logged in then all views should redirect to home page '''
@@ -3204,7 +3171,7 @@ class CategoryViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotIn(archived_quest, displayed_quests)
 
 
-class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AjaxSubmissionCountTest(ByteDeckTenantTestCase):
     """ Tests for:
     def ajax_submission_count(request, quest_id=None)
 
@@ -3223,10 +3190,6 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         teacher_block = baker.make('courses.Block', current_teacher=cls.test_teacher)
         baker.make('courses.CourseStudent', block=teacher_block,
                    user=cls.test_student, semester=SiteConfig.get().active_semester)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_ajax_submission_count__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
@@ -3304,7 +3267,7 @@ class AjaxSubmissionCountTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.json()['count'], 2)
 
 
-class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AjaxQuestInfoTest(ByteDeckTenantTestCase):
 
     """Tests for:
     def ajax_quest_info(request, quest_id=None)
@@ -3325,7 +3288,6 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the student."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
     def test_ajax_quest_info__get_returns_403(self):
@@ -3427,7 +3389,7 @@ class AjaxQuestInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             self.assertNotIn('id="export-quest"', html)
 
 
-class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AjaxApprovalInfoTest(ByteDeckTenantTestCase):
     """Tests for:
     def ajax_approval_info(request, submission_id=None)
 
@@ -3451,10 +3413,6 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.another_student = User.objects.create_user('another_student')
         cls.quest = baker.make(Quest, instructor_notes=cls.INSTRUCTOR_NOTES)
         cls.submission = baker.make(QuestSubmission, user=cls.test_student, quest=cls.quest)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_ajax_approval_info__get_returns_403(self):
         """ This view is only accessible by an ajax POST request """
@@ -3541,7 +3499,7 @@ class AjaxApprovalInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertIn(reverse(settings.LOGIN_URL), response.url)
 
 
-class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AjaxSubmissionInfoTest(ByteDeckTenantTestCase):
     """Tests for:
     def ajax_submission_info(request, submission_id=None)
 
@@ -3564,7 +3522,6 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the student."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
     def test_ajax_submission_info__get_returns_403(self):
@@ -3689,7 +3646,7 @@ class AjaxSubmissionInfoTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertNotContains(response, reverse('quests:quest_copy', args=[self.submission.quest.id]))
 
 
-class AjaxFlagTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AjaxFlagTest(ByteDeckTenantTestCase):
     """Tests for:
     def ajax_flag(request)
 
@@ -3706,7 +3663,6 @@ class AjaxFlagTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the staff user."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_teacher)
 
     def test_ajax_flag__ajax_post_flags_submission(self):
@@ -3732,7 +3688,7 @@ class AjaxFlagTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class DetailViewTest(ByteDeckTenantTestCase):
     """ Tests for:
 
             def detail(request, quest_id):
@@ -3752,7 +3708,6 @@ class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the student."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_student)
 
     def test_detail__quest_is_available(self):
@@ -3842,7 +3797,7 @@ class DetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertFalse(response.context['can_export'])
 
 
-class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class ApproveViewTest(ByteDeckTenantTestCase):
     """ Tests for:
 
             def approve(request, submission_id):
@@ -3863,7 +3818,6 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the teacher."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.test_teacher)
 
     def test_approve__get_returns_404(self):
@@ -4233,7 +4187,7 @@ class ApproveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class QuestSubmissionSummaryTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestSubmissionSummaryTest(ByteDeckTenantTestCase):
     """Tests for the staff QuestSubmissionSummary metrics view (quests:summary)."""
 
     @classmethod
@@ -4244,7 +4198,6 @@ class QuestSubmissionSummaryTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the teacher."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.teacher)
 
     def test_summary__with_approved_submission_computes_stats(self):
@@ -4264,7 +4217,7 @@ class QuestSubmissionSummaryTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(response.context['percent_returned'], 0)  # none returned -> 0%
 
 
-class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class ApprovalsViewTest(ByteDeckTenantTestCase):
     """ Tests for:
 
             def approvals(request, quest_id=None):
@@ -4308,7 +4261,6 @@ class ApprovalsViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the teacher."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.current_teacher)
 
     def test_approvals__submitted_tab(self):
@@ -4541,7 +4493,7 @@ class Is_staff_or_TA_test(ByteDeckTenantTestCase):
         self.assertFalse(is_staff_or_TA(AnonymousUser()))
 
 
-class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class CommonDataViewTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -4549,10 +4501,6 @@ class CommonDataViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.teacher = baker.make(User, is_staff=True)
 
         cls.cqi = baker.make(CommonData)
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_page_status_code__anonymous(self):
         """Anonymous users are redirected to login for all CommonData views."""
@@ -4657,7 +4605,6 @@ class QuestArchiveViewTest(ByteDeckTenantTestCase):
 
     def setUp(self):
         """Set up a tenant-aware test client and log in the staff user."""
-        self.client = TenantClient(self.tenant)
         self.client.force_login(self.staff_user)
 
     def test_get_context__includes_prereq_of(self):

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -3,10 +3,9 @@ import json
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
 from questions.models import Question, QuestionSubmission
 from questions.utils import sync_draft_question_submissions
@@ -14,7 +13,7 @@ from questions.utils import sync_draft_question_submissions
 User = get_user_model()
 
 
-class QuestionSubmissionFlowTestBase(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestionSubmissionFlowTestBase(ByteDeckTenantTestCase):
     """Shared fixtures for the submission-flow integration tests: a quest with a required
     short answer + an optional long answer, and a student mid-submission."""
 
@@ -37,7 +36,6 @@ class QuestionSubmissionFlowTestBase(ViewTestUtilsMixin, ByteDeckTenantTestCase)
     def setUp(self):
         """Tenant client, and a fresh in-progress submission with its draft comment (created
         the same way the submission view does)."""
-        self.client = TenantClient(self.tenant)
         self.submission = baker.make(QuestSubmission, quest=self.quest, user=self.test_student)
         # visiting the submission page creates the draft comment and the draft answer
         # rows; do it through the view so tests exercise the real flow

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -2,17 +2,16 @@ from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest
 from questions.models import Question
 
 User = get_user_model()
 
 
-class QuestionCRUDViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestionCRUDViewTest(ByteDeckTenantTestCase):
     """Tests for the staff-only question CRUD views (list/create/update/delete)."""
 
     @classmethod
@@ -39,7 +38,6 @@ class QuestionCRUDViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     def setUp(self):
         """Set up a tenant test client, per-test form data, and a file_upload question
         (per-test because its uploaded file is consumed when read)."""
-        self.client = TenantClient(self.tenant)
         self.question_form_data = {
             "type": "short_answer",
             "instructions": "Test instructions",
@@ -239,7 +237,7 @@ class QuestionCRUDViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertTrue(Question.objects.filter(id=self.question1.id).exists())
 
 
-class QuestionMoveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class QuestionMoveViewTest(ByteDeckTenantTestCase):
     """Tests for QuestionMoveView: staff-only up/down reordering of a quest's questions."""
 
     @classmethod
@@ -254,10 +252,6 @@ class QuestionMoveViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.q1 = baker.make(Question, quest=cls.quest, ordinal=1, instructions="Q1")
         cls.q2 = baker.make(Question, quest=cls.quest, ordinal=2, instructions="Q2")
         cls.q3 = baker.make(Question, quest=cls.quest, ordinal=3, instructions="Q3")
-
-    def setUp(self):
-        """Set up a tenant test client for each test."""
-        self.client = TenantClient(self.tenant)
 
     def _move(self, question, direction, quest=None):
         """POST to move `question` in `direction`, scoped to `quest` (defaults to its own quest)."""

--- a/src/siteconfig/tests/test_views.py
+++ b/src/siteconfig/tests/test_views.py
@@ -6,9 +6,8 @@ from django.core.cache import cache
 from django.forms.models import model_to_dict
 from django.shortcuts import reverse
 
-from django_tenants.test.client import TenantClient
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
 
 from siteconfig.forms import SiteConfigForm
@@ -19,7 +18,7 @@ from model_bakery import baker
 User = get_user_model()
 
 
-class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SiteConfigViewTest(ByteDeckTenantTestCase):
     """Tests for the SiteConfig View
     """
 
@@ -29,8 +28,6 @@ class SiteConfigViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         that is created upon first access via the get() method.
         """
         self.config = SiteConfig.get()
-        self.client = TenantClient(self.tenant)
-
     def test_siteconfig_page_status_codes__anonymous(self):
         """Anonymous users are redirected to login from the siteconfig update views."""
         self.assertRedirectsLogin('config:site_config_update', args=[self.config.get().id])

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 
 from django.utils.text import slugify
 
-from django_tenants.test.client import TenantClient
 
 from model_bakery import baker
 from tags.forms import TagForm
@@ -19,7 +18,7 @@ from taggit.forms import TagField
 from taggit.models import Tag
 from siteconfig.models import SiteConfig
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin, generate_form_data
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase, generate_form_data
 
 User = get_user_model()
 
@@ -30,16 +29,12 @@ class TaggitSelect2WidgetForm(forms.Form):
     )
 
 
-class AutoResponseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class AutoResponseViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
         """Create a tag for the autocomplete view tests."""
         Tag.objects.create(name="test-tag")
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_autocomplete_view__accessible(self):
         """ Make sure our custom django-select2 view for tag widget is accessible"""
@@ -76,7 +71,7 @@ class AutoResponseViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(data['results'][0]['text'], 'test-tag')
 
 
-class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class TagCRUDViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -85,10 +80,6 @@ class TagCRUDViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.test_student = User.objects.create_user('test_student')
 
         cls.tag = Tag.objects.create(name="test-tag")
-
-    def setUp(self):
-        """Set up a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_page_status_code__anonymous(self):
         """Make sure the all views are not accessible to anonymous users"""

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -1224,6 +1224,10 @@ class SyncFromStripeActionTest(ByteDeckTenantTestCase):
     """Tests for the "Sync selected deck(s) from Stripe" changelist action
     (epic #1729 PR 7, plan §5.3 -- missed-webhook recovery + #2043 hand-linking)."""
 
+    # The superuser driving these actions lives on the public schema, so the requests
+    # must not be addressed to this tenant's domain (see ByteDeckTenantTestCase).
+    tenant_client = False
+
     @classmethod
     def setUpTestData(cls):
         """Build the public schema and a superuser (the admin lives on public)."""

--- a/src/tenant/tests/test_middleware.py
+++ b/src/tenant/tests/test_middleware.py
@@ -6,7 +6,6 @@ from django.core.cache import cache
 from django.shortcuts import reverse
 from django.utils.timezone import localdate
 
-from django_tenants.test.client import TenantClient
 from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
@@ -27,7 +26,6 @@ class OwnerOnlyWhenSuspendedMiddlewareTest(ByteDeckTenantTestCase):
         """Build per-role users and clear the cached deck row (the cache backend
         outlives each test's transaction)."""
         cache.delete(deck_cache_key(self.tenant.schema_name))
-        self.client = TenantClient(self.tenant)
         self.staff = baker.make(User, is_staff=True)
         self.student = baker.make(User)
         self.owner = SiteConfig.get().deck_owner

--- a/src/tenant/tests/test_schema_aware_user_delete.py
+++ b/src/tenant/tests/test_schema_aware_user_delete.py
@@ -174,7 +174,6 @@ class SchemaAwareUserDeleteAdminTenantTest(ByteDeckTenantTestCase):
 
     def setUp(self):
         """Build a tenant-schema client and a superuser to drive the admin."""
-        self.client = TenantClient(self.tenant)
         self.superuser = User.objects.create_superuser(
             username="tenant_admin", email="ta@example.com", password="pw",
         )

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -15,7 +15,7 @@ from django_tenants.test.client import TenantClient
 from django_tenants.utils import get_public_schema_name
 from django_tenants.utils import tenant_context
 
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from tenant.views import (
     non_public_only_view, public_only_view, TenantCreate, TenantForm, EmailVerificationRequiredMixin, _humanize_seconds,
 )
@@ -37,7 +37,7 @@ def view_accessible_by_non_public_only(request):
     return HttpResponse(status=200)
 
 
-class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class ViewsTest(ByteDeckTenantTestCase):
     def setUp(self):
         """Build a request factory and an empty request for calling the views directly."""
         self.factory = RequestFactory()
@@ -71,7 +71,7 @@ class ViewsTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             view_accessible_by_non_public_only(self.request)
 
 
-class TenantCreateViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class TenantCreateViewTest(ByteDeckTenantTestCase):
     """Various tests for `TenantCreate` view class."""
 
     @classmethod
@@ -678,7 +678,6 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         from tenant.utils import deck_cache_key
 
         cache.delete(deck_cache_key(self.tenant.schema_name))
-        self.client = TenantClient(self.tenant)
         self.staff = baker.make(User, is_staff=True)
         self.student = baker.make(User)
 
@@ -860,7 +859,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
         self.set_deck(paid_until=None)
 
 
-class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
     """Access and rendering tests for the staff-facing Subscription details page
     (epic #1729 PR 6; maintainer-requested admin-menu page)."""
 
@@ -876,7 +875,6 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         from tenant.utils import deck_cache_key
 
         cache.delete(deck_cache_key(self.tenant.schema_name))
-        self.client = TenantClient(self.tenant)
         self.staff = baker.make(User, is_staff=True)
         self.student = baker.make(User)
         self.client.force_login(self.staff)
@@ -1188,7 +1186,7 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'Subscription')
 
 
-class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class SubscriptionCheckoutTest(ByteDeckTenantTestCase):
     """Stripe checkout/portal flow tests for the subscription page (epic #1729 PR 6).
 
     Stripe is never called for real: the SDK entry points used by tenant.billing
@@ -1203,7 +1201,6 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         from tenant.utils import deck_cache_key
 
         cache.delete(deck_cache_key(self.tenant.schema_name))
-        self.client = TenantClient(self.tenant)
         self.staff = baker.make(User, is_staff=True)
         self.client.force_login(self.staff)
 
@@ -1389,7 +1386,7 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.stripe_customer_id, '')
 
 
-class StripeWebhookViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class StripeWebhookViewTest(ByteDeckTenantTestCase):
     """Tests for the Stripe webhook endpoint (epic #1729 PR 7, plan §5.2).
 
     The endpoint is public-schema-only, so these tests build the public tenant

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -14,14 +14,13 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from queryset_sequence import QuerySetSequence
 
 from utilities.models import MenuItem, VideoResource
 from utilities.fields import GFKChoiceField
 from utilities.views import QuerySetSequenceAutoResponseView
 from utilities.widgets import GFKSelect2Widget
-from hackerspace_online.tests.utils import ByteDeckTenantTestCase, ViewTestUtilsMixin
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 User = get_user_model()
 
@@ -54,7 +53,7 @@ class CustomGFKSelect2Widget(GFKSelect2Widget):
         return str(obj.name).upper()
 
 
-class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class TestAutoResponseView(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -62,10 +61,6 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         cls.groups = Group.objects.bulk_create(
             [Group(pk=pk, name=random_string(50)) for pk in range(100)]
         )
-
-    def setUp(self):
-        """Build a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def _ct_pk(self, obj):
         """Return the "<content_type_pk>-<object_pk>" string the GFK choice field uses to identify obj."""
@@ -185,7 +180,7 @@ class TestAutoResponseView(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertEqual(QuerySetSequenceAutoResponseView().get_model_name(proxy), "widget thing")
 
 
-class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class MenuItemViewTests(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -195,10 +190,6 @@ class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         # need a teacher before students can be created or the profile creation will fail when trying to notify
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
-
-    def setUp(self):
-        """Build a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to login '''
@@ -289,7 +280,7 @@ class MenuItemViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, leading_slash_error)
 
 
-class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class FlatPageViewTests(ByteDeckTenantTestCase):
 
     @staticmethod
     def create_flatpage(**kwargs) -> FlatPage:
@@ -327,10 +318,6 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
 
         cls.flatpage_nonlogin = [FlatPageViewTests.create_flatpage(registration_required=False) for i in range(3)]
         cls.flatpage_login = [FlatPageViewTests.create_flatpage(registration_required=True) for i in range(3)]
-
-    def setUp(self):
-        """Build a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_all_page_status_codes__anonymous(self):
         """
@@ -510,7 +497,7 @@ class FlatPageViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assert404URL(absolute_url)
 
 
-class VideosViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
+class VideosViewTests(ByteDeckTenantTestCase):
     """The Video Resources page (utilities:videos): lists videos and accepts uploads from staff."""
 
     @classmethod
@@ -537,10 +524,6 @@ class VideosViewTests(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         """Create a teacher (who may manage videos) and a student (who may not)."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
-
-    def setUp(self):
-        """Build a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def test_videos__anonymous_is_redirected_to_login(self):
         """An anonymous visitor can't reach the page: the upload form writes to the deck's storage."""

--- a/src/utilities/tests/test_widgets.py
+++ b/src/utilities/tests/test_widgets.py
@@ -10,7 +10,6 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
-from django_tenants.test.client import TenantClient
 from queryset_sequence import QuerySetSequence
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
@@ -54,10 +53,6 @@ class TestGFKSelect2Widget(ByteDeckTenantTestCase):
         cls.groups = Group.objects.bulk_create(
             [Group(pk=pk, name=random_string(50)) for pk in range(100)]
         )
-
-    def setUp(self):
-        """Build a tenant-aware test client."""
-        self.client = TenantClient(self.tenant)
 
     def _ct_pk(self, obj):
         """Return the "<content_type_pk>-<object_pk>" string the GFK choice field uses to identify obj."""


### PR DESCRIPTION
### What?

`ByteDeckTenantTestCase` now inherits `ViewTestUtilsMixin` and builds its own `TenantClient`, so a tenant test class gets both without declaring anything.

That deletes a lot of repetition:

| | count |
| --- | --- |
| classes that listed `ViewTestUtilsMixin` | 71 |
| imports of the mixin | 20 |
| `setUp` methods that only built a client | 59 |
| `self.client = TenantClient(self.tenant)` lines removed in total | 89 |

Net: 33 files, +321 / -571.

**No test method was added or removed.** The 33 touched files hold 975 tests before and after, and the full suite runs 1965 green either way.

### Why?

Second PR from the test-suite review. Every tenant test class needed the same two lines of ceremony before it could do anything, and the cost was not just noise: a class that forgot the mixin couldn't use `assertRedirectsLogin` / `assert403` / `assert200`, so its author hand-rolled `self.assertEqual(response.status_code, 302)` instead. 220 of the 290 tenant test classes were in that position. Putting the helpers on the base class is the precondition for the assertion cleanup that follows, and for new view tests to reach for the helper rather than the literal.

### How?

**The client is built in `_pre_setup`, not `setUp`,** so it lands before any subclass hook and can't be forgotten. It has to come *after* `super()._pre_setup()`, which assigns Django's plain `Client` from `client_class` and would otherwise overwrite it. `TenantClient` takes the tenant as a constructor argument, so it can't simply be named as `client_class`. Like Django's own `_pre_setup` this is a `classmethod` invoked once per test method, so each test still gets a fresh client and no login session carries into the next test.

**The 71 classes had to stop naming the mixin**, rather than merely being allowed to. `class Foo(ViewTestUtilsMixin, ByteDeckTenantTestCase)` names a mixin ahead of a base that already inherits it, which is an unresolvable MRO:

```python
>>> class Mixin: pass
>>> class Base(Mixin): pass
>>> class Sub(Mixin, Base): pass
TypeError: Cannot create a consistent method resolution order (MRO) for bases Mixin, Base
```

So this is a `TypeError` at import, not harmless duplication, and the sweep is mandatory rather than cosmetic. The mixin's docstring now says so, so the next person who adds it back finds out why. All 71 were `ByteDeckTenantTestCase`-based, so nothing outside this hierarchy lost the mixin.

**One class needs the plain client.** `SyncFromStripeActionTest` drives the tenant admin, which lives on the *public* schema. A `TenantClient` addresses this tenant's own domain, so its requests switch the connection to this tenant's schema, where the public-schema superuser doesn't exist and `force_login`'s `last_login` write fails with `DatabaseError: Save with update_fields did not affect any rows`. It sets a new `tenant_client = False` opt-out, mirroring the existing `reuse_schema = False` one, with a comment saying why.

That class was the only casualty. It surfaced as three failures in a full-suite run, which is also the honest answer to "how risky is this": the sweep is mechanical, but it does change the client type for every class that previously had no client-building `setUp` at all, and the suite is what proves that only one of them cared.

### Testing?

Full suite against a local Postgres 16 + Redis, on this branch rebased onto the merged `develop`:

```
Ran 1965 tests in 361.231s
OK
```

`ruff check src` clean, `manage.py check` clean, `makemigrations --check --dry-run` reports no changes.

Test-count check, to prove the `setUp` deletions didn't take a test with them:

```
test methods in the 33 changed files, before: 975
test methods in the 33 changed files, after:  975
```

### Screenshots (if front end is affected)

N/A: test infrastructure only, no application code changed.

### Anything Else?

Review this as a noise PR: the interesting part is `src/hackerspace_online/tests/utils.py`, and the other 32 files are the mechanical consequence. `ViewTestUtilsMixin` moves above `ByteDeckTenantTestCase` in that file (it has to be defined before the class that inherits it), so git renders it as a delete-and-add; the class body itself is unchanged apart from the added docstring paragraph.

Next in the sequence is the assertion sweep: replacing the ~430 hand-rolled `assertEqual(response.status_code, ...)` call sites with the mixin helpers, now that every class can reach them.

### Review request
@tylerecouture

- Claude Code (`bytedeck - test suite review`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Centralized tenant-aware test client setup across the test suite.
  * Simplified numerous test classes by removing redundant local setup and shared utility inheritance.
  * Preserved existing authentication, fixtures, assertions, and behavior coverage.
  * Added support for tests that explicitly require public-schema client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->