### PR TITLE
test: cover the TA publish and editor-clearing rules instead of a TODO

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1871,6 +1871,17 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
             'time_available': "14:30:59",
         }
 
+    def _make_TA(self, username='test_ta'):
+        """Create and return a TA (a student with permission to work on quest drafts).
+
+        Profiles are created automatically by a User post_save signal, so the flag goes on
+        the profile that already exists.
+        """
+        test_ta = User.objects.create_user(username)
+        test_ta.profile.is_TA = True
+        test_ta.profile.save()
+        return test_ta
+
     def test_quest_form__quick_reply_field_below_tags(self):
         """The Quick Reply Text field renders below the Tags field on the quest form (#2114)."""
         self.client.force_login(self.test_teacher)
@@ -1929,9 +1940,7 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
     def test_quest_create__TA_creates_drafts_and_deletes_own(self):
         """TAs can create draft quests (as editor) and delete their own but not others'."""
         # simulate a logged in TA (teaching assistant = a student with extra permissions)
-        test_ta = User.objects.create_user('test_ta')
-        test_ta.profile.is_TA = True  # profiles are create automatically via User post_save signal
-        test_ta.profile.save()
+        test_ta = self._make_TA()
         self.client.force_login(test_ta)
 
         # Can access the Create view
@@ -2005,9 +2014,7 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
     def test_quest_update__ta_can_update_own_draft(self):
         """TAs can update only their own unpublished quests, not published ones or others'."""
         # simulate a logged in TA (teaching assistant = a student with extra permissions)
-        test_ta = User.objects.create_user('test_ta')
-        test_ta.profile.is_TA = True  # profiles are create automatically via User post_save signal
-        test_ta.profile.save()
+        test_ta = self._make_TA()
         self.client.force_login(test_ta)
 
         # make a quest for us to update, use the form data so easier to track what we're updating
@@ -2072,9 +2079,85 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
         self.assertEqual(len(messages), 1)
         self.assertIn(scape.name, str(messages[0]))
 
-    # TODO
-    # TAs should not be able to make a quest published
-    # When a quest is published by a teacher, the editor should be removed
+    def test_quest_create__TA_publishing_is_overridden(self):
+        """A TA who posts published (the field is on their form, only hidden) still gets a draft
+        with themselves as editor: QuestFormViewMixin.form_valid overrides both, so a hand-made
+        POST can't put a TA's quest in front of students.
+        """
+        test_ta = self._make_TA()
+        self.client.force_login(test_ta)
+
+        form_data = {
+            **self.minimal_valid_form_data,
+            'published': True,
+            'editor': self.test_teacher.id,  # and they can't hand the draft to someone else
+        }
+        response = self.client.post(reverse('quests:quest_create'), data=form_data)
+
+        new_quest = Quest.objects.latest('datetime_created')
+        self.assertRedirects(response, new_quest.get_absolute_url())
+        self.assertFalse(new_quest.published)
+        self.assertEqual(new_quest.editor, test_ta)
+
+    def test_quest_update__TA_publishing_their_draft_is_overridden(self):
+        """The same override applies when a TA updates the draft they own: it stays unpublished
+        and stays theirs, so publishing remains a teacher's decision.
+        """
+        test_ta = self._make_TA()
+        quest = Quest.objects.create(**self.minimal_valid_form_data)
+        quest.editor = test_ta
+        quest.published = False
+        quest.save()
+        self.client.force_login(test_ta)
+
+        form_data = {**self.minimal_valid_form_data, 'published': True, 'editor': test_ta.id}
+        response = self.client.post(reverse('quests:quest_update', args=[quest.pk]), data=form_data)
+
+        self.assertRedirects(response, quest.get_absolute_url())
+        quest.refresh_from_db()
+        self.assertFalse(quest.published)
+        self.assertEqual(quest.editor, test_ta)
+
+    def test_quest_update__teacher_publishing_removes_the_editor(self):
+        """When a teacher publishes a TA's draft, the TA's editor access is removed with it, so
+        they can no longer edit a quest students are now working on.
+        """
+        test_ta = self._make_TA()
+        quest = Quest.objects.create(**self.minimal_valid_form_data)
+        quest.editor = test_ta
+        quest.published = False
+        quest.save()
+        self.client.force_login(self.test_teacher)
+
+        form_data = {**self.minimal_valid_form_data, 'published': True, 'editor': test_ta.id}
+        response = self.client.post(reverse('quests:quest_update', args=[quest.pk]), data=form_data)
+
+        self.assertRedirects(response, quest.get_absolute_url())
+        quest.refresh_from_db()
+        self.assertTrue(quest.published)
+        self.assertIsNone(quest.editor)
+        # and the TA has indeed lost access to it
+        self.assertFalse(quest.is_editable(test_ta))
+
+    def test_quest_update__teacher_leaving_a_quest_unpublished_keeps_the_editor(self):
+        """A teacher editing a draft without publishing it leaves the TA as editor, so the TA can
+        keep working on it.
+        """
+        test_ta = self._make_TA()
+        quest = Quest.objects.create(**self.minimal_valid_form_data)
+        quest.editor = test_ta
+        quest.published = False
+        quest.save()
+        self.client.force_login(self.test_teacher)
+
+        # 'published' is a checkbox: leaving it out of the POST is how the form says "draft"
+        form_data = {**self.minimal_valid_form_data, 'editor': test_ta.id}
+        response = self.client.post(reverse('quests:quest_update', args=[quest.pk]), data=form_data)
+
+        self.assertRedirects(response, quest.get_absolute_url())
+        quest.refresh_from_db()
+        self.assertFalse(quest.published)
+        self.assertEqual(quest.editor, test_ta)
 
     def test_quest_create__with_new_prereqs(self):
         """ Add a quest and badge prereq during quest creation """


### PR DESCRIPTION
### What?

Answers the last bare TODO in the quest CRUD tests with four tests, covering both halves of the TA / editor rule in `QuestFormViewMixin.form_valid`.

### Why?

```python
    # TODO
    # TAs should not be able to make a quest published
    # When a quest is published by a teacher, the editor should be removed
```

Both rules are implemented, in `QuestFormViewMixin.form_valid`:

```python
# TA created quests should not be published.
if self.request.user.profile.is_TA:
    form.instance.published = False
    form.instance.editor = self.request.user
# When a teacher makes a form published, remove editor abilities.
elif form.instance.published:
    form.instance.editor = None
```

Neither was covered where it counts.

**The TA half.** `TAQuestForm` only *hides* the fields a TA should not set:

```python
self.fields['published'].widget = forms.HiddenInput()
...
self.fields['editor'].widget = forms.HiddenInput()
```

A hidden input still binds posted data, so the widget is cosmetic: nothing stops a TA from posting `published=on` (or an `editor` of their choosing) by hand. The only thing that does is the view override above. The existing TA tests post `minimal_valid_form_data`, which has no `published` key at all, and `published` is a checkbox, so its absence already means `False`. `assertFalse(new_quest.published)` in `test_quest_create__TA_creates_drafts_and_deletes_own` therefore passed whether or not the guard existed: it was asserting the form default, not the rule.

**The teacher half.** Clearing the editor on publish was covered for *bulk* edit (`test_bulk_edit__publishes_unpublished_quests`) but not for the ordinary "teacher opens the TA's draft, ticks Published, saves" path, which is how it actually happens.

### How?

Four tests, each posting the field the old data left out:

* `test_quest_create__TA_publishing_is_overridden`: a TA posts `published=True` and an `editor` of someone else; the quest is still saved as a draft with the TA as editor.
* `test_quest_update__TA_publishing_their_draft_is_overridden`: same override when a TA saves the draft they own, so publishing stays a teacher's decision.
* `test_quest_update__teacher_publishing_removes_the_editor`: a teacher publishing a TA's draft clears `editor`, and the TA has genuinely lost access (`is_editable(ta)` is False).
* `test_quest_update__teacher_leaving_a_quest_unpublished_keeps_the_editor`: the other side of that `elif`, so the TA keeps the draft they are still working on.

Also factors the repeated three-line TA setup into a `_make_TA()` helper and uses it in the two existing TA tests.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2095 tests in 358.696s

OK
```

`ruff check src` passes.

Checked against broken code, not just passing code:

* disabling the `is_TA` branch fails 3 tests: both new TA tests, and the existing `test_quest_create__TA_creates_drafts_and_deletes_own` (which was catching the editor half, but not the published half).
* disabling the `elif form.instance.published: form.instance.editor = None` branch fails `test_quest_update__teacher_publishing_removes_the_editor`, and nothing else in the class.

`quest_manager/views.py` was restored afterwards; no source file is changed by this PR.

Run against a real Postgres 16 + Redis dev environment, not a mocked one.

### Screenshots (if front end is affected)

N/A, tests only.

### Anything Else?

Tenth in the test-suite cleanup after #2306, #2309, #2321, #2322, #2327, #2333, #2334, #2335 and #2342. #2342 answered the prereq-formset TODOs; this one answers the TA/editor TODO, which was the remaining "we never checked this" note in that file.

If you would rather the hidden fields were removed from `TAQuestForm` outright (so a TA's POST can't even bind them, instead of relying on the view to override), say the word and I will open that as a separate change: it is a behaviour change rather than a test one, so I have kept it out of this PR.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured quests created or edited by teaching assistants remain unpublished and retain the teaching assistant as editor.
  * Confirmed teacher publication removes the previous editor assignment.
  * Preserved the teaching assistant’s editor assignment when a teacher leaves the quest unpublished.

* **Tests**
  * Added coverage for quest publishing and editor-assignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->