### PR TITLE
feat: add a Manage Questions button to the quest form (#2347)

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -124,6 +124,18 @@ class QuestForm(forms.ModelForm):
             'Edit Prerequisites</a>' \
             '{% else %}<button type="button" class="btn btn-default" disabled title="You need to create this new quest first, ' \
             'before you can add prerequisites.">Edit Prerequisites</button>' \
+            '{% endif %} '
+
+        # Questions are managed on their own page, so link to it from the form where the rest of
+        # the quest is configured (#2347); the detail page's "Submission Questions" panel is the
+        # other way in. Staff-only, because every view in the questions app requires staff and
+        # TAQuestForm inherits this layout, so an unguarded button would 403 for a TA.
+        questions_btn = '{% if request.user.is_staff %}' \
+            '{% if object.id %}<a role="button" class="btn btn-default" href="{% url \'questions:list\' object.id %}">' \
+            'Manage Questions</a>' \
+            '{% else %}<button type="button" class="btn btn-default" disabled title="You need to create this new quest first, ' \
+            'before you can add submission questions.">Manage Questions</button>' \
+            '{% endif %}' \
             '{% endif %}'
 
         self.helper = FormHelper()
@@ -131,6 +143,7 @@ class QuestForm(forms.ModelForm):
             HTML(cancel_btn),
             HTML(submit_btn),
             HTML(prereqs_btn),
+            HTML(questions_btn),
             Div(
                 'name',
                 'xp',

--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -112,6 +112,17 @@ class QuestForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        """Build the quest form's crispy layout.
+
+        Beyond the model fields, the layout carries the form's action buttons (cancel and submit,
+        repeated top and bottom) and links out to the two parts of a quest configured on their own
+        pages: prerequisites and submission questions. Both of those need a saved quest to attach
+        to, so on the create form they render as disabled placeholders explaining why.
+
+        Args:
+            *args: positional arguments passed through to ``forms.ModelForm``.
+            **kwargs: keyword arguments passed through to ``forms.ModelForm``.
+        """
         super().__init__(*args, **kwargs)
 
         self.fields['common_data'].label = 'Common Quest Info'

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1882,6 +1882,43 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
             self.assertContains(response, 'data-warn-unsaved')
             self.assertContains(response, 'warn-unsaved-changes.js')
 
+    def test_quest_form__manage_questions_button_links_to_the_quests_questions(self):
+        """Editing a quest offers a Manage Questions button linking to that quest's question list (#2347)."""
+        self.client.force_login(self.test_teacher)
+        quest = Quest.objects.create(**self.minimal_valid_form_data)
+
+        response = self.client.get(reverse('quests:quest_update', args=[quest.pk]))
+
+        self.assertContains(response, 'Manage Questions')
+        self.assertContains(response, reverse('questions:list', args=[quest.pk]))
+
+    def test_quest_form__manage_questions_button_disabled_when_creating(self):
+        """On the create form there is no quest to hang questions on yet, so the button is disabled (#2347)."""
+        self.client.force_login(self.test_teacher)
+
+        content = self.client.get(reverse('quests:quest_create')).content.decode()
+
+        self.assertIn('Manage Questions', content)
+        # the disabled placeholder is a <button>, not a link to the (non-existent) quest's questions
+        self.assertIn('disabled title="You need to create this new quest first, '
+                      'before you can add submission questions."', content)
+        self.assertNotIn('/questions/quest/', content)
+
+    def test_quest_form__manage_questions_button_hidden_from_tas(self):
+        """TAs can edit their draft quests but can't manage questions (staff-only), so they don't see the button (#2347)."""
+        test_ta = User.objects.create_user('test_ta_questions')
+        test_ta.profile.is_TA = True  # profiles are created automatically via User post_save signal
+        test_ta.profile.save()
+        self.client.force_login(test_ta)
+
+        # a TA may only edit an unpublished quest they are the editor of
+        quest = Quest.objects.create(**self.minimal_valid_form_data, editor=test_ta, published=False)
+
+        content = self.client.get(reverse('quests:quest_update', args=[quest.pk])).content.decode()
+
+        self.assertNotIn('Manage Questions', content)
+        self.assertNotIn(reverse('questions:list', args=[quest.pk]), content)
+
     def test_quest_create__teacher_can_create_and_delete(self):
         """Teachers can create quests and delete both live and archived quests."""
         # simulate a logged in teacher

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1889,8 +1889,10 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
 
         response = self.client.get(reverse('quests:quest_update', args=[quest.pk]))
 
-        self.assertContains(response, 'Manage Questions')
-        self.assertContains(response, reverse('questions:list', args=[quest.pk]))
+        # assert the label and the href together, so the test can't pass on a button that
+        # merely sits near an unrelated occurrence of the URL
+        questions_url = reverse('questions:list', args=[quest.pk])
+        self.assertContains(response, f'href="{questions_url}">Manage Questions</a>')
 
     def test_quest_form__manage_questions_button_disabled_when_creating(self):
         """On the create form there is no quest to hang questions on yet, so the button is disabled (#2347)."""


### PR DESCRIPTION
### What?
Adds a **Manage Questions** button to the quest edit/create form's button row, beside **Edit Prerequisites**, so a quest's submission questions are reachable from the page where the quest is configured.

Closes #2347

### Why?
Submission questions shipped in 1.31.0, but the only way in was the **Manage Questions** button inside the staff-only "Submission Questions" panel on a quest's *detail* page (`quest_detail_content.html`, included by `detail.html` and `submission.html`). That page is the read-only view of a quest.

A teacher setting a quest up is on the **edit form**, where instructions, submission details, instructor notes, campaign, and prerequisites all live. Nothing there mentions questions, so the feature reads as unavailable. This was hit on production: the maintainer reported not being able to find how to turn the feature on at all, while looking at the quest form.

Prerequisites have the same "configured on their own page, linked from the form" shape, so this follows that existing pattern rather than inventing a new one.

### How?
`quest_manager/forms.py`, in `QuestForm.__init__`'s crispy layout:

- New `questions_btn`, rendered right after `prereqs_btn` in the top button row.
- **Existing quest**: links to `questions:list` for that quest.
- **Create form**: renders `disabled` with a `title` explaining you need to save the quest first, mirroring Edit Prerequisites exactly (there is no quest to attach questions to yet).
- **Staff-only**: wrapped in `{% if request.user.is_staff %}`. Every view in the `questions` app is `StaffMemberRequiredMixin`, and `TAQuestForm` subclasses `QuestForm` (inheriting this layout), so an unguarded button would show TAs a link that 403s.
- `prereqs_btn` gains a trailing space, matching the spacing convention the other buttons in this row already use.
- `QuestForm.__init__` gains a docstring (it had none, though it carries the form's whole layout), covering what the layout builds and why the two buttons that link to a quest's other configuration pages render disabled on the create form.

No template, model, or migration changes.

### Testing?
Three new tests in `QuestCRUDViewsTest` covering each branch:

- `test_quest_form__manage_questions_button_links_to_the_quests_questions`: teacher editing a quest gets an anchor whose `href` is that quest's question list, asserted as a single `href="...">Manage Questions</a>` match so the label and URL can't drift apart.
- `test_quest_form__manage_questions_button_disabled_when_creating`: the create form shows the disabled placeholder and no link.
- `test_quest_form__manage_questions_button_hidden_from_tas`: a TA editing their own draft sees neither the label nor the URL.

Verified test-driven: with the `forms.py` change stashed, the first two fail (`'Manage Questions' not found`) and the TA guard test still passes, as intended for a regression guard.

Local run on a Python 3.12 venv against Postgres 16:
- `python src/manage.py test quest_manager questions` -> **497 tests, OK**
- `ruff check src` -> All checks passed
- `python src/manage.py check` -> no issues
- `python src/manage.py makemigrations --check --dry-run` -> No changes detected

### Screenshots (if front end is affected)
Captured from the real `hackerspace` dev deck, logged in as a teacher, on quest 7 ("Design Portfolio Submission"), which already has three questions.

**Before** (edit form: no way to reach questions)

![before, quest edit form](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2347/before-edit-form.png)

**After** (edit form: Manage Questions beside Edit Prerequisites)

![after, quest edit form](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2347/after-edit-form.png)

**After** (create form: both buttons disabled until the quest is saved)

![after, quest create form](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2347/after-create-form.png)

**After** (clicking it lands on the quest's question list, verified in the running app)

![after, questions list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2347/after-questions-list.png)

### Anything Else?
Two things spotted while capturing the screenshots, both left out of this PR to keep it focused, happy to take either as a follow-up:

1. `questions/question_list.html`'s help text contains em dashes in user-facing copy ("submitting the quest &mdash; each question...", "for marking &mdash; right beside..."), which the project style rules out.
2. The 1.31.0 changelog files submission questions under **Codebase** as "groundwork ... (still being rolled out)", which reads as not-yet-usable even though the staff UI and student submission flow are both live. It may deserve a **New Features** entry describing the teacher flow.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - multiple submission types`)