### PR TITLE
refactor: remove the dead change_domain_urls Site signal (#2258)

### DIFF
--- a/src/hackerspace_online/apps.py
+++ b/src/hackerspace_online/apps.py
@@ -7,11 +7,8 @@ class HackerspaceConfig(AppConfig):
 
     def ready(self):
 
-        from django.contrib.sites.models import Site
-        from django.db.models.signals import post_save
         from django_tenants.models import TenantMixin, post_schema_sync
-        from hackerspace_online.signals import change_domain_urls, handle_tenant_site_domain_update
+        from hackerspace_online.signals import handle_tenant_site_domain_update
         import hackerspace_online.celerybeat_signals # noqa
 
-        post_save.connect(change_domain_urls, sender=Site)
         post_schema_sync.connect(handle_tenant_site_domain_update, sender=TenantMixin)

--- a/src/hackerspace_online/signals.py
+++ b/src/hackerspace_online/signals.py
@@ -1,46 +1,5 @@
 from django.contrib.sites.models import Site
-from django.core.exceptions import ObjectDoesNotExist
-from django.db import transaction
 from django_tenants.utils import get_public_schema_name, tenant_context
-
-from tenant.models import Tenant
-
-
-def change_domain_urls(sender, *args, **kwargs):
-    """ Called via post_save signal from Sites app so that when the domain of the site changes,
-    the tenants' domains would be updated to match.
-
-    ``domain_url`` is no longer a field on the tenant model: django-tenants stores
-    domains in the separate ``Domain``/``TenantDomain`` relation, so
-    ``tenant.domain_url`` is always ``None``. This handler is therefore effectively
-    inert -- there is no ``domain_url`` column to rewrite -- and is guarded so that
-    saving a ``Site`` while any non-public tenant exists cannot raise
-    ``AttributeError: 'NoneType' object has no attribute 'split'`` (previously this
-    crashed e.g. ``initdb``'s ``site.save()`` whenever a deck already existed). A
-    proper reimplementation would update each tenant's primary ``Domain`` instead.
-
-    This should probably be in the Tenant app?
-    """
-    if 'instance' in kwargs and 'created' in kwargs and not kwargs['created']:
-        try:
-            public_tenant = Tenant.objects.get(schema_name='public')
-        except ObjectDoesNotExist:
-            return
-
-        with transaction.atomic():
-            all_tenants = Tenant.objects.exclude(schema_name='public')
-            for tenant in all_tenants:
-                # domain_url is a removed field (always None); this always continues, so the
-                # rewrite below is dead until the handler is reimplemented against Domain (#2258).
-                if not tenant.domain_url:  # pragma: no branch -- domain_url is always None
-                    continue
-                domain = tenant.domain_url.split(public_tenant.domain_url)[0]  # pragma: no cover -- dead, see #2258
-                tenant.domain_url = '{}{}'.format(domain, kwargs['instance'].domain)  # pragma: no cover
-                tenant.save()  # pragma: no cover
-            # public_tenant.domain_url is likewise always None, so this block is dead (#2258).
-            if public_tenant.domain_url:  # pragma: no branch -- domain_url is always None
-                public_tenant.domain_url = kwargs['instance'].domain  # pragma: no cover
-                public_tenant.save()  # pragma: no cover
 
 
 def handle_tenant_site_domain_update(tenant, **kwargs):

--- a/src/hackerspace_online/tests/test_signals.py
+++ b/src/hackerspace_online/tests/test_signals.py
@@ -1,11 +1,8 @@
-from unittest.mock import patch
-
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 
 from django_tenants.utils import get_public_schema_name, schema_context, tenant_context
 
-from hackerspace_online.signals import change_domain_urls
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from tenant.models import Tenant
 
@@ -46,20 +43,3 @@ class SignalTest(ByteDeckTenantTestCase):
             self.assertEqual(site.domain, full_domain)
             self.assertEqual(site.name, full_domain[:name_max])
             self.assertLessEqual(len(site.name), name_max)
-
-    def test_change_domain_urls__is_a_noop_on_create(self):
-        """change_domain_urls only acts on Site updates; a create (created=True) returns
-        immediately, before even looking up the public tenant."""
-        with schema_context(get_public_schema_name()):
-            site = Site.objects.first()
-            with patch.object(Tenant.objects, 'get') as mock_get:
-                self.assertIsNone(change_domain_urls(sender=Site, instance=site, created=True))
-            # The guard returns before the tenant lookup, so get() is never reached.
-            mock_get.assert_not_called()
-
-    def test_change_domain_urls__returns_when_public_tenant_missing(self):
-        """If the public tenant lookup fails, the handler returns quietly rather than raising."""
-        with schema_context(get_public_schema_name()):
-            site = Site.objects.first()
-            with patch.object(Tenant.objects, 'get', side_effect=Tenant.DoesNotExist):
-                self.assertIsNone(change_domain_urls(sender=Site, instance=site, created=False))


### PR DESCRIPTION
### What?
Removes the `change_domain_urls` `post_save` signal handler (on the Sites app) from `src/hackerspace_online/signals.py`, its connection in `hackerspace_online/apps.py`, and its two coverage-only tests. Closes #2258.

### Why?
The handler rewrote `tenant.domain_url` (and `public_tenant.domain_url`) whenever a `Site` was saved, so that tenant domains tracked the site domain. But `domain_url` is no longer a field on the tenant model: django-tenants stores domains in the separate `Domain`/`TenantDomain` relation, so `tenant.domain_url` is always `None`. Every line of the handler's body was therefore dead:

```python
for tenant in all_tenants:
    if not tenant.domain_url:   # always True -> always continues
        continue
    ...                          # dead
if public_tenant.domain_url:     # always False
    ...                          # dead
```

It was being kept only as a guard so that saving a `Site` while a non-public tenant existed couldn't raise `AttributeError: 'NoneType' object has no attribute 'split'`, with `# pragma: no cover` on the dead lines to keep coverage honest. Since each tenant's own `Site.domain` is already set on tenant creation by `handle_tenant_site_domain_update` (the `post_schema_sync` handler, untouched here), the cross-tenant rewrite is obsolete. Removing the whole handler is cleaner than reimplementing an inert sync, and it drops the pragmas the issue flagged.

### How?
- `signals.py`: deleted `change_domain_urls` and the now-unused imports (`ObjectDoesNotExist`, `transaction`, `Tenant`). `handle_tenant_site_domain_update` is unchanged.
- `apps.py`: dropped the `from ... import change_domain_urls`, the `post_save.connect(change_domain_urls, sender=Site)` line, and the now-unused `Site` / `post_save` imports in `ready()`.
- `tests/test_signals.py`: removed the two `test_change_domain_urls__*` tests (which only exercised the guard/early-return of the dead handler) and their now-unused `patch` / `change_domain_urls` imports. The live `test_handle_tenant_site_domain_update__long_domain_truncates_site_name` test stays.

Saving a `Site` (e.g. `initdb`'s `site.save()` with a deck present) no longer runs any custom handler, so the historical `AttributeError` cannot occur: there is no code left to raise it.

### Testing?
- `python src/manage.py test hackerspace_online.tests.test_signals` passes (the remaining domain-truncation test still green).
- `ruff check` clean on the three touched files.
- No other references to `change_domain_urls` remain (`grep` across `src/`).

### Screenshots (if front end is affected)
N/A (internal signal cleanup, no user-facing or front-end change).

### Anything Else?
If a future need arises to re-base every deck's subdomain onto a new `ROOT_DOMAIN`, that is better done as an explicit management command over the `Domain`/`TenantDomain` relation than as a `Site` `post_save` side effect, as the issue notes.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete automatic domain URL updates triggered when site records are saved.
  * Preserved tenant schema synchronization and tenant domain update behavior.
  * Simplified handling of site updates by eliminating unused signal logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->