### PR TITLE
fix: make requirements.txt the single source of truth for the ruff version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,14 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install ruff
-      run: pip install ruff
+      # Install the constraint requirements.txt pins, so CI, the pre-commit hook
+      # and a local venv all lint with the same ruff. requirements.txt stays the
+      # single place the version is set, and its upper cap applies here too, so a
+      # new ruff minor cannot reach CI unpinned and fail the build on new rules.
+      run: |
+        ruff_spec=$(grep -m1 -E '^ruff([<>=!~,]|$)' requirements.txt | cut -d'#' -f1 | tr -d '[:space:]')
+        echo "Installing $ruff_spec"
+        pip install "$ruff_spec"
     - name: Lint
       # Config lives in pyproject.toml ([tool.ruff]). --output-format=github
       # emits inline PR annotations (replaces the old flake8-annotations action).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,10 @@ repos:
   # autoflake (unused-import/variable removal via --fix on the F rules).
   # Config lives in pyproject.toml ([tool.ruff]); the formatter (ruff-format)
   # is deliberately not enabled.
+  # Keep this rev in step with the ruff pin in requirements.txt, so the hook and
+  # CI lint with the same version and cannot disagree about what passes.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.2
     hooks:
       - id: ruff
         args: [ "--fix" ]


### PR DESCRIPTION
### What?
Points the pre-commit hook and the CI lint job at the same ruff version that `requirements.txt` pins, so all three agree.

```diff
# .pre-commit-config.yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.2
```

```diff
# .github/workflows/lint.yml
-      run: pip install ruff
+      run: |
+        ruff_spec=$(grep -m1 -E '^ruff([<>=!~,]|$)' requirements.txt | cut -d'#' -f1 | tr -d '[:space:]')
+        echo "Installing $ruff_spec"
+        pip install "$ruff_spec"
```

### Why?
Three places decide which ruff runs, and all three disagreed on `develop`:

| Where | ruff version it used |
|-------|----------------------|
| `requirements.txt` (a local venv) | `>=0.16.1,<0.17` |
| `.pre-commit-config.yaml` | 0.15.22 |
| `.github/workflows/lint.yml` | whatever `pip install ruff` resolves to, latest at run time |

Ruff's rule behaviour changes between minors, so this is a trap in several directions: a commit that passes the hook locally can fail the lint job, and the hook's `--fix` can rewrite code differently from the version CI then checks.

The CI half is the more consequential one. `requirements.txt` caps ruff at `<0.17` precisely so, in its own words, "a new rule set can't land unpinned". Because the workflow installed ruff without reference to that file, **the cap did not apply where it matters most**: the day ruff 0.17 ships, CI would have picked it up unprompted and could fail the build on rules nobody opted into.

None of this was introduced by a Dependabot bump: Dependabot updates `requirements.txt` and has no visibility into either the pre-commit hook or the workflow, so every ruff bump widened the gap.

### How?
- **Hook:** moved the rev to `v0.16.2`, with a comment noting it tracks the pin.
- **CI:** the lint job now reads the spec out of `requirements.txt` rather than naming a version, so the pin (cap included) governs CI too and there is still only one place to edit when the version changes. It echoes the spec it resolved, so the installed constraint is visible in the job log.

### Testing?
Ran the version the bumped hook installs against the codebase:

```
$ ruff --version
ruff 0.16.2
$ ruff check src
All checks passed!
```

Checked the extraction against the current `requirements.txt`: it yields `ruff>=0.16.1,<0.17` (the inline comment and trailing whitespace stripped), which pip accepts and resolves to 0.16.2. Both changed YAML files still parse. CI's own lint job exercises the new install step on this PR.

### Screenshots (if front end is affected)
N/A: tooling config only.

### Anything Else?
- **Unblocks #2337** (Dependabot's ruff `0.16.1` to `0.16.2`), which CodeRabbit had blocked over the hook mismatch since 11 August; its autofix could not apply the change because it cannot push to a Dependabot branch. Doing it here keeps Dependabot managing that PR, and repairs the drift on `develop` regardless of whether #2337 merges. Once both land, all three places read 0.16.2.
- **Worth considering separately:** adding a `pre-commit` entry to `.github/dependabot.yml` would let Dependabot bump hook revisions too. Left out here because it would also start opening PRs for the other hooks (`pre-commit-hooks` is on v4.3.0, `pyupgrade` on v3.21.2), which is a separate call on how much Dependabot noise you want.

### Review request
@tylerecouture

- Claude Code (Bytedeck - dependancies upgrades)