### PR TITLE
test: cover what skipping a quest actually does

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -944,14 +944,24 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
         response = self.client.post(reverse('quests:complete', args=[sub.id]), data={'complete': True})
         self.assertEqual(response.status_code, 404)
 
-    def test_skip__student_not_earning_xp_redirects_to_quests(self):
-        """A non-staff student who is not earning XP can skip their own submission and is sent to the quest list."""
+    def test_skip__student_not_earning_xp_transfers_their_own_submission(self):
+        """A student who is not earning XP can skip their own submission: it is approved as a transfer.
+
+        Transfer students carry their marks in from elsewhere, so the quest has to end up approved
+        (it counts as done, and unlocks whatever it is a prerequisite for) while granting no XP.
+        """
         profile = self.test_student.profile
         profile.not_earning_xp = True
         profile.save()
 
         response = self.client.get(reverse('quests:skip', args=[self.sub.id]))
+
         self.assertRedirects(response, reverse('quests:quests'), fetch_redirect_response=False)
+        self.sub.refresh_from_db()
+        self.assertTrue(self.sub.is_completed)
+        self.assertTrue(self.sub.is_approved)
+        self.assertTrue(self.sub.do_not_grant_xp)
+        self.assertSuccessMessage(response)
 
     def post_complete(self, button='complete', submission_comment="test comment", teachers_list=None):
         """ Convenience method for posting the complete() view.
@@ -2613,6 +2623,88 @@ class HideQuestViewTests(ByteDeckTenantTestCase):
 
         self.test_student.profile.refresh_from_db()
         self.assertEqual(self.test_student.profile.get_hidden_quests_as_list(), [])
+
+
+class SkipQuestViewTests(ByteDeckTenantTestCase):
+    """Tests skipping a quest, which approves it as a transfer: done, but worth no XP.
+
+    Two urls reach the same code. `quests:skip` transfers a submission that already exists, and
+    `quests:skip_for_quest` starts the quest first, so a teacher can transfer a quest the student
+    never opened.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a teacher, a transfer student, a regular student, and a quest worth XP."""
+        cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.transfer_student = User.objects.create_user('transfer_student')
+        cls.test_student = User.objects.create_user('test_student')
+
+        cls.semester = SiteConfig.get().active_semester
+        cls.quest = baker.make(Quest, xp=25)
+        cls.submission = baker.make(
+            QuestSubmission, user=cls.transfer_student, quest=cls.quest, semester=cls.semester,
+        )
+
+    def test_skip__teacher_approves_the_submission_as_a_transfer(self):
+        """A teacher skipping a submission marks it completed and approved, and back to the approvals queue."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:skip', args=[self.submission.pk]))
+
+        self.assertRedirects(response, reverse('quests:approvals'), fetch_redirect_response=False)
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.is_completed)
+        self.assertTrue(self.submission.is_approved)
+        self.assertSuccessMessage(response)
+
+    def test_skip__grants_the_student_no_xp(self):
+        """The point of skipping: the quest is approved, but its XP is not added to the student's total."""
+        self.client.force_login(self.test_teacher)
+        xp_before = self.transfer_student.profile.xp_cached
+
+        self.client.get(reverse('quests:skip', args=[self.submission.pk]))
+
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.do_not_grant_xp)
+        self.transfer_student.profile.refresh_from_db()
+        self.assertEqual(self.transfer_student.profile.xp_cached, xp_before)
+
+    def test_skip__student_still_earning_xp_cannot_skip_their_own_submission(self):
+        """A student who is earning XP gets a 404, and their submission is left untouched.
+
+        Skipping is otherwise a free approval, so it is limited to staff and to students marked
+        as not earning XP.
+        """
+        self.client.force_login(self.transfer_student)
+
+        self.assert404('quests:skip', args=[self.submission.pk])
+
+        self.submission.refresh_from_db()
+        self.assertFalse(self.submission.is_approved)
+
+    def test_skip_for_quest__starts_the_quest_then_transfers_it(self):
+        """Skipping a quest the student never started creates the submission and approves it as a transfer."""
+        profile = self.test_student.profile
+        profile.not_earning_xp = True
+        profile.save()
+        self.client.force_login(self.test_student)
+        self.assertFalse(QuestSubmission.objects.filter(user=self.test_student, quest=self.quest).exists())
+
+        response = self.client.get(reverse('quests:skip_for_quest', args=[self.quest.pk]))
+
+        self.assertRedirects(response, reverse('quests:quests'), fetch_redirect_response=False)
+        submission = QuestSubmission.objects.get(user=self.test_student, quest=self.quest)
+        self.assertTrue(submission.is_approved)
+        self.assertTrue(submission.do_not_grant_xp)
+
+    def test_skip_for_quest__nonexistent_quest_is_a_404(self):
+        """A skip url for a missing quest 404s rather than creating a submission for nothing."""
+        self.client.force_login(self.test_teacher)
+
+        self.assert404('quests:skip_for_quest', args=[0])
+
+        self.assertFalse(QuestSubmission.objects.filter(user=self.test_teacher).exists())
 
 
 class QuestListViewTest(ByteDeckTenantTestCase):


### PR DESCRIPTION
### What?

Adds `SkipQuestViewTests` (five tests) for `quests:skip` and `quests:skip_for_quest`, and strengthens the one existing skip test so it asserts the transfer rather than only the redirect.

### Why?

Skipping approves a quest as a transfer: `mark_completed()` then `mark_approved(transfer=True)`, so the submission ends up done, unlocking whatever it is a prerequisite for, while granting no XP. Nothing asserted any of that. The whole of its coverage was where it lands and who is turned away:

```python
self.assert404('quests:skip', args=[s1_pk])                       # student earning XP
self.assertRedirects(..., expected_url=reverse('quests:approvals'))  # teacher
self.assertRedirects(response, reverse('quests:quests'), ...)      # transfer student
```

Both urls could have redirected exactly where they do today and approved nothing, and the suite would have stayed green.

`quests:skip_for_quest` was worse off: its only appearance in the whole suite is `self.assert404('quests:skip_for_quest', args=[q_pk])` inside the student permission umbrella. That line does execute the view (it starts the quest, then `skip()` raises the 404), so the lines counted as covered while nothing checked the behaviour they exist for.

This is not a quiet corner of the app either. Skipping is a free approval: it marks a quest done without the work, so the staff-only limit and the "no XP" half both matter.

### How?

`SkipQuestViewTests` in `quest_manager/tests/test_views.py`, with a quest worth 25 XP and a transfer student holding a submission for it:

* **teacher skip** marks the submission completed and approved and returns to the approvals queue with a success message,
* **no XP is granted**: the submission ends up `do_not_grant_xp`, and the student's `xp_cached` is unchanged after the skip,
* a **student who is still earning XP** gets a 404 on their own submission, and the submission is left unapproved. Skipping is otherwise a free approval, so this is the line that keeps it staff-only,
* **skip_for_quest** on a quest the student never started creates the submission and approves it as a transfer, which is the whole point of that second url,
* **skip_for_quest for a nonexistent quest** is a 404 with no submission created.

`test_skip__student_not_earning_xp_redirects_to_quests` becomes `test_skip__student_not_earning_xp_transfers_their_own_submission`: it keeps the redirect assertion and adds the completed/approved/`do_not_grant_xp` state and the success message.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2086 tests in 319.032s

OK
```

`ruff check src` passes.

The tests were checked against a broken view, not just a passing one: dropping the `submission.mark_approved(transfer=True)` line from `skip()` fails 3 of the 5 new tests (the other two cover the 404 paths, which that line does not reach). `views.py` was restored afterwards and is not part of this diff.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, test-only change with no front-end or user-visible effect.

### Anything Else?

Seventh in the test-suite cleanup after #2306, #2309, #2321, #2322, #2327 and #2333. #2327 pinned the hide and ban endpoints; this is the same gap on the skip pair, which #2333 left asserting only its destination.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quest-skipping behavior for eligible students.
  * Skipped quests now correctly approve and complete submissions without awarding XP.
  * Added appropriate redirects when skipping quests, including when starting an unstarted quest.
  * Students without eligibility are rejected, and missing quests return a not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->