### PR TITLE
fix: point the seeded homepage TRY IT buttons at the deck-request form

### DIFF
--- a/src/hackerspace_online/management/commands/initdb.py
+++ b/src/hackerspace_online/management/commands/initdb.py
@@ -175,7 +175,7 @@ def get_homepage_content():
             <a class="btn btn-block BD-btn BD-bg-LightBlue BD-btn-LightBlue-1" href="#teachers" role="button">TEACHERS</a>
           </div>
           <div class="col-md-4">
-            <a class="btn btn-block BD-btn BD-bg-LightBlue BD-btn-LightBlue-1" href="#contact" role="button">TRY IT</a>
+            <a class="btn btn-block BD-btn BD-bg-LightBlue BD-btn-LightBlue-1" href="/decks/request/" role="button">TRY IT</a>
           </div>
         </div>
         <!-- /row -->
@@ -258,7 +258,7 @@ def get_homepage_content():
             open-ended, self-directed activities, where students can showcase their learning and creativity.</p>
             <div class="row">
               <div class="col-lg-4 BD-title-pixels">
-                <a class="btn btn-block BD-btn BD-bg-DarkBlue" href="#contact" role="button">TRY IT!</a>
+                <a class="btn btn-block BD-btn BD-bg-DarkBlue" href="/decks/request/" role="button">TRY IT!</a>
                 <!-- <div>
                   <img class="students-pixels BD-img-pixels" src="https://d10ge8y4vx8iud.cloudfront.net/static/public/images/pixels%203.png">
                 </div> -->
@@ -302,7 +302,7 @@ def get_homepage_content():
             where they're at.</p>
             <div class="row">
               <div class="col-lg-4">
-                <a class="btn btn-block BD-btn BD-bg-LightBlue BD-bg-LightBlue BD-btn-LightBlue-2" href="#contact" role="button">TRY IT!!</a>
+                <a class="btn btn-block BD-btn BD-bg-LightBlue BD-bg-LightBlue BD-btn-LightBlue-2" href="/decks/request/" role="button">TRY IT!!</a>
               </div>
             </div>
           </div>

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -70,9 +70,9 @@ class InitDbTest(TestCase, CommandMixin):
 
         with tenant_context(public_tenant):
             homepage = FlatPage.objects.get(url='/home/')  # will throw exception if doesn't exist
-            # the seeded TRY IT buttons must point at the deck-request form: the old
-            # "#contact" anchor target no longer exists anywhere on the seeded page
-            self.assertIn('href="/decks/request/"', homepage.content)
+            # ALL THREE seeded TRY IT buttons must point at the deck-request form:
+            # the old "#contact" anchor target no longer exists anywhere on the page
+            self.assertEqual(homepage.content.count('href="/decks/request/"'), 3)
             self.assertNotIn('href="#contact"', homepage.content)
             user = User.objects.get(username='admin')
             self.assertTrue(user.is_superuser)

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -69,7 +69,11 @@ class InitDbTest(TestCase, CommandMixin):
         public_tenant = Tenant.objects.get(schema_name="public")  # no assert, but will throw exception if doesn't exist
 
         with tenant_context(public_tenant):
-            FlatPage.objects.get(url='/home/')  # no assert, but will throw exception if doesn't exist
+            homepage = FlatPage.objects.get(url='/home/')  # will throw exception if doesn't exist
+            # the seeded TRY IT buttons must point at the deck-request form: the old
+            # "#contact" anchor target no longer exists anywhere on the seeded page
+            self.assertIn('href="/decks/request/"', homepage.content)
+            self.assertNotIn('href="#contact"', homepage.content)
             user = User.objects.get(username='admin')
             self.assertTrue(user.is_superuser)
             self.assertTrue(Site.objects.exists())


### PR DESCRIPTION
### What

The public homepage that `initdb` seeds (the `/home/` flatpage) contains three TRY IT buttons that link the `#contact` anchor, but no `#contact` section exists anywhere on the seeded page, so on a fresh install the site's main call to action does nothing when clicked. They now link `/decks/request/` (the deck-request form), matching where the public navbar's and footer's "Try it" links already point.

Scope note: this only changes what a **fresh `initdb` seeds**. The homepage is created with `get_or_create`, so existing deployments (staging/production) keep their database copy of the page; their TRY IT buttons are edited in the flatpage editor directly (maintainer is handling that on staging, 2026-08-09).

### Testing

`test_initdb__sets_up_public_tenant` now also asserts the seeded homepage content links `/decks/request/` and carries no `#contact` hrefs; it fails without the fix. Full suite, ruff, and `makemigrations --check` pass locally.

### Screenshots

N/A for a rendered before/after: the change is to the content string `initdb` seeds into a fresh database, and every running deployment's homepage is its own database copy (the deployed pages are unaffected). The diff is three `href="#contact"` to `href="/decks/request/"` swaps in the seeded HTML.

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated all homepage “TRY IT” links to direct visitors to the deck request page.
  - Removed outdated links that previously jumped to the contact section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->