### PR TITLE
HOTFIX: feat: name the deck on every Stripe page an owner sees

### DIFF
--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -61,6 +61,78 @@ ZERO_DECIMAL_CURRENCIES = frozenset((
     'pyg', 'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
 ))
 
+# How long a deck's Billing Portal configuration id (the one whose headline names
+# the deck) is remembered. Configurations are permanent Stripe objects, so this
+# only decides how often we re-create one: on a cache miss the deck gets a fresh
+# configuration, leaving the previous one unused on the account.
+PORTAL_CONFIGURATION_CACHE_SECONDS = 60 * 60 * 24 * 30
+
+
+def deck_label(deck):
+    """The deck's domain, the name its owner recognizes it by.
+
+    Stripe's hosted pages show the product ("Bytedeck Subscription - 120
+    Students"), which is identical for every deck on that tier, so an owner with
+    several decks cannot tell which one they are paying for (production find,
+    2026-08-10). This label goes into the places Stripe will display.
+
+    Args:
+        deck (Tenant): The deck being billed.
+
+    Returns:
+        str: The deck's primary domain, e.g. ``hackerspace.bytedeck.com``.
+    """
+    return deck.primary_domain_url
+
+
+def _portal_configuration_cache_key(schema_name):
+    """Cache key holding a deck's Billing Portal configuration id."""
+    return f'stripe-portal-config:{schema_name}'
+
+
+def portal_configuration_id(deck):
+    """A Billing Portal configuration whose headline names this deck; None when
+    one cannot be prepared.
+
+    The portal is Stripe-hosted and takes no per-session copy, so naming the deck
+    there means giving the session its own configuration. The configuration is
+    cloned from the account's default so every feature the dashboard enables
+    (cancel, update, invoice history, payment methods) is preserved, with only
+    the headline replaced. Returning None makes the caller fall back to the
+    account default: an unnamed portal is a far better outcome than no portal.
+
+    Args:
+        deck (Tenant): The deck being billed.
+
+    Returns:
+        str | None: The configuration id (``bpc_...``), or None if Stripe could
+        not provide one.
+    """
+    cache_key = _portal_configuration_cache_key(deck.schema_name)
+    configuration_id = cache.get(cache_key)
+    if configuration_id:
+        return configuration_id
+    try:
+        defaults = stripe.billing_portal.Configuration.list(
+            api_key=settings.STRIPE_SECRET_KEY, is_default=True, limit=1)
+        default = defaults.data[0]
+        configuration = stripe.billing_portal.Configuration.create(
+            api_key=settings.STRIPE_SECRET_KEY,
+            business_profile={
+                **to_plain_dict(default.business_profile),
+                'headline': f'Subscription for {deck_label(deck)}',
+            },
+            features=to_plain_dict(default.features),
+            metadata={'schema_name': deck.schema_name},
+        )
+    except (stripe.StripeError, IndexError, AttributeError) as e:
+        # no default configuration to clone, or Stripe refused the copy: the
+        # portal still works without a configuration, so never block on this
+        logger.warning("could not prepare a portal configuration for %s: %s", deck.schema_name, e)
+        return None
+    cache.set(cache_key, configuration.id, PORTAL_CONFIGURATION_CACHE_SECONDS)
+    return configuration.id
+
 
 def to_plain_dict(stripe_obj):
     """A stripe-python object (or a dict) as plain nested dicts/lists.
@@ -171,8 +243,14 @@ def create_checkout_session(deck):
         # the deck's existing trial ends
         subscription_data={
             'metadata': {'schema_name': deck.schema_name},
+            # the deck this pays for, in Stripe's own displayable field: the
+            # product name is the same for every deck on a tier, so this is what
+            # tells an owner with several decks which one they are paying for
+            'description': f'Deck: {deck_label(deck)}',
             **({'trial_end': int(trial_end.timestamp())} if trial_end else {}),
         },
+        # the same fact on the payment page itself, above the pay button
+        custom_text={'submit': {'message': f'You are subscribing the deck {deck_label(deck)}.'}},
         # Checkout substitutes the real session id into the literal placeholder
         success_url=deck.get_root_url() + reverse('decks:subscription_activating') + '?session_id={CHECKOUT_SESSION_ID}',
         cancel_url=_subscription_page_url(deck),
@@ -241,7 +319,10 @@ def create_portal_session(deck):
     """Create a Billing Portal session for a Stripe-linked deck; return its URL.
 
     The portal is where a linked deck renews, upgrades, changes card, or cancels
-    -- Stripe hosts all of it; we only need the customer id.
+    -- Stripe hosts all of it; we only need the customer id. The session carries
+    a configuration whose headline names the deck (see
+    :func:`portal_configuration_id`), so an owner with several decks can see
+    which one the portal is billing.
 
     Args:
         deck (Tenant): The current deck; must have a stripe_customer_id.
@@ -249,10 +330,14 @@ def create_portal_session(deck):
     Returns:
         str: The Stripe-hosted portal URL to redirect the owner to.
     """
+    configuration_id = portal_configuration_id(deck)
     session = stripe.billing_portal.Session.create(
         api_key=settings.STRIPE_SECRET_KEY,
         customer=deck.stripe_customer_id,
         return_url=_subscription_page_url(deck),
+        # a configuration headlined with the deck's domain; omitted when one
+        # could not be prepared, which falls back to the account default
+        **({'configuration': configuration_id} if configuration_id else {}),
     )
     return session.url
 
@@ -557,7 +642,32 @@ def _sync_deck_from_subscription_id(deck, subscription_id):
     if not settings.STRIPE_SECRET_KEY:
         return 'STRIPE_SECRET_KEY unset; retrieve skipped'
     subscription = to_plain_dict(stripe.Subscription.retrieve(subscription_id, api_key=settings.STRIPE_SECRET_KEY))
+    stamp_subscription_description(deck, subscription)
     return deck.sync_from_stripe_subscription(subscription)
+
+
+def stamp_subscription_description(deck, subscription):
+    """Best-effort: label the Stripe subscription with the deck it pays for.
+
+    Checkout sets this at creation, so this is the path that reaches everything
+    older: legacy subscriptions linked by hand, and anything created before the
+    label existed. Stripe shows the description alongside the plan, which is
+    what tells an owner with several decks which one a subscription belongs to.
+    Purely cosmetic, so a Stripe error is logged and swallowed: it must never
+    fail the sync it rides along with.
+
+    Args:
+        deck (Tenant): The deck the subscription pays for.
+        subscription (dict): The retrieved subscription, as a plain dict.
+    """
+    wanted = f'Deck: {deck_label(deck)}'
+    if subscription.get('description') == wanted:
+        return
+    try:
+        stripe.Subscription.modify(
+            subscription['id'], api_key=settings.STRIPE_SECRET_KEY, description=wanted)
+    except stripe.StripeError as e:
+        logger.warning("could not label subscription %s for %s: %s", subscription.get('id'), deck.schema_name, e)
 
 
 def handle_webhook_event(event):

--- a/src/tenant/billing.py
+++ b/src/tenant/billing.py
@@ -86,7 +86,15 @@ def deck_label(deck):
 
 
 def _portal_configuration_cache_key(schema_name):
-    """Cache key holding a deck's Billing Portal configuration id."""
+    """The cache key holding one deck's Billing Portal configuration id.
+
+    Args:
+        schema_name (str): The deck's schema name, which namespaces the entry so
+            decks never read each other's configuration.
+
+    Returns:
+        str: The key, ``stripe-portal-config:{schema_name}``.
+    """
     return f'stripe-portal-config:{schema_name}'
 
 
@@ -116,6 +124,9 @@ def portal_configuration_id(deck):
         defaults = stripe.billing_portal.Configuration.list(
             api_key=settings.STRIPE_SECRET_KEY, is_default=True, limit=1)
         default = defaults.data[0]
+        # the login page is a flag, not copyable state: its url is read-only and
+        # Stripe mints a fresh one per configuration, so only `enabled` carries over
+        login_page = to_plain_dict(default.login_page) if getattr(default, 'login_page', None) else {}
         configuration = stripe.billing_portal.Configuration.create(
             api_key=settings.STRIPE_SECRET_KEY,
             business_profile={
@@ -123,6 +134,7 @@ def portal_configuration_id(deck):
                 'headline': f'Subscription for {deck_label(deck)}',
             },
             features=to_plain_dict(default.features),
+            **({'login_page': {'enabled': True}} if login_page.get('enabled') else {}),
             metadata={'schema_name': deck.schema_name},
         )
     except (stripe.StripeError, IndexError, AttributeError) as e:
@@ -260,9 +272,12 @@ def create_checkout_session(deck):
         # while an identical retry still reuses the session
         # a customer-bound (renewal) session has different parameters than an
         # email-identified one, so it gets its own key: a deck that abandoned an
-        # unlinked checkout earlier the same day can still renew after linking
+        # unlinked checkout earlier the same day can still renew after linking.
+        # The v2 generation marks the request shape that carries the deck label:
+        # Stripe rejects a key replayed with different parameters for 24 hours,
+        # so a same-day retry across a deploy must not reuse the older key.
         idempotency_key=(
-            f'deck-checkout-{deck.schema_name}-{localdate()}'
+            f'deck-checkout-v2-{deck.schema_name}-{localdate()}'
             + (f'-trial-{int(trial_end.timestamp())}' if trial_end else '')
             + (f'-{deck.stripe_customer_id}' if deck.stripe_customer_id else '')
         ),

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -344,7 +344,7 @@ class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
         # must not fail the unmarked-key assertion
         self.assertEqual(
             kwargs['idempotency_key'],
-            f'deck-checkout-{self.tenant.schema_name}-{timezone.localdate()}')
+            f'deck-checkout-v2-{self.tenant.schema_name}-{timezone.localdate()}')
 
 
 @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
@@ -970,12 +970,21 @@ class DeckLabelOnStripeSurfacesTest(ByteDeckTenantTestCase):
         """Start each test with an empty portal-configuration cache."""
         cache.delete(_portal_configuration_cache_key(self.tenant.schema_name))
 
-    def default_configuration(self):
-        """A stand-in for the account's default portal configuration."""
+    def default_configuration(self, login_page_enabled=False):
+        """A stand-in for the account's default portal configuration.
+
+        Args:
+            login_page_enabled (bool): Whether the account's default offers the
+                hosted login page, which the clone has to carry over as a flag.
+
+        Returns:
+            Mock: The configuration double.
+        """
         return Mock(
             id='bpc_default',
             business_profile={'headline': 'ByteDeck Learning Society', 'privacy_policy_url': 'https://x.test/p'},
             features={'subscription_cancel': {'enabled': True}, 'invoice_history': {'enabled': True}},
+            login_page={'enabled': login_page_enabled, 'url': 'https://billing.stripe.test/p/login/x'},
         )
 
     def test_deck_label__is_the_decks_domain(self):
@@ -1013,6 +1022,36 @@ class DeckLabelOnStripeSurfacesTest(ByteDeckTenantTestCase):
         self.assertEqual(kwargs['features'], {'subscription_cancel': {'enabled': True}, 'invoice_history': {'enabled': True}})
         self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
         self.assertEqual(cache.get(_portal_configuration_cache_key(self.tenant.schema_name)), 'bpc_deck')
+
+    def test_portal_configuration_id__carries_the_default_login_page_setting(self):
+        """A default with the hosted login page enabled produces a clone with it
+        enabled too; a default without it produces a clone that omits the field.
+        Only the flag travels: the url is read-only and Stripe mints a fresh one
+        per configuration (review find on #2331)."""
+        with patch('tenant.billing.stripe.billing_portal.Configuration.list',
+                   return_value=Mock(data=[self.default_configuration(login_page_enabled=True)])), \
+                patch('tenant.billing.stripe.billing_portal.Configuration.create',
+                      return_value=Mock(id='bpc_deck')) as mock_create:
+            portal_configuration_id(self.tenant)
+        self.assertEqual(mock_create.call_args.kwargs['login_page'], {'enabled': True})
+
+        cache.delete(_portal_configuration_cache_key(self.tenant.schema_name))
+        with patch('tenant.billing.stripe.billing_portal.Configuration.list',
+                   return_value=Mock(data=[self.default_configuration(login_page_enabled=False)])), \
+                patch('tenant.billing.stripe.billing_portal.Configuration.create',
+                      return_value=Mock(id='bpc_deck')) as mock_create:
+            portal_configuration_id(self.tenant)
+        self.assertNotIn('login_page', mock_create.call_args.kwargs)
+
+    def test_create_checkout_session__idempotency_key_marks_the_labelled_request_shape(self):
+        """The key carries a v2 generation. Stripe rejects a key replayed within
+        24 hours with different parameters, and this release added the deck
+        label to the request, so a same-day retry across the deploy must not
+        reuse the pre-label key (review find on #2331)."""
+        with patch('tenant.billing.stripe.checkout.Session.create') as mock_create:
+            mock_create.return_value.url = 'https://stripe.example/session'
+            create_checkout_session(self.tenant)
+        self.assertTrue(mock_create.call_args.kwargs['idempotency_key'].startswith('deck-checkout-v2-'))
 
     def test_portal_configuration_id__served_from_cache_without_calling_stripe(self):
         """A cached configuration id is reused: no Stripe call, no second configuration."""

--- a/src/tenant/tests/test_billing.py
+++ b/src/tenant/tests/test_billing.py
@@ -13,9 +13,10 @@ from django_tenants.utils import schema_context
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from tenant.billing import (
-    _plan_summary_from_subscription, billing_configured, checkout_trial_end, clear_plan_summary_cache,
-    create_checkout_session, has_manageable_subscription, reconcile_checkout_session, subscription_period_end_date,
-    subscription_plan_summary,
+    _plan_summary_from_subscription, _portal_configuration_cache_key, billing_configured, checkout_trial_end,
+    clear_plan_summary_cache, create_checkout_session, create_portal_session, deck_label,
+    has_manageable_subscription, portal_configuration_id, reconcile_checkout_session, stamp_subscription_description,
+    subscription_period_end_date, subscription_plan_summary,
 )
 from tenant.models import Tenant
 
@@ -326,9 +327,8 @@ class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
         self.tenant.refresh_from_db()
         kwargs = self.create_session()
         expected = int(timezone.make_aware(datetime(2026, 9, 15, 0, 0)).timestamp())
-        self.assertEqual(
-            kwargs['subscription_data'],
-            {'metadata': {'schema_name': self.tenant.schema_name}, 'trial_end': expected})
+        self.assertEqual(kwargs['subscription_data']['metadata'], {'schema_name': self.tenant.schema_name})
+        self.assertEqual(kwargs['subscription_data']['trial_end'], expected)
         self.assertTrue(kwargs['idempotency_key'].endswith(f'-trial-{expected}'))
 
     def test_create_checkout_session__no_trial_end_when_not_applicable(self):
@@ -338,7 +338,8 @@ class CreateCheckoutSessionTrialEndTest(ByteDeckTenantTestCase):
         Tenant.objects.filter(pk=self.tenant.pk).update(trial_end_date=date(2026, 8, 10), paid_until=None)
         self.tenant.refresh_from_db()
         kwargs = self.create_session()
-        self.assertEqual(kwargs['subscription_data'], {'metadata': {'schema_name': self.tenant.schema_name}})
+        self.assertEqual(kwargs['subscription_data']['metadata'], {'schema_name': self.tenant.schema_name})
+        self.assertNotIn('trial_end', kwargs['subscription_data'])
         # the full base key, not a substring check: a schema name containing "trial"
         # must not fail the unmarked-key assertion
         self.assertEqual(
@@ -954,3 +955,118 @@ class ResolveDeckTest(ByteDeckTenantTestCase):
         self.tenant.refresh_from_db()
         self.assertEqual(self.tenant.stripe_customer_id, 'cus_only')
         self.assertEqual(self.tenant.stripe_subscription_id, '')
+
+
+@override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
+class DeckLabelOnStripeSurfacesTest(ByteDeckTenantTestCase):
+    """Every Stripe-hosted page an owner sees names the deck being billed.
+
+    The product ("Bytedeck Subscription - 120 Students") is identical for every
+    deck on a tier, so an owner with several decks could not tell which one a
+    checkout or portal belonged to (production find, 2026-08-10).
+    """
+
+    def setUp(self):
+        """Start each test with an empty portal-configuration cache."""
+        cache.delete(_portal_configuration_cache_key(self.tenant.schema_name))
+
+    def default_configuration(self):
+        """A stand-in for the account's default portal configuration."""
+        return Mock(
+            id='bpc_default',
+            business_profile={'headline': 'ByteDeck Learning Society', 'privacy_policy_url': 'https://x.test/p'},
+            features={'subscription_cancel': {'enabled': True}, 'invoice_history': {'enabled': True}},
+        )
+
+    def test_deck_label__is_the_decks_domain(self):
+        """The label is the deck's primary domain, the name its owner knows it by."""
+        self.assertEqual(deck_label(self.tenant), self.tenant.primary_domain_url)
+
+    def test_create_checkout_session__names_the_deck_on_the_payment_page_and_subscription(self):
+        """Checkout carries the deck two ways Stripe displays: the subscription
+        description (which follows the subscription onto the portal and invoices)
+        and the custom text above the pay button."""
+        with patch('tenant.billing.stripe.checkout.Session.create') as mock_create:
+            mock_create.return_value.url = 'https://stripe.example/session'
+            create_checkout_session(self.tenant)
+        kwargs = mock_create.call_args.kwargs
+        self.assertEqual(kwargs['subscription_data']['description'], f'Deck: {self.tenant.primary_domain_url}')
+        self.assertEqual(
+            kwargs['custom_text'],
+            {'submit': {'message': f'You are subscribing the deck {self.tenant.primary_domain_url}.'}})
+        # the schema stamping the webhooks rely on is untouched
+        self.assertEqual(kwargs['subscription_data']['metadata'], {'schema_name': self.tenant.schema_name})
+
+    def test_portal_configuration_id__clones_the_default_with_a_deck_headline(self):
+        """The deck's configuration copies the account default's features (so no
+        portal capability is lost) and replaces only the headline; the id is
+        cached so later portal visits reuse the same configuration."""
+        with patch('tenant.billing.stripe.billing_portal.Configuration.list',
+                   return_value=Mock(data=[self.default_configuration()])), \
+                patch('tenant.billing.stripe.billing_portal.Configuration.create',
+                      return_value=Mock(id='bpc_deck')) as mock_create:
+            self.assertEqual(portal_configuration_id(self.tenant), 'bpc_deck')
+        kwargs = mock_create.call_args.kwargs
+        self.assertEqual(kwargs['business_profile']['headline'], f'Subscription for {self.tenant.primary_domain_url}')
+        # the default's other business-profile fields and ALL its features survive
+        self.assertEqual(kwargs['business_profile']['privacy_policy_url'], 'https://x.test/p')
+        self.assertEqual(kwargs['features'], {'subscription_cancel': {'enabled': True}, 'invoice_history': {'enabled': True}})
+        self.assertEqual(kwargs['metadata'], {'schema_name': self.tenant.schema_name})
+        self.assertEqual(cache.get(_portal_configuration_cache_key(self.tenant.schema_name)), 'bpc_deck')
+
+    def test_portal_configuration_id__served_from_cache_without_calling_stripe(self):
+        """A cached configuration id is reused: no Stripe call, no second configuration."""
+        cache.set(_portal_configuration_cache_key(self.tenant.schema_name), 'bpc_cached', 60)
+        with patch('tenant.billing.stripe.billing_portal.Configuration.create') as mock_create:
+            self.assertEqual(portal_configuration_id(self.tenant), 'bpc_cached')
+        mock_create.assert_not_called()
+
+    def test_portal_configuration_id__none_when_stripe_cannot_provide_one(self):
+        """A Stripe failure (or an account with no default configuration) yields
+        None rather than raising: an unnamed portal beats no portal at all."""
+        import stripe as stripe_lib
+
+        with patch('tenant.billing.stripe.billing_portal.Configuration.list',
+                   side_effect=stripe_lib.StripeError('nope')):
+            self.assertIsNone(portal_configuration_id(self.tenant))
+        with patch('tenant.billing.stripe.billing_portal.Configuration.list', return_value=Mock(data=[])):
+            self.assertIsNone(portal_configuration_id(self.tenant))
+
+    def test_create_portal_session__passes_the_deck_configuration_and_survives_without_one(self):
+        """The portal session carries the deck's configuration; when none could
+        be prepared the session is created without one (the account default)."""
+        Tenant.objects.filter(pk=self.tenant.pk).update(stripe_customer_id='cus_1')
+        self.tenant.refresh_from_db()
+        with patch('tenant.billing.portal_configuration_id', return_value='bpc_deck'), \
+                patch('tenant.billing.stripe.billing_portal.Session.create',
+                      return_value=Mock(url='https://portal.test/s')) as mock_create:
+            create_portal_session(self.tenant)
+        self.assertEqual(mock_create.call_args.kwargs['configuration'], 'bpc_deck')
+
+        with patch('tenant.billing.portal_configuration_id', return_value=None), \
+                patch('tenant.billing.stripe.billing_portal.Session.create',
+                      return_value=Mock(url='https://portal.test/s')) as mock_create:
+            create_portal_session(self.tenant)
+        self.assertNotIn('configuration', mock_create.call_args.kwargs)
+
+    def test_stamp_subscription_description__labels_legacy_subscriptions_once(self):
+        """Syncing a subscription labels it with the deck (the path that reaches
+        legacy links and anything created before the label existed), and skips
+        the write when the label is already right."""
+        with patch('tenant.billing.stripe.Subscription.modify') as mock_modify:
+            stamp_subscription_description(self.tenant, {'id': 'sub_1', 'description': None})
+        self.assertEqual(mock_modify.call_args.args, ('sub_1',))
+        self.assertEqual(mock_modify.call_args.kwargs['description'], f'Deck: {self.tenant.primary_domain_url}')
+
+        with patch('tenant.billing.stripe.Subscription.modify') as mock_modify:
+            stamp_subscription_description(
+                self.tenant, {'id': 'sub_1', 'description': f'Deck: {self.tenant.primary_domain_url}'})
+        mock_modify.assert_not_called()
+
+    def test_stamp_subscription_description__stripe_error_never_fails_the_sync(self):
+        """The label is cosmetic: a Stripe failure is logged and swallowed so the
+        billing sync it rides along with still completes."""
+        import stripe as stripe_lib
+
+        with patch('tenant.billing.stripe.Subscription.modify', side_effect=stripe_lib.StripeError('boom')):
+            stamp_subscription_description(self.tenant, {'id': 'sub_1', 'description': ''})


### PR DESCRIPTION
### What

Stripe's hosted pages showed no sign of **which deck** was being paid for (production find, 2026-08-10). The product name is identical for every deck on a tier ("Bytedeck Subscription - 120 Students"), so an owner with more than one deck could not tell, on the checkout page or in the billing portal, which deck they were subscribing or cancelling. This puts the deck's domain into each place Stripe will display it:

- **Checkout**: the session now carries `subscription_data.description` (`Deck: hackerspace.bytedeck.com`), which Stripe attaches to the subscription itself and shows on its own surfaces and on invoices, plus `custom_text.submit.message` ("You are subscribing the deck hackerspace.bytedeck.com.") right above the pay button.
- **Billing portal**: the portal takes no per-session copy, so naming the deck there means giving the session its own configuration. `portal_configuration_id()` clones the account's **default** configuration, so every feature the dashboard enables (cancel, update, invoice history, payment methods) is preserved, and replaces only `business_profile.headline` with "Subscription for `<deck domain>`". The id is cached per deck for 30 days, so a portal visit normally costs no extra Stripe calls.
- **Legacy and hand-linked subscriptions**: `stamp_subscription_description()` rides along with the existing sync path (the "Sync selected deck(s) from Stripe" admin action and the webhook sync), so subscriptions created before this, or linked by hand during the go-live backfill, get the same label on their next sync. It skips the write when the label is already correct.

Both new Stripe touchpoints are best-effort by design: if the configuration cannot be prepared (no default to clone, or any Stripe error), the portal session is created without one and behaves exactly as it does today; if the description stamp fails, it is logged and the billing sync it rides along with still completes. Naming a deck is never allowed to break billing.

**Deliberate non-change**: the configuration id is cached rather than stored on `Tenant`. A new field would mean a `0026` migration on `staging` colliding with `0026_releasenotification` on `develop`, forcing a merge migration during the next merge-back. The cost is that a cache eviction mints a fresh configuration for that deck, leaving the previous one unused on the account; the configurations carry `metadata.schema_name` so they are identifiable in the dashboard.

**HOTFIX to `staging`**: owners are on live billing pages now.

### Testing

New `DeckLabelOnStripeSurfacesTest` covers: the label is the deck's domain; checkout sends both the description and the custom text while keeping the schema metadata the webhooks depend on; the portal configuration clones the default's features and other business-profile fields and replaces only the headline, then caches the id; a cached id is reused without calling Stripe; a Stripe error or an account with no default configuration yields None; the portal session passes the configuration when there is one and omits it when there is not; and the description stamp writes once, skips when already correct, and swallows Stripe errors. Two existing trial-end assertions were narrowed to the fields they are actually about, since `subscription_data` now always carries the description.

Full suite (2047 tests), ruff, and `makemigrations --check` pass locally.

### Screenshots

N/A: the changed surfaces are Stripe-hosted pages, which cannot be rendered from this sandbox (they need a live Stripe session against your account). The exact strings sent to Stripe are pinned by the tests quoted above. Worth eyeballing on staging in test mode after merge: the checkout page's text above the pay button, and the portal headline.

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deck-specific labels to checkout pages, subscription descriptions, and billing portal experiences.
  * Added customized billing portal configurations for each deck, with caching for faster access.
* **Bug Fixes**
  * Billing portal creation now falls back gracefully when customized configuration setup fails.
  * Existing subscriptions are labeled on a best-effort basis without interrupting billing synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->