### PR TITLE
fix: validate notification redirect target to close an open redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,3 +164,7 @@ TENANT_DEFAULT_OWNER_PASSWORD=password
 # scope). Without it the poll no-ops.
 #GITHUB_API_TOKEN=
 #RELEASE_ANNOUNCEMENT_REPO=bytedeck/bytedeck
+# External hosts a notification's "click to open" may redirect to (comma-separated).
+# The release-announcement notice links out to the GitHub discussion, so github.com
+# is trusted by default; any other off-site link is refused.
+#NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS=github.com

--- a/src/hackerspace_online/settings.py
+++ b/src/hackerspace_online/settings.py
@@ -708,6 +708,13 @@ GITHUB_API_TOKEN = env('GITHUB_API_TOKEN', default='')
 # owner/name of the repo whose Announcements discussions carry the changelog.
 RELEASE_ANNOUNCEMENT_REPO = env('RELEASE_ANNOUNCEMENT_REPO', default='bytedeck/bytedeck')
 
+# External hosts a notification click-through may redirect to. The notifications
+# read view forwards its ?next= target, which for most notices is an internal
+# relative path but for the release-announcement notice is the GitHub Discussion
+# link, so github.com is trusted here; any other absolute URL is refused and the
+# user is sent to their notifications list instead (closes an open redirect).
+NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS = env.list('NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS', default=['github.com'])
+
 # STRIPE ##########################################################
 
 # Automated deck subscriptions (epic #1729). All default to None: when the keys

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.shortcuts import reverse
+from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 
 from model_bakery import baker
@@ -316,6 +317,39 @@ class NotificationViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('notifications:read', args=[note.id]), {'next': github_url})
 
         self.assertRedirects(response, github_url, fetch_redirect_response=False)
+
+    @override_settings(NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS=['example.org'])
+    def test_read__configured_extra_host_next_is_followed(self):
+        """A ?next= host that isn't the current deck but is listed in
+        NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS is followed, so the allowlist setting (not just
+        the hardcoded default) actually widens the trusted destinations."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(
+            Notification, recipient=self.test_student1, unread=True,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+        configured_url = 'https://example.org/whats-new'
+
+        response = self.client.get(reverse('notifications:read', args=[note.id]), {'next': configured_url})
+
+        self.assertRedirects(response, configured_url, fetch_redirect_response=False)
+
+    def test_read__insecure_next_rejected_on_secure_request(self):
+        """On an HTTPS request, an http:// ?next= (even to an allowed host) is refused and falls
+        back to the list: require_https follows the request scheme, so a secure page won't bounce
+        the user down to an insecure URL."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(
+            Notification, recipient=self.test_student1, unread=True,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+
+        # secure=True makes request.is_secure() True, so require_https rejects the http:// target.
+        response = self.client.get(
+            reverse('notifications:read', args=[note.id]), {'next': 'http://github.com/bytedeck/bytedeck'}, secure=True,
+        )
+
+        self.assertRedirects(response, reverse('notifications:list'), fetch_redirect_response=False)
 
     def test_read__other_users_notification_raises_404(self):
         """Reading a notification that belongs to another user is a 404 (not readable)."""

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -290,6 +290,33 @@ class NotificationViewTests(ByteDeckTenantTestCase):
 
         self.assertRedirects(response, '/quests/available/', fetch_redirect_response=False)
 
+    def test_read__external_untrusted_next_falls_back_to_list(self):
+        """A ?next= pointing at an untrusted external host is refused: the user is sent to
+        the notifications list instead of being redirected off-site (open-redirect guard)."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(
+            Notification, recipient=self.test_student1, unread=True,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+
+        response = self.client.get(reverse('notifications:read', args=[note.id]), {'next': 'https://evil.example.com/phish'})
+
+        self.assertRedirects(response, reverse('notifications:list'), fetch_redirect_response=False)
+
+    def test_read__trusted_github_next_is_followed(self):
+        """A ?next= pointing at the trusted release-announcement host (github.com) is followed,
+        so the release-announcement notice can still link out to its GitHub discussion."""
+        self.client.force_login(self.test_student1)
+        note = baker.make(
+            Notification, recipient=self.test_student1, unread=True,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+        github_url = 'https://github.com/bytedeck/bytedeck/discussions/2318'
+
+        response = self.client.get(reverse('notifications:read', args=[note.id]), {'next': github_url})
+
+        self.assertRedirects(response, github_url, fetch_redirect_response=False)
+
     def test_read__other_users_notification_raises_404(self):
         """Reading a notification that belongs to another user is a 404 (not readable)."""
         self.client.force_login(self.test_student1)

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -65,6 +65,18 @@ def read_all(request):
 @non_public_only_view
 @login_required
 def read(request, id):
+    """Mark the requester's own notification `id` as read, then redirect onward.
+
+    `id` is the notification's primary key (from the URL). The notification is
+    marked read only when it belongs to `request.user`; another user's id raises
+    a 404. On success the view redirects to the `?next=` URL when that URL is
+    safe, meaning a same-deck link (relative, or the current host) or one whose
+    host is in `settings.NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS` (github.com by
+    default, for the release-announcement notice). Any other `next` (or none)
+    falls back to the notifications list, so a crafted `next` can't turn this
+    into an open redirect. A missing or deleted notification id also redirects
+    to the list, with an error message. Returns an HttpResponseRedirect.
+    """
     try:
         next = request.GET.get('next', None)
         notification = Notification.objects.get(id=id)

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
@@ -7,6 +8,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import Http404, HttpResponseRedirect, get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from tenant.views import non_public_only_view
 
 from hackerspace_online.decorators import xml_http_request_required
@@ -70,7 +72,12 @@ def read(request, id):
             notification.unread = False
             notification.time_read = timezone.now()
             notification.save()
-            if next is not None:
+            # Only follow ?next= when it stays on this deck or points at an
+            # explicitly trusted host (github.com, for the release-announcement
+            # notice); anything else falls back to the list so a crafted link
+            # can't turn this into an open redirect.
+            allowed_hosts = {request.get_host(), *settings.NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS}
+            if next and url_has_allowed_host_and_scheme(next, allowed_hosts=allowed_hosts, require_https=request.is_secure()):
                 return HttpResponseRedirect(next)
             else:
                 return HttpResponseRedirect(reverse('notifications:list'))


### PR DESCRIPTION
### What?
The notifications "read" view (`/notifications/read/<id>/?next=...`) forwarded its `next` query parameter straight into `HttpResponseRedirect` without checking where it pointed. A crafted link could therefore bounce a logged-in user to any external site (a classic **open redirect**). This validates `next` against an allowlist so only same-deck links and one explicitly trusted host (GitHub, for the release-announcement notice) are followed; anything else falls back to the user's notifications list.

### Why?
`read()` marks a notification read and then redirects to `next`. Because `next` came from the query string with no validation, an attacker could send a victim a link like `.../notifications/read/<id>/?next=https://evil.example.com` and, if the victim was logged in and owned that notification (ids are sequential, so guessable), silently redirect them off-site. That is a phishing vector. It is also the pre-existing behavior the new release-to-staff notifications feature (#2316) leaned on to link out to the GitHub discussion, so the two are worth reconciling: keep the one legitimate off-site destination, refuse the rest.

### How?
- **`notifications/views.py`**: validate `next` with Django's `url_has_allowed_host_and_scheme(next, allowed_hosts=..., require_https=request.is_secure())`. The allowlist is `{request.get_host()} ∪ settings.NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS`. Internal notification links are relative paths (from `target_object.get_absolute_url()`), which the helper always allows; absolute URLs must match an allowed host. A failed check falls back to `reverse('notifications:list')` (the same fallback the no-`next` case already used). The `read` view also gains a docstring describing the id input, the validated redirect behavior, the response, and the 404 case.
- **`settings.py`**: new `NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS = env.list(..., default=['github.com'])`. `github.com` is trusted because the release-announcement notice links to its GitHub Discussion; the value is env-overridable.
- **`.env.example`**: documents the new variable.

The helper also rejects non-http(s) schemes (e.g. `javascript:`), so those can't slip through either.

### Testing?
Full stack stood up locally (Python 3.12 venv + Postgres + Redis) and the suite run against it:
- **4 new tests** in `notifications.tests.test_views`:
  - `test_read__external_untrusted_next_falls_back_to_list`: `?next=https://evil.example.com/phish` now redirects to the notifications list, not off-site. **Verified it fails without the view change** (redirects to `evil.example.com`) and passes with it, so the fix is genuinely test-driven.
  - `test_read__trusted_github_next_is_followed`: `?next=https://github.com/.../discussions/2318` is still followed, so the release notice's link-out keeps working.
  - `test_read__configured_extra_host_next_is_followed`: with `NOTIFICATIONS_ALLOWED_REDIRECT_HOSTS` overridden to a non-default host, a `?next=` to that host is followed, proving the setting actually widens the allowlist (not just the hardcoded `github.com`).
  - `test_read__insecure_next_rejected_on_secure_request`: on an HTTPS request, an `http://` `?next=` (even to an allowed host) is refused and falls back to the list, covering the `require_https` branch.
- The existing `test_read__redirects_to_next_when_provided` (a relative `/quests/available/` link) still passes, guarding internal navigation.
- No regressions: the full `notifications` app suite passes, plus the `hackerspace_online.tests.test_conventions` meta-test.
- `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` are all clean (no model changes).

### Screenshots (if front end is affected)
N/A: no template, CSS, or JS changed. The only user-visible behavior change is that a click-through to an untrusted external URL now lands on the notifications list instead of the external site; legitimate internal and GitHub links are unchanged.

### Anything Else?
- **Branch target:** opened against `develop` (normal cycle). This is a pre-existing, low-severity open redirect and the feature that uses the GitHub link-out is off by default in production, so it doesn't seem to warrant a production hotfix. Happy to cherry-pick it onto `staging` if you'd rather it ship sooner.
- No `CHANGELOG.md` entry here: changelog updates are batched into the release PR (as with #2317). This would fit a future **Bugfixes** line, e.g. "a crafted notification link could redirect you to an external site; notification links now only go to this deck (or the GitHub release notes)."
- CodeRabbit review addressed in `1563320`: added the `read` docstring and the two extra branch-coverage tests above.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - integrations and automations`)