### PR TITLE
test: answer the flagged_by TODO instead of asserting a stale object

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -643,20 +643,20 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
 
         # View it
         self.assert200('quests:submission', args=[s1_pk])
-        # Flag it
-        # self.assertEqual(self.client.get(reverse('quests:flag', args=[s1_pk])).status_code, 200)
+        # Flag it: the view updates the row, so this object has to be re-read to see it
         self.assertRedirects(
             response=self.client.get(reverse('quests:flag', args=[s1_pk])),
             expected_url=reverse('quests:approvals'),
         )
-        # TODO Why does this fail? Why is self.sub1.flagged_by == None
-        # self.assertEqual(self.sub1.flagged_by, self.test_teacher)
+        self.sub1.refresh_from_db()
+        self.assertEqual(self.sub1.flagged_by, self.test_teacher)
 
         # Unflag it
         self.assertRedirects(
             response=self.client.get(reverse('quests:unflag', args=[s1_pk])),
             expected_url=reverse('quests:approvals'),
         )
+        self.sub1.refresh_from_db()
         self.assertIsNone(self.sub1.flagged_by)
 
         # self.assertEqual(self.client.get(reverse('quests:drop', args=[s1_pk])).status_code, 200)
@@ -2623,6 +2623,59 @@ class HideQuestViewTests(ByteDeckTenantTestCase):
 
         self.test_student.profile.refresh_from_db()
         self.assertEqual(self.test_student.profile.get_hidden_quests_as_list(), [])
+
+
+class FlagSubmissionViewTests(ByteDeckTenantTestCase):
+    """Tests flagging a submission for follow up, and unflagging it again.
+
+    Flagging records which teacher raised it, so the flag is attributable rather than anonymous
+    on a deck with several teachers.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create two teachers, a student, and a submission for them to flag."""
+        cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.other_teacher = User.objects.create_user('other_teacher', is_staff=True)
+        cls.test_student = User.objects.create_user('test_student')
+
+        cls.quest = baker.make(Quest)
+        cls.submission = baker.make(
+            QuestSubmission, user=cls.test_student, quest=cls.quest,
+            semester=SiteConfig.get().active_semester,
+        )
+
+    def test_flag__records_which_teacher_raised_it(self):
+        """Flagging stores the teacher who flagged it, not merely that a flag exists."""
+        self.client.force_login(self.other_teacher)
+
+        response = self.client.get(reverse('quests:flag', args=[self.submission.pk]))
+
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.flagged_by, self.other_teacher)
+        self.assertSuccessMessage(response)
+
+    def test_unflag__clears_the_flag_and_says_which_submission(self):
+        """Unflagging clears the flag and reports the quest and student, so the right one is confirmed."""
+        self.submission.flagged_by = self.test_teacher
+        self.submission.save()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:unflag', args=[self.submission.pk]))
+
+        self.submission.refresh_from_db()
+        self.assertIsNone(self.submission.flagged_by)
+        self.assertSuccessMessage(response)
+        message = self.get_message_list(response)[0].message
+        self.assertIn(self.quest.name, message)
+        self.assertIn(str(self.test_student), message)
+
+    def test_flag__nonexistent_submission_is_a_404(self):
+        """A flag url for a missing submission 404s rather than reporting a flag it did not set."""
+        self.client.force_login(self.test_teacher)
+
+        self.assert404('quests:flag', args=[0])
+        self.assert404('quests:unflag', args=[0])
 
 
 class SkipQuestViewTests(ByteDeckTenantTestCase):

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2266,7 +2266,7 @@ def ajax_submission_count(request):
 def flag(request, submission_id):
     sub = get_object_or_404(QuestSubmission, pk=submission_id)
 
-    # approve quest automatically, and mark as transfer.
+    # record who raised the flag, so it is attributable on a deck with several teachers
     sub.flagged_by = request.user
     sub.save()
 
@@ -2294,7 +2294,6 @@ def ajax_flag(request):
 def unflag(request, submission_id):
     sub = get_object_or_404(QuestSubmission, pk=submission_id)
 
-    # approve quest automatically, and mark as transfer.
     sub.flagged_by = None
     sub.save()
 


### PR DESCRIPTION
### What?

Restores the disabled `flagged_by` assertion in the teacher submission test, fixes the assertion below it that was passing for the wrong reason, and adds `FlagSubmissionViewTests` for what flagging and unflagging actually do.

### Why?

The test carried an open question:

```python
# TODO Why does this fail? Why is self.sub1.flagged_by == None
# self.assertEqual(self.sub1.flagged_by, self.test_teacher)

# Unflag it
self.assertRedirects(...)
self.assertIsNone(self.sub1.flagged_by)
```

The answer is that `self.sub1` is built once in `setUpTestData` and never re-read, so it still holds the values it had before the request. The view updated the row; the Python object in the test did not hear about it.

That also means the surviving `assertIsNone` was passing for exactly the same reason, not because unflagging works. It reads like the unflag is verified, but `flagged_by` on that object was `None` the whole time: it would pass just as happily if `unflag()` were a no-op.

So the pair of urls that teachers use to mark a submission for follow up had **no** assertion that flagging records anything, and a green assertion that unflagging works which could not fail.

### How?

* `refresh_from_db()` after each request, then the real assertions: `flagged_by` is the teacher who flagged it, and `None` again after unflagging. The TODO goes away because it is answered.
* `FlagSubmissionViewTests` covers the parts the umbrella does not:
  * flagging records **which** teacher raised it (a second teacher does the flagging, so the test would fail if the view stored the wrong user or merely a boolean),
  * unflagging clears it and reports the quest name and student in its message, so a teacher confirms the submission they meant,
  * both urls 404 on a submission that does not exist.
* Both views carried the same copy-paste comment, `# approve quest automatically, and mark as transfer.`, which describes `skip()` rather than flagging. Flagging approves nothing. The one above `flag()` is replaced with what that line is actually for (attribution), and the stray one above `unflag()` is dropped.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2089 tests in 316.792s

OK
```

`ruff check src` passes.

Checked against a broken view, not just a passing one: dropping `sub.flagged_by = request.user; sub.save()` from `flag()` fails 2 tests (the restored umbrella assertion and the attribution test). Before this change, that same sabotage left the suite green. `views.py` was restored afterwards; the only view change here is the comment.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, no front-end or user-visible change. The one source change is a comment.

### Anything Else?

Eighth in the test-suite cleanup after #2306, #2309, #2321, #2322, #2327, #2333 and #2334. #2334 covered the skip pair; this is the flag pair, where the gap was hiding behind a TODO rather than behind a bare status code.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission flagging behavior to accurately record and display the teacher responsible for a flag.
  * Clarified success messaging when flags are removed.
  * Added proper handling for attempts to flag nonexistent submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->