### PR TITLE
chore: pull fresh base images when the deploy builds

### DIFF
--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -104,7 +104,10 @@ git pull                      # master (prod) or staging (staging host)
 
 `production/server-update.sh` does the following:
 
-1. `docker compose ... build` the images.
+1. `docker compose ... build --pull` the images. `--pull` re-fetches each base
+   image (`python:3.12-slim`, `nginx:stable`) so a deploy always builds on the
+   current base and picks up its OS-level security updates, rather than on an
+   older copy of the tag left on the host.
 2. Copy `production/systemd/bytedeck.com.service` into `/etc/systemd/system/`.
 3. Install the certbot-renew override (see [TLS](#tls--certificates)) and the
    `redis-host-setup.service` host tuning (disables THP, sets

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -105,9 +105,13 @@ git pull                      # master (prod) or staging (staging host)
 `production/server-update.sh` does the following:
 
 1. `docker compose ... build --pull` the images. `--pull` re-fetches each base
-   image (`python:3.12-slim`, `nginx:stable`) so a deploy always builds on the
-   current base and picks up its OS-level security updates, rather than on an
-   older copy of the tag left on the host.
+   image (`python:3.12-slim`, `nginx:stable`) so a deploy builds on the current
+   base and picks up its OS-level security updates, rather than on an older copy
+   of the tag left on the host. The pull is best effort: if it fails (say the
+   registry is unreachable) the build is retried without `--pull`, using the base
+   images already on the host, so an outage can still not block a deploy or a
+   rollback. A build that fails for any other reason fails the retry too and
+   stops the deploy.
 2. Copy `production/systemd/bytedeck.com.service` into `/etc/systemd/system/`.
 3. Install the certbot-renew override (see [TLS](#tls--certificates)) and the
    `redis-host-setup.service` host tuning (disables THP, sets

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -23,7 +23,18 @@ docker builder prune -f || echo "WARN: docker builder prune failed; continuing."
 # deploy, so the OS-level security updates published under those tags reach the
 # containers: Docker builds on whatever copy of a tag is already on the host,
 # however old it is, and these tags are updated in place upstream.
-$COMPOSE build --pull
+#
+# The pull is best effort, like the prunes above. --pull makes the build require
+# the registry, and it aborts rather than falling back when the registry cannot
+# be reached, which would leave us unable to deploy (or to roll back, exactly
+# when speed matters) during a registry outage. Retrying without it builds on the
+# base already on the host, trading a possibly stale base for a deploy that still
+# works offline. A build that fails for any other reason fails again on the
+# retry, so real errors still stop the deploy.
+$COMPOSE build --pull || {
+  echo "WARN: build with --pull failed (registry unreachable?); retrying with the base images already on this host."
+  $COMPOSE build
+}
 
 # Update the web app's systemd unit file
 sudo cp production/systemd/bytedeck.com.service /etc/systemd/system/bytedeck.com.service

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -18,7 +18,12 @@ COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
 docker image prune -f || echo "WARN: docker image prune failed; continuing."
 docker builder prune -f || echo "WARN: docker builder prune failed; continuing."
 
-$COMPOSE build
+# Build on freshly pulled base images. --pull re-fetches each FROM image
+# (python:3.12-slim for web/celery/celery-beat, nginx:stable for nginx) on every
+# deploy, so the OS-level security updates published under those tags reach the
+# containers: Docker builds on whatever copy of a tag is already on the host,
+# however old it is, and these tags are updated in place upstream.
+$COMPOSE build --pull
 
 # Update the web app's systemd unit file
 sudo cp production/systemd/bytedeck.com.service /etc/systemd/system/bytedeck.com.service


### PR DESCRIPTION
### What?
Refreshes the base images when the deploy builds, and documents it in `production/SERVER-README.md`.

```sh
$COMPOSE build --pull || {
  echo "WARN: build with --pull failed (registry unreachable?); retrying with the base images already on this host."
  $COMPOSE build
}
```

### Why?
`docker compose build` builds on whatever copy of a `FROM` tag already exists on the host. Both base images the deploy builds are **mutable tags that upstream updates in place**:

| Service | Base image |
|---------|-----------|
| web, celery, celery-beat | `python:3.12-slim` |
| nginx (prod overlay) | `nginx:stable` |

So a host that pulled `python:3.12-slim` months ago kept rebuilding on that same months-old base. OS-level security updates inside it (openssl, libpq, and the rest of the base) never reached the containers no matter how often we deployed, because nothing in the deploy ever re-fetched the tag: the build passed no `--pull`, and there is no `pull_policy` in either compose file.

This came out of the Django 5.2.17 work (#2339), while checking whether a deploy actually picks up new dependencies. The two are different mechanisms:

- **Python dependencies** are installed by a Dockerfile layer keyed on `requirements-production.txt` / `requirements.txt`, so they refresh when those files change (which is what #2339 did).
- **The base image** is refreshed only by `--pull`, which is what this PR adds. No requirements change causes the base to be re-fetched.

### How?
The flag, plus a comment explaining why it is there, and the matching update to the "what `server-update.sh` does" list in `SERVER-README.md`.

**The pull is best effort.** `--pull` makes the build require the registry: it aborts rather than falling back when the registry cannot be reached, which would leave the host unable to deploy (or to roll back, exactly when speed matters) during an outage. Retrying once without `--pull` builds on the base already present, trading a possibly stale base for a deploy that still works. This matches how the two prunes above it already warn and continue. A build that fails for any other reason fails the retry too, so real errors still stop the deploy.

`--pull` also costs a registry round trip per base image on each deploy: a manifest check, and a layer download only when the tag actually moved.

### Testing?
`sh -n production/server-update.sh` passes. No application code is touched, so the test suite is unaffected.

The fallback logic was exercised with stubbed builds, since the real script only runs on the deploy hosts:

- **Registry outage** (`--pull` build fails, plain build succeeds): warns, retries, and the deploy continues. Exit 0.
- **Genuine build error** (every build fails, e.g. a pip error): warns, retries, and the retry failure still aborts the deploy. Exit 1.

The real exercise is the next deploy: it should show the base images being pulled at the start of the build.

### Screenshots (if front end is affected)
N/A: deploy script and docs only.

### Anything Else?
- `.github/workflows/deploy.yml` only fires on pushes to `master` and `staging`, so this takes effect once it is promoted `develop` to `staging` to `master`, or on the next manual `./production/server-update.sh` run on a host.
- Review follow-up: CodeRabbit also flagged that a rollback rebuilds from source rather than restoring a known-good artifact, and that a rebuilt old commit can resolve to newer bases and dependencies than that release shipped with. That is the existing deploy model rather than something this PR changes, and fixing it properly means versioned release images or digest-pinned bases, so it is tracked separately in #2346.

### Review request
@tylerecouture

- Claude Code (Bytedeck - dependancies upgrades)