### PR TITLE
docs: tell sessions to build a real test environment, not default to static review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ The site only works via `http://localhost:8000` (not `0.0.0.0`) because the mult
 
 ### Tests and Linting
 
+**Claude Code: stand up the environment and run these for real: don't default to a static-only review.** A fresh session (web/remote sessions included) starts with no venv, no Postgres, and no running containers, but they can be built, so don't announce something like "no Postgres/Docker/venv here, so this is a static-only review" and skip actually running things. Bring the stack up the way CI does and run against it: `cp .env.example .env` (if absent), `docker compose up -d`, then `docker compose exec -T web python src/manage.py test src` (and `docker compose exec -T web ruff check src`). `TenantTestCase` builds its own test schemas, so you don't need a manual `initdb` just to run the suite. Building the images the first time takes a few minutes; do it once at the start rather than treating it as a blocker. Only fall back to a static-only review if the environment genuinely can't be brought up, and then say exactly which step failed (e.g. Docker daemon unavailable, image build error) instead of presuming it can't be done: running the real migrations and suite catches what static reading can't (migration state, tenant-schema behavior, actual pass/fail).
+
 ```bash
 # Full test suite + style check (expected before every commit/PR)
 python src/manage.py test src && ruff check src


### PR DESCRIPTION
### What?
Adds a directive to the top of CLAUDE.md's **Tests and Linting** section telling Claude Code sessions to actually stand up the environment and run the suite, instead of defaulting to a static-only review.

### Why?
New sessions (web/remote especially) tend to open a task with something like *"No test-runnable environment here (no Postgres/Docker/venv), so this will be a rigorous static review"* and then skip running anything, even though the environment can be built. Static reading misses migration state, tenant-schema behavior, and real pass/fail. This makes "build it and run it" the explicit default, and "static only" the documented fallback of last resort.

### How?
A short bold callout right where a session decides how to test, pointing at the same path CI uses:
- `cp .env.example .env` (if absent), `docker compose up -d`, then `docker compose exec -T web python src/manage.py test src` (and `ruff check src`).
- Notes that `TenantTestCase` builds its own test schemas, so no manual `initdb` is needed just to run the suite.
- Notes the first image build takes a few minutes and should be done once up front, not treated as a blocker.
- Fall back to a static-only review only if the environment genuinely can't be brought up, and then state exactly which step failed (e.g. Docker daemon unavailable, image build error) rather than presuming it can't be done.

Placed in the Tests section (rather than the `Claude Code:` convention bullets) because that's where a session forms the "how do I run this" decision, and it sits near the actual commands.

### Testing?
Docs-only; no code paths affected. Verified no em dashes (house style).

### Screenshots (if front end is affected)
N/A (documentation only).

### Anything Else?
A CLAUDE.md directive relies on the session reading and following it. If you want this enforced rather than advised, a `SessionStart` hook that runs `docker compose up -d` (and warms the image build) would guarantee the environment is up before the model starts, independent of whether it reads this section. Happy to add one as a follow-up if you'd like: say the word.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - integrations and automations`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_