### PR TITLE
test: use the mixin status helpers instead of hand-rolled GET assertions

### DIFF
--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -83,7 +83,7 @@ class BadgeViewTests(ByteDeckTenantTestCase):
         self.assert403('badges:revoke', args=[s_pk])
         self.assert403('badges:grant_qualifying', args=[b_pk])
 
-        self.assertEqual(self.client.get(reverse('badges:badge_prereqs_update', args=[b_pk])).status_code, 403)
+        self.assert403('badges:badge_prereqs_update', args=[b_pk])
 
     def test_all_badge_page_status_codes__teachers(self):
         """Teachers get 200 on every badge view, including create/update/grant/revoke."""
@@ -237,8 +237,7 @@ class BadgeViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
 
         # user_id=0 and badge_id=0 skip the get_object_or_404 initial lookups
-        response = self.client.get(reverse('badges:grant', kwargs={'user_id': 0, 'badge_id': 0}))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('badges:grant', kwargs={'user_id': 0, 'badge_id': 0})
         # neither field is pre-filled because both id lookups were skipped
         self.assertNotIn('user', response.context['form'].initial)
         self.assertNotIn('badge', response.context['form'].initial)
@@ -570,8 +569,7 @@ class BadgeTypeViewTests(ByteDeckTenantTestCase):
     def test_BadgeTypeList_view__staff_can_view(self):
         """ Admin should be able to view badge type list """
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('badges:badge_types'))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('badges:badge_types')
 
     def test_BadgeTypeCreate_view__staff_can_create(self):
         """ Admin should be able to create a course """

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -72,13 +72,11 @@ class RankViewTests(ByteDeckTenantTestCase):
 
         # student
         self.client.force_login(self.test_student1)
-        response = self.client.get(reverse('courses:ranks'))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('courses:ranks')
 
         # teacher
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('courses:ranks'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:ranks')
 
         # Should contain 13 default ranks e.g. Digital Novice, Digital Ameteur II, etc
         self.assertEqual(response.context['object_list'].count(), 13)
@@ -405,8 +403,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
     def test_CourseList_view__staff_can_view(self):
         """ Admin should be able to view course list """
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('courses:course_list'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:course_list')
 
         # Should contain Default and another one via bake
         self.assertEqual(response.context['object_list'].count(), 2)
@@ -543,8 +540,7 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         course_student = baker.make(CourseStudent, user=self.test_student1)
 
         # can access the Delete View
-        response = self.client.get(reverse('courses:coursestudent_delete', args=[course_student.id]))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('courses:coursestudent_delete', args=[course_student.id])
 
         before_delete_count = CourseStudent.objects.count()
         response = self.client.post(reverse('courses:coursestudent_delete', args=[course_student.id]))
@@ -954,8 +950,7 @@ class SemesterViewTests(ByteDeckTenantTestCase):
         """The semester list view renders each semester with its day counts and excluded-date counts."""
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('courses:semester_list'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:semester_list')
         self.assertEqual(response.context['object_list'].count(), 1)
 
         for obj in response.context['object_list']:
@@ -970,8 +965,7 @@ class SemesterViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
 
         semester = baker.make(Semester, name='', first_day=None, last_day=None)
-        response = self.client.get(reverse('courses:semester_list'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:semester_list')
         self.assertContains(response, str(semester))
 
     def test_SemesterCreate__without_ExcludedDates__view(self):
@@ -1222,8 +1216,7 @@ class BlockViewTests(ByteDeckTenantTestCase):
     def test_BlockList_view__staff_can_view(self):
         """ Admin should be able to view block list """
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('courses:block_list'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:block_list')
 
         # Should contain one block
         self.assertEqual(response.context['object_list'].count(), 1)
@@ -1800,8 +1793,7 @@ class MarkCalculationsViewTests(ByteDeckTenantTestCase):
     def test_mark_calculations__staff_can_view_another_students_marks(self):
         """Staff can view a specific student's mark page via the user_id URL."""
         self.client.force_login(baker.make(User, is_staff=True))
-        response = self.client.get(reverse('courses:marks', args=[self.student.pk]))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('courses:marks', args=[self.student.pk])
 
     @patch('courses.models.Semester.fraction_complete')
     def test_current_mark_ranges_by_xp__correct_values(self, mock_sem_fraction_complete):
@@ -2045,8 +2037,7 @@ class DeckCapacityEnforcementTests(ByteDeckTenantTestCase):
         self.tenant.save()
         self.client.force_login(self.newcomer)
 
-        response = self.client.get(reverse('courses:create'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:create')
         self.assertNotContains(response, 'reached its limit of current students')
 
     def test_student_registration__simplified_auto_create_blocked_at_cap(self):
@@ -2082,8 +2073,7 @@ class DeckCapacityEnforcementTests(ByteDeckTenantTestCase):
         other_staff = baker.make(User, is_staff=True)
         self.client.force_login(self.staff)
 
-        response = self.client.get(reverse('courses:join', args=[other_staff.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('courses:join', args=[other_staff.id])
         self.assertNotContains(response, 'Current-student limit reached')
 
     def test_archive_students_help__staff_only(self):
@@ -2093,5 +2083,4 @@ class DeckCapacityEnforcementTests(ByteDeckTenantTestCase):
         self.assertContains(response, 'Freeing up student seats')
 
         self.client.force_login(self.newcomer)
-        response = self.client.get(reverse('courses:archive_students_help'))
-        self.assertEqual(response.status_code, 403)
+        self.assert403('courses:archive_students_help')

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -240,8 +240,7 @@ class QuestMapAccessAndInterlinkTests(ByteDeckTenantTestCase):
         # A map exists (so the welcome-quest auto-generation is skipped), but none is primary.
         CytoScape.objects.update(is_the_primary_scape=False)
         self.client.force_login(self.teacher)
-        response = self.client.get(reverse('djcytoscape:primary'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('djcytoscape:primary')
         self.assertTemplateUsed(response, 'djcytoscape/generate_new_form.html')
 
 

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -46,8 +46,8 @@ class NotificationViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_student1)
 
         # Accessible views:
-        self.assertEqual(self.client.get(reverse('notifications:list')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('notifications:list_unread')).status_code, 200)
+        self.assert200('notifications:list')
+        self.assert200('notifications:list_unread')
 
         self.assertRedirects(
             response=self.client.get(reverse('notifications:read_all')),
@@ -67,8 +67,8 @@ class NotificationViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
 
         # Accessible views:
-        self.assertEqual(self.client.get(reverse('notifications:list')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('notifications:list_unread')).status_code, 200)
+        self.assert200('notifications:list')
+        self.assert200('notifications:list_unread')
 
         # Bad id notification read request should redirect to list view
         self.assertRedirects(

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -82,9 +82,9 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         # viewing the profile of another student
         self.assertRedirectsQuests('profiles:profile_detail', args=[s2_pk])
 
-        self.assertEqual(self.client.get(reverse('profiles:comment_ban', args=[s_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('profiles:comment_ban_toggle', args=[s_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('profiles:xp_toggle', args=[s_pk])).status_code, 403)
+        self.assert403('profiles:comment_ban', args=[s_pk])
+        self.assert403('profiles:comment_ban_toggle', args=[s_pk])
+        self.assert403('profiles:xp_toggle', args=[s_pk])
         # self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
         self.assert404('profiles:profile_update', args=[s2_pk])
@@ -108,9 +108,9 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.assert200('profiles:profile_list_inactive')
         self.assert200('profiles:tag_chart', args=[s_pk])
         self.assert200('profiles:profile_delete', args=[s_pk])
-        self.assertEqual(self.client.get(reverse('profiles:comment_ban', args=[s_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('profiles:comment_ban_toggle', args=[s_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('profiles:xp_toggle', args=[s_pk])).status_code, 302)
+        self.assert302('profiles:comment_ban', args=[s_pk])
+        self.assert302('profiles:comment_ban_toggle', args=[s_pk])
+        self.assert302('profiles:xp_toggle', args=[s_pk])
         # self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
     def test_profile_recalculate_xp__status_codes(self):
@@ -118,7 +118,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         # why testing this here?
         self.assertEqual(self.active_sem.pk, SiteConfig.get().active_semester.pk)
 
-        self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
+        self.assert302('profiles:recalculate_xp_current')
 
     def test_recalculate_current_xp__dispatches_background_task(self):
         """recalculate_current_xp hands the all-student XP recompute to a background task
@@ -910,8 +910,7 @@ class OAuthMergeAccountViewTests(ByteDeckTenantTestCase):
     def test_oauth_merge_account__get_renders_merge_page(self):
         """GET shows the merge confirmation page with the matched account's username and email."""
         self._seed_merge_session()
-        response = self.client.get(reverse('profiles:oauth_merge_account'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('profiles:oauth_merge_account')
         self.assertEqual(response.context['other_account_username'], self.user.username)
         self.assertEqual(response.context['email_address'], self.user.email)
 
@@ -951,5 +950,4 @@ class OAuthMergeAccountViewTests(ByteDeckTenantTestCase):
         """With no ``merge_with_user_id`` in the session, ``get_object_or_404`` short-circuits to a
         404 before any POST handling — which is why the view's own ``if not merge_with_user_id``
         guard can never be reached."""
-        response = self.client.get(reverse('profiles:oauth_merge_account'))
-        self.assertEqual(response.status_code, 404)
+        self.assert404('profiles:oauth_merge_account')

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -85,7 +85,6 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.assert403('profiles:comment_ban', args=[s_pk])
         self.assert403('profiles:comment_ban_toggle', args=[s_pk])
         self.assert403('profiles:xp_toggle', args=[s_pk])
-        # self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
         self.assert404('profiles:profile_update', args=[s2_pk])
 
@@ -111,14 +110,16 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.assert302('profiles:comment_ban', args=[s_pk])
         self.assert302('profiles:comment_ban_toggle', args=[s_pk])
         self.assert302('profiles:xp_toggle', args=[s_pk])
-        # self.assertEqual(self.client.get(reverse('profiles:recalculate_xp_current')).status_code, 302)
 
-    def test_profile_recalculate_xp__status_codes(self):
-        """Need to test this view with students in an active course"""
-        # why testing this here?
-        self.assertEqual(self.active_sem.pk, SiteConfig.get().active_semester.pk)
+    def test_recalculate_current_xp__requires_staff(self):
+        """Only staff can trigger the current-semester XP recalculation: an anonymous visitor is sent
+        to the login page and a logged-in student is refused. The staff path is covered by
+        test_recalculate_current_xp__dispatches_background_task.
+        """
+        self.assertRedirectsLogin('profiles:recalculate_xp_current')
 
-        self.assert302('profiles:recalculate_xp_current')
+        self.client.force_login(self.test_student1)
+        self.assert403('profiles:recalculate_xp_current')
 
     def test_recalculate_current_xp__dispatches_background_task(self):
         """recalculate_current_xp hands the all-student XP recompute to a background task

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -98,51 +98,51 @@ class QuestViewQuickTests(ByteDeckTenantTestCase):
         q2_pk = self.quest2.pk
         archived_quest_pk = self.archived_quest.pk
 
-        self.assertEqual(self.client.get(reverse('quests:quests')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:quests')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:available')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:available_all')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:inprogress')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:completed')).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:past')).status_code, 200)
+        self.assert200('quests:quests')
+        self.assert200('quests:quests')
+        self.assert200('quests:available')
+        self.assert200('quests:available_all')
+        self.assert200('quests:inprogress')
+        self.assert200('quests:completed')
+        self.assert200('quests:past')
         # anyone can view drafts if they figure out the url, but it will be blank for them
-        self.assertEqual(self.client.get(reverse('quests:drafts')).status_code, 200)
+        self.assert200('quests:drafts')
 
-        self.assertEqual(self.client.get(reverse('quests:quest_detail', args=[q_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:quest_detail', args=[q_pk])).status_code, 200)
+        self.assert200('quests:quest_detail', args=[q_pk])
+        self.assert200('quests:quest_detail', args=[q_pk])
 
         #  students shouldn't have access to these and should be redirected to login
-        self.assertEqual(self.client.get(reverse('quests:approvals')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:submitted')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:submitted_all')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:in_progress')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:approved')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:quest_user_status', args=[q_pk])).status_code, 403)
+        self.assert403('quests:approvals')
+        self.assert403('quests:submitted')
+        self.assert403('quests:submitted_all')
+        self.assert403('quests:in_progress')
+        self.assert403('quests:approved')
+        self.assert403('quests:flagged')
+        self.assert403('quests:quest_user_status', args=[q_pk])
         # self.assertEqual(self.client.get(reverse('quests:skipped')).status_code, 302)
         # self.assertEqual(self.client.get(reverse('quests:submitted_for_quest', args=[q_pk])).status_code, 302)
         # self.assertEqual(self.client.get(reverse('quests:returned_for_quest', args=[q_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:approved_for_quest', args=[q_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:approved_for_quest_all', args=[q_pk])).status_code, 403)
+        self.assert403('quests:approved_for_quest', args=[q_pk])
+        self.assert403('quests:approved_for_quest_all', args=[q_pk])
         # self.assertEqual(self.client.get(reverse('quests:skipped_for_quest', args=[q_pk])).status_code, 302)
 
         # summary stats
-        self.assertEqual(self.client.get(reverse('quests:summary', args=[q_pk])).status_code, 403)
+        self.assert403('quests:summary', args=[q_pk])
 
-        self.assertEqual(self.client.get(reverse('quests:start', args=[q2_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:hide', args=[q_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:unhide', args=[q_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:skip_for_quest', args=[q_pk])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:unarchive', args=[archived_quest_pk])).status_code, 403)
+        self.assert302('quests:start', args=[q2_pk])
+        self.assert302('quests:hide', args=[q_pk])
+        self.assert302('quests:unhide', args=[q_pk])
+        self.assert404('quests:skip_for_quest', args=[q_pk])
+        self.assert403('quests:unarchive', args=[archived_quest_pk])
 
-        self.assertEqual(self.client.get(reverse('quests:quest_prereqs_update', args=[q_pk])).status_code, 403)
+        self.assert403('quests:quest_prereqs_update', args=[q_pk])
 
         # 403 for CRUD views:
-        self.assertEqual(self.client.get(reverse('quests:quest_create')).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:quest_update', args=[q_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:quest_copy', args=[q_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:quest_delete', args=[q_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:unarchive', args=[archived_quest_pk])).status_code, 403)
+        self.assert403('quests:quest_create')
+        self.assert403('quests:quest_update', args=[q_pk])
+        self.assert403('quests:quest_copy', args=[q_pk])
+        self.assert403('quests:quest_delete', args=[q_pk])
+        self.assert403('quests:unarchive', args=[archived_quest_pk])
 
     def test_all_quest_pages__teacher_access_codes(self):
         """Teachers can reach the staff quest management and summary views."""
@@ -153,13 +153,13 @@ class QuestViewQuickTests(ByteDeckTenantTestCase):
         q2_pk = self.quest2.pk
         archived_quest_pk = self.archived_quest.pk
 
-        self.assertEqual(self.client.get(reverse('quests:quest_delete', args=[q2_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:quest_copy', args=[q_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:quest_user_status', args=[q_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:quest_prereqs_update', args=[q_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:unarchive', args=[archived_quest_pk])).status_code, 302)
+        self.assert200('quests:quest_delete', args=[q2_pk])
+        self.assert200('quests:quest_copy', args=[q_pk])
+        self.assert200('quests:quest_user_status', args=[q_pk])
+        self.assert200('quests:quest_prereqs_update', args=[q_pk])
+        self.assert302('quests:unarchive', args=[archived_quest_pk])
 
-        self.assertEqual(self.client.get(reverse('quests:summary', args=[q_pk])).status_code, 200)
+        self.assert200('quests:summary', args=[q_pk])
         self.assertEqual(self.client.get(reverse('quests:ajax_summary_histogram', args=[q_pk])).status_code, 403)  # Ajax only
         response = self.client.get(
             reverse('quests:ajax_summary_histogram', args=[q_pk]),
@@ -193,8 +193,7 @@ class QuestViewQuickTests(ByteDeckTenantTestCase):
         # if the quest is unavailable to the student, then should get a 404 if there is no submission started yet
         # but we don't care about implementation of `is_available()` here, so just patch it to return False
         with patch('quest_manager.models.Quest.is_available', return_value=False):
-            response = self.client.get(reverse('quests:start', args=[self.quest1.pk]))
-            self.assertEqual(response.status_code, 404)
+            self.assert404('quests:start', args=[self.quest1.pk])
 
         # if the quest has not been started yet, and it's available to the student,
         # (quests created with default settings should be to students, as long as they are registered in a course)
@@ -388,37 +387,37 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         s2_pk = self.sub2.pk
 
         # Student's own submission
-        self.assertEqual(self.client.get(reverse('quests:submission', args=[s1_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:drop', args=[s1_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:submission_past', args=[s1_pk])).status_code, 200)
+        self.assert200('quests:submission', args=[s1_pk])
+        self.assert200('quests:drop', args=[s1_pk])
+        self.assert200('quests:submission_past', args=[s1_pk])
 
         # Students shouldn't have access to these
-        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 403)
+        self.assert403('quests:flagged')
 
         # Student's own submission
-        self.assertEqual(self.client.get(reverse('quests:skip', args=[s1_pk])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:approve', args=[s1_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:submission_past', args=[s1_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:flag', args=[s1_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:unflag', args=[s1_pk])).status_code, 403)
-        self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
+        self.assert404('quests:skip', args=[s1_pk])
+        self.assert403('quests:approve', args=[s1_pk])
+        self.assert200('quests:submission_past', args=[s1_pk])
+        self.assert403('quests:flag', args=[s1_pk])
+        self.assert403('quests:unflag', args=[s1_pk])
+        self.assert404('quests:complete', args=[s1_pk])
 
         # Not this student's submission
-        self.assertEqual(self.client.get(reverse('quests:submission', args=[s2_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:drop', args=[s2_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:skip', args=[s2_pk])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:submission_past', args=[s2_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:complete', args=[s2_pk])).status_code, 404)
+        self.assert302('quests:submission', args=[s2_pk])
+        self.assert302('quests:drop', args=[s2_pk])
+        self.assert404('quests:skip', args=[s2_pk])
+        self.assert302('quests:submission_past', args=[s2_pk])
+        self.assert404('quests:complete', args=[s2_pk])
 
         # Non existent submissions
-        self.assertEqual(self.client.get(reverse('quests:submission', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:drop', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:skip', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:submission_past', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:complete', args=[0])).status_code, 404)
+        self.assert404('quests:submission', args=[0])
+        self.assert404('quests:drop', args=[0])
+        self.assert404('quests:skip', args=[0])
+        self.assert404('quests:submission_past', args=[0])
+        self.assert404('quests:complete', args=[0])
 
         # These Needs to be completed via POST
-        self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
+        self.assert404('quests:complete', args=[s1_pk])
 
     def test_submission__student_can_view_completed_submission_when_hidden(self):
         """
@@ -429,8 +428,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
 
         s4_pk = self.sub4.pk
 
-        response = self.client.get(reverse('quests:submission', args=[s4_pk]))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('quests:submission', args=[s4_pk])
 
     def test_submission_view__staff_buttons_include_completion_statuses_link(self):
         """The staff quick-link button group on the submission detail page must include
@@ -486,8 +484,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.sub1.save()
         self.client.force_login(self.test_student1)
 
-        response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:submission', args=[self.sub1.pk])
         # Assert each explanatory text sits inside its button's title attribute (tie the phrase to
         # the title="..." so the test can't pass on the text appearing elsewhere on the page).
         self.assertContains(
@@ -527,8 +524,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
 
         s4_pk = self.sub4.pk
 
-        response = self.client.get(reverse('quests:drop', args=[s4_pk]))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('quests:drop', args=[s4_pk])
 
     def test_submission__hidden_quest_hides_submit_button(self):
         """
@@ -575,8 +571,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.quest3.archived = True
         self.quest3.save()
 
-        response = self.client.get(reverse('quests:submission', args=[self.sub4.pk]))
-        self.assertEqual(response.status_code, 404)
+        self.assert404('quests:submission', args=[self.sub4.pk])
 
     def test_submission__drop_button_hidden_when_approved(self):
         """
@@ -601,8 +596,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.sub4.save()
         s4_pk = self.sub4.pk
 
-        response = self.client.get(reverse('quests:drop', args=[s4_pk]))
-        self.assertEqual(response.status_code, 404)
+        self.assert404('quests:drop', args=[s4_pk])
 
     def test_drop__deletes_comment_and_submission(self):
         """Ensure that the draft_comment (foreignkey to Comment object) is deleted
@@ -642,10 +636,10 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         s1_pk = self.sub1.pk
         # s2_pk = self.sub2.pk
 
-        self.assertEqual(self.client.get(reverse('quests:flagged')).status_code, 200)
+        self.assert200('quests:flagged')
 
         # View it
-        self.assertEqual(self.client.get(reverse('quests:submission', args=[s1_pk])).status_code, 200)
+        self.assert200('quests:submission', args=[s1_pk])
         # Flag it
         # self.assertEqual(self.client.get(reverse('quests:flag', args=[s1_pk])).status_code, 200)
         self.assertRedirects(
@@ -663,18 +657,18 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertIsNone(self.sub1.flagged_by)
 
         # self.assertEqual(self.client.get(reverse('quests:drop', args=[s1_pk])).status_code, 200)
-        self.assertEqual(self.client.get(reverse('quests:submission_past', args=[s1_pk])).status_code, 200)
+        self.assert200('quests:submission_past', args=[s1_pk])
 
         # Non existent submissions
-        self.assertEqual(self.client.get(reverse('quests:submission', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:drop', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:skip', args=[0])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:submission_past', args=[0])).status_code, 404)
+        self.assert404('quests:submission', args=[0])
+        self.assert404('quests:drop', args=[0])
+        self.assert404('quests:skip', args=[0])
+        self.assert404('quests:submission_past', args=[0])
 
         # These Needs to be completed via POST
         # self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
-        self.assertEqual(self.client.get(reverse('quests:skip', args=[s1_pk])).status_code, 302)
-        self.assertEqual(self.client.get(reverse('quests:approve', args=[s1_pk])).status_code, 404)
+        self.assert302('quests:skip', args=[s1_pk])
+        self.assert404('quests:approve', args=[s1_pk])
 
     def test_submission__quest_not_visible_returns_404(self):
         """When a quest is hidden from students, they should still be able to to see their submission in a static way"""
@@ -687,7 +681,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertFalse(self.quest1.published)
 
         # TODO: should redirect, not 404?
-        self.assertEqual(self.client.get(reverse('quests:submission', args=[self.sub1.pk])).status_code, 404)
+        self.assert404('quests:submission', args=[self.sub1.pk])
 
     def test_submission__xp_entered_remains_when_submission_returned(self):
         """A student's requested XP is preserved on the form after a submission is returned."""
@@ -1734,8 +1728,7 @@ class QuestUserStatusViewTests(ByteDeckTenantTestCase):
             semester=SiteConfig.get().active_semester,
         )
 
-        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:quest_user_status', args=[self.quest.id])
         statuses = {entry['user'].username: entry['status'] for entry in response.context['user_status_list']}
         self.assertEqual(statuses[self.student1.username], 'Awaiting Approval')
 
@@ -2358,8 +2351,7 @@ class QuestCopyViewTest(ByteDeckTenantTestCase):
         """ initial values in form GET is the same as the self.quest (quest that is being copied)  """
         self.client.force_login(self.test_teacher)
 
-        get_response = self.client.get(reverse('quests:quest_copy', args=[self.quest.id]))
-        self.assertEqual(get_response.status_code, 200)
+        get_response = self.assert200('quests:quest_copy', args=[self.quest.id])
 
         # Get the data from the form  (initial visit to the page)
         form_data = get_response.context['form'].initial
@@ -2396,8 +2388,7 @@ class QuestCopyViewTest(ByteDeckTenantTestCase):
     def test_quest_copy__ta_get_initial_values(self):
         """A TA copying a quest sees the same copied initial form values as a teacher."""
         self.client.force_login(self.test_ta)
-        get_response = self.client.get(reverse('quests:quest_copy', args=[self.quest.id]))
-        self.assertEqual(get_response.status_code, 200)
+        get_response = self.assert200('quests:quest_copy', args=[self.quest.id])
 
         # Get the data from the form  (initial visit to the page)
         form_data = get_response.context['form'].initial
@@ -2445,8 +2436,7 @@ class QuestCopyViewTest(ByteDeckTenantTestCase):
         """ When copying a quest should be able to set new prereqs """
         self.client.force_login(self.test_teacher)
 
-        get_response = self.client.get(reverse('quests:quest_copy', args=[self.quest.id]))
-        self.assertEqual(get_response.status_code, 200)
+        get_response = self.assert200('quests:quest_copy', args=[self.quest.id])
 
         # See above tests for explanation of this....(EXPLANATION REMOVED because above tests changed)
         form_data = get_response.context['form'].initial
@@ -2816,8 +2806,7 @@ class CategoryViewTests(ByteDeckTenantTestCase):
     def test_CategoryList_view__staff_can_view(self):
         """ Admin should be able to view course list """
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('quests:categories'))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('quests:categories')
 
     def test_CategoryDetail_view__student_vs_admin_visibility(self):
         """ Admin and students should be able to view course details
@@ -2833,8 +2822,7 @@ class CategoryViewTests(ByteDeckTenantTestCase):
 
         # Admin should be able to access view
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('quests:category_detail', kwargs={"pk": view_test_campaign.pk}))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:category_detail', kwargs={"pk": view_test_campaign.pk})
 
         # Admin should be able to see every quest assigned to the viewed campaign
         displayed_quests = response.context["category_displayed_quests"]
@@ -2843,8 +2831,7 @@ class CategoryViewTests(ByteDeckTenantTestCase):
 
         # Students should be able to access view
         self.client.force_login(self.test_student1)
-        response = self.client.get(reverse('quests:category_detail', kwargs={"pk": view_test_campaign.pk}))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:category_detail', kwargs={"pk": view_test_campaign.pk})
 
         # Students should only be able to see active quests assigned to the viewed campaign
         displayed_quests = response.context["category_displayed_quests"]
@@ -3781,8 +3768,7 @@ class DetailViewTest(ByteDeckTenantTestCase):
         site_config.save()
 
         # Staff user in a normal tenant schema
-        response = self.client.get(reverse('quests:quest_detail', args=[self.quest.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:quest_detail', args=[self.quest.id])
 
         # Should be in the context
         self.assertIn('can_export', response.context)
@@ -3792,8 +3778,7 @@ class DetailViewTest(ByteDeckTenantTestCase):
 
         # Now test as normal student
         self.client.force_login(self.test_student)
-        response = self.client.get(reverse('quests:quest_detail', args=[self.quest.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:quest_detail', args=[self.quest.id])
         self.assertFalse(response.context['can_export'])
 
 
@@ -4210,8 +4195,7 @@ class QuestSubmissionSummaryTest(ByteDeckTenantTestCase):
             QuestSubmission, quest=self.quest, is_approved=True, is_completed=True,
             semester=SiteConfig.get().active_semester, time_approved=timezone.now(),
         )
-        response = self.client.get(reverse('quests:summary', args=[self.quest.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:summary', args=[self.quest.id])
         self.assertIsNotNone(response.context['latest_submission_time'])
         self.assertEqual(response.context['count_total'], 1)
         self.assertEqual(response.context['percent_returned'], 0)  # none returned -> 0%

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -65,8 +65,7 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
     def test_submission_page__student_sees_question_formset(self):
         """A student working a quest with questions sees one answer form per question,
         including each question's instructions."""
-        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("quests:submission", args=[self.submission.id])
         formset = response.context["question_formset"]
         self.assertEqual(len(formset.forms), 2)
         self.assertContains(response, "What is your website URL?")
@@ -100,8 +99,7 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
     def test_submission_page__question_deleted_mid_draft_excluded(self):
         """Deleting a question mid-draft removes its form without crashing the page."""
         self.short_question.delete()
-        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("quests:submission", args=[self.submission.id])
         formset = response.context["question_formset"]
         self.assertEqual(len(formset.forms), 1)
         self.assertEqual(formset.forms[0].question, self.long_question)
@@ -391,8 +389,7 @@ class QuestDetailEntryPointTest(QuestionSubmissionFlowTestBase):
     def test_quest_detail__student_sees_no_manage_button(self):
         """Students don't see the staff questions panel (checked on the submission page,
         which embeds the same quest detail content and renders for the owning student)."""
-        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("quests:submission", args=[self.submission.id])
         self.assertNotContains(response, "Manage Questions")
 
 

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -88,8 +88,7 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
         """Teachers can view a quest's question list, which displays each question's
         (truncated) instructions."""
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse("questions:list", kwargs={"quest_id": self.quest.id}))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
         self.assertTemplateUsed(response, "questions/question_list.html")
         # NOTE: instructions are truncated at 20 characters in the table, so these
         # fixture instructions must be shorter than that to assert on them

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -199,8 +199,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         since they refresh nightly rather than on page load (#1729 PR 2)."""
         self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))  # move client to public schema
         self.client.force_login(self.superuser)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
         # setUpTestData refreshed the cached fields, so a timestamped message shows
         self.assertContains(response, "were last refreshed")
 
@@ -209,8 +208,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         Tenant.objects.update(cached_fields_updated_on=None)
         self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))  # move client to public schema
         self.client.force_login(self.superuser)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
         self.assertContains(response, "have not been refreshed yet")
 
     def test_changelist_view__freshness_notice_not_duplicated_by_action_posts(self):
@@ -277,15 +275,13 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
         # second case, access /admin/tenant/ page as authenticated superuser
         # should returns 200 (ok)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "John Doe")
 
@@ -305,15 +301,13 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
         # second case, access /admin/tenant/ page as authenticated superuser
         # should returns 200 (ok)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
         # assert the content of custom column is present on changelist page (both verified and unverified emails)
         self.assertContains(response, "john@doe.com")  # verified email
         self.assertContains(response, "jane@doe.com")  # unverified email
@@ -324,15 +318,13 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
         # second case, access /admin/tenant/ page as authenticated superuser
         # should returns 200 (ok)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "<span data-date=\"2032-01-01\">Jan. 1, 2032</span>")
 
@@ -342,15 +334,13 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
         # second case, access /admin/tenant/ page as authenticated superuser
         # should returns 200 (ok)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
         # assert the content of custom column is present on changelist page
         self.assertContains(response, "<span data-date=\"2022-01-01\">Jan. 1, 2022</span>")
 
@@ -360,8 +350,7 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -999,15 +988,13 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
         # second case, access /admin/tenant/ page as authenticated superuser
         # should returns 200 (ok)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         # third case, select tenants and execute "message_unverified" action
         # should returns 200 (intermediate page)
@@ -1086,15 +1073,13 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
         """
         # first case, access /admin/tenant/ page as anonymous user
         # should returns 302 (login required)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 302)
+        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
         # second case, access /admin/tenant/ page as authenticated superuser
         # should returns 200 (ok)
-        response = self.client.get(reverse("admin:{}_{}_changelist".format("tenant", "tenant")))
-        self.assertEqual(response.status_code, 200)
+        self.assert200("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         # third case, select tenants and execute "send_email_message" action
         # should returns 200 (intermediate page)

--- a/src/tenant/tests/test_middleware.py
+++ b/src/tenant/tests/test_middleware.py
@@ -73,8 +73,7 @@ class OwnerOnlyWhenSuspendedMiddlewareTest(ByteDeckTenantTestCase):
         """Anonymous requests pass through: the sign-in page renders normally on a
         suspended deck (with the suspended status banner, no redirect loop)."""
         self.suspend_deck()
-        response = self.client.get(reverse('account_login'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('account_login')
         self.assertContains(response, 'This deck is suspended')
 
     def test_bounce__nobody_bounced_while_not_suspended(self):

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -115,8 +115,7 @@ class TenantCreateViewTest(ByteDeckTenantTestCase):
 
     def test_get__anonymous_denied_without_verified_deck_request(self):
         """Anonymous users without a verified deck request are denied access."""
-        response = self.client.get(reverse("tenant:new"))
-        self.assertEqual(response.status_code, 403)
+        response = self.assert403("tenant:new")
         self.assertTemplateUsed(response, "tenant/deck_request_denied.html")
 
     def test_get__create_deck_page_extends_public_base_and_keeps_progress_modal(self):
@@ -126,8 +125,7 @@ class TenantCreateViewTest(ByteDeckTenantTestCase):
         deck-generation progress modal that animates on submit. Staff bypass the
         email-verification gate, so the superuser can load the form directly."""
         self.client.force_login(self.superuser)
-        response = self.client.get(reverse("tenant:new"))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("tenant:new")
         # rendered through the shared public base template (the extension), not standalone
         self.assertTemplateUsed(response, "tenant/tenant_form.html")
         self.assertTemplateUsed(response, "public/base.html")
@@ -217,8 +215,7 @@ class TenantCreateViewTest(ByteDeckTenantTestCase):
         """The confirmation page renders through the public base template and lays
         out the 3-step onboarding workflow plus the validity window, single-use
         constraint, spam reminder, and resend cooldown."""
-        response = self.client.get(reverse("decks:request_new_deck_submitted"))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("decks:request_new_deck_submitted")
         self.assertTemplateUsed(response, "tenant/request_new_deck_submitted.html")
         self.assertTemplateUsed(response, "public/base.html")
 
@@ -255,8 +252,7 @@ class TenantCreateViewTest(ByteDeckTenantTestCase):
         instead of showing a bare email form (maintainer request, 2026-08-08)."""
         from tenant.models import TRIAL_LENGTH_DAYS, TRIAL_MAX_ACTIVE_USERS
 
-        response = self.client.get(reverse("decks:request_new_deck"))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200("decks:request_new_deck")
         self.assertContains(response, "Verify your email")
         self.assertContains(response, "login credentials")
         self.assertContains(response, f"{TRIAL_LENGTH_DAYS} days")
@@ -692,8 +688,7 @@ class DeckStatusBannerTest(ByteDeckTenantTestCase):
     def get_quests_page(self, user):
         """Return the quest-list page (which extends base.html) as the given user."""
         self.client.force_login(user)
-        response = self.client.get(reverse('quests:quests'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('quests:quests')
         return response
 
     def test_banner__renders_inside_messages_container(self):
@@ -889,19 +884,17 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
 
     def get_page(self):
         """GET the subscription page, asserting 200."""
-        response = self.client.get(reverse('decks:subscription'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('decks:subscription')
         return response
 
     def test_page__staff_only(self):
         """Anonymous users are redirected to login; students get 403; staff get 200."""
         self.client.logout()
-        response = self.client.get(reverse('decks:subscription'))
-        self.assertEqual(response.status_code, 302)
+        response = self.assert302('decks:subscription')
         self.assertIn('login', response.url)
 
         self.client.force_login(self.student)
-        self.assertEqual(self.client.get(reverse('decks:subscription')).status_code, 403)
+        self.assert403('decks:subscription')
 
         self.client.force_login(self.staff)
         self.get_page()
@@ -1389,8 +1382,7 @@ class SubscriptionCheckoutTest(ByteDeckTenantTestCase):
     def test_activating_page__renders_for_staff_with_polling_script(self):
         """The post-checkout page renders the activating message and polls the
         status endpoint."""
-        response = self.client.get(reverse('decks:subscription_activating'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('decks:subscription_activating')
         self.assertContains(response, 'Activating your subscription')
         self.assertContains(response, reverse('decks:subscription_status'))
         # polling is capped so an abandoned checkout can't hammer Stripe forever

--- a/src/utilities/tests/test_views.py
+++ b/src/utilities/tests/test_views.py
@@ -213,8 +213,7 @@ class MenuItemViewTests(ByteDeckTenantTestCase):
     def test_MenuItemListView__admin_can_view(self):
         ''' Admin should be able to view menu item list '''
         self.client.force_login(self.test_teacher)
-        response = self.client.get(reverse('utilities:menu_items'))
-        self.assertEqual(response.status_code, 200)
+        self.assert200('utilities:menu_items')
 
     def test_MenuItemCreateView__admin_can_create(self):
         ''' Admin should be able to create a menu item '''
@@ -545,8 +544,7 @@ class VideosViewTests(ByteDeckTenantTestCase):
     def test_videos__student_get_is_forbidden(self):
         """A logged-in student can't even read the page: it is the staff upload form."""
         self.client.force_login(self.test_student)
-        response = self.client.get(reverse('utilities:videos'))
-        self.assertEqual(response.status_code, 403)
+        self.assert403('utilities:videos')
 
     def test_videos__student_post_does_not_upload(self):
         """A logged-in student gets a 403 and their upload is not saved."""
@@ -566,8 +564,7 @@ class VideosViewTests(ByteDeckTenantTestCase):
             title="Intro Video",
             video_file=SimpleUploadedFile("intro.mp4", b"fake video bytes", content_type="video/mp4"),
         )
-        response = self.client.get(reverse('utilities:videos'))
-        self.assertEqual(response.status_code, 200)
+        response = self.assert200('utilities:videos')
         self.assertTemplateUsed(response, 'utilities/videos.html')
         self.assertIn(video, list(response.context['videos']))
 


### PR DESCRIPTION
### What?

Replaces 144 hand-rolled GET-and-check-status assertions with the `ViewTestUtilsMixin` helpers that already do exactly that (`assert200`, `assert302`, `assert403`, `assert404`), across 12 test files.

Two shapes were converted:

```python
# inline
self.assertEqual(self.client.get(reverse(&#39;quests:available&#39;)).status_code, 200)
self.assert200(&#39;quests:available&#39;)

# GET assigned, next line asserts its status
response = self.client.get(reverse(&#39;quests:submission&#39;, args=[s4_pk]))
self.assertEqual(response.status_code, 200)
self.assert200(&#39;quests:submission&#39;, args=[s4_pk])
```

Where the response is read after the assertion, the helper&#39;s return value is kept (`response = self.assert200(...)`); where it is not, the assignment goes away with the assertion.

The sweep also surfaced a test that was asserting nothing, so the second commit fixes it (see **A test the sweep exposed** below).

### Why?

Third follow-up in the test-suite cleanup: #2306 put `ViewTestUtilsMixin` on `ByteDeckTenantTestCase` so every tenant test has these helpers, and #2309 removed the setup the base class had made redundant. This removes the assertions the base class had made redundant.

The helpers are not just shorter. `self.assert403(&#39;quests:approve&#39;, args=[s1_pk])` states the expectation of the test (this user may not approve that submission), while the long form buries it in plumbing. In a block of a dozen such checks (`QuestViewQuickTests`, `SubmissionViewTests`) the status code is the only thing that varies between lines, and the hand-rolled form makes it the hardest part to see.

### How?

The sweep was scripted, then read through as a diff. Three constraints kept it mechanical:

* **Only classes that actually have the helpers.** The script resolves class inheritance across `src/` and rewrites only inside classes whose bases lead back to `ViewTestUtilsMixin` or `ByteDeckTenantTestCase`. `SimpleTestCase` classes in the same files (e.g. `PaginateHelperTest`) are untouched.
* **Only requests the helpers can express.** The helpers do `self.client.get(reverse(...))` and nothing else, so only that exact call was converted. POSTs, `follow=True`, `HTTP_X_REQUESTED_WITH` and other request kwargs, and literal (non-reversed) URLs have no equivalent helper and are left alone. `assertEqual(response.status_code, 405)` is left alone too: there is no `assert405`.
* **No code movement.** The assignment and its assertion had to sit at the same indentation, so a pair straddling a `with patch(...)` boundary is skipped rather than quietly pulled inside the context manager.

The remaining `assertEqual(..., status_code, ...)` call sites in the suite are the ones the above excludes; they need judgement (or new helpers) rather than a sweep, so they are out of scope here.

### A test the sweep exposed

`test_profile_recalculate_xp__status_codes` logged nobody in and asserted a 302 from `profiles:recalculate_xp_current`. That view is `@staff_member_required` (the local decorator in `hackerspace_online/decorators.py`), which redirects an anonymous visitor to the login page, so the assertion was passing on the login redirect. It established neither that staff can reach the view nor that anyone else cannot. Reading it beside the converted lines is what made that obvious, and CodeRabbit flagged it too.

It now asserts the boundary it was standing in front of, and is renamed to sit beside the sibling test that covers the staff path (`test_recalculate_current_xp__dispatches_background_task`):

```python
def test_recalculate_current_xp__requires_staff(self):
    """Only staff can trigger the current-semester XP recalculation: an anonymous visitor is sent
    to the login page and a logged-in student is refused. The staff path is covered by
    test_recalculate_current_xp__dispatches_background_task.
    """
    self.assertRedirectsLogin(&#39;profiles:recalculate_xp_current&#39;)

    self.client.force_login(self.test_student1)
    self.assert403(&#39;profiles:recalculate_xp_current&#39;)
```

Removing `@staff_member_required` from the view fails this test (`AssertionError: 302 != 200`); the old version passed without it. The setup-only `assertEqual(self.active_sem.pk, ...)` is gone, along with two commented-out copies of the old assertion in the neighbouring access tests, now that both of those cases have a real test.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2019 tests in 525.935s

OK
```

`ruff check src` passes. The new authorization test was also checked against a view with the decorator removed, to confirm it fails there.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, test-only change with no front-end or user-visible effect.

### Anything Else?

The assertion count per file: `quest_manager` 66, `tenant/tests/test_admin.py` 20, `courses` 17, `tenant/tests/test_views.py` 13, `profile_manager` 9, with the rest spread over `badges`, `notifications`, `questions`, `utilities`, `djcytoscape` and `tenant/tests/test_middleware.py`.

A few commented-out assertions in `quest_manager/tests/test_views.py` still use the old spelling. They are dead code and were left as they are rather than mixed into this diff.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)