### PR TITLE
test: say where the remaining bare 302 assertions land

### DIFF
--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -1,6 +1,7 @@
 import re
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.shortcuts import reverse
@@ -45,7 +46,8 @@ class NonPublicOnlyAuthViewTests(ByteDeckTenantTestCase):
         """
         self.assert200('account_signup')  # ok
         self.assert200('account_login')  # ok
-        self.assert302('account_logout')  # redirect
+        # logging out lands on ACCOUNT_LOGOUT_REDIRECT_URL, which this project points at the login page
+        self.assertRedirects(self.client.get(reverse('account_logout')), reverse(settings.LOGIN_URL))
         self.assertRedirectsLogin('account_change_password')  # login required
         self.assertRedirectsLogin('account_set_password')  # login required
         self.assert200('account_inactive')  # ok

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -15,7 +15,6 @@ from model_bakery import baker
 
 import json
 import re
-import warnings
 
 from urllib.parse import urlencode
 
@@ -43,20 +42,20 @@ class ViewTestUtilsMixin():
     than being silently redundant. Only a test case built on some other base needs it.
     """
 
-    def assertRedirectsAdmin(self, url_name, *args, **kwargs):
+    def assertRedirectsAdminLogin(self, url_name, *args, **kwargs):
         """
-        Redirection to django admin is now deprecated.
-        Use assertRedirectsLogin(self, url_name, *args, **kwargs) instead.
+        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the django
+        admin's own login page, with appropriate ?next= query string. Provide any url and path
+        parameters as args or kwargs.
 
-        Assert that a GET response to reverse(url_name, *args, **kwargs) redirected to the admin login page.
-        with appropriate ?next= query string. Provide any url and path parameters as args or kwargs.
-
+        This is for urls under /admin/ only. The admin sends an unauthenticated visitor to
+        ``admin:login``, not to ``settings.LOGIN_URL``, so assertRedirectsLogin is the wrong
+        assertion there; for the site's own views it is the right one.
         """
-        warnings.warn("Redirection to django admin is now deprecated.\nUse assertRedirectsLogin(self, url_name, *args, **kwargs) instead...",
-                      stacklevel=2)
+        target = reverse(url_name, *args, **kwargs)
         self.assertRedirects(
-            response=self.client.get(reverse(url_name, *args, **kwargs)),
-            expected_url='{}?next={}'.format('/admin/login/', reverse(url_name, *args, **kwargs)),
+            response=self.client.get(target),
+            expected_url=f'{reverse("admin:login")}?{urlencode({"next": target})}',
         )
 
     def assertRedirectsHome(self, url_name, *args, **kwargs):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -156,7 +156,11 @@ class QuestViewQuickTests(ByteDeckTenantTestCase):
         self.assert200('quests:quest_copy', args=[q_pk])
         self.assert200('quests:quest_user_status', args=[q_pk])
         self.assert200('quests:quest_prereqs_update', args=[q_pk])
-        self.assert302('quests:unarchive', args=[archived_quest_pk])
+        # unarchiving unpublishes the quest, so it lands on the Drafts tab where the quest now is
+        self.assertRedirects(
+            response=self.client.get(reverse('quests:unarchive', args=[archived_quest_pk])),
+            expected_url=reverse('quests:drafts'),
+        )
 
         self.assert200('quests:summary', args=[q_pk])
         self.assertEqual(self.client.get(reverse('quests:ajax_summary_histogram', args=[q_pk])).status_code, 403)  # Ajax only
@@ -401,11 +405,11 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assert403('quests:unflag', args=[s1_pk])
         self.assert404('quests:complete', args=[s1_pk])
 
-        # Not this student's submission
-        self.assert302('quests:submission', args=[s2_pk])
-        self.assert302('quests:drop', args=[s2_pk])
+        # Not this student's submission: sent back to their own quests page, not shown someone else's work
+        self.assertRedirectsQuests('quests:submission', args=[s2_pk])
+        self.assertRedirectsQuests('quests:drop', args=[s2_pk])
         self.assert404('quests:skip', args=[s2_pk])
-        self.assert302('quests:submission_past', args=[s2_pk])
+        self.assertRedirectsQuests('quests:submission_past', args=[s2_pk])
         self.assert404('quests:complete', args=[s2_pk])
 
         # Non existent submissions
@@ -666,7 +670,11 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
 
         # These Needs to be completed via POST
         # self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
-        self.assert302('quests:skip', args=[s1_pk])
+        # skipping is a staff transfer, so it returns the teacher to the approvals queue
+        self.assertRedirects(
+            response=self.client.get(reverse('quests:skip', args=[s1_pk])),
+            expected_url=reverse('quests:approvals'),
+        )
         self.assert404('quests:approve', args=[s1_pk])
 
     def test_submission__quest_not_visible_returns_404(self):

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -274,8 +274,8 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         Test whether content of custom column "owner_full_name_text" is present in admin list view or not.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -300,8 +300,8 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         Test whether content of custom column "owner_email_text" is present in admin list view or not.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -317,8 +317,8 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         Test whether content of htmlized column "paid_until_text" is present in admin list view or not.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -333,8 +333,8 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         Test whether content of htmlized column "trial_end_date" is present in admin list view or not.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -377,8 +377,8 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         Test whether content of custom fields is searchable in admin list view or not.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -1015,8 +1015,8 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
         using both *verified* and *unverified* email addresses.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 
@@ -1100,8 +1100,8 @@ class TenantAdminActionsTest(ByteDeckTenantTestCase):
         using *verified* only email addresses.
         """
         # first case, access /admin/tenant/ page as anonymous user
-        # should returns 302 (login required)
-        self.assert302("admin:{}_{}_changelist".format("tenant", "tenant"))
+        # should be sent to the admin login page, carrying the page asked for in ?next=
+        self.assertRedirectsAdminLogin("admin:{}_{}_changelist".format("tenant", "tenant"))
 
         self.client.force_login(self.superuser)
 

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -890,8 +890,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
     def test_page__staff_only(self):
         """Anonymous users are redirected to login; students get 403; staff get 200."""
         self.client.logout()
-        response = self.assert302('decks:subscription')
-        self.assertIn('login', response.url)
+        self.assertRedirectsLogin('decks:subscription')
 
         self.client.force_login(self.student)
         self.assert403('decks:subscription')


### PR DESCRIPTION
### What?

Replaces the remaining `assert302` calls that were hiding a real destination with assertions that name it, and turns the unused, deprecated `assertRedirectsAdmin` helper into a working `assertRedirectsAdminLogin`.

### Why?

`assert302` proves a view redirected, not where to. That is fine when the redirect is the endpoint doing its job (the permission umbrellas), but several of these were standing in for behaviour worth pinning:

```python
# Not this student's submission
self.assert302('quests:submission', args=[s2_pk])
self.assert302('quests:drop', args=[s2_pk])
```

That is the authorization boundary between two students' work. It passes whether the view sends the student back to their own quests page or forwards them to a page about someone else's submission, and it passes if the destination silently changes to anything at all. The same for an anonymous request to the tenant admin: a 302 could be the admin login, or it could be a redirect off to the public tenant.

### How?

Each of the following now asserts a destination:

* a student opening **another student's** submission, drop or past-submission page goes back to their own quests page (`assertRedirectsQuests`),
* a teacher **skipping** a submission returns to the approvals queue,
* **unarchiving** a quest lands on the Drafts tab, which is where unarchiving just put the quest,
* **logging out** lands on the login page (`ACCOUNT_LOGOUT_REDIRECT_URL`),
* an anonymous request for the **tenant admin changelist** goes to the admin login carrying the page it asked for in `?next=` (7 call sites),
* `decks:subscription` uses `assertRedirectsLogin` instead of a 302 plus `assertIn('login', response.url)`, which would also have accepted, say, `/blogin-widget/`.

The admin case needs its own helper, because the django admin sends unauthenticated visitors to `admin:login` and not to `settings.LOGIN_URL`, so `assertRedirectsLogin` is the wrong assertion for an `/admin/` url. `ViewTestUtilsMixin` already had that helper: `assertRedirectsAdmin`, called from nowhere, emitting a `DeprecationWarning` telling callers to use `assertRedirectsLogin` instead. It becomes `assertRedirectsAdminLogin` with the warning dropped, a docstring saying when each of the two is right, `reverse('admin:login')` instead of a hard-coded `/admin/login/`, and `urlencode` for the `?next=` value like `login_url_with_next` does.

The `assert302` calls left alone are the ones inside the student and teacher permission umbrellas (`quests:start`, `quests:hide`, `profiles:comment_ban` and friends), where the 302 means the endpoint ran and #2327 covers what it did.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2070 tests in 295.934s

OK
```

`ruff check src` passes.

The new assertions were checked for real: the tenant admin destination was confirmed by running `tenant.tests.test_admin` (71 tests) against `admin:login` rather than assuming it, and `quest_manager.tests.test_views` (230 tests) plus `hackerspace_online.tests.test_auth` and `tenant.tests.test_views` (95 tests) all pass with the named targets.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, test-only change with no front-end or user-visible effect.

### Anything Else?

Sixth in the test-suite cleanup after #2306, #2309, #2321, #2322 and #2327. #2322 made the anonymous redirect assertions say where they went; this one finishes that job for the redirects that were not anonymous, and clears the last dead helper the earlier passes left behind.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened authentication and admin access checks to verify redirects to the configured login page, including the original destination.
  - Updated quest workflow tests to confirm correct redirects when unarchiving, accessing unauthorized submissions, and skipping submissions.
  - Standardized subscription access tests to use shared login redirect assertions.
  - Improved test helpers for validating admin login redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->