### PR TITLE
HOTFIX: feat: name the plan on the subscription page and gate managing it to the deck owner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,10 @@ EMAIL_USE_TLS=True
 
 #DEFAULT_FROM_EMAIL=
 
+# Where "Contact ByteDeck" links in subscription-related copy point
+# (rendered as mailto: links). Defaults to contact@bytedeck.com.
+#SUPPORT_EMAIL=
+
 # SERVER ERRORS EMAIL (comma seperated list)
 ADMINS=Admin Name:admin@exmaple.com,Admin2 Name:admin2@exmaple.com
 #SERVER_EMAIL=server@example.com

--- a/.env.example.aws
+++ b/.env.example.aws
@@ -47,6 +47,10 @@ EMAIL_USE_TLS=True
 
 #DEFAULT_FROM_EMAIL=
 
+# Where "Contact ByteDeck" links in subscription-related copy point
+# (rendered as mailto: links). Defaults to contact@bytedeck.com.
+#SUPPORT_EMAIL=
+
 # SERVER ERRORS EMAIL (comma seperated list)
 ADMINS=Admin Name:admin@exmaple.com,Admin2 Name:admin2@exmaple.com
 #SERVER_EMAIL=server@example.com

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -567,6 +567,11 @@ EMAIL_USE_TLS = env('EMAIL_USE_TLS', default=True)
 
 DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default=None)
 
+# Where "Contact ByteDeck" copy points (subscription page, activation flow):
+# rendered as a mailto: link so users always have a way to actually reach us
+# (maintainer request, 2026-08-09).
+SUPPORT_EMAIL = env('SUPPORT_EMAIL', default='contact@bytedeck.com')
+
 # SERVER ERRORS EMAIL
 admins_raw = env('ADMINS', default=[])
 if admins_raw:  # pragma: no cover -- ADMINS env unset under the test harness

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -22,6 +22,7 @@ from datetime import datetime, time as dt_time, timedelta, timezone as dt_timezo
 import stripe
 
 from django.conf import settings
+from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import localdate
@@ -45,6 +46,12 @@ except (ImportError, AttributeError):  # pragma: no cover -- requires a differen
 # hour absorbs clock skew and request latency so a boundary-day checkout can't
 # fail at Stripe after passing our check
 CHECKOUT_TRIAL_END_MINIMUM = timedelta(hours=49)
+
+# How long the subscription page's plan summary (product name, price, cadence)
+# may serve from cache before re-asking Stripe. The billing write paths clear
+# the cache on sync, so this only bounds staleness for dashboard-side edits
+# (e.g. a renamed product) that fire no event we act on.
+PLAN_SUMMARY_CACHE_SECONDS = 60 * 15
 
 
 def to_plain_dict(stripe_obj):
@@ -208,6 +215,119 @@ def stamp_customer_description(deck, customer_id):
         logger.warning('could not stamp deck description on Stripe customer %s: %s', customer_id, e)
 
 
+def _plan_summary_cache_key(schema_name, subscription_id):
+    """Cache key for one deck's plan summary, keyed on the linked subscription."""
+    return f'stripe-plan-summary:{schema_name}:{subscription_id}'
+
+
+def clear_plan_summary_cache(schema_name, *subscription_ids):
+    """Drop cached plan summaries so the subscription page re-fetches from Stripe.
+
+    Called from the billing write paths (checkout reconciliation and
+    ``Tenant.sync_from_stripe_subscription``) so a plan switched in the billing
+    portal shows on the page as soon as its webhook syncs, rather than after the
+    cache TTL runs out.
+
+    Args:
+        schema_name (str): The deck's schema.
+        *subscription_ids: Subscription ids whose cached summaries may exist
+            (typically the event's and the previously linked one); falsy and
+            duplicate entries are skipped.
+    """
+    for subscription_id in set(subscription_ids):
+        if subscription_id:
+            cache.delete(_plan_summary_cache_key(schema_name, subscription_id))
+
+
+def _plan_summary_from_subscription(subscription):
+    """Condense a retrieved subscription (price + product expanded) to display parts.
+
+    Args:
+        subscription (dict): A Stripe Subscription with ``items.data.price.product``
+            expanded (or an equivalent test double).
+
+    Returns:
+        dict | None: ``{'name': ..., 'renewal_phrase': ...}`` -- the Product's name
+        and a cadence-plus-price phrase like "renewed annually at $75.00 per year"
+        or "renewed every 6 months at $50.00" (empty string when the price has no
+        recurrence). None when there's no expanded product name to show.
+    """
+    data = (subscription.get('items') or {}).get('data') or []
+    price = (data[0].get('price') or {}) if data else {}
+    product = price.get('product')
+    name = product.get('name') if isinstance(product, dict) else None
+    if not name:
+        return None
+
+    recurring = price.get('recurring') or {}
+    interval = recurring.get('interval')
+    count = recurring.get('interval_count') or 1
+    if interval == 'year' and count == 1:
+        cadence, per_suffix = 'renewed annually', ' per year'
+    elif interval == 'month' and count == 1:
+        cadence, per_suffix = 'renewed monthly', ' per month'
+    elif interval:
+        cadence, per_suffix = f'renewed every {count} {interval}s', ''
+    else:  # a one-time price shouldn't arise on a subscription, but Stripe allows odd data
+        cadence, per_suffix = '', ''
+
+    amount = price.get('unit_amount')
+    money = ''
+    if amount is not None:
+        currency = (price.get('currency') or '').lower()
+        rendered = f'{amount / 100:,.2f}'
+        money = f'${rendered}' if currency in ('', 'usd') else f'{rendered} {currency.upper()}'
+
+    if cadence and money:
+        phrase = f'{cadence} at {money}{per_suffix}'
+    else:
+        # a cadence alone still reads fine; a price with no cadence would dangle, so drop it
+        phrase = cadence
+    return {'name': name, 'renewal_phrase': phrase}
+
+
+def subscription_plan_summary(deck):
+    """What the deck's linked Stripe subscription buys, for the status line, or None.
+
+    Retrieves the subscription with its price and product expanded and condenses
+    it via :func:`_plan_summary_from_subscription` to the Product name plus a
+    renewal phrase (e.g. "Bytedeck Subscription - 40 Students" / "renewed
+    annually at $75.00 per year"). The result is cached for
+    PLAN_SUMMARY_CACHE_SECONDS per (deck, subscription) and cleared by the
+    billing write paths, so the page doesn't call Stripe on every load yet shows
+    a portal plan switch as soon as its webhook syncs.
+
+    Returns None -- the page then renders its usual copy with no plan info --
+    when the deck has no linked subscription, no secret key is configured, the
+    retrieve fails (logged, swallowed: a Stripe hiccup must not break the page),
+    or the data carries no product name.
+
+    Args:
+        deck (Tenant): The current deck.
+
+    Returns:
+        dict | None: ``{'name': str, 'renewal_phrase': str}`` or None.
+    """
+    if not deck.stripe_subscription_id or not settings.STRIPE_SECRET_KEY:
+        return None
+    cache_key = _plan_summary_cache_key(deck.schema_name, deck.stripe_subscription_id)
+    summary = cache.get(cache_key)
+    if summary is not None:
+        return summary
+    try:
+        subscription = to_plain_dict(stripe.Subscription.retrieve(
+            deck.stripe_subscription_id, api_key=settings.STRIPE_SECRET_KEY,
+            expand=['items.data.price.product'],
+        ))
+    except stripe.StripeError as e:
+        logger.warning('could not fetch the plan summary for %s: %s', deck.schema_name, e)
+        return None
+    summary = _plan_summary_from_subscription(subscription)
+    if summary is not None:
+        cache.set(cache_key, summary, PLAN_SUMMARY_CACHE_SECONDS)
+    return summary
+
+
 def subscription_period_end_date(subscription):
     """The subscription's current period end as a local date, or None.
 
@@ -274,6 +394,7 @@ def reconcile_checkout_session(deck, session_id):
     newly_linked = bool(updates['stripe_customer_id']) and deck.stripe_customer_id != updates['stripe_customer_id']
     Tenant.objects.filter(schema_name=deck.schema_name).update(**updates)
     invalidate_current_deck_cache(deck.schema_name)  # the banner should update immediately
+    clear_plan_summary_cache(deck.schema_name, deck.stripe_subscription_id, updates['stripe_subscription_id'])
     if newly_linked:
         stamp_customer_description(deck, updates['stripe_customer_id'])
     return True

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -53,6 +53,14 @@ CHECKOUT_TRIAL_END_MINIMUM = timedelta(hours=49)
 # (e.g. a renamed product) that fire no event we act on.
 PLAN_SUMMARY_CACHE_SECONDS = 60 * 15
 
+# Currencies whose Stripe amounts are already whole units rather than cents
+# (https://docs.stripe.com/currencies#zero-decimal): dividing by 100 would
+# display a hundredth of the real price.
+ZERO_DECIMAL_CURRENCIES = frozenset((
+    'bif', 'clp', 'djf', 'gnf', 'jpy', 'kmf', 'krw', 'mga',
+    'pyg', 'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
+))
+
 
 def to_plain_dict(stripe_obj):
     """A stripe-python object (or a dict) as plain nested dicts/lists.
@@ -266,6 +274,9 @@ def _plan_summary_from_subscription(subscription):
         cadence, per_suffix = 'renewed annually', ' per year'
     elif interval == 'month' and count == 1:
         cadence, per_suffix = 'renewed monthly', ' per month'
+    elif interval and count == 1:
+        # a singular day/week cadence reads without the count ("renewed every week")
+        cadence, per_suffix = f'renewed every {interval}', ''
     elif interval:
         cadence, per_suffix = f'renewed every {count} {interval}s', ''
     else:  # a one-time price shouldn't arise on a subscription, but Stripe allows odd data
@@ -275,7 +286,13 @@ def _plan_summary_from_subscription(subscription):
     money = ''
     if amount is not None:
         currency = (price.get('currency') or '').lower()
-        rendered = f'{amount / 100:,.2f}'
+        # Stripe amounts are in the currency's SMALLEST unit: cents for most
+        # currencies, but zero-decimal currencies (Stripe's documented list)
+        # carry the whole amount already, so 7500 JPY is 7,500, not 75.00.
+        if currency in ZERO_DECIMAL_CURRENCIES:
+            rendered = f'{amount:,.0f}'
+        else:
+            rendered = f'{amount / 100:,.2f}'
         money = f'${rendered}' if currency in ('', 'usd') else f'{rendered} {currency.upper()}'
 
     if cadence and money:

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -469,7 +469,7 @@ class Tenant(TenantMixin):
         Returns:
             str: A short human-readable summary of what changed, for logs.
         """
-        from tenant.billing import subscription_max_active_users, subscription_period_end_date
+        from tenant.billing import clear_plan_summary_cache, subscription_max_active_users, subscription_period_end_date
         from tenant.utils import invalidate_current_deck_cache
 
         status = subscription.get('status')
@@ -517,6 +517,12 @@ class Tenant(TenantMixin):
 
             if updates:
                 Tenant.objects.filter(pk=self.pk).update(**updates)
+
+        # The subscription page's cached plan summary can go stale even when no
+        # Tenant field changes (a portal plan switch can keep the period end and
+        # cap while changing the product/price on display), so it is cleared on
+        # every sync, for the event's subscription and the previously linked one.
+        clear_plan_summary_cache(self.schema_name, sub_id, current.stripe_subscription_id)
 
         if updates:
             for field, value in updates.items():

--- a/src/tenant/templates/tenant/_subscription_manage_button.html
+++ b/src/tenant/templates/tenant/_subscription_manage_button.html
@@ -1,0 +1,26 @@
+{% comment %}
+The Manage subscription / Subscribe now action button, shared by the top of the
+subscription page (under Status) and its Upgrade-or-renew section. The help text
+lives in the button's native title popup (project convention for action buttons).
+Managing the subscription is the deck owner's action alone: everyone else gets
+the button disabled, with the owner's name in the popup. Context: deck,
+is_deck_owner, deck_owner_name (from SubscriptionDetail).
+{% endcomment %}
+{% if is_deck_owner %}
+  <form method="post" action="{% url 'decks:subscription' %}">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-primary"
+      title="{% if deck.stripe_customer_id %}Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.{% else %}Opens Stripe's secure checkout to start a subscription for this deck.{% endif %}">
+      <i class="fa fa-credit-card"></i>&nbsp;
+      {% if deck.stripe_customer_id %}Manage subscription{% else %}Subscribe now{% endif %}
+    </button>
+  </form>
+{% else %}
+  {# disabled controls swallow hover events in some browsers, so the wrapping span carries the popup #}
+  <span title="Only the deck owner, {{ deck_owner_name }}, can manage the subscription.">
+    <button type="button" class="btn btn-primary" disabled>
+      <i class="fa fa-credit-card"></i>&nbsp;
+      {% if deck.stripe_customer_id %}Manage subscription{% else %}Subscribe now{% endif %}
+    </button>
+  </span>
+{% endif %}

--- a/src/tenant/templates/tenant/subscription_activating.html
+++ b/src/tenant/templates/tenant/subscription_activating.html
@@ -8,7 +8,7 @@
 <p id="activating-message">
   <i class="fa fa-spinner fa-spin"></i>&nbsp;
   Thanks! Your payment went through and we're confirming your subscription with Stripe.
-  This page will update automatically &mdash; it usually takes just a few seconds.
+  This page will update automatically: it usually takes just a few seconds.
 </p>
 <p id="activated-message" style="display: none;" class="text-success">
   <i class="fa fa-check-circle"></i>&nbsp;
@@ -18,12 +18,12 @@
 <p id="poll-timeout-message" style="display: none;" class="text-warning">
   <i class="fa fa-clock-o"></i>&nbsp;
   <strong>This is taking longer than expected.</strong>
-  Your payment is safe &mdash; the subscription can take a little while to register with Stripe.
+  Your payment is safe: the subscription can take a little while to register with Stripe.
 </p>
 <p class="help-block">
-  Taking longer than a minute? Your payment is safe &mdash; the subscription can take a little while to
-  register. Check <a href="{% url 'decks:subscription' %}">subscription details</a> later, and contact
-  ByteDeck if it still hasn't appeared.
+  Taking longer than a minute? Your payment is safe: the subscription can take a little while to
+  register. Check <a href="{% url 'decks:subscription' %}">subscription details</a> later, and
+  <a href="mailto:{{ support_email }}">contact ByteDeck</a> if it still hasn't appeared.
 </p>
 {% endblock %}
 

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -27,13 +27,18 @@
 {% elif deck.is_on_maintenance %}
   {# the countdown pairs with the PAID date it sits beside (days_until_expiry can track a longer leftover trial clock) #}
   <p><span class="label label-primary">Maintenance</span>
-    This deck is on a maintenance subscription through <strong>{{ deck.paid_until }}</strong>
+    This deck is on a maintenance subscription{% if plan_summary %}
+    (<strong>{{ plan_summary.name }}</strong>{% if plan_summary.renewal_phrase %}, {{ plan_summary.renewal_phrase }}{% endif %}){% endif %}
+    through <strong>{{ deck.paid_until }}</strong>
     ({{ paid_until_phrase }}): it won't expire,
     be suspended, or time out for deletion, but registration stays capped at the trial limit
     (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}).
     Upgrade any time to raise the cap.</p>
 {% elif deck.subscription_active %}
+  {# what the money buys, straight from the linked Stripe plan (maintainer request, 2026-08-09); omitted when Stripe can't say #}
   <p><span class="label label-success">Subscribed</span>
+    {% if plan_summary %}to <strong>{{ plan_summary.name }}</strong>{% if plan_summary.renewal_phrase %},
+    {{ plan_summary.renewal_phrase }}{% endif %}.{% endif %}
     Paid through <strong>{{ deck.paid_until }}</strong>
     ({{ paid_until_phrase }}).</p>
 {% elif deck.is_on_trial %}
@@ -42,8 +47,13 @@
     ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining).</p>
 {% else %}
   <p><span class="label label-default">Managed manually</span>
-    This deck has no trial or subscription end date, so it never expires on its own. Contact ByteDeck
-    if this doesn't look right.</p>
+    This deck has no trial or subscription end date, so it never expires on its own.
+    <a href="mailto:{{ support_email }}">Contact ByteDeck</a> if this doesn't look right.</p>
+{% endif %}
+
+{# the manage action right under the status (maintainer request, 2026-08-09); the same button anchors Upgrade-or-renew below #}
+{% if stripe_configured and not manually_subscribed %}
+  {% include "tenant/_subscription_manage_button.html" %}
 {% endif %}
 
 <h3>Dates</h3>
@@ -105,16 +115,11 @@
 {% if stripe_configured %}
   {% if manually_subscribed %}
     <p>This deck's subscription is <strong>managed manually</strong>: starting a new online
-      subscription here would double-bill you. Contact ByteDeck to renew, upgrade, or switch this
+      subscription here would double-bill you.
+      <a href="mailto:{{ support_email }}">Contact ByteDeck</a> to renew, upgrade, or switch this
       deck to online billing.</p>
   {% else %}
-  <form method="post" action="{% url 'decks:subscription' %}">
-    {% csrf_token %}
-    <button type="submit" class="btn btn-primary">
-      <i class="fa fa-credit-card"></i>&nbsp;
-      {% if deck.stripe_customer_id %}Manage subscription{% else %}Subscribe now{% endif %}
-    </button>
-  </form>
+  {% include "tenant/_subscription_manage_button.html" %}
   <p class="help-block" style="margin-top: 0.5em;">
     {% if deck.stripe_customer_id %}
       Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timezone as dt_timezone
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 
@@ -12,8 +13,8 @@ from django_tenants.utils import schema_context
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from tenant.billing import (
-    billing_configured, checkout_trial_end, create_checkout_session, reconcile_checkout_session,
-    subscription_period_end_date,
+    _plan_summary_from_subscription, billing_configured, checkout_trial_end, clear_plan_summary_cache,
+    create_checkout_session, reconcile_checkout_session, subscription_period_end_date, subscription_plan_summary,
 )
 from tenant.models import Tenant
 
@@ -60,6 +61,147 @@ class SubscriptionPeriodEndDateTest(SimpleTestCase):
         """No period end in either shape (or no items at all) -> None."""
         self.assertIsNone(subscription_period_end_date({}))
         self.assertIsNone(subscription_period_end_date({'items': {'data': []}}))
+
+
+class PlanSummaryFromSubscriptionTest(SimpleTestCase):
+    """Tests for condensing an expanded subscription into the status line's plan
+    summary: product name plus a cadence-and-price renewal phrase (maintainer
+    request, 2026-08-09)."""
+
+    def subscription(self, product='Bytedeck Subscription - 40 Students', unit_amount=7500,
+                     currency='usd', interval='year', interval_count=1):
+        """A minimal subscription double shaped like Stripe's expanded retrieve.
+
+        Args:
+            product (str | None): The expanded Product's name; None leaves the
+                product unexpanded (the plain id string Stripe returns without
+                ``expand``).
+            unit_amount (int | None): The price in cents, or None (e.g. metered).
+            currency (str): The price's currency code.
+            interval (str | None): ``recurring.interval``; None makes a one-time
+                price with no recurrence.
+            interval_count (int): ``recurring.interval_count``.
+
+        Returns:
+            dict: The subscription double.
+        """
+        price = {
+            'product': {'name': product} if product is not None else 'prod_123',
+            'unit_amount': unit_amount,
+            'currency': currency,
+        }
+        if interval:
+            price['recurring'] = {'interval': interval, 'interval_count': interval_count}
+        return {'items': {'data': [{'price': price}]}}
+
+    def test_summary__yearly_price_reads_renewed_annually(self):
+        """A $75/year price reads "renewed annually at $75.00 per year"."""
+        self.assertEqual(
+            _plan_summary_from_subscription(self.subscription()),
+            {'name': 'Bytedeck Subscription - 40 Students',
+             'renewal_phrase': 'renewed annually at $75.00 per year'},
+        )
+
+    def test_summary__monthly_price_reads_renewed_monthly(self):
+        """An $8/month price reads "renewed monthly at $8.00 per month"."""
+        summary = _plan_summary_from_subscription(self.subscription(unit_amount=800, interval='month'))
+        self.assertEqual(summary['renewal_phrase'], 'renewed monthly at $8.00 per month')
+
+    def test_summary__multi_month_price_reads_renewed_every_n_months(self):
+        """A $50-per-6-months price reads "renewed every 6 months at $50.00"
+        (the maintainer's half-year plan example)."""
+        summary = _plan_summary_from_subscription(
+            self.subscription(unit_amount=5000, interval='month', interval_count=6)
+        )
+        self.assertEqual(summary['renewal_phrase'], 'renewed every 6 months at $50.00')
+
+    def test_summary__non_usd_currency_is_spelled_out(self):
+        """Only USD gets the $ sign; other currencies read "75.00 CAD" so the
+        amount is never misattributed to the wrong currency."""
+        summary = _plan_summary_from_subscription(self.subscription(currency='cad'))
+        self.assertEqual(summary['renewal_phrase'], 'renewed annually at 75.00 CAD per year')
+
+    def test_summary__no_recurrence_or_no_amount_degrades_gracefully(self):
+        """A one-time price yields an empty renewal phrase (name still shows); a
+        recurring price without a unit amount keeps the cadence alone."""
+        self.assertEqual(_plan_summary_from_subscription(self.subscription(interval=None))['renewal_phrase'], '')
+        self.assertEqual(
+            _plan_summary_from_subscription(self.subscription(unit_amount=None))['renewal_phrase'],
+            'renewed annually',
+        )
+
+    def test_summary__missing_product_name_or_items_returns_none(self):
+        """An unexpanded product (a plain id string) or a subscription without
+        items can't be summarized: None, so the page shows its usual copy."""
+        self.assertIsNone(_plan_summary_from_subscription(self.subscription(product=None)))
+        self.assertIsNone(_plan_summary_from_subscription({}))
+        self.assertIsNone(_plan_summary_from_subscription({'items': {'data': []}}))
+
+
+class SubscriptionPlanSummaryTest(SimpleTestCase):
+    """Tests for the cached Stripe fetch behind the status line's plan summary.
+
+    Deliberately SimpleTestCase (the approved exception for pure in-memory model
+    tests): the deck is an unsaved Tenant carrying only its schema name and
+    linked subscription id, and the Stripe retrieve is mocked at the SDK seam,
+    so no query ever runs."""
+
+    RETRIEVED = {'items': {'data': [{'price': {
+        'product': {'name': 'Bytedeck Subscription - 40 Students'},
+        'unit_amount': 7500, 'currency': 'usd',
+        'recurring': {'interval': 'year', 'interval_count': 1},
+    }}]}}
+
+    def setUp(self):
+        """An in-memory linked deck, with its summary cache entry emptied."""
+        from tenant.billing import _plan_summary_cache_key
+
+        self.deck = Tenant(schema_name='plancache', stripe_subscription_id='sub_1')
+        cache.delete(_plan_summary_cache_key('plancache', 'sub_1'))
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123')
+    def test_summary__fetches_once_expanded_then_serves_from_cache(self):
+        """The subscription is retrieved once (price and product expanded),
+        condensed, and cached: a second call within the TTL never re-asks Stripe."""
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=self.RETRIEVED) as mock_retrieve:
+            first = subscription_plan_summary(self.deck)
+            second = subscription_plan_summary(self.deck)
+        self.assertEqual(first, {'name': 'Bytedeck Subscription - 40 Students',
+                                 'renewal_phrase': 'renewed annually at $75.00 per year'})
+        self.assertEqual(second, first)
+        self.assertEqual(mock_retrieve.call_count, 1)
+        self.assertEqual(mock_retrieve.call_args.kwargs['expand'], ['items.data.price.product'])
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123')
+    def test_summary__clearing_the_cache_refetches(self):
+        """clear_plan_summary_cache drops the entry (the billing write paths call
+        it on every sync, so a portal plan switch shows immediately); falsy ids
+        in the call are skipped harmlessly."""
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=self.RETRIEVED) as mock_retrieve:
+            subscription_plan_summary(self.deck)
+            clear_plan_summary_cache('plancache', 'sub_1', '')
+            subscription_plan_summary(self.deck)
+        self.assertEqual(mock_retrieve.call_count, 2)
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123')
+    def test_summary__stripe_error_returns_none_and_caches_nothing(self):
+        """A Stripe failure yields None (the page renders its usual copy, no
+        error) and caches nothing, so a later load can still succeed."""
+        import stripe as stripe_lib
+
+        with patch('tenant.billing.stripe.Subscription.retrieve', side_effect=stripe_lib.StripeError('boom')):
+            self.assertIsNone(subscription_plan_summary(self.deck))
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=self.RETRIEVED):
+            self.assertIsNotNone(subscription_plan_summary(self.deck))
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123')
+    def test_summary__unlinked_deck_or_unconfigured_server_short_circuits(self):
+        """No linked subscription, or no secret key: None without any Stripe call."""
+        with patch('tenant.billing.stripe.Subscription.retrieve') as mock_retrieve:
+            self.assertIsNone(subscription_plan_summary(Tenant(schema_name='x', stripe_subscription_id='')))
+            with override_settings(STRIPE_SECRET_KEY=None):
+                self.assertIsNone(subscription_plan_summary(self.deck))
+        mock_retrieve.assert_not_called()
 
 
 @freeze_time("2026-08-15 20:00:00")  # midday Pacific so localtime dates are stable

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -115,11 +115,27 @@ class PlanSummaryFromSubscriptionTest(SimpleTestCase):
         )
         self.assertEqual(summary['renewal_phrase'], 'renewed every 6 months at $50.00')
 
+    def test_summary__singular_day_or_week_cadence_reads_without_a_count(self):
+        """A weekly or daily price with interval_count=1 reads "renewed every
+        week", never the mis-pluralized "renewed every 1 weeks" (review find)."""
+        summary = _plan_summary_from_subscription(self.subscription(unit_amount=200, interval='week'))
+        self.assertEqual(summary['renewal_phrase'], 'renewed every week at $2.00')
+        summary = _plan_summary_from_subscription(
+            self.subscription(unit_amount=200, interval='day', interval_count=3)
+        )
+        self.assertEqual(summary['renewal_phrase'], 'renewed every 3 days at $2.00')
+
     def test_summary__non_usd_currency_is_spelled_out(self):
         """Only USD gets the $ sign; other currencies read "75.00 CAD" so the
         amount is never misattributed to the wrong currency."""
         summary = _plan_summary_from_subscription(self.subscription(currency='cad'))
         self.assertEqual(summary['renewal_phrase'], 'renewed annually at 75.00 CAD per year')
+
+    def test_summary__zero_decimal_currency_is_not_divided_by_100(self):
+        """Stripe amounts for zero-decimal currencies (e.g. JPY) are already
+        whole units: 7500 renders as "7,500 JPY", not "75.00 JPY" (review find)."""
+        summary = _plan_summary_from_subscription(self.subscription(currency='jpy'))
+        self.assertEqual(summary['renewal_phrase'], 'renewed annually at 7,500 JPY per year')
 
     def test_summary__no_recurrence_or_no_amount_degrades_gracefully(self):
         """A one-time price yields an empty renewal phrase (name still shows); a

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -195,6 +195,17 @@ class SubscriptionPlanSummaryTest(SimpleTestCase):
             self.assertIsNotNone(subscription_plan_summary(self.deck))
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123')
+    def test_summary__unusable_subscription_data_is_not_cached(self):
+        """A retrieve that succeeds but can't be summarized (e.g. the product came
+        back unexpanded) yields None and caches nothing, so the next load retries
+        rather than pinning the page to a bad answer for the TTL."""
+        bare = {'items': {'data': [{'price': {'product': 'prod_123'}}]}}
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=bare) as mock_retrieve:
+            self.assertIsNone(subscription_plan_summary(self.deck))
+            self.assertIsNone(subscription_plan_summary(self.deck))
+        self.assertEqual(mock_retrieve.call_count, 2)
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123')
     def test_summary__unlinked_deck_or_unconfigured_server_short_circuits(self):
         """No linked subscription, or no secret key: None without any Stripe call."""
         with patch('tenant.billing.stripe.Subscription.retrieve') as mock_retrieve:

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1181,6 +1181,86 @@ class SubscriptionDetailViewTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
         self.assertContains(response, 'managed manually')
         self.assertNotContains(response, 'Subscribe now')
 
+    def test_page__status_names_the_plan_after_the_subscribed_badge(self):
+        """A linked, subscribed deck's status line names the Stripe plan and its
+        renewal terms after the badge -- "Subscribed to <product>, renewed
+        annually at $75.00 per year. Paid through ..." (maintainer request,
+        2026-08-09) -- and degrades to the plain paid-through line when Stripe
+        can't say."""
+        self.set_deck(stripe_customer_id='cus_9', stripe_subscription_id='sub_9')
+        summary = {'name': 'Bytedeck Subscription - 40 Students', 'renewal_phrase': 'renewed annually at $75.00 per year'}
+        with patch('tenant.billing.subscription_plan_summary', return_value=summary):
+            text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn(
+            'Subscribed</span> to <strong>Bytedeck Subscription - 40 Students</strong>, '
+            'renewed annually at $75.00 per year. Paid through',
+            text,
+        )
+
+        with patch('tenant.billing.subscription_plan_summary', return_value=None):
+            text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn('Subscribed</span> Paid through', text)
+
+    def test_page__maintenance_status_names_the_plan_when_known(self):
+        """A maintenance deck's status parenthesizes its plan when Stripe data is
+        available: "on a maintenance subscription (<product>, renewed annually
+        at $10.00 per year) through ..."."""
+        self.set_deck(max_active_users=5, stripe_customer_id='cus_9', stripe_subscription_id='sub_9')
+        summary = {'name': 'Bytedeck Maintenance', 'renewal_phrase': 'renewed annually at $10.00 per year'}
+        with patch('tenant.billing.subscription_plan_summary', return_value=summary):
+            text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn(
+            'maintenance subscription (<strong>Bytedeck Maintenance</strong>, '
+            'renewed annually at $10.00 per year) through',
+            text,
+        )
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+    def test_page__manage_button_shows_at_top_and_bottom_owner_only(self):
+        """The manage action appears TWICE -- under Status and in Upgrade-or-renew
+        (maintainer request, 2026-08-09). Staff who are not the deck owner get
+        both copies disabled with a popup naming who can act; the owner gets the
+        live forms with the portal/checkout help text as the title popup."""
+        from siteconfig.models import SiteConfig
+
+        owner = SiteConfig.get().deck_owner
+        self.set_deck(stripe_customer_id='cus_9')
+
+        # setUp's staff user is NOT the owner: disabled buttons, owner named in the popup
+        response = self.get_page()
+        self.assertContains(response, 'Manage subscription', count=2)
+        self.assertContains(
+            response, f'Only the deck owner, {owner.get_username()}, can manage the subscription.', count=2
+        )
+        self.assertNotContains(response, '<form method="post"')
+
+        # the owner: two live forms, the help text riding on the buttons' title popups
+        self.client.force_login(owner)
+        response = self.get_page()
+        self.assertContains(response, 'Manage subscription', count=2)
+        self.assertContains(response, '<form method="post"', count=2)
+        self.assertNotContains(response, 'disabled')
+
+    def test_page__contact_copy_links_the_support_address(self):
+        """Copy that says to contact ByteDeck links the support address as a
+        mailto (maintainer request, 2026-08-09): the managed-manually status, the
+        manual-billing note, and the activating page's check-later copy."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(trial_end_date=None, paid_until=None)  # the managed-manually status
+        self.assertContains(self.get_page(), 'mailto:contact@bytedeck.com')
+
+        # actively paid + unlinked with Stripe configured: the manual-billing note
+        with override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123'):
+            self.set_deck(paid_until=localdate() + timedelta(days=100))
+            self.assertContains(self.get_page(), 'mailto:contact@bytedeck.com')
+
+        # the activating page's "contact ByteDeck if it still hasn't appeared"
+        response = self.client.get(reverse('decks:subscription_activating'))
+        self.assertContains(response, 'mailto:contact@bytedeck.com')
+
     def test_menu__admin_dropdown_links_subscription_page_for_staff(self):
         """The navbar admin menu contains the Subscription entry for staff."""
         response = self.client.get(reverse('quests:quests'))
@@ -1196,18 +1276,23 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
     """
 
     def setUp(self):
-        """Log in staff on an unlinked deck with billing configured via override in
-        each test (the deck's owner email resolution is exercised as-is). The
-        cosmetic customer-description stamp is stubbed so link-path tests never
-        attempt a real Stripe call."""
+        """Log in the DECK OWNER (the only user who may start checkout or open the
+        portal) on an unlinked deck with billing configured via override in each
+        test (the deck's owner email resolution is exercised as-is). A non-owner
+        staff member is kept around for the rejection test. The cosmetic
+        customer-description stamp is stubbed so link-path tests never attempt a
+        real Stripe call."""
         from model_bakery import baker
+
+        from siteconfig.models import SiteConfig
 
         from tenant.utils import deck_cache_key
 
         cache.delete(deck_cache_key(self.tenant.schema_name))
         self.client = TenantClient(self.tenant)
         self.staff = baker.make(User, is_staff=True)
-        self.client.force_login(self.staff)
+        self.owner = SiteConfig.get().deck_owner
+        self.client.force_login(self.owner)
         patcher = patch('tenant.billing.stripe.Customer.modify')
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -1276,6 +1361,19 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
                    return_value=Mock(url='https://checkout.stripe.test/cs_g')) as mock_create:
             response = self.client.post(reverse('decks:subscription'))
         self.assertEqual(response.url, 'https://checkout.stripe.test/cs_g')
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+    def test_post__non_owner_staff_rejected_with_the_owners_name(self):
+        """POST from staff who are not the deck owner starts nothing: no Stripe
+        call, a redirect back with an error naming who CAN act (the server-side
+        guard behind the disabled button; maintainer request, 2026-08-09)."""
+        self.client.force_login(self.staff)
+        with patch('tenant.billing.stripe.checkout.Session.create') as mock_create:
+            response = self.client.post(reverse('decks:subscription'), follow=True)
+        mock_create.assert_not_called()
+        self.assertContains(
+            response, f'Only the deck owner, {self.owner.get_username()}, can manage the subscription.'
+        )
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
     def test_post__stripe_error_redirects_back_with_message(self):

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1352,6 +1352,8 @@ class SubscriptionCheckoutTest(ViewTestUtilsMixin, ByteDeckTenantTestCase):
             response = self.client.post(reverse('decks:subscription'), follow=True)
         mock_create.assert_not_called()
         self.assertContains(response, 'double-bill')
+        # the error message renders its contact address as a clickable mailto link
+        self.assertContains(response, 'mailto:contact@bytedeck.com')
         # the page itself shows the manual-subscription note instead of the button
         self.assertContains(self.client.get(reverse('decks:subscription')), 'managed manually')
 

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -12,6 +12,7 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonRespons
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.utils.html import format_html
 from django.utils.text import slugify
 from django.utils import timezone
 from django.views.generic.edit import CreateView
@@ -542,11 +543,17 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         # (Grace-period decks are past paid_until, so renewing via checkout is
         # exactly what they should do.)
         if not deck.stripe_customer_id and deck.subscription_active and not deck.in_grace_period:
+            # format_html marks the message safe so the message banner (which
+            # renders message HTML) shows a clickable contact link, while still
+            # escaping the interpolated address itself
             messages.error(
                 request,
-                "This deck's subscription is managed manually -- starting a new online "
-                f"subscription would double-bill you. Contact ByteDeck ({settings.SUPPORT_EMAIL}) "
-                "to switch to online billing."
+                format_html(
+                    "This deck's subscription is managed manually -- starting a new online "
+                    'subscription would double-bill you. <a href="mailto:{0}">Contact ByteDeck</a> ({0}) '
+                    "to switch to online billing.",
+                    settings.SUPPORT_EMAIL,
+                )
             )
             return redirect('decks:subscription')
         try:

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -454,12 +454,13 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         """
         from datetime import timedelta
 
-        from .billing import billing_configured, checkout_trial_end
+        from .billing import billing_configured, checkout_trial_end, subscription_plan_summary
         from .models import GRACE_PERIOD_DAYS, TRIAL_MAX_ACTIVE_USERS
         from .utils import get_public_subscribe_url
 
         context = super().get_context_data(**kwargs)
         deck = self.request.tenant
+        deck_owner = SiteConfig.get().deck_owner
         current_student_count = deck.get_active_user_count()  # live, not cached
         cap = deck.effective_max_active_users
         context.update({
@@ -499,6 +500,15 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             # your trial ends" note beside the subscribe button
             'checkout_trial_end': checkout_trial_end(deck),
             'public_subscribe_url': get_public_subscribe_url(),
+            # what the linked subscription buys (product name, price, cadence),
+            # for the status line; None (no plan info shown) on unlinked decks
+            # or when Stripe can't say
+            'plan_summary': subscription_plan_summary(deck),
+            # managing the subscription is the deck OWNER's action alone; other
+            # staff see the button disabled with the owner's name in its popup
+            'is_deck_owner': self.request.user == deck_owner,
+            'deck_owner_name': deck_owner.get_username(),
+            'support_email': settings.SUPPORT_EMAIL,
         })
         return context
 
@@ -517,6 +527,16 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         if not billing_configured():
             messages.error(request, "Online billing isn't configured on this server.")
             return redirect('decks:subscription')
+        # Managing the subscription (checkout or the billing portal, where the
+        # card lives) is the deck OWNER's action alone; the page renders the
+        # button disabled for other staff, and this guard enforces it server-side.
+        deck_owner = SiteConfig.get().deck_owner
+        if request.user != deck_owner:
+            messages.error(
+                request,
+                f"Only the deck owner, {deck_owner.get_username()}, can manage the subscription."
+            )
+            return redirect('decks:subscription')
         # An unlinked deck that is still inside its PAID period has a manually
         # managed subscription -- starting a Stripe checkout would double-bill it.
         # (Grace-period decks are past paid_until, so renewing via checkout is
@@ -525,7 +545,8 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             messages.error(
                 request,
                 "This deck's subscription is managed manually -- starting a new online "
-                "subscription would double-bill you. Contact ByteDeck to switch to online billing."
+                f"subscription would double-bill you. Contact ByteDeck ({settings.SUPPORT_EMAIL}) "
+                "to switch to online billing."
             )
             return redirect('decks:subscription')
         try:
@@ -554,6 +575,12 @@ class SubscriptionActivating(NonPublicOnlyViewMixin, TemplateView):
     def dispatch(self, *args, **kwargs):
         """Require staff, like the subscription page it forwards back to."""
         return super().dispatch(*args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        """Add the support address for the check-later copy's contact link."""
+        context = super().get_context_data(**kwargs)
+        context['support_email'] = settings.SUPPORT_EMAIL
+        return context
 
 
 @non_public_only_view


### PR DESCRIPTION
### What

Four maintainer requests from the staging rehearsal (2026-08-09), all on the Subscription details page:

1. **The status line names the plan.** After the Subscribed badge it now reads e.g. "Subscribed to **Bytedeck Subscription - 40 Students**, renewed annually at $75.00 per year. Paid through **Aug. 8, 2027** (364 days remaining)." The product name, price, and cadence come from the linked Stripe subscription (`Subscription.retrieve` with `items.data.price.product` expanded), condensed by the new `subscription_plan_summary()` in `tenant/billing.py`. Cadence phrasing covers yearly ("renewed annually at $75.00 per year"), monthly, and multi-month plans ("renewed every 6 months at $50.00"); non-USD amounts are spelled with their currency code. Maintenance decks get the same info in parentheses inside their status line. The result is cached for 15 minutes per (deck, subscription) and the cache is cleared on every billing sync (webhook or checkout reconciliation), so a plan switched in the billing portal shows as soon as its webhook lands. When Stripe can't say (unlinked deck, no key, API error, unexpanded data), the page renders exactly its old copy: no error, no plan info.
2. **The manage button also sits at the top**, right under the status, with its help text moved into the button's native `title` popup (project convention for action-button tooltips). The button markup is shared by both placements via a new `_subscription_manage_button.html` include.
3. **Only the deck owner can manage the subscription.** Staff who are not the deck owner see both button copies disabled, with the popup "Only the deck owner, [owner username], can manage the subscription." The POST is enforced server-side with the same message, since a disabled button is only cosmetics.
4. **"Contact ByteDeck" copy now links `mailto:contact@bytedeck.com`** (new `SUPPORT_EMAIL` setting, env-overridable, documented in both env examples): the managed-manually status, the manual-billing note, the double-bill error message, and the activating page's check-later copy. While touching the activating page's copy its `&mdash;`es became colons per the no-em-dash convention.

**HOTFIX to `staging`**: the maintainer wants these in before staging promotes to production (master).

### Testing

* New `PlanSummaryFromSubscriptionTest` pins the phrase building: yearly / monthly / every-6-months cadences, non-USD currencies, one-time prices (empty phrase), amountless prices (cadence alone), and unexpanded or missing product data (None).
* New `SubscriptionPlanSummaryTest` pins the fetch seam: expanded retrieve called once then served from cache, `clear_plan_summary_cache` forcing a refetch, a `StripeError` yielding None without caching, a successful retrieve with unsummarizable data (unexpanded product) yielding None without caching, and unlinked/unconfigured short-circuits with no Stripe call.
* View tests pin the status line with and without plan data (Subscribed and Maintenance), the button appearing twice, the disabled-with-named-popup rendering for non-owner staff, the owner's live forms, the mailto links in all three spots, and the server-side POST rejection naming the owner (with no Stripe call). Existing checkout/portal POST tests now run as the deck owner.
* `tenant/billing.py` sits at 100% line and branch coverage under the tenant suite. Full suite (1943 tests), ruff, and `makemigrations --check` pass locally.

### Screenshots

Captured from the running `hackerspace` dev deck (`http://hackerspace.localhost:8000/decks/subscription/`), seeded as a subscribed 40-student deck paid through Aug. 8, 2027.

**Before (deck owner):** status gives only the paid-through date; single button at the bottom.

![before, deck owner](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-owner-plan/before-owner.png)

**After (deck owner):** the status names the plan and its renewal terms, and the manage button also sits right below it. Hovering either button pops "Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel."

![after, deck owner](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-owner-plan/after-owner.png)

**After (staff who is not the deck owner, `admin`):** both buttons disabled; hovering pops "Only the deck owner, owner, can manage the subscription." (native title popups don't render in a static screenshot).

![after, non-owner staff](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/subscription-owner-plan/after-nonowner.png)

- Claude Code (`Bytedeck - payments integration`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription pages now show plan names, pricing, renewal cadence, and clearer billing status.
  * Deck owners can manage subscriptions directly; non-owners see disabled controls with guidance.
  * Added support contact links for billing assistance.
  * Added configurable support email settings, defaulting to `contact@bytedeck.com`.

* **Bug Fixes**
  * Subscription plan details remain responsive when billing data is unavailable or temporarily fails.
  * Plan information is refreshed after subscription changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->