### PR TITLE
HOTFIX: fix: send expired decks to checkout instead of a dead-end billing portal

### DIFF
--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -130,18 +130,21 @@ def checkout_trial_end(deck):
 
 
 def create_checkout_session(deck):
-    """Create a subscription Checkout Session for an unlinked deck; return its URL.
+    """Create a subscription Checkout Session for the deck; return its URL.
 
     The deck is identified to Stripe three ways (client_reference_id, metadata,
-    and the customer email), so the webhook (PR 7) and manual reconciliation can
-    always find their way back to the schema. A mid-trial deck's remaining free
-    time rides along as ``subscription_data.trial_end`` (see
-    :func:`checkout_trial_end`). The idempotency key means a double-click or
-    same-day retry with identical parameters reuses the same session instead of
-    minting duplicates.
+    and the customer identity), so the webhook (PR 7) and manual reconciliation
+    can always find their way back to the schema. A first-time deck checks out
+    under the owner's email (Stripe mints the customer); a deck that already
+    has a ``stripe_customer_id`` (renewing after its old subscription fully
+    ended) checks out AS that customer, keeping its saved cards and invoice
+    history. A mid-trial deck's remaining free time rides along as
+    ``subscription_data.trial_end`` (see :func:`checkout_trial_end`). The
+    idempotency key means a double-click or same-day retry with identical
+    parameters reuses the same session instead of minting duplicates.
 
     Args:
-        deck (Tenant): The current deck; must not already have a stripe_customer_id.
+        deck (Tenant): The current deck.
 
     Returns:
         str: The Stripe-hosted checkout URL to redirect the owner to.
@@ -152,7 +155,15 @@ def create_checkout_session(deck):
         mode='subscription',
         line_items=[{'price': settings.STRIPE_PRICE_ID, 'quantity': 1}],
         client_reference_id=deck.schema_name,
-        customer_email=deck.get_owner_email_cached() or None,
+        # a returning deck checks out as its EXISTING Stripe customer, so the
+        # saved cards and invoice history carry over and the dashboard shows one
+        # customer per deck; Stripe forbids passing customer and customer_email
+        # together, so a first-time deck is identified by the owner's email
+        **(
+            {'customer': deck.stripe_customer_id}
+            if deck.stripe_customer_id
+            else {'customer_email': deck.get_owner_email_cached() or None}
+        ),
         metadata={'schema_name': deck.schema_name},
         # stamp the subscription too, so webhook subscription events (PR 7)
         # self-identify without a lookup; a mid-trial deck's remaining free time
@@ -169,12 +180,54 @@ def create_checkout_session(deck):
         # trial variant carries the trial-end timestamp: a same-day retry after the
         # cutoff passed, or after an admin moved trial_end_date, gets a fresh key
         # while an identical retry still reuses the session
+        # a customer-bound (renewal) session has different parameters than an
+        # email-identified one, so it gets its own key: a deck that abandoned an
+        # unlinked checkout earlier the same day can still renew after linking
         idempotency_key=(
             f'deck-checkout-{deck.schema_name}-{localdate()}'
             + (f'-trial-{int(trial_end.timestamp())}' if trial_end else '')
+            + (f'-{deck.stripe_customer_id}' if deck.stripe_customer_id else '')
         ),
     )
     return session.url
+
+
+def has_manageable_subscription(deck):
+    """Whether the deck's linked Stripe subscription is one the Billing Portal
+    can still act on (renew, fix the card, switch plans, cancel).
+
+    The portal manages LIVE subscriptions only. A fully canceled (or absent)
+    subscription cannot be restarted there: the portal home shows just payment
+    methods and invoice history, a dead end for an expired deck trying to come
+    back (production find, 2026-08-09). Those decks need a fresh Checkout
+    instead. Stripe is asked at call time so the answer matches what the portal
+    will actually offer: ``past_due``/``unpaid`` subscriptions count as
+    manageable (fixing the card in the portal is their cure), while
+    ``canceled`` and ``incomplete_expired`` are dead ends.
+
+    Args:
+        deck (Tenant): The current deck.
+
+    Returns:
+        bool: True when the portal is the right destination for the manage
+        button; False when a new Checkout is (no linked subscription, it no
+        longer exists on this Stripe account/mode, or its status is terminal).
+
+    Raises:
+        stripe.StripeError: On Stripe/network failures other than the
+        subscription not existing (the caller's existing error handling shows
+        the try-again message).
+    """
+    if not deck.stripe_subscription_id:
+        return False
+    try:
+        subscription = stripe.Subscription.retrieve(
+            deck.stripe_subscription_id, api_key=settings.STRIPE_SECRET_KEY)
+    except stripe.InvalidRequestError:
+        # no such subscription for this key (deleted upstream, or a test/live
+        # mode mismatch): nothing for the portal to manage
+        return False
+    return subscription.status not in ('canceled', 'incomplete_expired')
 
 
 def create_portal_session(deck):

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -214,19 +214,26 @@ def has_manageable_subscription(deck):
         longer exists on this Stripe account/mode, or its status is terminal).
 
     Raises:
-        stripe.StripeError: On Stripe/network failures other than the
-        subscription not existing (the caller's existing error handling shows
-        the try-again message).
+        stripe.StripeError: On any Stripe failure that leaves the
+        subscription's state unknown (transport errors, and invalid requests
+        other than the subscription not existing), so the caller shows its
+        try-again message rather than starting a checkout.
     """
     if not deck.stripe_subscription_id:
         return False
     try:
         subscription = stripe.Subscription.retrieve(
             deck.stripe_subscription_id, api_key=settings.STRIPE_SECRET_KEY)
-    except stripe.InvalidRequestError:
-        # no such subscription for this key (deleted upstream, or a test/live
-        # mode mismatch): nothing for the portal to manage
-        return False
+    except stripe.InvalidRequestError as error:
+        # resource_missing means no such subscription for this key (deleted
+        # upstream, or a test/live mode mismatch): nothing for the portal to
+        # manage. Every OTHER invalid request (a malformed id, a bad parameter)
+        # leaves the subscription's real state unknown, and treating unknown as
+        # "gone" would offer a checkout that could duplicate a live
+        # subscription, so those propagate to the caller's error handling.
+        if error.code == 'resource_missing':
+            return False
+        raise
     return subscription.status not in ('canceled', 'incomplete_expired')
 
 

--- a/src/tenant/templates/tenant/_subscription_manage_button.html
+++ b/src/tenant/templates/tenant/_subscription_manage_button.html
@@ -1,18 +1,22 @@
 {% comment %}
-The Manage subscription / Subscribe now action button, shared by the top of the
-subscription page (under Status) and its Upgrade-or-renew section. The help text
-lives in the button's native title popup (project convention for action buttons).
-Managing the subscription is the deck owner's action alone: everyone else gets
-the button disabled, with the owner's name in the popup. Context: deck,
-is_deck_owner, deck_owner_name (from SubscriptionDetail).
+The Manage subscription / Renew subscription / Subscribe now action button,
+shared by the top of the subscription page (under Status) and its
+Upgrade-or-renew section. The help text lives in the button's native title
+popup (project convention for action buttons). A linked deck past its deadline
+(grace or suspended) gets renewal wording: the POST routes it to a fresh
+Checkout when its old subscription is fully canceled, or the portal while the
+subscription is still live. Managing the subscription is the deck owner's
+action alone: everyone else gets the button disabled, with the owner's name in
+the popup. Context: deck, is_deck_owner, deck_owner_name (from
+SubscriptionDetail).
 {% endcomment %}
 {% if is_deck_owner %}
   <form method="post" action="{% url 'decks:subscription' %}">
     {% csrf_token %}
     <button type="submit" class="btn btn-primary"
-      title="{% if deck.stripe_customer_id %}Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.{% else %}Opens Stripe's secure checkout to start a subscription for this deck.{% endif %}">
+      title="{% if deck.stripe_customer_id %}{% if deck.is_suspended or deck.in_grace_period %}Opens Stripe's secure billing page to renew this deck's subscription.{% else %}Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.{% endif %}{% else %}Opens Stripe's secure checkout to start a subscription for this deck.{% endif %}">
       <i class="fa fa-credit-card"></i>&nbsp;
-      {% if deck.stripe_customer_id %}Manage subscription{% else %}Subscribe now{% endif %}
+      {% if deck.stripe_customer_id %}{% if deck.is_suspended or deck.in_grace_period %}Renew subscription{% else %}Manage subscription{% endif %}{% else %}Subscribe now{% endif %}
     </button>
   </form>
 {% else %}
@@ -20,7 +24,7 @@ is_deck_owner, deck_owner_name (from SubscriptionDetail).
   <span title="Only the deck owner, {{ deck_owner_name }}, can manage the subscription.">
     <button type="button" class="btn btn-primary" disabled>
       <i class="fa fa-credit-card"></i>&nbsp;
-      {% if deck.stripe_customer_id %}Manage subscription{% else %}Subscribe now{% endif %}
+      {% if deck.stripe_customer_id %}{% if deck.is_suspended or deck.in_grace_period %}Renew subscription{% else %}Manage subscription{% endif %}{% else %}Subscribe now{% endif %}
     </button>
   </span>
 {% endif %}

--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -122,7 +122,13 @@
   {% include "tenant/_subscription_manage_button.html" %}
   <p class="help-block" style="margin-top: 0.5em;">
     {% if deck.stripe_customer_id %}
-      Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.
+      {% if deck.is_suspended or deck.in_grace_period %}
+        Opens Stripe's secure billing page to renew this deck's subscription: checkout for a fresh
+        subscription if your old one has fully ended, or the billing portal while it can still be
+        renewed there. Your saved card and invoice history carry over either way.
+      {% else %}
+        Opens Stripe's secure billing portal, where you can renew, upgrade, update your card, or cancel.
+      {% endif %}
     {% else %}
       Opens Stripe's secure checkout to start a subscription for this deck.
       {% if checkout_trial_end %}

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timezone as dt_timezone
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
@@ -14,7 +14,8 @@ from django_tenants.utils import schema_context
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from tenant.billing import (
     _plan_summary_from_subscription, billing_configured, checkout_trial_end, clear_plan_summary_cache,
-    create_checkout_session, reconcile_checkout_session, subscription_period_end_date, subscription_plan_summary,
+    create_checkout_session, has_manageable_subscription, reconcile_checkout_session, subscription_period_end_date,
+    subscription_plan_summary,
 )
 from tenant.models import Tenant
 
@@ -343,6 +344,108 @@ class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
         self.assertEqual(
             kwargs['idempotency_key'],
             f'deck-checkout-{self.tenant.schema_name}-{timezone.localdate()}')
+
+
+@override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+class HasManageableSubscriptionTest(ByteDeckTenantTestCase):
+    """has_manageable_subscription decides the subscription page's manage-button
+    destination: the Billing Portal only when Stripe still has a live
+    subscription to act on, otherwise a fresh Checkout (production find,
+    2026-08-09: an expired deck's portal offered nothing but old invoices)."""
+
+    def set_deck(self, **fields):
+        """Persist billing fields on this deck's Tenant row and refresh the instance."""
+        Tenant.objects.filter(schema_name=self.tenant.schema_name).update(**fields)
+        self.tenant.refresh_from_db()
+
+    def test_has_manageable_subscription__false_without_a_subscription_id(self):
+        """A deck with no linked subscription needs no Stripe call: there is
+        nothing for the portal to manage."""
+        self.set_deck(stripe_subscription_id='')
+        with patch('tenant.billing.stripe.Subscription.retrieve') as mock_retrieve:
+            self.assertFalse(has_manageable_subscription(self.tenant))
+        mock_retrieve.assert_not_called()
+
+    def test_has_manageable_subscription__true_for_live_statuses(self):
+        """A subscription Stripe still considers live is manageable in the
+        portal, including past_due and unpaid (fixing the card there is exactly
+        their cure)."""
+        self.set_deck(stripe_subscription_id='sub_1')
+        for status in ('active', 'trialing', 'past_due', 'unpaid', 'paused'):
+            with self.subTest(status=status):
+                with patch('tenant.billing.stripe.Subscription.retrieve', return_value=Mock(status=status)):
+                    self.assertTrue(has_manageable_subscription(self.tenant))
+
+    def test_has_manageable_subscription__false_for_terminal_statuses(self):
+        """A canceled (or expired-incomplete) subscription is a dead end in the
+        portal: it cannot be restarted there, so the deck needs a Checkout."""
+        self.set_deck(stripe_subscription_id='sub_1')
+        for status in ('canceled', 'incomplete_expired'):
+            with self.subTest(status=status):
+                with patch('tenant.billing.stripe.Subscription.retrieve', return_value=Mock(status=status)):
+                    self.assertFalse(has_manageable_subscription(self.tenant))
+
+    def test_has_manageable_subscription__false_when_stripe_has_no_such_subscription(self):
+        """A subscription id this key can't see (deleted upstream, or a
+        test/live mode mismatch on a hand-linked legacy deck) is not
+        manageable, rather than a 500."""
+        import stripe as stripe_lib
+
+        self.set_deck(stripe_subscription_id='sub_gone')
+        with patch('tenant.billing.stripe.Subscription.retrieve',
+                   side_effect=stripe_lib.InvalidRequestError('No such subscription', param='id')):
+            self.assertFalse(has_manageable_subscription(self.tenant))
+
+    def test_has_manageable_subscription__other_stripe_errors_propagate(self):
+        """A transport/API failure is NOT silently read as "no subscription":
+        it propagates so the view shows its try-again message instead of
+        starting a checkout that could double-bill a live subscriber."""
+        import stripe as stripe_lib
+
+        self.set_deck(stripe_subscription_id='sub_1')
+        with patch('tenant.billing.stripe.Subscription.retrieve', side_effect=stripe_lib.APIConnectionError('down')):
+            with self.assertRaises(stripe_lib.StripeError):
+                has_manageable_subscription(self.tenant)
+
+
+@override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+class CreateCheckoutSessionCustomerTest(ByteDeckTenantTestCase):
+    """create_checkout_session identifies the payer by existing customer when the
+    deck has one (a renewal after cancellation), else by the owner's email."""
+
+    def create_session(self, customer_id):
+        """Put the deck on this stripe_customer_id ('' = unlinked), run
+        create_checkout_session with Stripe mocked, and return the call kwargs.
+
+        The customer id is always set explicitly: ``self.tenant`` is a
+        class-level instance, so a value left over from another test in this
+        class would otherwise leak in through the in-memory model.
+        """
+        Tenant.objects.filter(pk=self.tenant.pk).update(stripe_customer_id=customer_id)
+        self.tenant.refresh_from_db()
+        with patch('tenant.billing.stripe.checkout.Session.create') as mock_create:
+            mock_create.return_value.url = 'https://stripe.example/session'
+            self.assertEqual(create_checkout_session(self.tenant), 'https://stripe.example/session')
+        return mock_create.call_args.kwargs
+
+    def test_create_checkout_session__linked_deck_checks_out_as_its_customer(self):
+        """A deck with a stripe_customer_id renews AS that customer (saved cards
+        and invoice history carry over, and the dashboard keeps one customer per
+        deck). Stripe rejects customer and customer_email together, so only
+        customer is sent, and the customer id joins the idempotency key so a
+        same-day unlinked attempt can't collide with the renewal."""
+        kwargs = self.create_session('cus_renew')
+        self.assertEqual(kwargs['customer'], 'cus_renew')
+        self.assertNotIn('customer_email', kwargs)
+        self.assertTrue(kwargs['idempotency_key'].endswith('-cus_renew'))
+
+    def test_create_checkout_session__unlinked_deck_checks_out_by_owner_email(self):
+        """A first-time deck sends no customer: Stripe mints one from the
+        owner's email, which is how the deck is identified back to its schema."""
+        kwargs = self.create_session('')
+        self.assertNotIn('customer', kwargs)
+        self.assertIn('customer_email', kwargs)
+        self.assertNotIn('-cus_', kwargs['idempotency_key'])
 
 
 @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -354,7 +354,12 @@ class HasManageableSubscriptionTest(ByteDeckTenantTestCase):
     2026-08-09: an expired deck's portal offered nothing but old invoices)."""
 
     def set_deck(self, **fields):
-        """Persist billing fields on this deck's Tenant row and refresh the instance."""
+        """Persist billing fields on this deck's Tenant row and refresh the instance.
+
+        Args:
+            **fields: Tenant field values to write on this deck's row (e.g.
+                ``stripe_subscription_id``), then reloaded into ``self.tenant``.
+        """
         Tenant.objects.filter(schema_name=self.tenant.schema_name).update(**fields)
         self.tenant.refresh_from_db()
 
@@ -388,13 +393,29 @@ class HasManageableSubscriptionTest(ByteDeckTenantTestCase):
     def test_has_manageable_subscription__false_when_stripe_has_no_such_subscription(self):
         """A subscription id this key can't see (deleted upstream, or a
         test/live mode mismatch on a hand-linked legacy deck) is not
-        manageable, rather than a 500."""
+        manageable, rather than a 500. Stripe signals exactly that case with
+        the resource_missing error code."""
         import stripe as stripe_lib
 
         self.set_deck(stripe_subscription_id='sub_gone')
         with patch('tenant.billing.stripe.Subscription.retrieve',
-                   side_effect=stripe_lib.InvalidRequestError('No such subscription', param='id')):
+                   side_effect=stripe_lib.InvalidRequestError(
+                       'No such subscription', param='id', code='resource_missing')):
             self.assertFalse(has_manageable_subscription(self.tenant))
+
+    def test_has_manageable_subscription__other_invalid_requests_propagate(self):
+        """An InvalidRequestError that is NOT resource_missing (a malformed id,
+        a rejected parameter) leaves the subscription's real state unknown, so
+        it propagates rather than being read as "gone": reading unknown as gone
+        would offer a checkout that could duplicate a live subscription."""
+        import stripe as stripe_lib
+
+        self.set_deck(stripe_subscription_id='sub_1')
+        with patch('tenant.billing.stripe.Subscription.retrieve',
+                   side_effect=stripe_lib.InvalidRequestError(
+                       'Invalid expand parameter', param='expand', code='parameter_unknown')):
+            with self.assertRaises(stripe_lib.InvalidRequestError):
+                has_manageable_subscription(self.tenant)
 
     def test_has_manageable_subscription__other_stripe_errors_propagate(self):
         """A transport/API failure is NOT silently read as "no subscription":

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1239,6 +1239,32 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, '<form method="post"', count=2)
         self.assertNotContains(response, 'disabled')
 
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+    def test_page__lapsed_linked_deck_button_says_renew(self):
+        """A linked deck past its governing deadline (grace or suspended) labels
+        the manage action "Renew subscription" with renewal help text: the POST
+        routes such a deck to renewal, so the button says so up front
+        (production find, 2026-08-09: an expired deck's button read "Manage
+        subscription" and led to a portal with nothing actionable on it)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        from siteconfig.models import SiteConfig
+
+        # grace (paid period just lapsed): staff still have access and see renew wording
+        self.set_deck(stripe_customer_id='cus_9', trial_end_date=None, paid_until=localdate() - timedelta(days=5))
+        response = self.get_page()
+        self.assertContains(response, 'Renew subscription', count=2)
+        self.assertNotContains(response, 'Manage subscription')
+
+        # suspended (grace fully lapsed): only the owner can still sign in; renew wording holds
+        self.client.force_login(SiteConfig.get().deck_owner)
+        self.set_deck(paid_until=localdate() - timedelta(days=45))
+        response = self.get_page()
+        self.assertContains(response, 'Renew subscription', count=2)
+        self.assertNotContains(response, 'Manage subscription')
+
     def test_page__contact_copy_links_the_support_address(self):
         """Copy that says to contact ByteDeck links the support address as a
         mailto (maintainer request, 2026-08-09): the managed-manually status, the
@@ -1325,15 +1351,61 @@ class SubscriptionCheckoutTest(ByteDeckTenantTestCase):
         self.assertIn(self.tenant.schema_name, kwargs['idempotency_key'])
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
-    def test_post__linked_deck_redirects_to_billing_portal(self):
-        """POST on a Stripe-linked deck opens the billing portal for that customer."""
-        self.set_deck(stripe_customer_id='cus_123')
-        with patch('tenant.billing.stripe.billing_portal.Session.create',
-                   return_value=Mock(url='https://portal.stripe.test/ps_123')) as mock_create:
+    def test_post__linked_deck_with_live_subscription_redirects_to_billing_portal(self):
+        """POST on a deck whose linked Stripe subscription is LIVE opens the
+        billing portal for that customer: the portal can act on a live
+        subscription (renew, fix the card, switch plans, cancel)."""
+        self.set_deck(stripe_customer_id='cus_123', stripe_subscription_id='sub_live')
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=Mock(status='active')), \
+                patch('tenant.billing.stripe.billing_portal.Session.create',
+                      return_value=Mock(url='https://portal.stripe.test/ps_123')) as mock_create:
             response = self.client.post(reverse('decks:subscription'))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, 'https://portal.stripe.test/ps_123')
         self.assertEqual(mock_create.call_args.kwargs['customer'], 'cus_123')
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+    def test_post__expired_deck_with_canceled_subscription_renews_via_checkout(self):
+        """POST on an expired deck whose old subscription is fully CANCELED gets
+        a fresh Checkout bound to its existing customer, NOT a portal session:
+        a canceled subscription cannot be restarted from the portal, which
+        showed only payment methods and invoices, a dead end exactly when the
+        deck was trying to come back (production find, 2026-08-09; this deck
+        shape reproduced it: suspended, ids present, subscription canceled)."""
+        from datetime import timedelta
+
+        from django.utils.timezone import localdate
+
+        self.set_deck(stripe_customer_id='cus_123', stripe_subscription_id='sub_dead',
+                      trial_end_date=None, paid_until=localdate() - timedelta(days=45))
+        with patch('tenant.billing.stripe.Subscription.retrieve', return_value=Mock(status='canceled')), \
+                patch('tenant.billing.stripe.billing_portal.Session.create') as mock_portal, \
+                patch('tenant.billing.stripe.checkout.Session.create',
+                      return_value=Mock(url='https://checkout.stripe.test/cs_renew')) as mock_checkout:
+            response = self.client.post(reverse('decks:subscription'))
+        mock_portal.assert_not_called()
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, 'https://checkout.stripe.test/cs_renew')
+        # the checkout is bound to the existing customer: saved cards and
+        # invoice history carry over instead of minting a duplicate customer
+        self.assertEqual(mock_checkout.call_args.kwargs['customer'], 'cus_123')
+
+    @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+    def test_post__customer_without_subscription_goes_to_checkout(self):
+        """POST on a deck with a customer id but NO subscription id (an
+        abandoned checkout, or a partial legacy link) starts a Checkout as that
+        customer without asking Stripe anything: there is no subscription the
+        portal could manage."""
+        self.set_deck(stripe_customer_id='cus_123')
+        with patch('tenant.billing.stripe.Subscription.retrieve') as mock_retrieve, \
+                patch('tenant.billing.stripe.billing_portal.Session.create') as mock_portal, \
+                patch('tenant.billing.stripe.checkout.Session.create',
+                      return_value=Mock(url='https://checkout.stripe.test/cs_c')) as mock_checkout:
+            response = self.client.post(reverse('decks:subscription'))
+        mock_retrieve.assert_not_called()
+        mock_portal.assert_not_called()
+        self.assertEqual(response.url, 'https://checkout.stripe.test/cs_c')
+        self.assertEqual(mock_checkout.call_args.kwargs['customer'], 'cus_123')
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
     def test_post__manually_subscribed_deck_refused_to_prevent_double_billing(self):

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -527,6 +527,13 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         dead end exactly when the deck is trying to come back (production find,
         2026-08-09).
 
+        Args:
+            request (HttpRequest): The POST from the manage/subscribe button;
+                its ``tenant`` is the deck being billed and its ``user`` must be
+                that deck's owner.
+            *args: Positional URL arguments (this route takes none).
+            **kwargs: Keyword URL arguments (this route takes none).
+
         Returns:
             HttpResponse: A redirect to the Stripe-hosted page, or back to this
             page with an error message when Stripe isn't configured or errors out.

--- a/src/tenant/views.py
+++ b/src/tenant/views.py
@@ -432,8 +432,10 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
     """Staff-facing "Subscription details" page for the current deck (epic #1729 PR 6).
 
     GET shows the deck's billing status, expiry dates, student-seat usage (live
-    count), and the upgrade/renew action. POST starts the Stripe flow: Checkout
-    for an unlinked deck, the Billing Portal for a linked one. When Stripe isn't
+    count), and the upgrade/renew action. POST starts the Stripe flow: the
+    Billing Portal when the deck has a live subscription to manage, otherwise a
+    Checkout (bound to the deck's existing Stripe customer, if any), so an
+    expired deck's button leads straight to renewal. When Stripe isn't
     configured the page says so and the action falls back to the public
     subscribe page. Linked from the admin menu for all staff.
     """
@@ -514,7 +516,16 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         return context
 
     def post(self, request, *args, **kwargs):
-        """Start the Stripe flow: Checkout (unlinked deck) or Billing Portal (linked).
+        """Start the Stripe flow: the Billing Portal or a Checkout, by live state.
+
+        The portal can only act on a LIVE subscription, so the routing asks
+        Stripe at click time: a deck whose linked subscription is alive gets the
+        portal; a deck with no live subscription (never linked, or its old one
+        fully canceled after expiry) gets a fresh Checkout instead, bound to its
+        existing Stripe customer when there is one. Routing on the customer id
+        alone sent expired decks to a portal with nothing actionable on it: a
+        dead end exactly when the deck is trying to come back (production find,
+        2026-08-09).
 
         Returns:
             HttpResponse: A redirect to the Stripe-hosted page, or back to this
@@ -522,7 +533,7 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
         """
         import stripe as stripe_lib
 
-        from .billing import billing_configured, create_checkout_session, create_portal_session
+        from .billing import billing_configured, create_checkout_session, create_portal_session, has_manageable_subscription
 
         deck = request.tenant
         if not billing_configured():
@@ -557,7 +568,7 @@ class SubscriptionDetail(NonPublicOnlyViewMixin, TemplateView):
             )
             return redirect('decks:subscription')
         try:
-            if deck.stripe_customer_id:
+            if deck.stripe_customer_id and has_manageable_subscription(deck):
                 url = create_portal_session(deck)
             else:
                 url = create_checkout_session(deck)


### PR DESCRIPTION
### What

An expired deck's "Manage subscription" button led nowhere useful (production find, 2026-08-09). The button routed every deck with a `stripe_customer_id` to the Stripe **Billing Portal**, but the portal can only act on a LIVE subscription: once the old subscription is fully canceled, the portal shows just saved cards and old invoices, with nothing that starts a new subscription. That is exactly the moment a suspended deck is trying to come back, so the owner is told to "subscribe to restore access" and then handed a page that cannot do it.

The manage action now routes on the deck's real Stripe state, asked at click time:

- **Live subscription** (`active`, `trialing`, `past_due`, `unpaid`, `paused`): the Billing Portal, as before. Fixing a card or switching plans belongs there.
- **Canceled, missing, or no subscription at all**: a fresh **Checkout**, created with the deck's existing `customer` attached, so the saved card, billing details, and invoice history carry over and the dashboard keeps one customer per deck (Stripe forbids sending `customer` and `customer_email` together, so a first-time deck is still identified by the owner's email). The customer id also joins the idempotency key, so a same-day abandoned unlinked checkout can't collide with the renewal.

Only Stripe's `resource_missing` error code counts as "no such subscription" (a subscription deleted upstream, or a test-mode id on a hand-linked legacy deck). Every other `InvalidRequestError`, and any transport failure, leaves the subscription's state unknown and propagates to the page's existing try-again message: reading unknown as "gone" would offer a checkout that could duplicate a live subscription.

**Copy follows the routing**: a linked deck past its governing deadline (grace or suspended) now labels the action **"Renew subscription"**, with help text saying it opens checkout for a fresh subscription if the old one has fully ended, or the portal while it can still be renewed there, and that the saved card and invoice history carry over. A healthy linked deck still reads "Manage subscription"; an unlinked deck still reads "Subscribe now".

**HOTFIX to `staging`**: found while linking legacy decks for the production go-live, and blocking for any expired deck that wants to renew.

### Testing

- View tests cover all three routes: a live subscription opens the portal; an expired deck with a canceled subscription gets checkout bound to its existing customer and never touches the portal (this test reproduces the reported deck shape: suspended, both Stripe ids present, subscription canceled); a customer with no subscription id goes straight to checkout with no Stripe call at all.
- Billing tests pin `has_manageable_subscription` across live statuses, terminal statuses, a `resource_missing` subscription, a non-missing `InvalidRequestError` (propagates), and a transport error (propagates), plus the customer-vs-email identity and idempotency-key shape of `create_checkout_session`.
- A page test pins the "Renew subscription" wording for both grace and suspended decks.
- Full suite (2038 tests), ruff, and `makemigrations --check` pass locally.

### Screenshots

Captured from the running dev app on the `hackerspace` deck, put into the reported state (linked to Stripe, paid period ended 45 days ago, so suspended), signed in as the deck owner.

**Before:** the action reads "Manage subscription" and the help text promises a portal where you can "renew, upgrade, update your card, or cancel", but for this deck the portal offers none of that.

![before, status block](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/renew-expired-checkout/before-status.png)
![before, upgrade or renew](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/renew-expired-checkout/before-renew.png)

**After:** the same deck reads "Renew subscription", and the help text says where it goes and that the saved card carries over.

![after, status block](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/renew-expired-checkout/after-status.png)
![after, upgrade or renew](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/renew-expired-checkout/after-renew.png)

- Claude Code (`Bytedeck - payments integration`)