### PR TITLE
HOTFIX: fix: make the tenant admin's Subscription column sortable

### DIFF
--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -16,6 +16,7 @@ from django.utils.html import format_html
 from django.utils.formats import date_format
 from django.urls import reverse
 
+
 from allauth.socialaccount.models import SocialApp
 from allauth.account.models import EmailAddress
 from allauth.account.utils import user_email

--- a/src/tenant/admin.py
+++ b/src/tenant/admin.py
@@ -380,12 +380,26 @@ class TenantAdmin(PublicSchemaOnlyAdminAccessMixin, admin.ModelAdmin):
                     return True
         return False
 
-    @admin.display(description="subscription")
+    def get_queryset(self, request):
+        """The changelist queryset, with each deck's lifecycle status ranked in SQL
+        so the Subscription column can be sorted on.
+
+        Args:
+            request (HttpRequest): The admin request.
+
+        Returns:
+            QuerySet: Tenants annotated with `subscription_status_rank`.
+        """
+        return Tenant.annotate_subscription_status(super().get_queryset(request))
+
+    @admin.display(description="subscription", ordering="subscription_status_rank")
     def subscription_status_text(self, obj):
         """The deck's lifecycle status as a colored badge: the same status (and
         the same word) the deck owner sees on their subscription details page,
         both rendered from the shared ``Tenant.subscription_status`` precedence
-        chain so the two can never disagree.
+        chain so the two can never disagree. Sorting the column orders by the
+        matching SQL ranking annotation (see ``get_queryset``), which puts the
+        decks needing attention first.
 
         Args:
             obj (Tenant): The changelist row's tenant.

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -4,6 +4,7 @@ from datetime import date
 from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
+from django.db.models.functions import Greatest
 from django.utils.timezone import localdate, now, timedelta
 from django.contrib.auth import get_user_model
 
@@ -308,13 +309,17 @@ class Tenant(TenantMixin):
 
     # one human label per subscription_status slug; the subscription page's badge
     # and the tenant admin's Subscription column both render from this map, so
-    # the same state always shows the same word everywhere
+    # the same state always shows the same word everywhere. The KEY ORDER is
+    # meaningful: it is the branch order of the subscription_status chain below,
+    # and doubles as the sort rank annotate_subscription_status() applies, so
+    # sorting the admin's Subscription column ascending lists the decks that
+    # need attention (suspended, then grace) before the settled ones.
     SUBSCRIPTION_STATUS_LABELS = {
         'suspended': 'Suspended',
         'grace': 'Grace period',
+        'trial': 'Free trial',
         'maintenance': 'Maintenance',
         'subscribed': 'Subscribed',
-        'trial': 'Free trial',
         'manual': 'Managed manually',
     }
 
@@ -352,6 +357,64 @@ class Tenant(TenantMixin):
         if self.subscription_active:
             return 'subscribed'
         return 'manual'
+
+    @classmethod
+    def annotate_subscription_status(cls, queryset):
+        """Annotate `subscription_status_rank`: the subscription_status precedence
+        chain, expressed in SQL so a list view can SORT on the status.
+
+        `subscription_status` is derived in Python, and a column of derived values
+        has nothing for the database to order by, which is why the tenant admin's
+        Subscription column needs this to be sortable at all.
+
+        Each `When` mirrors the property of the same name, and the rank is the
+        slug's position in SUBSCRIPTION_STATUS_LABELS, so ascending lists suspended
+        decks first and managed-manually ones last. The two implementations must
+        agree: `test_annotate_subscription_status__matches_the_python_chain` builds
+        a deck in every status and asserts the annotation reproduces the property
+        exactly, so changing one without the other fails the suite.
+
+        Args:
+            queryset (QuerySet): Any Tenant queryset.
+
+        Returns:
+            QuerySet: The same queryset with `governing_deadline_date` and
+            `subscription_status_rank` annotated. The deadline alias deliberately
+            differs from the `governing_deadline` property so it doesn't shadow it
+            on the returned instances.
+        """
+        today = localdate()
+        # the day a deck's grace window closes: a governing deadline older than
+        # this is suspended, one on or after it is still inside grace
+        grace_cutoff = today - timedelta(days=GRACE_PERIOD_DAYS)
+        rank = {slug: position for position, slug in enumerate(cls.SUBSCRIPTION_STATUS_LABELS)}
+        # subscription_active: a paid clock whose grace tail has not run out
+        paid_access = models.Q(paid_until__isnull=False, paid_until__gte=grace_cutoff)
+        return queryset.annotate(
+            # Postgres GREATEST skips NULLs, so this is governing_deadline: the
+            # later of the two clocks, and NULL only when neither is set (a NULL
+            # then fails every date comparison below and falls through to 'manual')
+            governing_deadline_date=Greatest('trial_end_date', 'paid_until'),
+        ).annotate(
+            subscription_status_rank=models.Case(
+                models.When(governing_deadline_date__lt=grace_cutoff, then=models.Value(rank['suspended'])),
+                # past the deadline; anything that also outlived the grace
+                # window was already claimed by the branch above
+                models.When(governing_deadline_date__lt=today, then=models.Value(rank['grace'])),
+                models.When(
+                    models.Q(trial_end_date__isnull=False)
+                    & (models.Q(paid_until__isnull=True) | models.Q(trial_end_date__gt=models.F('paid_until'))),
+                    then=models.Value(rank['trial']),
+                ),
+                models.When(
+                    paid_access & ~models.Q(max_active_users=-1) & models.Q(max_active_users__lte=TRIAL_MAX_ACTIVE_USERS),
+                    then=models.Value(rank['maintenance']),
+                ),
+                models.When(paid_access, then=models.Value(rank['subscribed'])),
+                default=models.Value(rank['manual']),
+                output_field=models.IntegerField(),
+            ),
+        )
 
     @property
     def subscription_status_label(self):

--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -374,6 +374,42 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
         # the badge styles ride along via the ModelAdmin's Media declaration
         self.assertContains(response, "css/admin_deck_status.css")
 
+    def test_subscription_status_text__column_is_sortable(self):
+        """The Subscription column sorts. Its header is rendered sortable (a column
+        of values derived in Python has nothing for the database to order by, so
+        without the ranking annotation the header is inert text), and ordering by
+        it lists the decks by lifecycle: suspended first, managed manually last."""
+        # three decks, three distinct statuses, deliberately NOT in rank order by pk
+        Tenant.objects.filter(pk=self.tenant.pk).update(  # suspended: every clock long lapsed
+            trial_end_date=date(2022, 1, 1), paid_until=None)
+        Tenant.objects.filter(pk=self.extra_tenant.pk).update(  # free trial: no paid clock
+            trial_end_date=date(2032, 1, 1), paid_until=None)
+        Tenant.objects.filter(pk=self.public_tenant.pk).update(  # managed manually: no clocks at all
+            trial_end_date=None, paid_until=None)
+
+        url = reverse("admin:{}_{}_changelist".format("tenant", "tenant"))
+        self.client.get(url)  # move client to public schema
+        self.client.force_login(self.superuser)
+
+        # the header itself is clickable, which is the whole complaint
+        response = self.client.get(url)
+        self.assertContains(response, 'class="sortable column-subscription_status_text"')
+
+        # Django's ordering param indexes into list_display, with the action
+        # checkbox column prepended ahead of it
+        column = list(TenantAdmin.list_display).index('subscription_status_text') + 1
+        response = self.client.get('{}?o={}'.format(url, column))
+        content = response.content.decode()
+        rows_in_rank_order = [self.tenant, self.extra_tenant, self.public_tenant]
+        positions = [content.index('/tenant/tenant/{}/change/'.format(deck.pk)) for deck in rows_in_rank_order]
+        self.assertEqual(positions, sorted(positions))
+
+        # and descending flips it, so the ordering is really being applied
+        response = self.client.get('{}?o=-{}'.format(url, column))
+        content = response.content.decode()
+        positions = [content.index('/tenant/tenant/{}/change/'.format(deck.pk)) for deck in rows_in_rank_order]
+        self.assertEqual(positions, sorted(positions, reverse=True))
+
     def test_subscription_status_text__no_status_for_public_schema(self):
         """The public schema row isn't a deck, so its Subscription cell is empty
         (None), while a real deck row renders its status badge."""

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -481,6 +481,14 @@ class TenantSubscriptionStatusAnnotationTest(ByteDeckTenantTestCase):
             'trial_end_date': FROZEN_TODAY + timedelta(days=30),
             'paid_until': FROZEN_TODAY - timedelta(days=1),
         },
+        # both clocks landing on the SAME day: subscription language wins the tie,
+        # so this must rank 'subscribed'. Both chains compare the trial strictly
+        # later, and this fixture is what holds them to it
+        'equal-deadlines': {
+            'trial_end_date': FROZEN_TODAY + timedelta(days=30),
+            'paid_until': FROZEN_TODAY + timedelta(days=30),
+            'max_active_users': 40,
+        },
     }
 
     @classmethod
@@ -525,13 +533,18 @@ class TenantSubscriptionStatusAnnotationTest(ByteDeckTenantTestCase):
 
     def test_annotate_subscription_status__covers_every_status(self):
         """The fixtures reach all six statuses (so the test above is not silently
-        checking a subset), each is the status its fixture name claims, and a
-        running trial outranks an older paid clock still inside its grace tail."""
+        checking a subset), and each is the status its fixture name claims.
+
+        The two clock-precedence cases are pinned by name: a running trial outranks
+        an older paid clock still inside its grace tail, and two clocks ending on
+        the SAME day are 'subscribed', which is what stops either chain from
+        relaxing its strict comparison to a >=."""
         statuses = {fixture: deck.subscription_status for fixture, deck in self.ranked().items()}
         self.assertEqual(set(statuses.values()), set(Tenant.SUBSCRIPTION_STATUS_LABELS))
         for status in Tenant.SUBSCRIPTION_STATUS_LABELS:
             self.assertEqual(statuses[status], status)
         self.assertEqual(statuses['trial-over-stale-paid'], 'trial')
+        self.assertEqual(statuses['equal-deadlines'], 'subscribed')
 
     def test_annotate_subscription_status__orders_suspended_first_and_manual_last(self):
         """Sorting ascending on the rank lists the decks needing attention first:

--- a/src/tenant/tests/test_models.py
+++ b/src/tenant/tests/test_models.py
@@ -448,6 +448,104 @@ class TenantBillingStatusTest(SimpleTestCase):
 
 
 @freeze_time(FROZEN_NOW)
+class TenantSubscriptionStatusAnnotationTest(ByteDeckTenantTestCase):
+    """Tests that Tenant.annotate_subscription_status ranks decks in SQL exactly the
+    way the subscription_status property classifies them in Python.
+
+    Needs the database (an annotation is evaluated by Postgres), but not schemas:
+    the rows are bulk_created, which skips Tenant.save() and so skips schema
+    creation, since only public-schema date columns are being ranked. The
+    annotation is always run from inside a test method, never from setUpTestData,
+    because it reads today() and only the test methods are frozen.
+    """
+
+    # one deck per status, keyed by the status it must rank as, plus the
+    # precedence case where a stale paid clock could mask a running trial
+    STATUS_FIXTURES = {
+        'suspended': {'trial_end_date': FROZEN_TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), 'paid_until': None},
+        'grace': {'trial_end_date': FROZEN_TODAY - timedelta(days=1), 'paid_until': None},
+        'trial': {'trial_end_date': FROZEN_TODAY + timedelta(days=30), 'paid_until': None},
+        # trial_end_date is spelled out on the paid fixtures too: it defaults to a
+        # live trial date, and a live trial clock outranks a paid one
+        'maintenance': {
+            'trial_end_date': None, 'paid_until': FROZEN_TODAY + timedelta(days=30),
+            'max_active_users': TRIAL_MAX_ACTIVE_USERS,
+        },
+        'subscribed': {
+            'trial_end_date': None, 'paid_until': FROZEN_TODAY + timedelta(days=30), 'max_active_users': 40,
+        },
+        'manual': {'trial_end_date': None, 'paid_until': None},
+        # a running trial alongside an OLDER paid date still inside its grace tail:
+        # the trial governs, so this must rank 'trial' rather than 'subscribed'
+        'trial-over-stale-paid': {
+            'trial_end_date': FROZEN_TODAY + timedelta(days=30),
+            'paid_until': FROZEN_TODAY - timedelta(days=1),
+        },
+    }
+
+    @classmethod
+    def schema_for(cls, fixture):
+        """The schema_name given to a fixture's row.
+
+        Args:
+            fixture (str): A STATUS_FIXTURES key.
+
+        Returns:
+            str: The row's schema_name, e.g. 'rank-suspended'.
+        """
+        return 'rank-{}'.format(fixture)
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create one dateless-schema Tenant row per fixture."""
+        with schema_context(get_public_schema_name()):
+            Tenant.objects.bulk_create([
+                Tenant(schema_name=cls.schema_for(fixture), name=cls.schema_for(fixture), **fields)
+                for fixture, fields in cls.STATUS_FIXTURES.items()
+            ])
+
+    def ranked(self):
+        """Annotate the fixture rows and key them by fixture name.
+
+        Returns:
+            dict: {fixture name: annotated Tenant}.
+        """
+        decks = Tenant.annotate_subscription_status(Tenant.objects.filter(schema_name__startswith='rank-'))
+        by_schema = {deck.schema_name: deck for deck in decks}
+        return {fixture: by_schema[self.schema_for(fixture)] for fixture in self.STATUS_FIXTURES}
+
+    def test_annotate_subscription_status__matches_the_python_chain(self):
+        """Every fixture's annotated rank is the rank of the status the Python
+        property reports for the same deck, so the SQL chain and the Python chain
+        cannot drift apart unnoticed."""
+        rank = {slug: position for position, slug in enumerate(Tenant.SUBSCRIPTION_STATUS_LABELS)}
+        for fixture, deck in self.ranked().items():
+            with self.subTest(fixture=fixture):
+                self.assertEqual(deck.subscription_status_rank, rank[deck.subscription_status])
+
+    def test_annotate_subscription_status__covers_every_status(self):
+        """The fixtures reach all six statuses (so the test above is not silently
+        checking a subset), each is the status its fixture name claims, and a
+        running trial outranks an older paid clock still inside its grace tail."""
+        statuses = {fixture: deck.subscription_status for fixture, deck in self.ranked().items()}
+        self.assertEqual(set(statuses.values()), set(Tenant.SUBSCRIPTION_STATUS_LABELS))
+        for status in Tenant.SUBSCRIPTION_STATUS_LABELS:
+            self.assertEqual(statuses[status], status)
+        self.assertEqual(statuses['trial-over-stale-paid'], 'trial')
+
+    def test_annotate_subscription_status__orders_suspended_first_and_manual_last(self):
+        """Sorting ascending on the rank lists the decks needing attention first:
+        suspended, grace, trial, maintenance, subscribed, then managed manually."""
+        one_per_status = [self.schema_for(status) for status in Tenant.SUBSCRIPTION_STATUS_LABELS]
+        ordered = Tenant.annotate_subscription_status(
+            Tenant.objects.filter(schema_name__in=one_per_status)).order_by('subscription_status_rank')
+        self.assertEqual(
+            [deck.subscription_status for deck in ordered],
+            ['suspended', 'grace', 'trial', 'maintenance', 'subscribed', 'manual'],
+        )
+
+
+@freeze_time(FROZEN_NOW)
 class TenantDeletionClockTest(ByteDeckTenantTestCase):
     """Tests for the suspension-keyed deletion clock (#1734 B3): Tenant.deletion_date
     and the is_deletable guard it drives.


### PR DESCRIPTION
### What?

The **Subscription** column in the tenant admin list view is now sortable: its header is clickable, and sorting it lists decks by lifecycle stage.

### Why?

The column was added in #2319 rendering a status derived in Python (`Tenant.subscription_status`). A derived value has no column for the database to order by, so Django rendered the header as inert text and silently ignored any ordering request for it. On a list of decks the status is one of the most useful things to sort by: it is how you pull every suspended or in-grace deck to the top instead of reading the whole list.

### How?

`Tenant.annotate_subscription_status(queryset)` expresses the same precedence chain in SQL, `When` for `When`, and annotates `subscription_status_rank`; `TenantAdmin.get_queryset` applies it and the column declares `ordering="subscription_status_rank"`.

The rank is the status slug's position in `SUBSCRIPTION_STATUS_LABELS`, so the label map is the single source of both the words and the sort order. Its keys are reordered to match the precedence chain's branch order (`trial` moves ahead of `maintenance`), which makes ascending read as most-attention-first: **Suspended, Grace period, Free trial, Maintenance, Subscribed, Managed manually**. The map is a lookup elsewhere, so the reorder changes nothing else.

Two implementations of one rule can drift, so the tests pin them together rather than checking the SQL in isolation: a fixture deck in every status asserts the annotation reproduces exactly what the Python property returns, and a coverage assertion fails if a new status is ever added without a fixture. That caught a real subtlety while writing it: `trial_end_date` has a live default, so the "paid" fixtures were also on a running trial, and both implementations agreed the trial governs.

No migration: the rank is computed per query, not stored.

### Testing?

* `test_annotate_subscription_status__matches_the_python_chain`: every fixture's SQL rank equals the rank of the status the Python property reports.
* `test_annotate_subscription_status__covers_every_status`: all six statuses are reached, each fixture is the status it claims, and the two clock-precedence cases are pinned by name: a running trial outranks an older paid clock still inside its grace tail, and two clocks ending on the SAME day rank `subscribed` (subscription language wins ties). The equal-deadline fixture was mutation-checked: relaxing either chain's strict trial comparison to `>=` fails the suite (added on CodeRabbit's review).
* `test_annotate_subscription_status__orders_suspended_first_and_manual_last`: ascending order is the lifecycle order.
* `test_subscription_status_text__column_is_sortable`: the changelist renders the header sortable, and `?o=` on that column really reorders the rows (both directions). Reverting just the `ordering=` argument fails this test on the header assertion, so it is test-driven.

Full suite 2055 tests OK, `ruff check src` clean, `makemigrations --check --dry-run` clean.

### Screenshots (if front end is affected)

Captured from the running dev app at `http://localhost:8000/admin/tenant/tenant/`, signed in as `admin`, against seeded decks covering every status. Both shots are the **same URL** (`?o=7`, the Subscription column).

**Before** (on `staging`): the ordering request is ignored, rows stay in default order, and the "Subscription" header is plain text while the sortable columns around it are links.

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/sortable-subscription-column/before.png)

**After**: the header is bold with an ascending caret, and the decks are ordered Suspended, Suspended, Grace period, Free trial, (public row, no badge), Maintenance, Managed manually.

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/sortable-subscription-column/after.png)

### Anything Else?

The public schema row still shows an empty Subscription cell (it is not a deck), but it does take part in the sort, landing wherever its dates put it. Giving it a rank that always sorts last would mean teaching the annotation about the public schema for one row whose cell is blank anyway.

Targets `staging` as a hotfix, following #2319 which added the column.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)