### PR TITLE
HOTFIX: feat: verify-owner-email and change-deck-owner from the tenant admin

### DIFF
--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -283,6 +283,15 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         tenant = queryset.first()
         with tenant_context(tenant):
             current_owner = SiteConfig.get().deck_owner
+            # the field is NOT NULL, but older admin code guards ownerless decks
+            # (message_selected), so match that caution instead of 500ing on .pk
+            if current_owner is None:
+                self.message_user(
+                    request,
+                    f"{tenant.schema_name}: this deck has no owner set in its SiteConfig; fix it there first.",
+                    messages.ERROR,
+                )
+                return None
             staff = User.objects.filter(is_staff=True).exclude(pk=current_owner.pk).order_by('username')
             choices = [
                 (user.username, f"{user.get_full_name() or user.username} ({user.username})")

--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -94,6 +94,29 @@ class SendEmailAdminForm(forms.Form):
     message = forms.CharField(widget=ByteDeckSummernoteSafeWidget)
 
 
+class ChangeDeckOwnerAdminForm(forms.Form):
+    """Intermediate form for the "Change deck owner" action: pick the new owner
+    from the selected deck's staff users (built per-deck by the action)."""
+    # '_selected_action' (ACTION_CHECKBOX_NAME) is required for the admin intermediate form to submit
+    _selected_action = forms.CharField(widget=forms.MultipleHiddenInput)
+
+    new_owner = forms.ChoiceField(
+        label="New deck owner",
+        help_text="Staff users on this deck. The chosen user is promoted to superuser; "
+                  "the current owner's permissions are untouched.",
+    )
+
+    def __init__(self, *args, choices=(), **kwargs):
+        """Attach the per-deck staff-user choices the action resolved.
+
+        Args:
+            choices (iterable): ``(username, label)`` pairs for the deck's
+                staff users, excluding the current owner.
+        """
+        super().__init__(*args, **kwargs)
+        self.fields['new_owner'].choices = choices
+
+
 class DeleteConfirmationForm(forms.Form):
     confirmation = forms.CharField(required=True, widget=widgets.AdminTextInputWidget)
 
@@ -140,7 +163,10 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
     delete_selected_confirmation_template = 'admin/tenant/tenant/delete_selected_confirmation.html'
     delete_confirmation_template = 'admin/tenant/tenant/delete_confirmation.html'
 
-    actions = ['refresh_cached_fields', 'sync_from_stripe', 'message_unverified', 'message_verified', 'enable_google_signin', 'disable_google_signin']
+    actions = [
+        'refresh_cached_fields', 'sync_from_stripe', 'verify_owner_email', 'change_deck_owner',
+        'message_unverified', 'message_verified', 'enable_google_signin', 'disable_google_signin',
+    ]
 
     @admin.action(description="Refresh deck stats for selected deck(s)")
     def refresh_cached_fields(self, request, queryset):
@@ -203,6 +229,115 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
                 f"Skipped {skipped} deck(s) with no stripe_subscription_id (link them first, or use checkout).",
                 messages.WARNING,
             )
+
+    @admin.action(description="Verify owner email for selected deck(s)")
+    def verify_owner_email(self, request, queryset):
+        """Normalize each selected deck owner's allauth EmailAddress to
+        verified+primary: the state deck creation produces (legacy decks predate
+        that flow, so their owners often have no EmailAddress row at all). Uses
+        the same write path as the ``backfill_owner_emails`` management command
+        (tenant.utils.normalize_owner_email) and reports each deck's outcome as
+        its own message; decks that need a human (no owner email, or the address
+        is verified by a different account) are flagged rather than guessed at.
+        """
+        from library.utils import get_library_schema_name
+
+        from .utils import normalize_owner_email
+
+        for tenant in queryset.exclude(schema_name__in=[get_public_schema_name(), get_library_schema_name()]):
+            try:
+                # atomic() so a broken schema can't poison the connection for the rest
+                with transaction.atomic(), tenant_context(tenant):
+                    status, owner_name, email, notes = normalize_owner_email(tenant, apply_changes=True)
+            except Exception as e:
+                self.message_user(request, f"{tenant.schema_name}: ERROR {type(e).__name__}: {e}", messages.ERROR)
+                continue
+            summary = {
+                'fixed': f"verified the owner's email ({owner_name} <{email}>)",
+                'ok': f"owner email already verified ({owner_name} <{email}>)",
+                'no-email': f"owner '{owner_name}' has NO email set: add one in the deck's Site Config first",
+                'skipped': f"'{email}' is already verified by another account on the deck: needs a human",
+            }[status]
+            level = {'fixed': messages.SUCCESS, 'ok': messages.INFO}.get(status, messages.WARNING)
+            note_suffix = f" ({notes})" if notes else ''
+            self.message_user(request, f"{tenant.schema_name}: {summary}{note_suffix}", level)
+
+    @admin.action(description="Change deck owner for the selected deck")
+    def change_deck_owner(self, request, queryset):
+        """Hand a deck to a new owner from the admin (legacy decks whose owner is
+        the wrong account). Works on exactly ONE selected deck: an intermediate
+        page lists that deck's staff users (minus the current owner) to pick
+        from, then the switch runs through the same write path as the
+        ``change_deck_owner`` management command (tenant.utils.switch_deck_owner):
+        the new owner is promoted to superuser, the previous owner's permissions
+        are untouched, and the deck's cached owner fields refresh immediately.
+        """
+        from library.utils import get_library_schema_name
+
+        from .utils import switch_deck_owner
+
+        queryset = queryset.exclude(schema_name__in=[get_public_schema_name(), get_library_schema_name()])
+        if queryset.count() != 1:
+            self.message_user(request, "Select exactly ONE deck to change its owner.", messages.ERROR)
+            return None
+        tenant = queryset.first()
+        with tenant_context(tenant):
+            current_owner = SiteConfig.get().deck_owner
+            staff = User.objects.filter(is_staff=True).exclude(pk=current_owner.pk).order_by('username')
+            choices = [
+                (user.username, f"{user.get_full_name() or user.username} ({user.username})")
+                for user in staff
+            ]
+        if not choices:
+            self.message_user(
+                request,
+                f"{tenant.schema_name}: no other staff users on the deck to hand it to.",
+                messages.WARNING,
+            )
+            return None
+
+        if request.POST.get("post"):  # if admin pressed 'Change owner' on the intermediate page
+            form = ChangeDeckOwnerAdminForm(data=request.POST, choices=choices)
+            if form.is_valid():
+                try:
+                    old_username, new_username = switch_deck_owner(tenant, form.cleaned_data['new_owner'])
+                except ValueError as e:  # pragma: no cover -- the form's choice validation already
+                    # rejects unknown/non-staff users; this only guards the race where the user's
+                    # account changes between the picker render and the confirm POST
+                    self.message_user(request, f"{tenant.schema_name}: {e}", messages.ERROR)
+                    return None
+                self.message_user(
+                    request,
+                    f"{tenant.schema_name}: owner changed from '{old_username}' to '{new_username}' "
+                    "(promoted to superuser). Now run \"Verify owner email\" on the deck to normalize "
+                    "the new owner's email verification.",
+                    messages.SUCCESS,
+                )
+                return None
+        else:
+            # '_selected_action' (ACTION_CHECKBOX_NAME) is required for the admin intermediate form to submit
+            form = ChangeDeckOwnerAdminForm(initial={helpers.ACTION_CHECKBOX_NAME: [tenant.pk]}, choices=choices)
+
+        adminform = helpers.AdminForm(form, [(None, {"fields": form.base_fields})], {})
+        media = self.media + adminform.media
+        request.current_app = self.admin_site.name
+        return TemplateResponse(
+            request,
+            "admin/tenant/tenant/change_deck_owner.html",
+            context={
+                **self.admin_site.each_context(request),
+                "title": f"Change the owner of deck '{tenant.schema_name}'",
+                "adminform": adminform,
+                "subtitle": None,
+                "tenant": tenant,
+                "current_owner": current_owner,
+                "queryset": queryset,
+                # building proper breadcrumb in admin
+                "opts": self.model._meta,
+                "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
+                "media": media,
+            },
+        )
 
     @admin.display(description="owner full name")
     def owner_full_name_text(self, obj):

--- a/src/tenant/management/commands/backfill_owner_emails.py
+++ b/src/tenant/management/commands/backfill_owner_emails.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from allauth.account.models import EmailAddress
@@ -25,7 +25,8 @@ class Command(BaseCommand):
     Dry-run by default: pass ``--apply`` to write. In apply mode each fixed
     deck's cached fields are refreshed immediately so ``owner_email_cached`` (the
     address the notice engine and the Stripe backfill report use) is correct
-    without waiting for the nightly task.
+    without waiting for the nightly task. ``--schema <deck>`` narrows the run to
+    a single deck, for cleaning up one legacy deck by hand.
 
     Every run also audits the owners that need a human: owners with no email at
     all, owners whose address is already verified by a different account on the
@@ -38,9 +39,10 @@ class Command(BaseCommand):
 
     help = (
         "Normalize every deck owner's allauth EmailAddress to verified+primary, matching "
-        "what deck creation sets up. Dry-run by default; pass --apply to write. Also "
-        "audits owners with no email, addresses already verified by another account, "
-        "and decks still on the heuristic default owner."
+        "what deck creation sets up. Dry-run by default; pass --apply to write and "
+        "--schema <deck> to process a single deck. Also audits owners with no email, "
+        "addresses already verified by another account, and decks still on the "
+        "heuristic default owner."
     )
 
     def add_arguments(self, parser):
@@ -55,13 +57,25 @@ class Command(BaseCommand):
             help="Write the EmailAddress fixes and refresh each fixed deck's cached fields. "
                  "Without this flag nothing is written.",
         )
+        parser.add_argument(
+            '--schema', default=None,
+            help="Only process this one deck (its schema name), e.g. a single legacy deck "
+                 "being cleaned up by hand. Without it every deck is processed.",
+        )
 
     def handle(self, *args, **options):
-        """Iterate every billable tenant, print one audit line each, then a summary."""
+        """Iterate the selected billable tenant(s), print one audit line each, then a summary."""
         apply_changes = options['apply']
         tenants = get_tenant_model().objects.exclude(
             schema_name__in=[get_public_schema_name(), get_library_schema_name()]
         ).order_by('schema_name')
+        if options['schema']:
+            tenants = tenants.filter(schema_name=options['schema'])
+            if not tenants.exists():
+                raise CommandError(
+                    f"No deck with schema name '{options['schema']}' "
+                    "(the public and library schemas are not decks)."
+                )
 
         header = f"{'deck':<24} {'status':<10} {'owner':<20} {'email':<32} notes"
         self.stdout.write(header)

--- a/src/tenant/management/commands/backfill_owner_emails.py
+++ b/src/tenant/management/commands/backfill_owner_emails.py
@@ -1,8 +1,6 @@
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
-from allauth.account.models import EmailAddress
 from django_tenants.utils import get_public_schema_name, get_tenant_model, tenant_context
 
 from library.utils import get_library_schema_name
@@ -118,7 +116,9 @@ class Command(BaseCommand):
     def _process_deck(self, tenant, apply_changes):
         """Audit (and in apply mode normalize) one deck's owner email bookkeeping.
 
-        Must run inside the deck's tenant context.
+        Thin wrapper over :func:`tenant.utils.normalize_owner_email` (the single
+        write path this command shares with the tenant admin's "Verify owner
+        email" action). Must run inside the deck's tenant context.
 
         Args:
             tenant (Tenant): The deck being processed (its public-schema row).
@@ -126,74 +126,8 @@ class Command(BaseCommand):
                 refresh the deck's cached fields; when False, only report.
 
         Returns:
-            tuple: ``(status, owner_name, email, notes)`` where ``status`` is
-            ``ok`` (nothing to do), ``fixed`` (bookkeeping created or corrected;
-            in dry-run mode this means it WOULD be), ``no-email`` (needs a
-            human), or ``skipped`` (a different account already verified the
-            address, so no write can succeed: needs a human); ``owner_name`` is
-            the owner's username; ``email`` is the owner's address or None;
-            ``notes`` is the semicolon-joined audit remarks for the report line.
+            tuple: The helper's ``(status, owner_name, email, notes)``.
         """
-        from siteconfig.models import SiteConfig
+        from tenant.utils import normalize_owner_email
 
-        owner = SiteConfig.get().deck_owner
-        notes = []
-        # the initial deck_owner default was a heuristic (oldest non-admin staff
-        # user, else a bare created account): flag decks that never chose for real
-        if owner.username == settings.TENANT_DEFAULT_OWNER_USERNAME:
-            notes.append("default owner account (heuristic guess, never chosen)")
-        # the deprecated hand-entered public-tenant address is often the best clue
-        # to who the owner SHOULD be when the schema's data is missing or wrong
-        legacy = (tenant.owner_email or '').strip()
-        if legacy and legacy.lower() != (owner.email or '').lower():
-            notes.append(f"public-tenant legacy owner_email differs: {legacy}")
-
-        if not owner.email:
-            return 'no-email', owner.username, None, '; '.join(notes)
-
-        # deterministic target row, preferring the form a save lands on:
-        # EmailAddress.clean() lowercases the address, so normalizing any other
-        # row rewrites it to the lowercase form; targeting the lowercase row
-        # first means that rewrite can never collide with a case-variant sibling
-        # under the unique (user, email) constraint. Fall back to the exact-case
-        # match, then the oldest case-variant duplicate.
-        canonical = owner.email.lower()
-        matches = list(EmailAddress.objects.filter(user=owner, email__iexact=owner.email).order_by('pk'))
-        email_address = next(
-            (row for row in matches if row.email == canonical),
-            next((row for row in matches if row.email == owner.email), matches[0] if matches else None),
-        )
-        already_ok = (
-            email_address is not None and email_address.verified and email_address.primary
-            and not EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).exists()
-        )
-        if already_ok:
-            return 'ok', owner.username, owner.email, '; '.join(notes)
-
-        # the DB allows one VERIFIED row per address across the whole schema
-        # (unique_verified_email, from ACCOUNT_UNIQUE_EMAIL): if a different
-        # account already verified this address, no write can succeed, and which
-        # account is really the owner's is a human call. Report and leave it.
-        if EmailAddress.objects.exclude(user=owner).filter(email=canonical, verified=True).exists():
-            notes.append("address already verified by another account on this deck")
-            return 'skipped', owner.username, owner.email, '; '.join(notes)
-
-        if apply_changes:
-            # mirror TenantCreate.form_valid: the owner's address exists, verified
-            # and primary. Every OTHER primary row is demoted BEFORE the target
-            # saves: the DB allows at most one primary per user
-            # (unique_primary_email), so the demote must come first, and excluding
-            # by pk (a brand-new target has none, so nothing is spared) also
-            # demotes a case-variant duplicate of the owner's own address.
-            if email_address is None:
-                email_address = EmailAddress(user=owner, email=owner.email, verified=True, primary=True)
-            else:
-                email_address.verified = True
-                email_address.primary = True
-            EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).update(primary=False)
-            email_address.full_clean()
-            email_address.save()
-            # land owner_email_cached now; the notice engine and the Stripe
-            # backfill report read the cache, not the schema
-            tenant.update_cached_fields()
-        return 'fixed', owner.username, owner.email, '; '.join(notes)
+        return normalize_owner_email(tenant, apply_changes)

--- a/src/tenant/management/commands/backfill_owner_emails.py
+++ b/src/tenant/management/commands/backfill_owner_emails.py
@@ -44,7 +44,10 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser):
-        """Register the --apply flag (without it the command only reports).
+        """Register the --apply flag and the --schema option.
+
+        Without --apply the command only reports; without --schema every deck
+        is processed.
 
         Args:
             parser (argparse.ArgumentParser): The command's argument parser,

--- a/src/tenant/management/commands/change_deck_owner.py
+++ b/src/tenant/management/commands/change_deck_owner.py
@@ -1,0 +1,90 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from django_tenants.utils import get_public_schema_name, get_tenant_model, tenant_context
+
+from library.utils import get_library_schema_name
+
+
+class Command(BaseCommand):
+    """Change a deck's owner to another staff user on that deck (legacy cleanup).
+
+    Mirrors what choosing a new Deck Owner in the SiteConfig admin does
+    (``SiteConfigForm.clean_deck_owner``): the new owner must be an existing
+    STAFF user on the deck and is promoted to superuser. The previous owner's
+    account and permissions are left untouched (demote them by hand if wanted).
+    The deck's cached owner fields are refreshed immediately so the public
+    admin, the notice engine, and the Stripe backfill report see the new owner
+    without waiting for the nightly task.
+
+    The new owner's email-verification bookkeeping is deliberately NOT touched
+    here: run ``backfill_owner_emails --schema <deck> --apply`` afterwards to
+    normalize their allauth EmailAddress to verified+primary.
+    """
+
+    help = (
+        "Change a deck's owner (SiteConfig.deck_owner) to another staff user on that deck: "
+        "change_deck_owner <schema_name> <username>. The new owner is promoted to superuser "
+        "(matching the SiteConfig admin); afterwards run "
+        "backfill_owner_emails --schema <deck> --apply to normalize their email verification."
+    )
+
+    def add_arguments(self, parser):
+        """Register the deck schema and new-owner username arguments.
+
+        Args:
+            parser (argparse.ArgumentParser): The command's argument parser,
+                mutated in place. Returns nothing.
+        """
+        parser.add_argument('schema_name', help="The deck's schema name, e.g. 'hackerspace'.")
+        parser.add_argument('username', help="The new owner: an existing STAFF user on that deck.")
+
+    def handle(self, *args, **options):
+        """Validate the deck and user, then switch the owner and refresh caches."""
+        from siteconfig.models import SiteConfig
+
+        User = get_user_model()
+        Tenant = get_tenant_model()
+        schema_name = options['schema_name']
+        if schema_name in (get_public_schema_name(), get_library_schema_name()):
+            raise CommandError(f"'{schema_name}' is not a deck.")
+        try:
+            tenant = Tenant.objects.get(schema_name=schema_name)
+        except Tenant.DoesNotExist:
+            raise CommandError(f"No deck with schema name '{schema_name}'.")
+
+        with transaction.atomic(), tenant_context(tenant):
+            try:
+                new_owner = User.objects.get(username=options['username'])
+            except User.DoesNotExist:
+                raise CommandError(f"No user '{options['username']}' on deck '{schema_name}'.")
+            if not new_owner.is_staff:
+                raise CommandError(
+                    f"'{new_owner.username}' is not a staff user on '{schema_name}': the deck owner "
+                    "must be staff. Make them staff first if this really is the right account."
+                )
+            config = SiteConfig.get()
+            old_owner = config.deck_owner
+            if old_owner == new_owner:
+                self.stdout.write(f"'{new_owner.username}' already owns '{schema_name}'; nothing to do.")
+                return
+            # mirror SiteConfigForm.clean_deck_owner: the deck owner is always a superuser
+            if not new_owner.is_superuser:
+                new_owner.is_superuser = True
+                new_owner.save()
+            config.deck_owner = new_owner
+            config.full_clean()
+            config.save()
+            # land the cached owner name/email now; the public admin, the notice
+            # engine, and the Stripe backfill report all read the cache
+            tenant.update_cached_fields()
+
+        self.stdout.write(self.style.SUCCESS(
+            f"'{schema_name}' owner changed: {old_owner.username} -> {new_owner.username} "
+            "(promoted to superuser; the previous owner's permissions are untouched)."
+        ))
+        self.stdout.write(
+            f"Reminder: run `backfill_owner_emails --schema {schema_name} --apply` to "
+            "normalize the new owner's email verification."
+        )

--- a/src/tenant/management/commands/change_deck_owner.py
+++ b/src/tenant/management/commands/change_deck_owner.py
@@ -1,8 +1,6 @@
-from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
 
-from django_tenants.utils import get_public_schema_name, get_tenant_model, tenant_context
+from django_tenants.utils import get_public_schema_name, get_tenant_model
 
 from library.utils import get_library_schema_name
 
@@ -10,13 +8,14 @@ from library.utils import get_library_schema_name
 class Command(BaseCommand):
     """Change a deck's owner to another staff user on that deck (legacy cleanup).
 
-    Mirrors what choosing a new Deck Owner in the SiteConfig admin does
-    (``SiteConfigForm.clean_deck_owner``): the new owner must be an existing
-    STAFF user on the deck and is promoted to superuser. The previous owner's
-    account and permissions are left untouched (demote them by hand if wanted).
-    The deck's cached owner fields are refreshed immediately so the public
-    admin, the notice engine, and the Stripe backfill report see the new owner
-    without waiting for the nightly task.
+    Thin CLI wrapper over :func:`tenant.utils.switch_deck_owner`, the single
+    write path this command shares with the tenant admin's "Change deck owner"
+    action: the new owner must be an existing STAFF user on the deck and is
+    promoted to superuser (mirroring ``SiteConfigForm.clean_deck_owner``); the
+    previous owner's account and permissions are left untouched, and the deck's
+    cached owner fields are refreshed immediately so the public admin, the
+    notice engine, and the Stripe backfill report see the new owner without
+    waiting for the nightly task.
 
     The new owner's email-verification bookkeeping is deliberately NOT touched
     here: run ``backfill_owner_emails --schema <deck> --apply`` afterwards to
@@ -41,10 +40,9 @@ class Command(BaseCommand):
         parser.add_argument('username', help="The new owner: an existing STAFF user on that deck.")
 
     def handle(self, *args, **options):
-        """Validate the deck and user, then switch the owner and refresh caches."""
-        from siteconfig.models import SiteConfig
+        """Validate the deck, then switch the owner via the shared helper."""
+        from tenant.utils import switch_deck_owner
 
-        User = get_user_model()
         Tenant = get_tenant_model()
         schema_name = options['schema_name']
         if schema_name in (get_public_schema_name(), get_library_schema_name()):
@@ -54,34 +52,16 @@ class Command(BaseCommand):
         except Tenant.DoesNotExist:
             raise CommandError(f"No deck with schema name '{schema_name}'.")
 
-        with transaction.atomic(), tenant_context(tenant):
-            try:
-                new_owner = User.objects.get(username=options['username'])
-            except User.DoesNotExist:
-                raise CommandError(f"No user '{options['username']}' on deck '{schema_name}'.")
-            if not new_owner.is_staff:
-                raise CommandError(
-                    f"'{new_owner.username}' is not a staff user on '{schema_name}': the deck owner "
-                    "must be staff. Make them staff first if this really is the right account."
-                )
-            config = SiteConfig.get()
-            old_owner = config.deck_owner
-            if old_owner == new_owner:
-                self.stdout.write(f"'{new_owner.username}' already owns '{schema_name}'; nothing to do.")
-                return
-            # mirror SiteConfigForm.clean_deck_owner: the deck owner is always a superuser
-            if not new_owner.is_superuser:
-                new_owner.is_superuser = True
-                new_owner.save()
-            config.deck_owner = new_owner
-            config.full_clean()
-            config.save()
-            # land the cached owner name/email now; the public admin, the notice
-            # engine, and the Stripe backfill report all read the cache
-            tenant.update_cached_fields()
+        try:
+            old_username, new_username = switch_deck_owner(tenant, options['username'])
+        except ValueError as e:
+            raise CommandError(str(e))
 
+        if old_username == new_username:
+            self.stdout.write(f"'{new_username}' already owns '{schema_name}'; nothing to do.")
+            return
         self.stdout.write(self.style.SUCCESS(
-            f"'{schema_name}' owner changed: {old_owner.username} -> {new_owner.username} "
+            f"'{schema_name}' owner changed: {old_username} -> {new_username} "
             "(promoted to superuser; the previous owner's permissions are untouched)."
         ))
         self.stdout.write(

--- a/src/tenant/templates/admin/tenant/tenant/change_deck_owner.html
+++ b/src/tenant/templates/admin/tenant/tenant/change_deck_owner.html
@@ -1,0 +1,67 @@
+<!-- tenant/templates/admin/tenant/tenant/change_deck_owner.html -->
+
+<!-- Intermediate page for the "Change deck owner" changelist action: pick the
+     new owner from the deck's staff users, then confirm. -->
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ul class="grp-horizontal-list">
+        <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+        <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+        <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a></li>
+        <li>{% trans 'Change deck owner' %}</li>
+    </ul>
+{% endblock %}
+{% block content-class %}{% endblock %}
+
+{% block content %}
+    <form action="" method="post" novalidate>{% csrf_token %}
+        {% if adminform.errors %}
+            <p class="errornote">{% if adminform.errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}</p>
+            <ul class="errorlist">{% for error in adminform.non_field_errors %}<li>{{ error }}</li>{% endfor %}</ul>
+        {% endif %}
+
+        <fieldset class="module grp-module">
+            <div class="form-row grp-row grp-cells-1 current_owner">
+                <div class="field-box l-2c-fluid l-d-4">
+                    <div class="c-1"><label>{% trans 'Current owner' %}</label></div>
+                    <div class="c-2">
+                        <p>{{ current_owner.get_full_name|default:current_owner.username }} ({{ current_owner.username }})</p>
+                        <p class="grp-help">{% trans 'The current owner keeps their account and permissions.' %}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="form-row grp-row grp-cells-1{% if adminform.form.new_owner.errors %} grp-errors{% endif %} new_owner">
+                <div class="field-box l-2c-fluid l-d-4">
+                    <div class="c-1"><label for="id_new_owner" class="required">{% trans 'New deck owner' %}</label></div>
+                    <div class="c-2">
+                        {{ adminform.form.new_owner }}
+                        {{ adminform.form.new_owner.errors }}
+                        {% if adminform.form.new_owner.help_text %}
+                            <p class="grp-help">{{ adminform.form.new_owner.help_text|safe }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </fieldset>
+
+        <div id="submit" class="grp-module grp-submit-row grp-fixed-footer">
+            {% for obj in queryset %}
+                <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
+            {% endfor %}
+            <input type="hidden" name="action" value="change_deck_owner" />
+            <input type="hidden" name="post" value="yes">
+            <ul>
+                <li class="grp-float-left"><a href="." class="grp-button grp-cancel-link">{% trans "No, take me back" %}</a></li>
+                <li><input type="submit" value="{% trans "Change owner" %}" class="grp-button grp-default" /></li>
+            </ul>
+        </div>
+    </form>
+{% endblock %}

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -1223,3 +1223,117 @@ class SyncFromStripeActionTest(ByteDeckTenantTestCase):
         with patch('tenant.billing.stripe.Subscription.retrieve', side_effect=stripe_lib.StripeError('nope')):
             response = self.post_action([self.tenant.pk])
         self.assertContains(response, "Stripe error")
+
+
+class TenantAdminOwnerActionsTest(PublicTenantTestAdminPublic):
+    """Tests for the tenant changelist's legacy owner cleanup actions
+    (maintainer request, 2026-08-09: these run from the admin, not SSH)."""
+
+    def login_admin(self):
+        """Move the client to the public schema, sign the superuser in, and
+        return the changelist URL the actions post to."""
+        url = reverse("admin:tenant_tenant_changelist")
+        self.client.get(url)  # move client to public schema
+        self.client.force_login(self.superuser)
+        return url
+
+    def test_verify_owner_email_action__verifies_the_owners_address(self):
+        """The action normalizes the selected deck owner's EmailAddress to
+        verified+primary (the state deck creation produces), reports the fix,
+        reports already-verified on a second run, and silently ignores a
+        selected public row (not a deck)."""
+        url = self.login_admin()
+        public_pk = Tenant.objects.get(schema_name=get_public_schema_name()).pk
+        with tenant_context(self.tenant):
+            owner = SiteConfig.get().deck_owner
+            self.assertFalse(EmailAddress.objects.get(user=owner, email='jane@doe.com').verified)
+
+        action_data = {"action": "verify_owner_email", ACTION_CHECKBOX_NAME: [self.tenant.pk, public_pk]}
+        response = self.client.post(url, action_data, follow=True)
+
+        self.assertContains(response, "verified the owner")
+        self.assertContains(response, "jane@doe.com")
+        with tenant_context(self.tenant):
+            row = EmailAddress.objects.get(user=owner, email='jane@doe.com')
+            self.assertTrue(row.verified)
+            self.assertTrue(row.primary)
+
+        response = self.client.post(url, {"action": "verify_owner_email",
+                                          ACTION_CHECKBOX_NAME: [self.tenant.pk]}, follow=True)
+        self.assertContains(response, "already verified")
+
+    def test_verify_owner_email_action__error_reported_not_raised(self):
+        """A deck that blows up mid-normalize (e.g. a broken schema) gets an
+        ERROR message for that deck instead of the whole action 500ing."""
+        url = self.login_admin()
+        action_data = {"action": "verify_owner_email", ACTION_CHECKBOX_NAME: [self.tenant.pk]}
+        with patch('tenant.utils.normalize_owner_email', side_effect=RuntimeError('boom')):
+            response = self.client.post(url, action_data, follow=True)
+        self.assertContains(response, "ERROR RuntimeError: boom")
+
+    def test_change_deck_owner_action__intermediate_page_then_switch(self):
+        """One selected deck: the intermediate page lists the deck's staff users
+        (minus the current owner), and confirming hands the deck over through the
+        shared write path: SiteConfig.deck_owner switches, the new owner is
+        promoted to superuser, and the cached owner fields land immediately."""
+        from model_bakery import baker
+
+        url = self.login_admin()
+        with tenant_context(self.tenant):
+            baker.make(User, is_staff=True, is_superuser=False, username='handover',
+                       first_name='Hand', last_name='Over', email='hand.over@example.com')
+
+        # step 1: the intermediate picker page
+        action_data = {"action": "change_deck_owner", ACTION_CHECKBOX_NAME: [self.tenant.pk]}
+        response = self.client.post(url, action_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Change the owner of deck")
+        self.assertContains(response, "handover")
+
+        # step 2: confirm the handover
+        action_data.update({"post": "yes", "new_owner": "handover"})
+        response = self.client.post(url, action_data, follow=True)
+        self.assertContains(response, "owner changed from")
+
+        with tenant_context(self.tenant):
+            new_owner = User.objects.get(username='handover')
+            self.assertEqual(SiteConfig.objects.get().deck_owner, new_owner)
+            self.assertTrue(new_owner.is_superuser)
+        self.assertEqual(Tenant.objects.get(pk=self.tenant.pk).owner_email_cached, 'hand.over@example.com')
+
+    def test_change_deck_owner_action__invalid_choice_rerenders_with_errors(self):
+        """Confirming with a username that isn't one of the deck's staff choices
+        re-renders the picker with a form error instead of writing anything."""
+        url = self.login_admin()
+        with tenant_context(self.tenant):
+            owner_before = SiteConfig.objects.get().deck_owner
+
+        action_data = {"action": "change_deck_owner", ACTION_CHECKBOX_NAME: [self.tenant.pk],
+                       "post": "yes", "new_owner": "nobody-here"}
+        response = self.client.post(url, action_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Change the owner of deck")
+
+        with tenant_context(self.tenant):
+            self.assertEqual(SiteConfig.objects.get().deck_owner, owner_before)
+
+    def test_change_deck_owner_action__requires_exactly_one_deck(self):
+        """Selecting two decks errors out with guidance instead of guessing
+        which deck to hand over."""
+        url = self.login_admin()
+        action_data = {"action": "change_deck_owner",
+                       ACTION_CHECKBOX_NAME: [self.tenant.pk, self.extra_tenant.pk]}
+        response = self.client.post(url, action_data, follow=True)
+        self.assertContains(response, "Select exactly ONE deck")
+
+    def test_change_deck_owner_action__warns_when_no_other_staff(self):
+        """A deck whose only staff user is the current owner has nobody to hand
+        the deck to: the action says so instead of rendering an empty picker."""
+        url = self.login_admin()
+        with tenant_context(self.extra_tenant):
+            owner = SiteConfig.objects.get().deck_owner
+            User.objects.filter(is_staff=True).exclude(pk=owner.pk).update(is_staff=False)
+
+        action_data = {"action": "change_deck_owner", ACTION_CHECKBOX_NAME: [self.extra_tenant.pk]}
+        response = self.client.post(url, action_data, follow=True)
+        self.assertContains(response, "no other staff users")

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -1313,6 +1313,7 @@ class TenantAdminOwnerActionsTest(PublicTenantTestAdminPublic):
         response = self.client.post(url, action_data)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Change the owner of deck")
+        self.assertContains(response, "Select a valid choice")
 
         with tenant_context(self.tenant):
             self.assertEqual(SiteConfig.objects.get().deck_owner, owner_before)
@@ -1325,6 +1326,18 @@ class TenantAdminOwnerActionsTest(PublicTenantTestAdminPublic):
                        ACTION_CHECKBOX_NAME: [self.tenant.pk, self.extra_tenant.pk]}
         response = self.client.post(url, action_data, follow=True)
         self.assertContains(response, "Select exactly ONE deck")
+
+    def test_change_deck_owner_action__ownerless_deck_reported_not_500(self):
+        """A deck whose SiteConfig has no owner (the field is NOT NULL, so this
+        is a defensive guard matching message_selected's caution) gets an ERROR
+        message instead of a 500 on the missing owner's pk (review find)."""
+        from unittest.mock import Mock
+
+        url = self.login_admin()
+        action_data = {"action": "change_deck_owner", ACTION_CHECKBOX_NAME: [self.tenant.pk]}
+        with patch('tenant.admin.SiteConfig.get', return_value=Mock(deck_owner=None)):
+            response = self.client.post(url, action_data, follow=True)
+        self.assertContains(response, "no owner set in its SiteConfig")
 
     def test_change_deck_owner_action__warns_when_no_other_staff(self):
         """A deck whose only staff user is the current owner has nobody to hand

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -426,6 +426,32 @@ class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
         # the healthy test deck was still processed after the broken one
         self.deck_line(output)
 
+    def test_backfill__schema_option_narrows_the_run_to_one_deck(self):
+        """--schema processes only the named deck (maintainer request, 2026-08-09:
+        clean up a single legacy deck by hand): another tenant row is not touched
+        or reported, and the summary counts one deck."""
+        with schema_context(get_public_schema_name()):
+            other = Tenant(name='otherdeck', schema_name='otherdeck')
+            other.auto_create_schema = False
+            other.full_clean()
+            other.save()
+        self.set_owner(email='legacy.owner@example.com')
+
+        output = self.run_command('--schema', self.tenant.schema_name, '--apply')
+        self.deck_line(output)  # exactly one line for the named deck
+        self.assertNotIn('otherdeck', output)  # the schema-less row would have been an ERROR line
+        self.assertIn('1 deck(s)', output)
+
+    def test_backfill__schema_option_rejects_unknown_and_non_deck_schemas(self):
+        """--schema with an unknown schema name, or the public schema (not a deck),
+        fails loudly instead of silently processing nothing."""
+        from django.core.management.base import CommandError
+
+        with self.assertRaises(CommandError):
+            self.run_command('--schema', 'no_such_deck')
+        with self.assertRaises(CommandError):
+            self.run_command('--schema', get_public_schema_name())
+
     def test_backfill__case_variant_primary_demoted_in_favor_of_exact_match(self):
         """When a case-variant duplicate of the owner's address holds primary, --apply
         demotes it (by pk, before the promote saves: the DB's unique_primary_email
@@ -443,3 +469,72 @@ class BackfillOwnerEmailsTest(ByteDeckTenantTestCase):
         self.assertTrue(exact.verified)
         self.assertFalse(variant.primary)
         self.assertEqual(EmailAddress.objects.filter(user=owner, primary=True).count(), 1)
+
+
+class ChangeDeckOwnerTest(ByteDeckTenantTestCase):
+    """Tests for the `change_deck_owner` management command (maintainer request,
+    2026-08-09: legacy decks whose owner is the wrong account)."""
+
+    def run_command(self, *args):
+        """Run change_deck_owner and capture its output.
+
+        Args:
+            *args: The command's positional arguments (schema_name, username).
+
+        Returns:
+            str: The command's full stdout.
+        """
+        out = StringIO()
+        call_command('change_deck_owner', *args, stdout=out)
+        return out.getvalue()
+
+    def test_change__switches_owner_promotes_superuser_and_refreshes_caches(self):
+        """The named staff user becomes SiteConfig.deck_owner, is promoted to
+        superuser (mirroring the SiteConfig admin), the deck's cached owner
+        fields land immediately, and the output names the handover plus the
+        backfill_owner_emails reminder. The previous owner keeps their account."""
+        old_owner = SiteConfig.get().deck_owner
+        new_owner = baker.make(User, is_staff=True, is_superuser=False,
+                               username='newowner', email='new.owner@example.com', first_name='New', last_name='Owner')
+
+        output = self.run_command(self.tenant.schema_name, 'newowner')
+
+        self.assertEqual(SiteConfig.objects.get().deck_owner, new_owner)
+        new_owner.refresh_from_db()
+        self.assertTrue(new_owner.is_superuser)
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.owner_email_cached, 'new.owner@example.com')
+        self.assertIn(f'{old_owner.username} -> newowner', output)
+        self.assertIn('backfill_owner_emails --schema', output)
+
+    def test_change__already_superuser_new_owner_is_left_as_is(self):
+        """A new owner who is already a superuser is simply set as owner, with no
+        redundant re-save of the user row."""
+        new_owner = baker.make(User, is_staff=True, is_superuser=True, username='superstaff')
+        self.run_command(self.tenant.schema_name, 'superstaff')
+        self.assertEqual(SiteConfig.objects.get().deck_owner, new_owner)
+
+    def test_change__same_owner_is_a_noop(self):
+        """Naming the current owner reports nothing-to-do and changes nothing."""
+        owner = SiteConfig.get().deck_owner
+        output = self.run_command(self.tenant.schema_name, owner.username)
+        self.assertIn('already owns', output)
+        self.assertEqual(SiteConfig.objects.get().deck_owner, owner)
+
+    def test_change__rejects_non_staff_unknown_user_and_non_deck_schemas(self):
+        """A non-staff user, an unknown username, an unknown schema, and the
+        public schema (not a deck) each fail loudly with the owner unchanged."""
+        from django.core.management.base import CommandError
+
+        owner = SiteConfig.get().deck_owner
+        baker.make(User, is_staff=False, username='student')
+
+        with self.assertRaises(CommandError):
+            self.run_command(self.tenant.schema_name, 'student')
+        with self.assertRaises(CommandError):
+            self.run_command(self.tenant.schema_name, 'no_such_user')
+        with self.assertRaises(CommandError):
+            self.run_command('no_such_deck', 'whoever')
+        with self.assertRaises(CommandError):
+            self.run_command(get_public_schema_name(), 'whoever')
+        self.assertEqual(SiteConfig.objects.get().deck_owner, owner)

--- a/src/tenant/tests/test_management_commands.py
+++ b/src/tenant/tests/test_management_commands.py
@@ -508,8 +508,7 @@ class ChangeDeckOwnerTest(ByteDeckTenantTestCase):
         self.assertIn('backfill_owner_emails --schema', output)
 
     def test_change__already_superuser_new_owner_is_left_as_is(self):
-        """A new owner who is already a superuser is simply set as owner, with no
-        redundant re-save of the user row."""
+        """A new owner who is already a superuser is simply set as owner."""
         new_owner = baker.make(User, is_staff=True, is_superuser=True, username='superstaff')
         self.run_command(self.tenant.schema_name, 'superstaff')
         self.assertEqual(SiteConfig.objects.get().deck_owner, new_owner)
@@ -520,6 +519,19 @@ class ChangeDeckOwnerTest(ByteDeckTenantTestCase):
         output = self.run_command(self.tenant.schema_name, owner.username)
         self.assertIn('already owns', output)
         self.assertEqual(SiteConfig.objects.get().deck_owner, owner)
+
+    def test_change__ownerless_deck_raises_the_callers_error_channel(self):
+        """A deck whose SiteConfig has no owner (defensive: the field is NOT
+        NULL) surfaces as the ValueError/CommandError the callers already handle,
+        never an AttributeError on the missing owner (review find)."""
+        from unittest.mock import Mock, patch
+
+        from django.core.management.base import CommandError
+
+        baker.make(User, is_staff=True, username='wouldbe')
+        with patch('tenant.utils.SiteConfig.get', return_value=Mock(deck_owner=None)):
+            with self.assertRaisesMessage(CommandError, 'no owner set in its SiteConfig'):
+                self.run_command(self.tenant.schema_name, 'wouldbe')
 
     def test_change__rejects_non_staff_unknown_user_and_non_deck_schemas(self):
         """A non-staff user, an unknown username, an unknown schema, and the

--- a/src/tenant/utils.py
+++ b/src/tenant/utils.py
@@ -1,9 +1,15 @@
 import secrets
 
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from django.db import transaction
 from django.template.loader import get_template
 from django.urls import reverse
 from django.utils.crypto import get_random_string
+
+from allauth.account.models import EmailAddress
+from django_tenants.utils import tenant_context
 
 from siteconfig.models import SiteConfig
 from .models import Tenant
@@ -325,3 +331,140 @@ def get_public_subscribe_url():
     if 'localhost' in settings.ROOT_DOMAIN:  # Development
         return f"http://{settings.ROOT_DOMAIN}:8000/pages/subscribe/"
     return f"https://{settings.ROOT_DOMAIN}/pages/subscribe/"
+
+
+def normalize_owner_email(tenant, apply_changes):
+    """Audit (and in apply mode normalize) one deck's owner email bookkeeping.
+
+    The single write path behind both the ``backfill_owner_emails`` management
+    command and the tenant admin's "Verify owner email" action: brings the
+    deck owner up to the state deck creation produces (the ``EmailAddress`` row
+    matching ``owner.email`` exists, is verified, and is the owner's only
+    primary address). Must run inside the deck's tenant context.
+
+    Args:
+        tenant (Tenant): The deck being processed (its public-schema row).
+        apply_changes (bool): When True, write the EmailAddress fixes and
+            refresh the deck's cached fields; when False, only report.
+
+    Returns:
+        tuple: ``(status, owner_name, email, notes)`` where ``status`` is
+        ``ok`` (nothing to do), ``fixed`` (bookkeeping created or corrected;
+        in dry-run mode this means it WOULD be), ``no-email`` (needs a
+        human), or ``skipped`` (a different account already verified the
+        address, so no write can succeed: needs a human); ``owner_name`` is
+        the owner's username; ``email`` is the owner's address or None;
+        ``notes`` is the semicolon-joined audit remarks for the report line.
+    """
+    owner = SiteConfig.get().deck_owner
+    notes = []
+    # the initial deck_owner default was a heuristic (oldest non-admin staff
+    # user, else a bare created account): flag decks that never chose for real
+    if owner.username == settings.TENANT_DEFAULT_OWNER_USERNAME:
+        notes.append("default owner account (heuristic guess, never chosen)")
+    # the deprecated hand-entered public-tenant address is often the best clue
+    # to who the owner SHOULD be when the schema's data is missing or wrong
+    legacy = (tenant.owner_email or '').strip()
+    if legacy and legacy.lower() != (owner.email or '').lower():
+        notes.append(f"public-tenant legacy owner_email differs: {legacy}")
+
+    if not owner.email:
+        return 'no-email', owner.username, None, '; '.join(notes)
+
+    # deterministic target row, preferring the form a save lands on:
+    # EmailAddress.clean() lowercases the address, so normalizing any other
+    # row rewrites it to the lowercase form; targeting the lowercase row
+    # first means that rewrite can never collide with a case-variant sibling
+    # under the unique (user, email) constraint. Fall back to the exact-case
+    # match, then the oldest case-variant duplicate.
+    canonical = owner.email.lower()
+    matches = list(EmailAddress.objects.filter(user=owner, email__iexact=owner.email).order_by('pk'))
+    email_address = next(
+        (row for row in matches if row.email == canonical),
+        next((row for row in matches if row.email == owner.email), matches[0] if matches else None),
+    )
+    already_ok = (
+        email_address is not None and email_address.verified and email_address.primary
+        and not EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).exists()
+    )
+    if already_ok:
+        return 'ok', owner.username, owner.email, '; '.join(notes)
+
+    # the DB allows one VERIFIED row per address across the whole schema
+    # (unique_verified_email, from ACCOUNT_UNIQUE_EMAIL): if a different
+    # account already verified this address, no write can succeed, and which
+    # account is really the owner's is a human call. Report and leave it.
+    if EmailAddress.objects.exclude(user=owner).filter(email=canonical, verified=True).exists():
+        notes.append("address already verified by another account on this deck")
+        return 'skipped', owner.username, owner.email, '; '.join(notes)
+
+    if apply_changes:
+        # mirror TenantCreate.form_valid: the owner's address exists, verified
+        # and primary. Every OTHER primary row is demoted BEFORE the target
+        # saves: the DB allows at most one primary per user
+        # (unique_primary_email), so the demote must come first, and excluding
+        # by pk (a brand-new target has none, so nothing is spared) also
+        # demotes a case-variant duplicate of the owner's own address.
+        if email_address is None:
+            email_address = EmailAddress(user=owner, email=owner.email, verified=True, primary=True)
+        else:
+            email_address.verified = True
+            email_address.primary = True
+        EmailAddress.objects.filter(user=owner, primary=True).exclude(pk=email_address.pk).update(primary=False)
+        email_address.full_clean()
+        email_address.save()
+        # land owner_email_cached now; the notice engine and the Stripe
+        # backfill report read the cache, not the schema
+        tenant.update_cached_fields()
+    return 'fixed', owner.username, owner.email, '; '.join(notes)
+
+
+def switch_deck_owner(tenant, username):
+    """Make ``username`` (an existing STAFF user on the deck) the deck's owner.
+
+    The single write path behind both the ``change_deck_owner`` management
+    command and the tenant admin's "Change deck owner" action. Mirrors the
+    SiteConfig admin's semantics (``SiteConfigForm.clean_deck_owner``): the new
+    owner is promoted to superuser, and the previous owner's account and
+    permissions are left untouched. The deck's cached owner fields are
+    refreshed immediately so the public admin, the notice engine, and the
+    Stripe backfill report see the new owner without waiting for the nightly
+    task. When the user already owns the deck, nothing is written.
+
+    Args:
+        tenant (Tenant): The deck whose owner changes (its public-schema row).
+        username (str): The new owner's username on that deck.
+
+    Returns:
+        tuple[str, str]: ``(old_username, new_username)``; equal when the user
+        already owned the deck and nothing was written.
+
+    Raises:
+        ValueError: When no such user exists on the deck, or the user is not staff.
+    """
+    User = get_user_model()
+    with transaction.atomic(), tenant_context(tenant):
+        try:
+            new_owner = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise ValueError(f"no user '{username}' exists on deck '{tenant.schema_name}'")
+        if not new_owner.is_staff:
+            raise ValueError(
+                f"'{username}' is not a staff user on '{tenant.schema_name}': the deck owner must be "
+                "staff. Make them staff first if this really is the right account."
+            )
+        config = SiteConfig.get()
+        old_owner = config.deck_owner
+        if old_owner == new_owner:
+            return old_owner.username, new_owner.username
+        # mirror SiteConfigForm.clean_deck_owner: the deck owner is always a superuser
+        if not new_owner.is_superuser:
+            new_owner.is_superuser = True
+            new_owner.save()
+        config.deck_owner = new_owner
+        config.full_clean()
+        config.save()
+        # land the cached owner name/email now; the public admin, the notice
+        # engine, and the Stripe backfill report all read the cache
+        tenant.update_cached_fields()
+    return old_owner.username, new_owner.username

--- a/src/tenant/utils.py
+++ b/src/tenant/utils.py
@@ -455,12 +455,23 @@ def switch_deck_owner(tenant, username):
             )
         config = SiteConfig.get()
         old_owner = config.deck_owner
+        # the field is NOT NULL, but older admin code guards ownerless decks
+        # (message_selected), so surface the state through the ValueError channel
+        # the callers already handle rather than an AttributeError below
+        if old_owner is None:
+            raise ValueError(
+                f"deck '{tenant.schema_name}' has no owner set in its SiteConfig; fix it there first"
+            )
         if old_owner == new_owner:
             return old_owner.username, new_owner.username
-        # mirror SiteConfigForm.clean_deck_owner: the deck owner is always a superuser
+        # mirror SiteConfigForm.clean_deck_owner: the deck owner is always a superuser.
+        # A narrow update_fields save so a concurrent edit to any OTHER column of
+        # this user row can't be clobbered; like the mirrored admin path, no
+        # full_clean here: validating the whole (possibly legacy) user row could
+        # block the promotion on data unrelated to the one boolean changing.
         if not new_owner.is_superuser:
             new_owner.is_superuser = True
-            new_owner.save()
+            new_owner.save(update_fields=['is_superuser'])
         config.deck_owner = new_owner
         config.full_clean()
         config.save()


### PR DESCRIPTION
### What

Two legacy-deck cleanup tools for the production go-live (maintainer request, 2026-08-09, items 1 and 3 of the batch), available **as actions on the tenant admin list** (`/admin/tenant/tenant/`) per the follow-up clarification, with management commands as thin CLI wrappers over the same shared write paths (`tenant/utils.py: normalize_owner_email`, `switch_deck_owner`).

1. **"Verify owner email for selected deck(s)"** (admin action, multi-select): normalizes each selected deck owner's allauth `EmailAddress` to verified+primary, the state deck creation produces (creates the missing row, promotes an existing one, demotes stale primaries, handles case-variant duplicates) and refreshes the deck's cached owner email immediately. Each deck's outcome posts as its own message; decks needing a human (no owner email, or the address is already verified by a different account) are flagged rather than guessed at, and a deck that errors mid-run gets an ERROR message without sinking the rest. CLI equivalent: `backfill_owner_emails --schema <deck> --apply` (the existing all-decks command gains the `--schema` filter; unknown/non-deck schemas fail loudly).

2. **"Change deck owner for the selected deck"** (admin action, exactly one deck): an intermediate page shows the current owner and a picker of the deck's staff users (minus the current owner); confirming switches `SiteConfig.deck_owner`, mirroring the SiteConfig admin's semantics (`SiteConfigForm.clean_deck_owner`): the new owner is promoted to superuser, the previous owner's account and permissions are untouched, and the deck's cached owner fields refresh immediately. The success message points at the verify action for the new owner's email bookkeeping. Selecting more than one deck, or a deck with no other staff, errors out with guidance. CLI equivalent: `change_deck_owner <schema> <username>`.

**HOTFIX to `staging`**: part of the legacy-deck cleanup the maintainer is testing on staging today before promoting to production.

### Testing

Admin tests pin: the verify action flipping an unverified owner address to verified+primary (public rows ignored, already-verified reported, a mid-run error reported without a 500), and the change-owner action's full loop (picker page listing the deck's staff, confirmed handover switching the owner + promoting superuser + landing the cached fields, an invalid choice re-rendering with errors and writing nothing, the exactly-one-deck guard, and the no-other-staff warning). Command tests pin the `--schema` filter and every `change_deck_owner` CLI path. Both commands and the shared helpers sit at 100% coverage of the new code; full suite, ruff, and `makemigrations --check` pass locally.

### Screenshots

Captured from the running dev app's public admin, walking the real flow on the `hackerspace` deck (this branch does not include #2315's column removals, so the list still shows the DEPRECATED columns here).

**Change deck owner: the intermediate picker** (current owner shown; staff-user dropdown):

![change owner picker](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/legacy-owner-actions/change-owner-picker.png)

**After confirming:** the owner switched (cached Owner full name/email updated instantly) and the message points at the verify action:

![change owner done](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/legacy-owner-actions/change-owner-done.png)

**Verify owner email on the same deck:** the new owner's address flips to verified (green check in the Email verified column):

![verify email done](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/legacy-owner-actions/verify-email-done.png)

- Claude Code (`Bytedeck - payments integration`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin actions to change a deck owner and verify or repair owner email addresses.
  - Added a command to change deck ownership from the command line.
  - Added an option to process a single deck when backfilling owner emails.
  - Added validation, status reporting, and safeguards for invalid selections or ownership changes.

- **Bug Fixes**
  - Improved handling of conflicting, missing, or duplicate owner email records.
  - Refreshed cached ownership information after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->