### PR TITLE
fix: require Django 5.2.17, which carries the latest 5.2 LTS security fixes

### DIFF
--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,4 +1,4 @@
-Django>=5.2.16,<5.3
+Django>=5.2.17,<5.3  # 5.2.17 is a security release: admin URLField XSS (CVE-2026-15920) plus three other fixes
 
 # Version policy: floors are the versions currently in use; ceilings block the
 # next MAJOR (allowing backwards-compatible minor/patch updates), except where a


### PR DESCRIPTION
### What?
Raises the Django floor from `5.2.16` to `5.2.17` (the ceiling stays `<5.3`, so we remain on the 5.2 LTS line), with a short inline note on why that floor is where it is.

```
-Django>=5.2.16,<5.3
+Django>=5.2.17,<5.3  # 5.2.17 is a security release: admin URLField XSS (CVE-2026-15920) plus three other fixes
```

### Why?
Django 5.2.17 (4 August 2026) is a **security release** for the 5.2 LTS line. It fixes four issues that are present in 5.2.16, our previous floor:

| CVE | Severity | Issue |
|-----|----------|-------|
| CVE-2026-15307 | high | Server-side file write and request forgery via spatial lookups |
| CVE-2026-15830 | moderate | Denial of service via nested geometry collections |
| CVE-2026-15920 | moderate | Cross-site scripting via `URLField` values rendered as links in the admin |
| CVE-2026-15337 | low | Denial of service in `check_for_language()` |

**None of the four is reachable in ByteDeck today**, so this is defense in depth rather than an urgent patch:

- **Both geometry issues (15307, 15830) do not apply:** we do not use `django.contrib.gis` anywhere (no `GEOSGeometry`, no `GDALRaster`).
- **15337 does not apply:** the `set_language` view is the only route to `check_for_language()` and it is not wired into our URLconf.
- **15920 does not apply as configured:** we have no plain `models.URLField`, but two `URLOrRelativeURLField` fields (`utilities.MenuItem.url` and `djcytoscape.CytoElement.href`), and that class does subclass `models.URLField`, which is what the patched `display_for_field()` keys on. However the vulnerable path only renders changelist columns and read-only fields: `MenuItemAdmin.list_display` is `('label', 'sort_order', 'visible')` (no `url`) with no `readonly_fields`, and `CytoElement` is not registered in the admin at all. The field also carries `url_or_relative_url_validator`, so a dangerous scheme is rejected on save through a validated form.

Worth keeping in mind for future work: adding `url` to a `list_display` or to `readonly_fields` would light that path up, which is a good reason to be on the patched version now rather than later.

### How?
One-line floor bump in `requirements-production.txt`, plus an inline comment following the existing convention in that file (compare `bleach[css]>=6.4.0,<7  # 6.4 includes the invisible-Unicode-character XSS fix`).

On a cache-cold build the previous floor already resolved to 5.2.17, since pip picks the newest match, so CI has been running 5.2.17 since it was published. The bump matters for the two paths where that does not hold:

- **The image build on the production and staging hosts.** The Dockerfile installs dependencies in a layer keyed on the requirements files (`COPY ./requirements-production.txt` and `./requirements.txt`, then `RUN python3 -m pip install -r requirements.txt`), so while those files are unchanged a warm layer cache can carry an older Django forward across rebuilds. `production/server-update.sh` runs `docker image prune -f` and `docker builder prune -f` before `docker compose build`, which makes a fresh install likely, but nothing in the build forces one (`--no-cache` and `--pull` are not used, and the prunes are not `--all`). Changing the content of `requirements-production.txt` invalidates that layer outright, so the next image build is guaranteed to reinstall and pick up 5.2.17.
- **An existing virtualenv or a constrained resolve**, where the floor is what stops an older, vulnerable 5.2.x from satisfying the requirement.

Compatibility with the rest of the pins is unaffected: `django-tenants` (3.12+) allows `django>=5.2,<6.2`, and `django-celery-beat 2.9.0` allows `Django<6.1`.

### Testing?
`ruff check src` passes. The change is a requirements floor only, with no code change, and CI installs and runs the full suite against 5.2.17.

### Screenshots (if front end is affected)
N/A: dependency pin only, nothing renders differently.

### Anything Else?
- **Operational follow-up:** merging this to `develop` does not deploy anything. `.github/workflows/deploy.yml` only fires on pushes to `master` (production) and `staging`, so the patched floor reaches the servers when this is promoted `develop` to `staging` to `master`. Until then, whether production is running 5.2.17 depends on whether its last image build re-ran `pip install` (see the layer-cache note above), so it is still worth confirming the version actually running there.
- Note that the production `web` service bind-mounts the repo (`.:/app`), so application code updates ship via the deploy's `git checkout` alone. Installed Python packages live in the image, which is why a dependency change specifically needs the image build to re-run.
- Related: Dependabot's Django 6.1 PR (#2325) was closed. 6.1 is non-LTS and fails dependency resolution against `django-celery-beat`; the 5.2 LTS line receives these same security fixes, which is exactly what this PR pins to. The next LTS is 6.2 (April 2027).

### Review request
@tylerecouture

- Claude Code (Bytedeck - dependancies upgrades)

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Django version to 5.2.17, including the latest security release while retaining compatibility with the 5.2 series.