### PR TITLE
test: answer the prereq-formset TODOs instead of asserting only a redirect

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -678,7 +678,14 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assert404('quests:approve', args=[s1_pk])
 
     def test_submission__quest_not_visible_returns_404(self):
-        """When a quest is hidden from students, they should still be able to to see their submission in a static way"""
+        """Unpublishing a quest hides an in-progress submission of it: the student gets a 404,
+        because the default QuestSubmission queryset excludes unpublished quests and the view's
+        fallback lookup only covers completed submissions.
+
+        A completed submission survives the quest being unpublished and still renders (see
+        test_submission__unavailable_quest_shows_notice_and_hides_form_for_student), so only
+        work the student hadn't finished disappears on them.
+        """
         # log in a student
         self.client.force_login(self.test_student1)
 
@@ -687,7 +694,7 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.quest1.save()
         self.assertFalse(self.quest1.published)
 
-        # TODO: should redirect, not 404?
+        self.assertFalse(self.sub1.is_completed)
         self.assert404('quests:submission', args=[self.sub1.pk])
 
     def test_submission__xp_entered_remains_when_submission_returned(self):
@@ -2166,7 +2173,10 @@ class QuestPrereqsUpdate(ByteDeckTenantTestCase):
         self.assertRedirects(response, self.parent_quest.get_absolute_url())
 
     def test_post_save_button__defaults(self):
-        """ Save button should redirect to the quest detail view, no changes to form data"""
+        """Posting the prereq back unchanged saves nothing: the view redirects to the quest
+        detail page, the prereq keeps its original values, and no "Prerequisites have been
+        updated" message is shown (the has_changed() early return, issue #1980).
+        """
         self.client.force_login(self.test_teacher)
 
         ct = ContentType.objects.get_for_model(self.prereq_quest)
@@ -2191,8 +2201,21 @@ class QuestPrereqsUpdate(ByteDeckTenantTestCase):
         # If get 200 then means probably a form is invalid.
         self.assertRedirects(response, self.parent_quest.get_absolute_url())
 
+        # nothing was saved: the same single prereq, with the values it started with
+        prereqs = self.parent_quest.prereqs()
+        self.assertEqual(prereqs.count(), 1)
+        unchanged_prereq = prereqs.get(pk=self.existing_prereq.pk)
+        self.assertEqual(unchanged_prereq.prereq_object, self.prereq_quest)
+        self.assertEqual(unchanged_prereq.prereq_count, 1)
+
+        # and the teacher isn't told anything was updated
+        messages = [str(m) for m in response.wsgi_request._messages]
+        self.assertFalse(any("Prerequisites have been updated" in m for m in messages))
+
     def test_post_save_button__delete(self):
-        """ Flag the prereq for deletion by setting the DELETE field to true"""
+        """Flagging the prereq for deletion (DELETE field true) removes it: the quest is left
+        with no prerequisites and the Prereq row is gone from the database.
+        """
         self.client.force_login(self.test_teacher)
 
         ct = ContentType.objects.get_for_model(self.prereq_quest)
@@ -2218,11 +2241,15 @@ class QuestPrereqsUpdate(ByteDeckTenantTestCase):
         # If get 200 then means probably a form is invalid.
         self.assertRedirects(response, self.parent_quest.get_absolute_url())
 
-        # TODO should no longer have the prereq.. but this doesn't work for some reason....
-        # self.assertEqual(self.parent_quest.prereqs().count(), 0)
+        # the prereq was deleted, so the quest has none left
+        self.assertEqual(self.parent_quest.prereqs().count(), 0)
+        self.assertFalse(Prereq.objects.filter(pk=self.existing_prereq.pk).exists())
 
     def test_post_save_button__new_values(self):
-        """ New prereq data in form should change the prereqs for the parent quest."""
+        """New prereq data in the form changes the parent quest's prereqs: the existing row is
+        updated in place to point at a different quest (with a new count), and the extra form
+        adds a second prereq.
+        """
         self.client.force_login(self.test_teacher)
         new_quest = baker.make(Quest, name="New Quest")
         new_quest_2 = baker.make(Quest, name="New Quest 2")
@@ -2261,10 +2288,17 @@ class QuestPrereqsUpdate(ByteDeckTenantTestCase):
         prereqs = self.parent_quest.prereqs()
         self.assertEqual(prereqs.count(), 2)
 
-        # TODO For some reason the original prereq is not getting replaced by the first form in the formset.
-        # print(prereqs)
-        # self.assertEqual(prereqs[0].prereq_object, new_quest)
-        # self.assertEqual(prereqs[1].prereq_object, new_quest_2)
+        # the first form edited the existing prereq row rather than adding another one, so it
+        # now requires new_quest (3 times) instead of the prereq_quest it was created with.
+        # Looked up by pk because prereqs() is unordered.
+        updated_prereq = prereqs.get(pk=self.existing_prereq.pk)
+        self.assertEqual(updated_prereq.prereq_object, new_quest)
+        self.assertEqual(updated_prereq.prereq_count, 3)
+
+        # the second (extra) form added the other quest as a new prereq
+        added_prereq = prereqs.exclude(pk=self.existing_prereq.pk).get()
+        self.assertEqual(added_prereq.prereq_object, new_quest_2)
+        self.assertEqual(added_prereq.prereq_count, 1)
 
     def _changed_formset_data(self):
         """Build POST data that changes the existing prereq (prereq_count 1 -> 3) so
@@ -2322,8 +2356,8 @@ class QuestPrereqsUpdate(ByteDeckTenantTestCase):
         messages = [str(m) for m in response.wsgi_request._messages]
         self.assertTrue(any('being updated' in m and scape.name in m for m in messages))
 
-        # TODO doesn't work.  Only one new prereq was added, the second one.  The first didn't change from original value.... WHY?!
-        # self.assertEqual(Prereq.objects.count(), old_num_prereqs + 2)
+        # the edit itself was saved: the same prereq row, with its new count
+        self.assertEqual(self.parent_quest.prereqs().get(pk=self.existing_prereq.pk).prereq_count, 3)
 
 
 class QuestCopyViewTest(ByteDeckTenantTestCase):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2207,6 +2207,10 @@ class QuestPrereqsUpdate(ByteDeckTenantTestCase):
         unchanged_prereq = prereqs.get(pk=self.existing_prereq.pk)
         self.assertEqual(unchanged_prereq.prereq_object, self.prereq_quest)
         self.assertEqual(unchanged_prereq.prereq_count, 1)
+        # the alternate (OR) half is still empty, as add_simple_prereqs left it: the form posts
+        # or_prereq_count but no or_prereq_object, so a save would be free to write to these
+        self.assertIsNone(unchanged_prereq.or_prereq_object)
+        self.assertEqual(unchanged_prereq.or_prereq_count, 1)
 
         # and the teacher isn't told anything was updated
         messages = [str(m) for m in response.wsgi_request._messages]


### PR DESCRIPTION
### What?

Turns on the three disabled assertions in the `QuestPrereqsUpdate` (advanced prerequisites) tests, and rewrites the docstring of a fourth test whose stated intent was the opposite of what it asserted.

### Why?

The advanced-prereqs formset is how a teacher edits a quest's prerequisites. Its tests posted the formset and then asserted the redirect, with the interesting half commented out:

```python
# TODO should no longer have the prereq.. but this doesn't work for some reason....
# self.assertEqual(self.parent_quest.prereqs().count(), 0)
```

```python
# TODO For some reason the original prereq is not getting replaced by the first form in the formset.
# self.assertEqual(prereqs[0].prereq_object, new_quest)
# self.assertEqual(prereqs[1].prereq_object, new_quest_2)
```

```python
# TODO doesn't work.  Only one new prereq was added, the second one.  The first didn't change from original value.... WHY?!
# self.assertEqual(Prereq.objects.count(), old_num_prereqs + 2)
```

So deleting a prerequisite, and editing an existing one, were only checked as far as "the response was a redirect", and a save that quietly did nothing would pass.

**The answer to all three is the test data, not the view.** The formset's hidden `id` field identifies the `Prereq` row being edited, and the original tests (2022) posted `self.parent_quest.pk` there, which is a different table's pk. Django's `BaseModelFormSet` resolves that id to an instance and, when it does not match a row in the formset's queryset, leaves the form with an unsaved instance; `save_existing_objects()` then skips any initial form whose instance has no pk. The row is silently dropped: no delete, no update, no error, and still a 302. Only the second (extra) form, which is a genuine new object, got inserted, which is exactly what the third TODO describes.

That id was corrected to the prereq's own pk during an earlier cleanup, so the behaviour the TODOs doubted has been real for a while. Nobody went back to uncomment the assertions.

### How?

* `test_post_save_button__delete`: asserts the quest has no prereqs left **and** that the `Prereq` row is gone.
* `test_post_save_button__new_values`: asserts the existing row was updated in place (same pk, now pointing at `new_quest`, count 3) and that the extra form added `new_quest_2`. Both are looked up by pk rather than by index, because `prereqs()` is unordered and Postgres is free to return the updated row after the inserted one.
* `test_form_valid__map_message_when_related_map_exists`: the stale TODO referenced an `old_num_prereqs` that no longer exists and a two-prereq scenario this test does not post. Replaced with an assertion that the edit was actually saved (the row's count is now 3), so the test covers the save and not only the message.
* `test_post_save_button__defaults`: this posts the prereq back **unchanged**, which is the `has_changed()` early return from #1980. It now asserts what that means: the prereq keeps its original values (both the main half and the alternate OR half, which the form posts a count for but no object), and no "Prerequisites have been updated" message is shown. The docstring says so too.
* `test_submission__quest_not_visible_returns_404`: the docstring claimed students "should still be able to to see their submission in a static way" while the test asserted a 404, with a `# TODO: should redirect, not 404?` beside it. Both halves are true, of different submissions: the view's fallback lookup covers **completed** submissions (what `test_submission__unavailable_quest_shows_notice_and_hides_form_for_student` exercises), so only work the student had not finished disappears when a quest is unpublished. The docstring now says that, and the test asserts `sub1` is in fact incomplete so it cannot drift into testing the other case.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2089 tests in 454.050s

OK
```

`ruff check src` passes.

Checked against broken code, not just passing code:

* commenting out `form.save()` in `ObjectPrereqsFormView.form_valid` fails 3 of these tests (delete, new values, and the map-message save assertion). Before this change, that sabotage left the whole class green.
* removing the `if not form.has_changed()` early return fails `test_post_save_button__defaults`, which previously could not detect it.
* putting the old `id` value back (`self.parent_quest.pk`) fails 4 tests while every `assertRedirects` in them still passes, which is the original bug reproduced: the silent no-op the redirect assertion was never able to see. It also shows the teacher gets a "Prerequisites have been updated" message in that state, because the tampered pk makes `has_changed()` true even though nothing is saved.

`prerequisites/views.py` was restored afterwards; no source file is changed by this PR.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, tests only.

### Anything Else?

Ninth in the test-suite cleanup after #2306, #2309, #2321, #2322, #2327, #2333, #2334 and #2335. The last two answered gaps hiding behind a bare status code and behind a stale object; this one answers the gaps hiding behind "doesn't work for some reason".

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_