### PR TITLE
fix: don't notify about system account creation (#2320)

### DIFF
--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -433,12 +433,12 @@ def create_profile(sender, **kwargs):
 
             new_profile.save()
 
-            # "New user registered" announces a newly self-registered student to staff.
-            # Staff and superuser accounts (the deck's system admin and owner, created
-            # when the deck itself is created, plus any teacher accounts staff add) are
-            # created administratively, not self-registered, so they should not generate
-            # this notification (#2320).
-            if not current_user.is_staff and not current_user.is_superuser:
+            # "New user registered" announces a newly created student or staff
+            # account to the deck's staff. The deck's system admin account is a
+            # superuser created automatically when the deck itself is created, so
+            # its creation is not a real registration and should not raise this
+            # notification (#2320). Students and teachers still do.
+            if not current_user.is_superuser:
                 staff_list = User.objects.filter(is_staff=True)
                 notify.send(
                     current_user,

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -433,14 +433,20 @@ def create_profile(sender, **kwargs):
 
             new_profile.save()
 
-            staff_list = User.objects.filter(is_staff=True)
-            notify.send(
-                current_user,
-                target=new_profile,
-                recipient=staff_list[0],
-                affected_users=staff_list,
-                icon="<i class='fa fa-fw fa-lg fa-user text-success'></i>",
-                verb='.  New user registered: ')
+            # "New user registered" announces a newly self-registered student to staff.
+            # Staff and superuser accounts (the deck's system admin and owner, created
+            # when the deck itself is created, plus any teacher accounts staff add) are
+            # created administratively, not self-registered, so they should not generate
+            # this notification (#2320).
+            if not current_user.is_staff and not current_user.is_superuser:
+                staff_list = User.objects.filter(is_staff=True)
+                notify.send(
+                    current_user,
+                    target=new_profile,
+                    recipient=staff_list[0],
+                    affected_users=staff_list,
+                    icon="<i class='fa fa-fw fa-lg fa-user text-success'></i>",
+                    verb='.  New user registered: ')
 
 
 @receiver(post_delete, sender=Profile)

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -162,15 +162,15 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         student = baker.make(User)  # non-staff, non-superuser by default
         self.assertTrue(self._new_user_notifications_for(student).exists())
 
-    def test_create_profile__no_notification_for_staff_account(self):
-        """A staff account (e.g. a teacher, or the deck owner created at deck creation) does not
-        fire the 'New user registered' notification (#2320)."""
+    def test_create_profile__notifies_staff_when_a_teacher_is_added(self):
+        """A staff (teacher) account is created administratively, but it still fires the
+        'New user registered' notification: only the superuser system account is suppressed (#2320)."""
         teacher = baker.make(User, is_staff=True)
-        self.assertFalse(self._new_user_notifications_for(teacher).exists())
+        self.assertTrue(self._new_user_notifications_for(teacher).exists())
 
     def test_create_profile__no_notification_for_superuser_account(self):
-        """A superuser account (the deck's system admin, created at deck creation) does not fire
-        the 'New user registered' notification (#2320)."""
+        """A superuser account (the deck's system admin, created automatically at deck creation) does
+        not fire the 'New user registered' notification, since it is not a real registration (#2320)."""
         admin = baker.make(User, is_superuser=True)
         self.assertFalse(self._new_user_notifications_for(admin).exists())
 

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -143,7 +143,14 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         self.assertEqual(str(self.user.profile), self.user.username)
 
     def _new_user_notifications_for(self, user):
-        """The 'New user registered' notifications whose target is this user's profile."""
+        """Return the 'New user registered' notifications whose target is this user's profile.
+
+        Args:
+            user: the User whose profile is the notification target to filter on.
+
+        Returns:
+            A lazy Notification QuerySet of the matching 'New user registered' notifications.
+        """
         return Notification.objects.filter(
             verb__icontains="New user registered",
             target_content_type=ContentType.objects.get_for_model(Profile),

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -142,6 +142,31 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         self.assertIsInstance(self.user.profile, Profile)
         self.assertEqual(str(self.user.profile), self.user.username)
 
+    def _new_user_notifications_for(self, user):
+        """The 'New user registered' notifications whose target is this user's profile."""
+        return Notification.objects.filter(
+            verb__icontains="New user registered",
+            target_content_type=ContentType.objects.get_for_model(Profile),
+            target_object_id=user.profile.id,
+        )
+
+    def test_create_profile__notifies_staff_when_a_student_registers(self):
+        """Creating a student (non-staff) user fires the 'New user registered' notification to staff."""
+        student = baker.make(User)  # non-staff, non-superuser by default
+        self.assertTrue(self._new_user_notifications_for(student).exists())
+
+    def test_create_profile__no_notification_for_staff_account(self):
+        """A staff account (e.g. a teacher, or the deck owner created at deck creation) does not
+        fire the 'New user registered' notification (#2320)."""
+        teacher = baker.make(User, is_staff=True)
+        self.assertFalse(self._new_user_notifications_for(teacher).exists())
+
+    def test_create_profile__no_notification_for_superuser_account(self):
+        """A superuser account (the deck's system admin, created at deck creation) does not fire
+        the 'New user registered' notification (#2320)."""
+        admin = baker.make(User, is_superuser=True)
+        self.assertFalse(self._new_user_notifications_for(admin).exists())
+
     def test_profile_deletion__cascades_to_user(self):
         """When a profile is deleted, via queryset (admin) or directly, the user should be deleted too. """
         Profile.objects.filter(pk=self.profile.pk).delete()


### PR DESCRIPTION
### What?
Stops the "New user registered" notification from firing when the deck's **system admin account** (a superuser, created automatically when the deck itself is created) is created, so it no longer generates a spurious notification with a generic user icon. Closes #2320.

### Why?
The `create_profile` `post_save` handler (on `User`) sent a "New user registered" notification for **every** new user. When a deck is created, `initdb` / the deck-creation flow creates the ByteDeck system admin account (a superuser) via `create_superuser`; its creation triggered the handler, so a notification about the system account appeared (with the generic user icon, the "wrong logo" in the issue) even though nobody had actually registered.

That notification exists to alert staff when a new **person** joins the deck (a student self-registering, or a teacher an admin adds). The system admin account is created automatically at deck creation, not as a real registration, so it should not produce it.

### How?
In `profile_manager/models.py`, gate the `notify.send(...)` on the new user not being a superuser:

```python
if not current_user.is_superuser:
    staff_list = User.objects.filter(is_staff=True)
    notify.send(... verb='.  New user registered: ')
```

Students (`is_staff=False`) and teachers (`is_staff=True`, non-superuser) still notify staff exactly as before. Only the deck's auto-created **superuser** system admin account is skipped. This adds superuser suppression on top of the original behavior (which notified for everyone), so there is no new empty-`staff_list` path: the only account that could be created with no staff present is the system admin itself, which is now skipped.

**Scope note (addresses CodeRabbit's out-of-scope warning):** an earlier revision of this PR also suppressed the notification for **all** staff (teacher) accounts. Per maintainer decision, teacher account creation should still notify staff, so the condition was narrowed to superuser-only. Verified on a dev deck that the auto-created account carrying the spurious notification is the superuser `admin` (the deck `owner`, `is_staff` but non-superuser, does not carry one), so superuser-only suppression fully resolves #2320.

### Testing?
Three tests in `profile_manager/tests/test_models.py` (each asserts against notifications whose target is the specific new user's profile, so they're robust to how many staff the notification fans out to):
- a **student** registration creates the "New user registered" notification;
- a **teacher** (staff, non-superuser) account creation **also** creates it (only the system account is suppressed);
- a **superuser** (system admin) account creation creates **no** such notification (fails without the fix).

`python src/manage.py test profile_manager.tests.test_models` passes (31 tests). `ruff check` clean.

### Screenshots (if front end is affected)
The visible effect is the **absence** of the notification for the system admin account; there is no new UI. The notification that this removes is the one in the issue (generic user icon, "New user registered" for the system account). Student and teacher registrations still produce the same notification staff see today, unchanged.

### Anything Else?
N/A.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed profile creation notifications for superuser accounts.
  * Continued sending “New user registered” notifications for student and staff profiles.
* **Tests**
  * Added coverage to verify notification behavior across account types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->