### PR TITLE
HOTFIX: feat: subscription status column in the tenant admin list

### DIFF
--- a/src/static/css/admin_deck_status.css
+++ b/src/static/css/admin_deck_status.css
@@ -1,0 +1,29 @@
+/* Status badges for the tenant admin changelist's Subscription column
+   (TenantAdmin.subscription_status_text). One class per
+   Tenant.subscription_status slug, mirroring the bootstrap-3 label colors the
+   deck subscription page uses for the same statuses (the admin doesn't load
+   bootstrap, so the badge look-alikes live here). */
+.deck-status {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 3px;
+    color: #fff;
+    font-weight: bold;
+    white-space: nowrap;
+}
+.deck-status-suspended,
+.deck-status-grace {
+    background-color: #d9534f;  /* bootstrap label-danger */
+}
+.deck-status-maintenance {
+    background-color: #337ab7;  /* bootstrap label-primary */
+}
+.deck-status-subscribed {
+    background-color: #5cb85c;  /* bootstrap label-success */
+}
+.deck-status-trial {
+    background-color: #5bc0de;  /* bootstrap label-info */
+}
+.deck-status-manual {
+    background-color: #777;  /* bootstrap label-default */
+}

--- a/src/static/css/admin_deck_status.css
+++ b/src/static/css/admin_deck_status.css
@@ -1,8 +1,10 @@
 /* Status badges for the tenant admin changelist's Subscription column
    (TenantAdmin.subscription_status_text). One class per
-   Tenant.subscription_status slug, mirroring the bootstrap-3 label colors the
-   deck subscription page uses for the same statuses (the admin doesn't load
-   bootstrap, so the badge look-alikes live here). */
+   Tenant.subscription_status slug, in darker shades of the bootstrap-3 label
+   hues the deck subscription page uses for the same statuses: the shared hue
+   keeps the two surfaces visually consistent, and every shade holds at least
+   a 4.5:1 (WCAG AA) contrast ratio against the white badge text. The admin
+   doesn't load bootstrap, so the badge styles live here. */
 .deck-status {
     display: inline-block;
     padding: 2px 6px;
@@ -13,17 +15,17 @@
 }
 .deck-status-suspended,
 .deck-status-grace {
-    background-color: #d9534f;  /* bootstrap label-danger */
+    background-color: #b52b27;  /* label-danger hue; 6.3:1 against the white text */
 }
 .deck-status-maintenance {
-    background-color: #337ab7;  /* bootstrap label-primary */
+    background-color: #286090;  /* label-primary hue; 6.6:1 */
 }
 .deck-status-subscribed {
-    background-color: #5cb85c;  /* bootstrap label-success */
+    background-color: #3c763d;  /* label-success hue; 5.5:1 */
 }
 .deck-status-trial {
-    background-color: #5bc0de;  /* bootstrap label-info */
+    background-color: #31708f;  /* label-info hue; 5.5:1 */
 }
 .deck-status-manual {
-    background-color: #777;  /* bootstrap label-default */
+    background-color: #5e5e5e;  /* label-default hue; 6.5:1 */
 }

--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -149,10 +149,16 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         'schema_name', 'owner_full_name_text',
         'owner_email_text', 'owner_email_verified_boolean',
         'last_staff_login', 'google_signon_enabled',
-        'paid_until_text', 'trial_end_date_text',
+        'subscription_status_text', 'paid_until_text', 'trial_end_date_text',
         'max_active_users', 'active_user_count', 'total_user_count',
         'quest_count',
     )
+
+    class Media:
+        # badge styles for the Subscription column (.deck-status-*); the admin
+        # doesn't load the app's bootstrap css, so the look-alikes live in their
+        # own small stylesheet
+        css = {'all': ('css/admin_deck_status.css',)}
     list_filter = ('paid_until', 'trial_end_date', 'active_user_count', 'last_staff_login')
     search_fields = ['schema_name', 'owner_full_name_cached', 'owner_email_cached']
 
@@ -373,6 +379,22 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
                 if primary_email_address.email == user_email(owner):
                     return True
         return False
+
+    @admin.display(description="subscription")
+    def subscription_status_text(self, obj):
+        """The deck's lifecycle status as a colored badge: the same status (and
+        the same word) the deck owner sees on their subscription details page,
+        both rendered from the shared ``Tenant.subscription_status`` precedence
+        chain so the two can never disagree. The public schema row isn't a
+        deck, so it shows no status.
+        """
+        if obj.schema_name == get_public_schema_name():
+            return None
+        return format_html(
+            '<span class="deck-status deck-status-{}">{}</span>',
+            obj.subscription_status,
+            obj.subscription_status_label,
+        )
 
     @admin.display(description="paid until", ordering="paid_until")
     def paid_until_text(self, obj):

--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -155,9 +155,9 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
     )
 
     class Media:
-        # badge styles for the Subscription column (.deck-status-*); the admin
-        # doesn't load the app's bootstrap css, so the look-alikes live in their
-        # own small stylesheet
+        """Extra assets for the changelist: the Subscription column's badge
+        stylesheet (.deck-status-*), since the admin doesn't load the app's
+        bootstrap css."""
         css = {'all': ('css/admin_deck_status.css',)}
     list_filter = ('paid_until', 'trial_end_date', 'active_user_count', 'last_staff_login')
     search_fields = ['schema_name', 'owner_full_name_cached', 'owner_email_cached']
@@ -385,8 +385,14 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
         """The deck's lifecycle status as a colored badge: the same status (and
         the same word) the deck owner sees on their subscription details page,
         both rendered from the shared ``Tenant.subscription_status`` precedence
-        chain so the two can never disagree. The public schema row isn't a
-        deck, so it shows no status.
+        chain so the two can never disagree.
+
+        Args:
+            obj (Tenant): The changelist row's tenant.
+
+        Returns:
+            SafeString | None: The rendered ``<span>`` badge for a deck row, or
+            None (an empty cell) for the public schema row, which isn't a deck.
         """
         if obj.schema_name == get_public_schema_name():
             return None

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -327,9 +327,12 @@ class Tenant(TenantMixin):
         Precedence matters: a deck past its grace window is 'suspended' even
         though its trial dates still exist, and a deck in the paid clock's
         grace window is 'grace' even though ``subscription_active`` is still
-        True there (access is retained through grace). 'manual' is the
-        both-dates-blank escape hatch for comped/legacy decks managed outside
-        the subscription lifecycle.
+        True there (access is retained through grace). The LATEST clock governs
+        the lifecycle (#1734 B4), so when the trial clock governs (and hasn't
+        lapsed into the branches above) the deck is 'trial' even if an older
+        ``paid_until`` still keeps ``subscription_active`` True through its
+        grace tail. 'manual' is the both-dates-blank escape hatch for
+        comped/legacy decks managed outside the subscription lifecycle.
 
         Returns:
             str: One of the ``SUBSCRIPTION_STATUS_LABELS`` keys: 'suspended',
@@ -339,12 +342,15 @@ class Tenant(TenantMixin):
             return 'suspended'
         if self.in_grace_period:
             return 'grace'
+        if self.governing_clock_is_trial:
+            # not suspended and not in grace, so the governing trial clock is
+            # still running: the deck is on trial regardless of any older,
+            # still-in-grace paid_until (which would misreport as subscribed)
+            return 'trial'
         if self.is_on_maintenance:
             return 'maintenance'
         if self.subscription_active:
             return 'subscribed'
-        if self.is_on_trial:
-            return 'trial'
         return 'manual'
 
     @property

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -306,6 +306,56 @@ class Tenant(TenantMixin):
             and self.max_active_users <= TRIAL_MAX_ACTIVE_USERS
         )
 
+    # one human label per subscription_status slug; the subscription page's badge
+    # and the tenant admin's Subscription column both render from this map, so
+    # the same state always shows the same word everywhere
+    SUBSCRIPTION_STATUS_LABELS = {
+        'suspended': 'Suspended',
+        'grace': 'Grace period',
+        'maintenance': 'Maintenance',
+        'subscribed': 'Subscribed',
+        'trial': 'Free trial',
+        'manual': 'Managed manually',
+    }
+
+    @property
+    def subscription_status(self):
+        """The deck's lifecycle status as a slug: the single precedence chain
+        behind every status display (the subscription page's badge and the
+        tenant admin's Subscription column), so the two can never disagree.
+
+        Precedence matters: a deck past its grace window is 'suspended' even
+        though its trial dates still exist, and a deck in the paid clock's
+        grace window is 'grace' even though ``subscription_active`` is still
+        True there (access is retained through grace). 'manual' is the
+        both-dates-blank escape hatch for comped/legacy decks managed outside
+        the subscription lifecycle.
+
+        Returns:
+            str: One of the ``SUBSCRIPTION_STATUS_LABELS`` keys: 'suspended',
+            'grace', 'maintenance', 'subscribed', 'trial' or 'manual'.
+        """
+        if self.is_suspended:
+            return 'suspended'
+        if self.in_grace_period:
+            return 'grace'
+        if self.is_on_maintenance:
+            return 'maintenance'
+        if self.subscription_active:
+            return 'subscribed'
+        if self.is_on_trial:
+            return 'trial'
+        return 'manual'
+
+    @property
+    def subscription_status_label(self):
+        """The human-readable label for ``subscription_status``, e.g. 'Free trial'.
+
+        Returns:
+            str: The ``SUBSCRIPTION_STATUS_LABELS`` entry for the current status.
+        """
+        return self.SUBSCRIPTION_STATUS_LABELS[self.subscription_status]
+
     @property
     def days_until_expiry(self):
         """Days until the deck's governing deadline: the LATEST of its set clocks

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -7,16 +7,17 @@
 {% block content %}
 
 <h3>Status</h3>
-{% if deck.is_suspended %}
-  <p><span class="label label-danger">Suspended</span>
+{# one branch per deck.subscription_status slug: the model property is the single precedence chain, shared with the admin's Subscription column #}
+{% if deck.subscription_status == 'suspended' %}
+  <p><span class="label label-danger">{{ deck.subscription_status_label }}</span>
     This deck's trial or subscription ended and the {{ grace_days }}-day grace period has run out:
     only the deck owner can sign in, and a deck
     suspended for 365 days may be permanently deleted. Nothing has been deleted yet: subscribe
     (any level, including the low-cost Maintenance subscription) to restore access.</p>
-{% elif deck.in_grace_period %}
+{% elif deck.subscription_status == 'grace' %}
   {# grace gets its own DANGER label -- a green "Subscribed" badge on an expired deck reads as a bug (maintainer review find) #}
   {# the GOVERNING clock (the latest one) picks the wording: an admin-extended trial can outlast an old paid date (#1734 B4) #}
-  <p><span class="label label-danger">Grace period</span>
+  <p><span class="label label-danger">{{ deck.subscription_status_label }}</span>
     {% if deck.governing_clock_is_trial %}The free trial ended on
     <strong>{{ deck.governing_deadline }}</strong>{% else %}The paid period ended on
     <strong>{{ deck.governing_deadline }}</strong>{% endif %} and the deck is in its
@@ -24,9 +25,9 @@
     keep full access; otherwise the deck will be
     suspended (only the deck owner will be able to sign in, and the 365-day countdown to deck
     deletion begins).</p>
-{% elif deck.is_on_maintenance %}
+{% elif deck.subscription_status == 'maintenance' %}
   {# the countdown pairs with the PAID date it sits beside (days_until_expiry can track a longer leftover trial clock) #}
-  <p><span class="label label-primary">Maintenance</span>
+  <p><span class="label label-primary">{{ deck.subscription_status_label }}</span>
     This deck is on a maintenance subscription{% if plan_summary %}
     (<strong>{{ plan_summary.name }}</strong>{% if plan_summary.renewal_phrase %}, {{ plan_summary.renewal_phrase }}{% endif %}){% endif %}
     through <strong>{{ deck.paid_until }}</strong>
@@ -34,19 +35,19 @@
     be suspended, or time out for deletion, but registration stays capped at the trial limit
     (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}).
     Upgrade any time to raise the cap.</p>
-{% elif deck.subscription_active %}
+{% elif deck.subscription_status == 'subscribed' %}
   {# what the money buys, straight from the linked Stripe plan (maintainer request, 2026-08-09); omitted when Stripe can't say #}
-  <p><span class="label label-success">Subscribed</span>
+  <p><span class="label label-success">{{ deck.subscription_status_label }}</span>
     {% if plan_summary %}to <strong>{{ plan_summary.name }}</strong>{% if plan_summary.renewal_phrase %},
     {{ plan_summary.renewal_phrase }}{% endif %}.{% endif %}
     Paid through <strong>{{ deck.paid_until }}</strong>
     ({{ paid_until_phrase }}).</p>
-{% elif deck.is_on_trial %}
-  <p><span class="label label-info">Free trial</span>
+{% elif deck.subscription_status == 'trial' %}
+  <p><span class="label label-info">{{ deck.subscription_status_label }}</span>
     Ends <strong>{{ deck.trial_end_date }}</strong>
     ({{ deck.days_until_expiry }} day{{ deck.days_until_expiry|pluralize }} remaining).</p>
 {% else %}
-  <p><span class="label label-default">Managed manually</span>
+  <p><span class="label label-default">{{ deck.subscription_status_label }}</span>
     This deck has no trial or subscription end date, so it never expires on its own.
     <a href="mailto:{{ support_email }}">Contact ByteDeck</a> if this doesn't look right.</p>
 {% endif %}

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -354,6 +354,34 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "<span data-date=\"2022-01-01\">Jan. 1, 2022</span>")
 
+    def test_subscription_status_text__shown_in_changelist(self):
+        """The Subscription column shows each deck's lifecycle status badge in the
+        admin list view, with the deck's status slug as its css class and the same
+        label the deck's subscription page badge shows for that state."""
+        # pin both decks to known, distinct states: a live subscription with a
+        # raised cap (Subscribed) and a live trial with no paid clock (Free trial)
+        Tenant.objects.filter(pk=self.extra_tenant.pk).update(
+            paid_until=date(2032, 1, 1), trial_end_date=date(2022, 1, 1), max_active_users=40)
+        Tenant.objects.filter(pk=self.tenant.pk).update(
+            paid_until=None, trial_end_date=date(2032, 1, 1))
+
+        self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))  # move client to public schema
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<span class="deck-status deck-status-subscribed">Subscribed</span>')
+        self.assertContains(response, '<span class="deck-status deck-status-trial">Free trial</span>')
+        # the badge styles ride along via the ModelAdmin's Media declaration
+        self.assertContains(response, "css/admin_deck_status.css")
+
+    def test_subscription_status_text__no_status_for_public_schema(self):
+        """The public schema row isn't a deck, so its Subscription cell is empty
+        (None), while a real deck row renders its status badge."""
+        public_row = Tenant.objects.get(schema_name=get_public_schema_name())
+        self.assertIsNone(self.tenant_model_admin.subscription_status_text(public_row))
+        badge = self.tenant_model_admin.subscription_status_text(self.extra_tenant)
+        self.assertIn("deck-status-", badge)
+
     def test_search__on_custom_fields(self):
         """
         Test whether content of custom fields is searchable in admin list view or not.

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -359,6 +359,54 @@ class TenantBillingStatusTest(SimpleTestCase):
         self.assertTrue(tenant.is_suspended)
         self.assertEqual(tenant.days_until_expiry, -(GRACE_PERIOD_DAYS + 5))
 
+    def test_subscription_status__one_slug_per_lifecycle_state(self):
+        """subscription_status maps each lifecycle state to its slug: the single
+        precedence chain behind the subscription page badge and the admin's
+        Subscription column."""
+        self.assertEqual(self.make_tenant().subscription_status, 'manual')
+        self.assertEqual(self.make_tenant(trial_end_date=FROZEN_TODAY).subscription_status, 'trial')
+        self.assertEqual(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=40).subscription_status, 'subscribed')
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=TRIAL_MAX_ACTIVE_USERS).subscription_status, 'maintenance')
+        self.assertEqual(self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).subscription_status, 'grace')
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), max_active_users=40).subscription_status,
+            'suspended')
+
+    def test_subscription_status__precedence_when_states_overlap(self):
+        """Where the underlying properties overlap, the more urgent state wins:
+        a deck in the paid clock's grace window is 'grace' even though
+        subscription_active (and the maintenance cap test) still hold there, and
+        a suspended deck is 'suspended' even though its old trial date still
+        exists. Unlimited (-1) paid decks are 'subscribed', never 'maintenance'."""
+        # paid grace: subscription_active is still True through the window, grace wins
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=1), max_active_users=40).subscription_status, 'grace')
+        # a lapsing maintenance deck in grace is 'grace' too, not 'maintenance'
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=1), max_active_users=TRIAL_MAX_ACTIVE_USERS).subscription_status,
+            'grace')
+        # suspension outranks the stale never-cleared trial date
+        self.assertEqual(
+            self.make_tenant(
+                trial_end_date=FROZEN_TODAY - timedelta(days=400),
+                paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 5),
+            ).subscription_status,
+            'suspended')
+        # unlimited seats is a real subscription, not maintenance
+        self.assertEqual(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=-1).subscription_status, 'subscribed')
+
+    def test_subscription_status_label__human_label_for_every_slug(self):
+        """subscription_status_label renders the human word for the current slug,
+        and every slug the property can return has a label to render."""
+        self.assertEqual(self.make_tenant().subscription_status_label, 'Managed manually')
+        self.assertEqual(self.make_tenant(trial_end_date=FROZEN_TODAY).subscription_status_label, 'Free trial')
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=40).subscription_status_label, 'Subscribed')
+        self.assertEqual(
+            sorted(Tenant.SUBSCRIPTION_STATUS_LABELS),
+            sorted(['grace', 'maintenance', 'manual', 'subscribed', 'suspended', 'trial']))
+
 
 @freeze_time(FROZEN_NOW)
 class TenantDeletionClockTest(ByteDeckTenantTestCase):

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -395,17 +395,56 @@ class TenantBillingStatusTest(SimpleTestCase):
             'suspended')
         # unlimited seats is a real subscription, not maintenance
         self.assertEqual(self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=-1).subscription_status, 'subscribed')
+        # the GOVERNING (latest) clock decides trial vs paid (#1734 B4): an
+        # admin-extended trial outranks an older paid_until even while that paid
+        # date's grace tail keeps subscription_active True (regression: this
+        # deck read as 'subscribed'/'maintenance' when only the paid flags were
+        # consulted), and also while the paid date is still current
+        self.assertEqual(
+            self.make_tenant(
+                trial_end_date=FROZEN_TODAY + timedelta(days=30), paid_until=FROZEN_TODAY - timedelta(days=1),
+                max_active_users=40,
+            ).subscription_status,
+            'trial')
+        self.assertEqual(
+            self.make_tenant(
+                trial_end_date=FROZEN_TODAY + timedelta(days=60), paid_until=FROZEN_TODAY + timedelta(days=30),
+            ).subscription_status,
+            'trial')
+        # a TIE between the clocks speaks subscription language (B4)
+        self.assertEqual(
+            self.make_tenant(
+                trial_end_date=FROZEN_TODAY + timedelta(days=30), paid_until=FROZEN_TODAY + timedelta(days=30),
+                max_active_users=40,
+            ).subscription_status,
+            'subscribed')
 
     def test_subscription_status_label__human_label_for_every_slug(self):
         """subscription_status_label renders the human word for the current slug,
-        and every slug the property can return has a label to render."""
+        for a deck in each of the six lifecycle states, and the label map holds
+        exactly those six labels (a typo in any one label fails here)."""
         self.assertEqual(self.make_tenant().subscription_status_label, 'Managed manually')
         self.assertEqual(self.make_tenant(trial_end_date=FROZEN_TODAY).subscription_status_label, 'Free trial')
         self.assertEqual(
             self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=40).subscription_status_label, 'Subscribed')
         self.assertEqual(
-            sorted(Tenant.SUBSCRIPTION_STATUS_LABELS),
-            sorted(['grace', 'maintenance', 'manual', 'subscribed', 'suspended', 'trial']))
+            self.make_tenant(paid_until=FROZEN_TODAY, max_active_users=TRIAL_MAX_ACTIVE_USERS).subscription_status_label,
+            'Maintenance')
+        self.assertEqual(
+            self.make_tenant(trial_end_date=FROZEN_TODAY - timedelta(days=1)).subscription_status_label, 'Grace period')
+        self.assertEqual(
+            self.make_tenant(paid_until=FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1)).subscription_status_label,
+            'Suspended')
+        self.assertEqual(
+            Tenant.SUBSCRIPTION_STATUS_LABELS,
+            {
+                'suspended': 'Suspended',
+                'grace': 'Grace period',
+                'maintenance': 'Maintenance',
+                'subscribed': 'Subscribed',
+                'trial': 'Free trial',
+                'manual': 'Managed manually',
+            })
 
 
 @freeze_time(FROZEN_NOW)


### PR DESCRIPTION
### What

Adds a **Subscription** column to the tenant admin changelist (maintainer request, 2026-08-09) showing each deck's lifecycle status as a colored badge: Suspended, Grace period, Maintenance, Subscribed, Free trial, or Managed manually. The public schema row shows no status (it isn't a deck).

The statuses are exactly the ones deck owners see on their subscription details page, guaranteed: a new `Tenant.subscription_status` property (plus `subscription_status_label` and the `SUBSCRIPTION_STATUS_LABELS` map) is now the single precedence chain behind both displays. The subscription page's badge chain was refactored to switch on the same property, so the admin column and the page badge can never disagree.

The shared chain also honors the **governing (latest) clock** per #1734 B4 (CodeRabbit review find): a deck whose admin-extended trial outlasts an older `paid_until` now reads **Free trial** on both surfaces, where the paid date's grace tail previously kept it misreporting as Subscribed/Maintenance.

Badge colors are darker shades of the same bootstrap label hues the page badges use, so every badge meets WCAG AA 4.5:1 contrast for its white text; since the admin doesn't load bootstrap, the styles live in a small dedicated stylesheet (`css/admin_deck_status.css`) attached via the ModelAdmin's `Media`.

**HOTFIX to `staging`**: an operational aid for the production go-live work happening now (linking legacy decks and auditing their billing state at a glance).

### Testing

- `TenantBillingStatusTest` gains slug tests for every lifecycle state, precedence tests for the overlapping ones (paid-clock grace outranks Subscribed/Maintenance, suspension outranks a stale trial date, unlimited seats is never Maintenance, the governing trial clock outranks a lapsed-but-in-grace paid date, a clock tie speaks subscription language), and a check pinning all six labels in the map.
- Admin tests pin the rendered badge in the changelist for two decks in distinct states, the Media stylesheet inclusion, and the empty status cell for the public row.
- Full suite (2027 tests), ruff, and `makemigrations --check` pass locally.

### Screenshots

Captured from the running dev app's public admin (`localhost:8000/admin/tenant/tenant/`, logged in as `admin`), with demo decks staged in every lifecycle state. Before: this page as it looks on current staging, with no status column, can be seen in #2315's "after" screenshot ([here](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/drop-dead-tenant-fields/after-list.png)).

**After:** one badge per deck; all six states visible (public row shows none), in the WCAG AA shades:

![after, tenant list with subscription status column](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/admin-subscription-status/after-status-column.png)

- Claude Code (`Bytedeck - payments integration`)