### PR TITLE
fix: name the deck in notification and announcement emails (#2338)

### DIFF
--- a/src/announcements/tasks.py
+++ b/src/announcements/tasks.py
@@ -1,3 +1,7 @@
+from email.utils import formataddr
+from urllib.parse import urlsplit
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives
 from django.shortcuts import get_object_or_404
@@ -34,7 +38,11 @@ def send_notifications(user_id, announcement_id):
 @app.task(name='announcements.tasks.send_announcement_emails')
 def send_announcement_emails(content, root_url, absolute_url):
     siteconfig = SiteConfig.get()
-    subject = f'{siteconfig.site_name_short} Announcement'
+    # Name the deck the email is from so recipients can tell decks apart even when a deck
+    # hasn't customised its logo (#2338). root_url is the deck's root URL, so its host is
+    # the deck's domain (e.g. "deckname.bytedeck.com"); .hostname drops any scheme/port.
+    deck_domain = urlsplit(root_url).hostname or root_url
+    subject = f'Announcement from {deck_domain}'
     text_content = content
     html_template = get_template('announcements/email_announcement.html')
     html_content = html_template.render({
@@ -47,9 +55,14 @@ def send_announcement_emails(content, root_url, absolute_url):
 
     profile_emails = Profile.objects.get_mailing_list(as_emails_list=True, for_announcement_email=True)
 
+    # Show the deck's domain as the sender name so a recipient can tell which deck an email is
+    # from at a glance, keeping the actual sending address (the one the mail server is
+    # authorised for) unchanged (#2338). Fall back to the default sender when unconfigured.
+    from_email = formataddr((deck_domain, settings.DEFAULT_FROM_EMAIL)) if settings.DEFAULT_FROM_EMAIL else None
     email_msg = EmailMultiAlternatives(
         subject,
         body=text_content,
+        from_email=from_email,
         to=['contact@bytedeck.com'],
         bcc=profile_emails,
     )

--- a/src/announcements/tasks.py
+++ b/src/announcements/tasks.py
@@ -37,6 +37,16 @@ def send_notifications(user_id, announcement_id):
 
 @app.task(name='announcements.tasks.send_announcement_emails')
 def send_announcement_emails(content, root_url, absolute_url):
+    """Send a published announcement by email to everyone on the announcement mailing list.
+
+    Args:
+        content: The announcement's HTML content (used as the email body).
+        root_url: The deck's root URL; its host names the deck in the subject and sender.
+        absolute_url: The announcement's absolute URL, linked from the email.
+
+    Returns:
+        list[str]: the recipient email addresses the announcement was bcc'd to.
+    """
     siteconfig = SiteConfig.get()
     # Name the deck the email is from so recipients can tell decks apart even when a deck
     # hasn't customised its logo (#2338). root_url is the deck's root URL, so its host is

--- a/src/announcements/tests/test_tasks.py
+++ b/src/announcements/tests/test_tasks.py
@@ -1,7 +1,10 @@
 from datetime import timedelta
+from email.utils import formataddr
 
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.db import connection
+from django.test import override_settings
 from django.utils import timezone
 from django.conf import settings
 
@@ -107,6 +110,22 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
             }
         )
         self.assertTrue(task_result.successful())
+
+    @override_settings(DEFAULT_FROM_EMAIL="noreply@bytedeck.com")
+    def test_send_announcement_emails__names_the_deck(self):
+        """The announcement email's subject and From name the deck's domain (host of root_url)
+        so recipients can tell which deck it's from (#2338)."""
+        mail.outbox = []
+        tasks.send_announcement_emails.apply(
+            kwargs={
+                "content": "Hello",
+                "root_url": "https://example.com",
+                "absolute_url": "/link/to/announcement/",
+            }
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Announcement from example.com")
+        self.assertEqual(mail.outbox[0].from_email, formataddr(("example.com", "noreply@bytedeck.com")))
 
     def test_publish_announcement__clears_draft_and_removes_task(self):
         """Publishing marks the announcement non-draft, disables auto_publish, and removes its periodic task."""

--- a/src/announcements/tests/test_tasks.py
+++ b/src/announcements/tests/test_tasks.py
@@ -127,6 +127,22 @@ class AnnouncementTasksTests(ByteDeckTenantTestCase):
         self.assertEqual(mail.outbox[0].subject, "Announcement from example.com")
         self.assertEqual(mail.outbox[0].from_email, formataddr(("example.com", "noreply@bytedeck.com")))
 
+    @override_settings(DEFAULT_FROM_EMAIL="")
+    def test_send_announcement_emails__from_falls_back_when_unconfigured(self):
+        """With no DEFAULT_FROM_EMAIL configured, the announcement From is left to Django's
+        default (the deck domain is not spliced into an empty address) (#2338)."""
+        mail.outbox = []
+        tasks.send_announcement_emails.apply(
+            kwargs={
+                "content": "Hello",
+                "root_url": "https://example.com",
+                "absolute_url": "/link/to/announcement/",
+            }
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        # from_email=None -> EmailMessage substitutes settings.DEFAULT_FROM_EMAIL (here "")
+        self.assertEqual(mail.outbox[0].from_email, "")
+
     def test_publish_announcement__clears_draft_and_removes_task(self):
         """Publishing marks the announcement non-draft, disables auto_publish, and removes its periodic task."""
         self.assertTrue(self.announcement.draft)

--- a/src/notifications/tasks.py
+++ b/src/notifications/tasks.py
@@ -72,7 +72,18 @@ def get_notification_emails(root_url):
 
 
 def generate_notification_email(user, root_url):
-    """Generate an email notification from user"""
+    """Build the daily unread-notifications digest email for a single user.
+
+    Args:
+        user: The recipient User; their unread notifications (and, for staff, submissions
+            awaiting approval) make up the email, and their email is the To address.
+        root_url: The deck's root URL; its host names the deck in the subject and sender.
+
+    Returns:
+        EmailMultiAlternatives ready to send, or None when there is nothing to send:
+        a non-staff user not currently enrolled, or a user with no unread notifications
+        and (for staff) no submissions awaiting approval.
+    """
     html_template = get_template('notifications/email_notifications.html')
     # Name the deck the email is from so recipients can tell decks apart even when a deck
     # hasn't customised its logo (#2338). root_url is the deck's root URL, so its host is

--- a/src/notifications/tasks.py
+++ b/src/notifications/tasks.py
@@ -1,4 +1,8 @@
 from datetime import timedelta
+from email.utils import formataddr
+from urllib.parse import urlsplit
+
+from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 from django.contrib.auth import get_user_model
@@ -12,8 +16,6 @@ from quest_manager.models import QuestSubmission
 from notifications.models import Notification
 
 from profile_manager.models import Profile
-
-from siteconfig.models import SiteConfig
 
 User = get_user_model()
 
@@ -72,7 +74,11 @@ def get_notification_emails(root_url):
 def generate_notification_email(user, root_url):
     """Generate an email notification from user"""
     html_template = get_template('notifications/email_notifications.html')
-    subject = f'{SiteConfig.get().site_name_short} Notifications'
+    # Name the deck the email is from so recipients can tell decks apart even when a deck
+    # hasn't customised its logo (#2338). root_url is the deck's root URL, so its host is
+    # the deck's domain (e.g. "deckname.bytedeck.com"); .hostname drops any scheme/port.
+    deck_domain = urlsplit(root_url).hostname or root_url
+    subject = f'Notifications from {deck_domain}'
     to_email_address = user.email
     unread_notifications = Notification.objects.all_unread(user)
     submissions_awaiting_approval = None
@@ -94,7 +100,12 @@ def generate_notification_email(user, root_url):
             'root_url': root_url,
             'profile_edit_url': reverse('profiles:profile_edit_own')
         })
-        email_msg = EmailMultiAlternatives(subject, text_content, to=[to_email_address])
+        # Show the deck's domain as the sender name so a recipient can tell which deck an
+        # email is from at a glance, while keeping the actual sending address (the one the
+        # mail server is authorised for) unchanged (#2338). Fall back to the default sender
+        # when DEFAULT_FROM_EMAIL isn't configured.
+        from_email = formataddr((deck_domain, settings.DEFAULT_FROM_EMAIL)) if settings.DEFAULT_FROM_EMAIL else None
+        email_msg = EmailMultiAlternatives(subject, text_content, from_email=from_email, to=[to_email_address])
         email_msg.attach_alternative(html_content, "text/html")
 
         return email_msg

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -173,7 +173,7 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         )
         email = generate_notification_email(self.test_student1, "https://test.com")
         # from_email=None -> EmailMessage substitutes settings.DEFAULT_FROM_EMAIL (here "")
-        self.assertNotIn("test.com <", email.from_email or "")
+        self.assertEqual(email.from_email, "")
 
     def test_generate_notification_email__staff(self):
         """ Test that staff notification emails include quests awaiting approval """

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
+from email.utils import formataddr
 from model_bakery import baker
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMultiAlternatives
+from django.test import override_settings
 from django.utils import timezone
 from django_tenants.utils import get_tenant_model
 
@@ -139,8 +141,8 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
 
         self.assertEqual(type(email), EmailMultiAlternatives)
         self.assertEqual(email.to, [self.test_student1.email])
-        # Default deck short name is "Deck"
-        self.assertEqual(email.subject, "Deck Notifications")
+        # Subject names the deck's domain (the host of root_url) so recipients can tell decks apart (#2338)
+        self.assertEqual(email.subject, "Notifications from test.com")
 
         # https://stackoverflow.com/questions/62958111/how-to-display-html-content-of-an-emailmultialternatives-mail-object
         html_content = email.alternatives[0][0]
@@ -150,6 +152,28 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         self.assertIn("Unread notifications:", html_content)
         self.assertIn(str(notifications[0]), html_content)  # Links to notifications
         self.assertIn(str(notifications[1]), html_content)  # Links to notifications
+
+    @override_settings(DEFAULT_FROM_EMAIL="noreply@bytedeck.com")
+    def test_generate_notification_email__from_names_the_deck(self):
+        """The From header shows the deck's domain as the sender name while keeping the
+        configured sending address, so recipients can tell which deck it's from (#2338)."""
+        baker.make(
+            Notification, recipient=self.test_student1,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+        email = generate_notification_email(self.test_student1, "https://test.com")
+        self.assertEqual(email.from_email, formataddr(("test.com", "noreply@bytedeck.com")))
+
+    @override_settings(DEFAULT_FROM_EMAIL="")
+    def test_generate_notification_email__from_falls_back_when_unconfigured(self):
+        """With no DEFAULT_FROM_EMAIL configured, the From is left to Django's default (#2338)."""
+        baker.make(
+            Notification, recipient=self.test_student1,
+            sender_content_type=ContentType.objects.get_for_model(User), sender_object_id=self.test_teacher.id,
+        )
+        email = generate_notification_email(self.test_student1, "https://test.com")
+        # from_email=None -> EmailMessage substitutes settings.DEFAULT_FROM_EMAIL (here "")
+        self.assertNotIn("test.com <", email.from_email or "")
 
     def test_generate_notification_email__staff(self):
         """ Test that staff notification emails include quests awaiting approval """


### PR DESCRIPTION
### What?
Notification-digest emails and announcement emails now **name the deck they came from**, in both the subject and the sender name. Closes #2338.

- Notification digest subject: `{short_name} Notifications` becomes **`Notifications from deckname.bytedeck.com`**
- Announcement subject: `{short_name} Announcement` becomes **`Announcement from deckname.bytedeck.com`**
- From header (both): the deck's domain as the sender **display name**, e.g. `deckname.bytedeck.com &lt;noreply@bytedeck.com&gt;`

### Why?
The issue reports that these emails give "no indication what deck it's from" when a deck hasn't customised its logo. The digest subject was just "Deck Notifications" and the From was the shared platform address, so a teacher on several decks couldn't tell which deck an email belonged to. (The issue title says "announcements" but the requested subject is "Notifications from ..."; the two deck emails are the announcement email and the notification digest, so this fixes **both** to remove the ambiguity.)

### How?
Both email tasks already receive the deck's `root_url`, whose host is the deck's domain, so `urlsplit(root_url).hostname` gives `deckname.bytedeck.com` (dropping scheme/port).

- `notifications/tasks.py::generate_notification_email` and `announcements/tasks.py::send_announcement_emails`: build the subject from that domain, and set the From via `formataddr((deck_domain, settings.DEFAULT_FROM_EMAIL))` so the inbox shows the deck as the sender name.

**On the From address:** the issue asked whether emails could be sent literally from `noreply@deckname.bytedeck.com`. Doing that changes the envelope/header domain and only works if SPF/DKIM/DMARC authorise sending as `*.bytedeck.com`, otherwise it risks spam-foldering or rejection. To get the same "which deck is this from" benefit with **zero deliverability risk**, this puts the deck domain in the From **display name** while keeping the actual sending address (the one the mail server is already authorised for) unchanged. If your mail infrastructure is set up for per-deck subdomains and you'd prefer the literal `noreply@deckname.bytedeck.com`, it's a one-line change, just say so. (Confirmed this approach with @tylerecouture before implementing.) When `DEFAULT_FROM_EMAIL` isn't configured, the From falls back to Django's default unchanged.

### Testing?
- `notifications.tests.test_tasks`: updated the digest subject assertion to `Notifications from test.com`; added tests that the From names the deck (display name `test.com`, address the configured `DEFAULT_FROM_EMAIL`) and that it falls back cleanly when `DEFAULT_FROM_EMAIL` is unset.
- `announcements.tests.test_tasks`: added a test asserting the announcement email's subject (`Announcement from example.com`) and From.
- `python src/manage.py test notifications.tests.test_tasks announcements.tests.test_tasks` passes (18 tests). `ruff check` clean.

### Screenshots (if front end is affected)
Both emails captured from **real sends on the running `hackerspace` dev deck** (file email backend, with `DEFAULT_FROM_EMAIL` set to `noreply@bytedeck.com`), rendered with their real headers. The deck's domain now appears in both the **Subject** and the **From** name (in dev the domain is `hackerspace.localhost`; in production it's `deckname.bytedeck.com`):

![notification and announcement emails](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2338/emails.png)

From the two real messages: the notification subject is `Notifications from hackerspace.localhost` and the announcement subject is `Announcement from hackerspace.localhost`; both have From display name `hackerspace.localhost` with address `noreply@bytedeck.com` (rendered together in the screenshot above).

### Email
The announcement email's plain-text part, verbatim, from the real send (only the subject/From changed; the body is unchanged):

    <p>School is closed Monday for a snow day. Stay warm!</p>

(The notification digest's `text/plain` part is a raw `NotificationQuerySet` repr: pre-existing behaviour, `text_content = str(unread_notifications)`, unchanged here.)

### Anything Else?
The notification digest's `text/plain` part being a raw queryset `repr` is out of scope for this issue; happy to tidy it in a follow-up if you want.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Announcement and notification emails now identify the relevant deck using its domain in the subject line.
  * Email sender names now display the deck domain, making messages easier to recognize.
  * Configured default sender addresses continue to be used, with graceful fallback when unavailable.

* **Tests**
  * Added coverage for domain-based subjects, sender names, and fallback sender address behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->