### PR TITLE
HOTFIX: fix: brand platform emails with the ByteDeck wordmark, not the deck's logo

### DIFF
--- a/src/tenant/templates/tenant/email/_email_footer.html
+++ b/src/tenant/templates/tenant/email/_email_footer.html
@@ -11,7 +11,10 @@
 {# on the public schema. width/height show the 510x128 wordmark at half size (maintainer request, #}
 {# 2026-08-08). #}
 <p><img alt="[Logo]" src="{% public_email_logo_url %}" width="255" height="64"></p>
+{# the emphasis run CLOSES before the link and reopens around it: html2text (which derives the #}
+{# email's plain-text part) drops the space in front of a link that sits inside an <em>, which #}
+{# reads as "awesome app?[Contact us]" for text-only clients. Rendered HTML is unchanged. #}
 <p><em>Bytedeck is a non-profit Society registered in British Columbia. The board members are
   volunteers, and put many hours into running and further developing Bytedeck. Interested in
-  joining our board and helping us steer the direction of this awesome app?
-  <a href="mailto:contact@bytedeck.com">Contact us</a>!</em></p>
+  joining our board and helping us steer the direction of this awesome app?</em>
+  <em><a href="mailto:contact@bytedeck.com">Contact us</a>!</em></p>

--- a/src/tenant/templates/tenant/email/_email_footer.html
+++ b/src/tenant/templates/tenant/email/_email_footer.html
@@ -1,14 +1,17 @@
 {% load utility_tags %}
-{# shared closing block for every subscription lifecycle email (maintainer requests, 2026-07-30): #}
-{# the non-profit Society note, a contact address for questions, and a fixed "Bytedeck" sign-off -- #}
-{# billing emails come from the platform, so they are signed Bytedeck rather than the deck's name. #}
-<p><em>Bytedeck is a non-profit Society. The board members are volunteers, and put many hours into
-  running and further developing Bytedeck. Our subscription pricing is competitive, and funds are
-  only utilized for maintaining systems and development.</em></p>
+{# shared closing block for every email the PLATFORM sends (subscription lifecycle notices, #}
+{# the deck-request verification, the new-deck welcome): a contact address for questions, a #}
+{# fixed "Bytedeck" sign-off, ByteDeck's wordmark, and the non-profit Society note beneath it #}
+{# (maintainer requests, 2026-07-30 and 2026-08-10). These come from Bytedeck rather than the #}
+{# deck, so they carry Bytedeck's branding throughout; a deck's own mail to its users #}
+{# (announcements, notifications) carries that deck's logo instead. #}
 <p>If you have any questions, contact us at <a href="mailto:contact@bytedeck.com">contact@bytedeck.com</a>.</p>
 <p>Bytedeck</p>
-{# platform emails (the deck-request sends) pass the wordmark's absolute URL as logo_url: #}
-{# there is no SiteConfig on the public schema, and mail clients can't resolve relative #}
-{# static paths anyway. width/height show the 510x128 wordmark at half size (maintainer #}
-{# request, 2026-08-08). Tenant lifecycle emails omit logo_url and get the deck's logo. #}
-{% if logo_url %}<p><img alt="[Logo]" src="{{ logo_url }}" width="255" height="64"></p>{% else %}<p><img alt="[Logo]" src="{% site_logo_url %}"></p>{% endif %}
+{# an absolute URL: mail clients can't resolve relative static paths, and there is no SiteConfig #}
+{# on the public schema. width/height show the 510x128 wordmark at half size (maintainer request, #}
+{# 2026-08-08). #}
+<p><img alt="[Logo]" src="{% public_email_logo_url %}" width="255" height="64"></p>
+<p><em>Bytedeck is a non-profit Society registered in British Columbia. The board members are
+  volunteers, and put many hours into running and further developing Bytedeck. Interested in
+  joining our board and helping us steer the direction of this awesome app?
+  <a href="mailto:contact@bytedeck.com">Contact us</a>!</em></p>

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -564,7 +564,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         # the Society note closes the email BENEATH the wordmark, and invites the
         # reader onto the board through a mailto (maintainer request, 2026-08-10)
         self.assertLess(html.index('alt="[Logo]"'), html.index('non-profit Society'))
-        self.assertIn('<a href="mailto:contact@bytedeck.com">Contact us</a>!', html)
+        self.assertIn('awesome app?</em> <em><a href="mailto:contact@bytedeck.com">Contact us</a>!</em>', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_follows_the_governing_trial_clock(self):

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -455,9 +455,9 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
     def test_process__grace_email_includes_dates_seats_and_logo(self):
         """The grace-period expiry email states every date the owner needs -- when
         the subscription expired and how long ago, when the grace period ends and
-        how many days remain -- plus current seat usage and the site logo
-        (maintainer request from staging live testing, 2026-07-25: the old email
-        gave no dates at all)."""
+        how many days remain -- plus current seat usage and the ByteDeck wordmark
+        (settings.PUBLIC_EMAIL_LOGO_URL) that signs every platform email
+        (maintainer request from staging live testing, 2026-07-25)."""
         Tenant.objects.filter(pk=self.tenant.pk).update(
             trial_end_date=None, paid_until=TODAY - timedelta(days=5),  # expired, in grace
             max_active_users=30, active_user_count=2,
@@ -565,6 +565,11 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         # reader onto the board through a mailto (maintainer request, 2026-08-10)
         self.assertLess(html.index('alt="[Logo]"'), html.index('non-profit Society'))
         self.assertIn('awesome app?</em> <em><a href="mailto:contact@bytedeck.com">Contact us</a>!</em>', html)
+        # the same separator in the PLAIN-TEXT part, which is what the split
+        # emphasis run buys: html2text drops the space in front of a link that
+        # sits inside an <em>, leaving text-only clients "awesome app?[Contact us]"
+        plain_text = ' '.join(mail.outbox[0].body.split())
+        self.assertIn('awesome app?_ _[Contact us](mailto:contact@bytedeck.com)!_', plain_text)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_follows_the_governing_trial_clock(self):

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -1,5 +1,6 @@
 from datetime import date, timedelta
 
+from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
 from django.test import override_settings
@@ -8,6 +9,7 @@ from freezegun import freeze_time
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from notifications.models import Notification
+from siteconfig.models import SiteConfig
 from tenant.models import GRACE_PERIOD_DAYS, DeckNotice, Tenant
 from tenant.notices import evaluate_deck_notices, process_deck_notices
 from tenant.utils import deck_cache_key
@@ -470,9 +472,9 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('Sept. 9, 2026', html)   # grace ends paid_until + 30 days...
         self.assertIn('25 days left', html)    # ...with the countdown
         self.assertIn('using <strong>2</strong> of <strong>30</strong> current student', ' '.join(html.split()))
-        self.assertIn('non-profit Society', html)  # every subscription email carries the Society blurb
+        self.assertIn('non-profit Society registered in British Columbia', html)  # every platform email carries the Society blurb
         self.assertIn('contact@bytedeck.com', html)  # ...and a contact address for questions
-        self.assertIn('alt="[Logo]"', html)
+        self.assertIn(f'alt="[Logo]" src="{settings.PUBLIC_EMAIL_LOGO_URL}" width="255" height="64"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__comped_deck_limit_email_renders_without_any_dates(self):
@@ -549,11 +551,20 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('only the deck owner can sign in', html)
         self.assertIn('your content and student data are intact', html)
         self.assertIn('<em>Maintenance</em> subscription', html)
-        self.assertIn('non-profit Society', html)  # every subscription email carries the Society blurb
+        self.assertIn('non-profit Society registered in British Columbia', html)  # every platform email carries the Society blurb
         self.assertIn('contact@bytedeck.com', html)  # ...and a contact address for questions
         # billing emails are signed by the platform, never the deck (maintainer request, 2026-07-30)
         self.assertIn('<p>Bytedeck</p>', html)
-        self.assertIn('alt="[Logo]"', html)
+        # ...and branded by the platform too: the ByteDeck wordmark at half its
+        # natural size, by absolute URL, with the deck's own logo nowhere in the
+        # message (maintainer request, 2026-08-10: a deck's logo belongs on the
+        # mail that deck sends its own users, not on mail from Bytedeck)
+        self.assertIn(f'alt="[Logo]" src="{settings.PUBLIC_EMAIL_LOGO_URL}" width="255" height="64"', html)
+        self.assertNotIn(SiteConfig.get().get_site_logo_url(), html)
+        # the Society note closes the email BENEATH the wordmark, and invites the
+        # reader onto the board through a mailto (maintainer request, 2026-08-10)
+        self.assertLess(html.index('alt="[Logo]"'), html.index('non-profit Society'))
+        self.assertIn('<a href="mailto:contact@bytedeck.com">Contact us</a>!', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
     def test_process__suspended_email_follows_the_governing_trial_clock(self):

--- a/src/tenant/utils.py
+++ b/src/tenant/utils.py
@@ -200,22 +200,19 @@ class DeckRequestService:
         Returns:
             None
         """
-        from django.conf import settings
-
         if request is not None:
             verification_link = DeckRequestService.build_verification_link(request, nonce)
         else:
             verification_link = reverse("decks:verify_deck_request", args=[nonce])
 
         # rendered as the email's HTML part (send_email_message derives the
-        # plain-text part from it); this email goes out on the PUBLIC schema, so
-        # the footer gets the platform wordmark's absolute URL explicitly (no
-        # SiteConfig here, and mail clients can't resolve relative paths)
+        # plain-text part from it); the shared footer supplies Bytedeck's
+        # wordmark, which works here on the PUBLIC schema (no SiteConfig) because
+        # it comes from settings as an absolute URL
         message = get_template("tenant/email/verify_deck_request.html").render({
             "first_name": first_name,
             "verification_link": verification_link,
             "verification_validity": _humanize_seconds(DeckRequestService.TOKEN_MAX_AGE),
-            "logo_url": settings.PUBLIC_EMAIL_LOGO_URL,
         })
 
         # send in the background so the request doesn't block on SMTP
@@ -250,19 +247,16 @@ class DeckRequestService:
         })
         subject = "".join(subject.splitlines())
 
-        from django.conf import settings
-
         # rendered as the email's HTML part (send_email_message derives the
-        # plain-text part from it). A platform email, so the sigblock shows the
-        # ByteDeck wordmark by absolute URL: a brand-new deck's SiteConfig only
-        # holds the seeded default logo as a schema-relative path, which mail
-        # clients render as a broken image.
+        # plain-text part from it). A platform email, so the shared footer signs
+        # it with the ByteDeck wordmark by absolute URL: a brand-new deck's
+        # SiteConfig only holds the seeded default logo as a schema-relative
+        # path, which mail clients render as a broken image.
         message = get_template("tenant/email/welcome_message.html").render({
             "config": SiteConfig.get(),
             "tenant": tenant,
             "user": user,
             "password": password,
-            "logo_url": settings.PUBLIC_EMAIL_LOGO_URL,
         })
 
         # send in the background so the request doesn't block on SMTP

--- a/src/utilities/templatetags/utility_tags.py
+++ b/src/utilities/templatetags/utility_tags.py
@@ -1,6 +1,7 @@
 import functools
 
 from django import template
+from django.conf import settings
 from django.db import connection
 
 from django_tenants.utils import get_public_schema_name
@@ -72,3 +73,20 @@ def checkcross(value):
         return 'fa fa-check'
     elif value is False:
         return 'fa fa-times'
+
+
+@register.simple_tag
+def public_email_logo_url():
+    """The absolute URL of the ByteDeck wordmark used in platform emails.
+
+    Emails the PLATFORM sends (deck lifecycle and billing notices, the
+    deck-request verification, the new-deck welcome) are signed by ByteDeck and
+    carry ByteDeck branding; a deck's own mail to its users (announcements,
+    notifications) carries that deck's logo through ``site_logo_url``. Reading
+    the URL from settings keeps this usable on the public schema, which has no
+    SiteConfig, and keeps it absolute, which mail clients require.
+
+    Returns:
+        str: settings.PUBLIC_EMAIL_LOGO_URL.
+    """
+    return settings.PUBLIC_EMAIL_LOGO_URL

--- a/src/utilities/tests/test_templatetags_filters.py
+++ b/src/utilities/tests/test_templatetags_filters.py
@@ -4,7 +4,7 @@ from django.template import Template, Context
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
-from utilities.templatetags.utility_tags import checkcross, favicon_url
+from utilities.templatetags.utility_tags import checkcross, favicon_url, public_email_logo_url
 
 
 class CheckcrossFilterTest(SimpleTestCase):
@@ -55,3 +55,15 @@ class PossessiveFilterTest(TestCase):
         context = Context({"name": "Mary"})
         output = template.render(context)
         self.assertEqual(output, "Mary&#x27;s")
+
+
+class PublicEmailLogoUrlTagTest(SimpleTestCase):
+    """Tests for the platform wordmark tag used in ByteDeck's own emails."""
+
+    def test_public_email_logo_url__returns_the_configured_wordmark(self):
+        """The tag serves settings.PUBLIC_EMAIL_LOGO_URL verbatim: an absolute
+        URL (mail clients cannot resolve relative static paths) read from
+        settings rather than SiteConfig, so it also works on the public schema,
+        which has no SiteConfig."""
+        with self.settings(PUBLIC_EMAIL_LOGO_URL='https://cdn.example.com/wordmark.png'):
+            self.assertEqual(public_email_logo_url(), 'https://cdn.example.com/wordmark.png')


### PR DESCRIPTION
### What

Deck lifecycle emails were signed "Bytedeck" but stamped with the **deck's own logo** (production find, 2026-08-10: a suspension notice for the `electrobotics` deck arrived carrying that deck's chip icon). Mail that ByteDeck sends should carry ByteDeck's branding; a deck's logo belongs on the mail that deck sends its own users.

- **Every email the platform sends now signs off with the ByteDeck wordmark.** The shared footer (`_email_footer.html`) takes the wordmark from a new `public_email_logo_url` template tag backed by `settings.PUBLIC_EMAIL_LOGO_URL`, so the four subscription lifecycle notices (expiry, limit, suspended, payment failed), the deck-request verification, and the new-deck welcome are all branded ByteDeck, as is any platform email added later that includes this footer. The tag reads settings rather than SiteConfig, so it works on the public schema too (which has no SiteConfig) and always yields the absolute URL mail clients need; the two callers that used to pass `logo_url` into their context no longer need to.
- **Deck-to-user mail is untouched**: announcements and notifications still render `site_logo_url`, so a deck's own messages keep that deck's logo.
- **The non-profit Society note moves below the wordmark and is reworded** (maintainer request): it now names the province and invites readers onto the board, with "Contact us" as a `mailto:contact@bytedeck.com` link.

One subtlety in the footer markup: the blurb's emphasis run closes before that link and reopens around it. `html2text`, which derives each email's plain-text part, drops the space in front of a link that sits inside an `<em>`, so text-only clients received "awesome app?[Contact us]". The rendered HTML is identical either way, and a test pins the markup.

**HOTFIX to `staging`**: branding on mail that is going out to real deck owners right now during the go-live.

### Testing

- Notice-email tests assert the wordmark by absolute URL at half size, assert the deck's own logo appears **nowhere** in the message, and pin the Society note below the logo along with the board-invitation mailto (including the space before it).
- A new templatetag test pins that `public_email_logo_url` serves `settings.PUBLIC_EMAIL_LOGO_URL` verbatim.
- Existing welcome/verification email tests continue to pin the wordmark.
- Full suite (2039 tests), ruff, and `makemigrations --check` pass locally.

### Screenshots

Captured from a **real send** on the `hackerspace` dev deck: the deck was put into a suspended state and the notice engine run, then the saved message from `_sent_mail/` was rendered. Both captures point the logo at the dev static host serving the very same `wordmark-v2.png` / deck-icon assets, because this sandbox cannot reach the production CloudFront host; the message content is otherwise exactly what was sent.

**Before** (current `staging`, same real send): the sigblock carries the deck's own logo.

![before, suspension email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/platform-email-wordmark/email-before.png)

**After**: the ByteDeck wordmark, with the reworded Society note beneath it.

![after, suspension email](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/platform-email-wordmark/email-after.png)

The plain-text part of that same send, verbatim:

```
Hi admin,

Your deck [hackerspace](http://hackerspace.localhost:8000) is **scheduled for
deletion on Aug. 10, 2027 (365 days from now)** , unless it gets a valid
subscription before then.

The deck has been **suspended** since **July 27, 2026** (its subscription was
paid through June 26, 2026, and the 30-day grace period ended on July 26,
2026): only the deck owner can sign in until the deck has a valid
subscription. Nothing has been deleted yet: your content and student data are
intact until the deletion date above.

[Subscribe here](http://hackerspace.localhost:8000/decks/subscription/) to
restore access: any level works, including the low-cost _Maintenance_
subscription, which keeps the deck online with trial-level limits (max 5
current students) and stops the deletion countdown (ideal if you just want to
keep the deck for later).

If you have any questions, contact us at
[contact@bytedeck.com](mailto:contact@bytedeck.com).

Bytedeck

[\[Logo\]](http://localhost:8000/static/public/images/wordmark-v2.png)

_Bytedeck is a non-profit Society registered in British Columbia. The board
members are volunteers, and put many hours into running and further developing
Bytedeck. Interested in joining our board and helping us steer the direction
of this awesome app?_ _[Contact us](mailto:contact@bytedeck.com)!_
```

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized branding across platform emails with a consistent wordmark and fixed sizing.
  * Added the configured platform logo to verification, welcome, subscription, and notice emails.
  * Updated Society notice wording and contact details in email footers.

* **Bug Fixes**
  * Corrected email footer layout and ensured notice and contact links appear consistently.
  * Prevented deck-specific logos from appearing in suspension notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->