### PR TITLE
test: assert where an anonymous request is actually redirected

### DIFF
--- a/src/badges/tests/test_views.py
+++ b/src/badges/tests/test_views.py
@@ -702,13 +702,13 @@ class BadgeAjaxTests(ByteDeckTenantTestCase):
         # test anon
         # ajax_on_show_badge_popup
         self.assert403('badges:ajax_on_show_badge_popup')
-        response = self.client.get(reverse('badges:ajax_on_show_badge_popup'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
+        url = reverse('badges:ajax_on_show_badge_popup')
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
         # ajax_on_close_badge_popup
         self.assert403('badges:ajax_on_close_badge_popup')
-        response = self.client.get(reverse('badges:ajax_on_close_badge_popup'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
+        url = reverse('badges:ajax_on_close_badge_popup')
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
         # test student
         self.client.force_login(self.student)

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1349,10 +1349,10 @@ class TestAjax_MarkDistributionChart(ByteDeckTenantTestCase):
         self.assert403('courses:mark_distribution_chart', args=[self.teacher.pk])
 
     def test_ajax_status_code__anonymous_redirected(self):
-        """An anonymous ajax request to the mark distribution chart is redirected (302)."""
-        # checks redirect with ajax style request "HTTP_X_REQUESTED_WITH='XMLHttpRequest'"
-        response = self.client.get(reverse('courses:mark_distribution_chart', args=[self.teacher.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
+        """An anonymous ajax request to the mark distribution chart is sent to the login page."""
+        # an ajax request clears the 403 the non-ajax test covers, so this reaches LoginRequiredMixin
+        url = reverse('courses:mark_distribution_chart', args=[self.teacher.pk])
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
     def test_ajax_status_code__students(self):
         """A logged-in student's ajax request to the mark distribution chart succeeds (200)."""
@@ -1460,12 +1460,9 @@ class TestAjax_TagChart(ByteDeckTenantTestCase):
         self.assert403('courses:ajax_tag_progress_chart', args=[self.user.pk])
 
     def test_ajax_status_code__anonymous_redirected(self):
-        """An anonymous ajax request to the tag chart is redirected to login (302)."""
-        response = self.client.get(
-            reverse('courses:ajax_tag_progress_chart', args=[self.user.pk]),
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
-        )
-        self.assertEqual(response.status_code, 302)
+        """An anonymous ajax request to the tag chart is sent to the login page."""
+        url = reverse('courses:ajax_tag_progress_chart', args=[self.user.pk])
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
     def test_ajax__no_tag_data_returns_empty_datasets(self):
         """With no tagged quests/badges, the chart returns 200 with empty quest/badge datasets."""
@@ -1592,15 +1589,11 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
         self.assert403('courses:ajax_progress_chart', args=[self.student.pk])
 
     def test_ajax_status_code__anonymous_redirected(self):
-        """ checks redirect with ajax style request "HTTP_X_REQUESTED_WITH='XMLHttpRequest'"
-        redirects because of LoginRequiredMixin
-        """
-        # post
-        response = self.client.post(reverse('courses:ajax_progress_chart', args=[self.student.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
-        # get
-        response = self.client.get(reverse('courses:ajax_progress_chart', args=[self.student.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
+        """An anonymous ajax request to the progress chart is sent to the login page, POST or GET."""
+        url = reverse('courses:ajax_progress_chart', args=[self.student.pk])
+
+        self.assertLoginRedirect(self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
     def test_ajax_status_code__student(self):
         """A student's ajax POST to the progress chart succeeds (200) while a GET returns 404."""
@@ -1870,13 +1863,13 @@ class AjaxRankPopupTests(ByteDeckTenantTestCase):
         # test anon
         # ajax_on_show_ranked_popup
         self.assert403('courses:ajax_on_show_ranked_popup')
-        response = self.client.get(reverse('courses:ajax_on_show_ranked_popup'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
+        url = reverse('courses:ajax_on_show_ranked_popup')
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
         # ajax_on_close_ranked_popup
         self.assert403('courses:ajax_on_close_ranked_popup')
-        response = self.client.get(reverse('courses:ajax_on_close_ranked_popup'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        self.assertEqual(response.status_code, 302)
+        url = reverse('courses:ajax_on_close_ranked_popup')
+        self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
         # test student
         self.client.force_login(self.student)

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -46,10 +46,10 @@ class NonPublicOnlyAuthViewTests(ByteDeckTenantTestCase):
         self.assert200('account_signup')  # ok
         self.assert200('account_login')  # ok
         self.assert302('account_logout')  # redirect
-        self.assert302('account_change_password')  # login required
-        self.assert302('account_set_password')  # login required
+        self.assertRedirectsLogin('account_change_password')  # login required
+        self.assertRedirectsLogin('account_set_password')  # login required
         self.assert200('account_inactive')  # ok
-        self.assert302('account_email')  # login required
+        self.assertRedirectsLogin('account_email')  # login required
         self.assert200('account_email_verification_sent')  # ok
         self.assert200('account_confirm_email', kwargs={'key': '123'})  # ok
         self.assert200('account_reset_password')  # ok

--- a/src/hackerspace_online/tests/test_utils.py
+++ b/src/hackerspace_online/tests/test_utils.py
@@ -165,3 +165,22 @@ class ByteDeckTenantTestCaseTest(ByteDeckTenantTestCase):
         Category = apps.get_model('quest_manager', 'Category')
         self.assertFalse(Category.objects.filter(title='mutated').exists())
         self.assertTrue(Category.objects.filter(title='setuptestdata-probe').exists())
+
+
+class ViewTestUtilsMixinTest(ByteDeckTenantTestCase):
+    """Tests the login-redirect helpers against a real login-required view (tags:list)."""
+
+    def test_assertLoginRedirect__next_url_carrying_a_query_string(self):
+        """The helper matches Django's redirect when the requested url has its own query string.
+
+        Django puts the whole path and query in ?next=, percent-encoded, so the expected url has to
+        be built by encoding the query rather than pasting next_url in: pasted, the requested url's
+        own & would start a second parameter of the login url instead of staying inside ?next=.
+        """
+        url = f"{reverse('tags:list')}?page=2&sort=name"
+
+        self.assertLoginRedirect(self.client.get(url), url)
+
+    def test_assertRedirectsLoginURL__next_url_carrying_a_query_string(self):
+        """assertRedirectsLoginURL takes a url rather than a url name, so it sees query strings too."""
+        self.assertRedirectsLoginURL(f"{reverse('tags:list')}?page=2&sort=name")

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -77,6 +77,21 @@ class ViewTestUtilsMixin():
             expected_url=f'{reverse(settings.LOGIN_URL)}?next={url_name}'
         )
 
+    def assertLoginRedirect(self, response, next_url):
+        """
+        Assert that a response the test already obtained redirected to the login page, with next_url
+        in its ?next= query string.
+
+        Takes the response rather than a url name, so it can check requests the other helpers cannot
+        make: an ajax request (``HTTP_X_REQUESTED_WITH``), a POST, or anything else with extra
+        arguments. When a plain GET is all that is needed, prefer assertRedirectsLogin, which makes
+        the request itself.
+        """
+        self.assertRedirects(
+            response=response,
+            expected_url=f'{reverse(settings.LOGIN_URL)}?next={next_url}'
+        )
+
     def assertRedirectsQuests(self, url_name, follow=False, *args, **kwargs):
         """
         Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the available quests page.

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -17,6 +17,20 @@ import json
 import re
 import warnings
 
+from urllib.parse import urlencode
+
+
+def login_url_with_next(next_url):
+    """
+    Build the url Django redirects an unauthenticated request to: the login page carrying next_url
+    in its ?next=.
+
+    The query is encoded rather than pasted together, so a next_url with a query string of its own
+    ("/tags/?page=2&sort=name") stays inside ?next= instead of its & starting another parameter of
+    the login url.
+    """
+    return f'{reverse(settings.LOGIN_URL)}?{urlencode({"next": next_url})}'
+
 
 class ViewTestUtilsMixin():
     """
@@ -62,7 +76,7 @@ class ViewTestUtilsMixin():
         """
         self.assertRedirects(
             response=self.client.get(reverse(url_name, *args, **kwargs)),
-            expected_url=f'{reverse(settings.LOGIN_URL)}?next={reverse(url_name, *args, **kwargs)}'
+            expected_url=login_url_with_next(reverse(url_name, *args, **kwargs))
         )
 
     def assertRedirectsLoginURL(self, url_name):
@@ -74,7 +88,7 @@ class ViewTestUtilsMixin():
         """
         self.assertRedirects(
             response=self.client.get(url_name),
-            expected_url=f'{reverse(settings.LOGIN_URL)}?next={url_name}'
+            expected_url=login_url_with_next(url_name)
         )
 
     def assertLoginRedirect(self, response, next_url):
@@ -89,7 +103,7 @@ class ViewTestUtilsMixin():
         """
         self.assertRedirects(
             response=response,
-            expected_url=f'{reverse(settings.LOGIN_URL)}?next={next_url}'
+            expected_url=login_url_with_next(next_url)
         )
 
     def assertRedirectsQuests(self, url_name, follow=False, *args, **kwargs):

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1121,13 +1121,7 @@ class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):
         """
         Anonymous users should be redirected to the login page when accessing the library overview.
         """
-        response = self.client.get(reverse('library:quest_list'))
-
-        # Expect a 302 redirect
-        self.assert302('library:quest_list')
-
-        # Should redirect to login page with next param
-        self.assertTrue(response.url.startswith('/accounts/login/'))
+        self.assertRedirectsLogin('library:quest_list')
 
     def test_library_overview__for_students(self):
         """

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -37,8 +37,10 @@ class NotificationViewTests(ByteDeckTenantTestCase):
 
         self.assert403('notifications:ajax')
         self.assert403('notifications:ajax_mark_read')
-        self.assertEqual(self.client.get(reverse('notifications:ajax_mark_read'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 302)
-        self.assertEqual(self.client.get(reverse('notifications:ajax'), HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code, 302)
+        # an ajax request clears the 403 above, so these reach LoginRequiredMixin and go to the login page
+        for url_name in ('notifications:ajax_mark_read', 'notifications:ajax'):
+            url = reverse(url_name)
+            self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest'), url)
 
     def test_notification_page_status_codes__students(self):
         """A logged-in student can view list pages but not the ajax-only endpoints."""

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -12,7 +12,6 @@ or they could be moved into a `test_urls.py` module.
 
 import re
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
@@ -3477,13 +3476,9 @@ class AjaxApprovalInfoTest(ByteDeckTenantTestCase):
 
     def test_ajax_approval_info__anonymous_is_redirected_to_login(self):
         """An anonymous ajax POST is sent to the login page rather than served the submission."""
-        response = self.client.post(
-            reverse('quests:ajax_approval_info', args=[self.submission.id]),
-            content_type='application/json',
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
-        )
-        self.assertEqual(response.status_code, 302)
-        self.assertIn(reverse(settings.LOGIN_URL), response.url)
+        url = reverse('quests:ajax_approval_info', args=[self.submission.id])
+        response = self.client.post(url, content_type='application/json', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertLoginRedirect(response, url)
 
 
 class AjaxSubmissionInfoTest(ByteDeckTenantTestCase):

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -85,8 +85,8 @@ class TagCRUDViewTests(ByteDeckTenantTestCase):
 
     def test_page_status_code__anonymous(self):
         """Make sure the all views are not accessible to anonymous users"""
-        self.assert302('tags:list')
-        self.assert302('tags:detail_student', args=[self.tag.pk, self.test_student.pk])
+        self.assertRedirectsLogin('tags:list')
+        self.assertRedirectsLogin('tags:detail_student', args=[self.tag.pk, self.test_student.pk])
         self.assertRedirectsLogin('tags:detail_staff', args=[self.tag.pk])
         self.assertRedirectsLogin('tags:create')
         self.assertRedirectsLogin('tags:update', args=[self.tag.pk])


### PR DESCRIPTION
### What?

A dozen tests checked that an anonymous request to a login-required view came back `302` and stopped there. They now assert **where** it went. Also adds one helper to `ViewTestUtilsMixin` for the cases the existing helpers cannot express, and fixes how all three login-redirect helpers build the url they expect.

Changed in `badges`, `courses` (three chart endpoints plus the rank popups), `notifications`, `quest_manager`, `tags`, `library` and `hackerspace_online`.

### Why?

`assertEqual(response.status_code, 302)` is satisfied by *any* redirect. If one of these views stopped redirecting to the login page and started redirecting somewhere else, every one of these tests would still pass. That is the same failure mode as the vacuous test #2321 turned up: the assertion was standing in front of an access-control boundary without checking it.

The suite already had the right tool for the plain cases (`assertRedirectsLogin` pins the exact login URL and its `?next=`), and several of these tests sat directly beside calls to it:

```python
def test_page_status_code__anonymous(self):
    self.assert302(&#39;tags:list&#39;)                       # any redirect will do
    self.assert302(&#39;tags:detail_student&#39;, ...)        # any redirect will do
    self.assertRedirectsLogin(&#39;tags:detail_staff&#39;, ...)   # pins the destination
    self.assertRedirectsLogin(&#39;tags:create&#39;)
```

### How?

Plain GETs use the existing `assertRedirectsLogin`. The ajax and POST cases could not: the url-name helpers build the request themselves, so there is nowhere to add `HTTP_X_REQUESTED_WITH` or a body. For those, a new helper takes a response the test has already obtained:

```python
def assertLoginRedirect(self, response, next_url):
    """
    Assert that a response the test already obtained redirected to the login page, with next_url
    in its ?next= query string.

    Takes the response rather than a url name, so it can check requests the other helpers cannot
    make: an ajax request (``HTTP_X_REQUESTED_WITH``), a POST, or anything else with extra
    arguments. When a plain GET is all that is needed, prefer assertRedirectsLogin, which makes
    the request itself.
    """
```

At the call site:

```python
url = reverse(&#39;courses:ajax_progress_chart&#39;, args=[self.student.pk])

self.assertLoginRedirect(self.client.post(url, HTTP_X_REQUESTED_WITH=&#39;XMLHttpRequest&#39;), url)
self.assertLoginRedirect(self.client.get(url, HTTP_X_REQUESTED_WITH=&#39;XMLHttpRequest&#39;), url)
```

Two call sites got a little more than a swapped assertion:

* `test_library_overview__redirects_anonymous` made the request twice (once for the status code, once through `assert302`) and checked the destination with `response.url.startswith(&#39;/accounts/login/&#39;)`, a hardcoded path. One `assertRedirectsLogin` covers all of it.
* `test_ajax_approval_info__anonymous_is_redirected_to_login` checked `assertIn(reverse(settings.LOGIN_URL), response.url)`, which passes on any URL merely containing the login path. It is exact now, and the `settings` import it was the last user of is gone.

Docstrings that described the old assertion ("is redirected (302)") now say the destination.

Left alone: the `assert302` calls that are not this pattern. The `tenant/tests/test_admin.py` ones redirect to the *admin* login rather than `settings.LOGIN_URL`, and the `quest_manager` / `profile_manager` ones are logged-in users hitting views that redirect back to the previous page, where the destination depends on the referrer rather than being fixed. Those need a different assertion, not this one.

### The ?next= the helpers expected

Raised in review, and it applied to the two older helpers as well: all three pasted `next_url` straight into the expected url. A `next_url` with a query string of its own then broke out of `?next=`, because its `&` started a second parameter of the *login* url:

```
AssertionError: '/accounts/login/?next=%2Ftags%2F%3Fpage%3D2%26sort%3Dname' != '/accounts/login/?next=%2Ftags%2F%3Fpage%3D2&sort=name'
```

Django percent-encodes the whole path and query inside `?next=`, so the helper was reporting a mismatch that was its own. All three now build the query with `urlencode`, through a shared `login_url_with_next()`. Two tests cover it, one per shape (`assertLoginRedirect` with a response, `assertRedirectsLoginURL` with a url); both fail without the change. `assertRedirectsLogin` takes a url name, so it cannot be handed a query string and has no case of its own, but it shares the same builder.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2021 tests in 371.179s

OK
```

`ruff check src` passes.

Every converted assertion passes against the real redirect, which is what confirms each destination: `assertRedirects` checks the exact URL and that the target itself resolves, so a wrong guess would have failed the run.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, test-only change with no front-end or user-visible effect.

### Anything Else?

Fourth in the test-suite cleanup after #2306, #2309 and #2321. That series has been about tests that look like they check something and do not; this is the same idea applied to redirect assertions.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)