### PR TITLE
ci: let Dependabot update the pre-commit hook revisions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+  # Keeps the hook revisions in .pre-commit-config.yaml current. The pip entry
+  # above only sees requirements.txt, and the ruff hook's rev has to track the
+  # ruff pin there so that the hook, CI and a local venv all lint with the same
+  # version.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,21 @@ jobs:
         ruff_spec=$(grep -m1 -E '^ruff([<>=!~,]|$)' requirements.txt | cut -d'#' -f1 | tr -d '[:space:]')
         echo "Installing $ruff_spec"
         pip install "$ruff_spec"
+    - name: Check the pre-commit hook pins the same ruff
+      # requirements.txt and .pre-commit-config.yaml are updated by separate
+      # Dependabot ecosystems, which cannot see each other's pins, so a hook bump
+      # past the requirement's upper cap would leave `pre-commit run` and this job
+      # linting with different rule sets. Comparing the hook against the version
+      # just installed from the requirement turns that into a failure here, rather
+      # than a lint result that only reproduces in one of the two places.
+      run: |
+        hook=$(grep -A2 'astral-sh/ruff-pre-commit' .pre-commit-config.yaml | sed -n 's/^ *rev: *v//p' | head -1)
+        installed=$(ruff --version | awk '{print $2}')
+        if [ "$hook" != "$installed" ]; then
+          echo "::error::pre-commit ruff hook is v$hook, but requirements.txt resolves to $installed. Update .pre-commit-config.yaml and the ruff pin in requirements.txt together."
+          exit 1
+        fi
+        echo "ok: pre-commit hook v$hook matches the ruff $installed installed from requirements.txt"
     - name: Lint
       # Config lives in pyproject.toml ([tool.ruff]). --output-format=github
       # emits inline PR annotations (replaces the old flake8-annotations action).


### PR DESCRIPTION
### What?
Two changes that together stop the ruff versions drifting apart:

1. **`.github/dependabot.yml`**: adds a `pre-commit` ecosystem, so Dependabot bumps the hook revisions in `.pre-commit-config.yaml` the way it already bumps the Python requirements.
2. **`.github/workflows/lint.yml`**: fails the lint job if the ruff hook revision is not the ruff that job installed from `requirements.txt`.

### Why?
The Dependabot config was `pip` only, so it saw `requirements.txt` and nothing else. Nothing kept `.pre-commit-config.yaml` moving, and the hooks drifted:

| Hook | Pinned rev | Status |
|------|-----------|--------|
| `astral-sh/ruff-pre-commit` | `v0.16.2` | current, after #2348 |
| `pre-commit/pre-commit-hooks` | `v4.3.0` | well behind |
| `asottile/pyupgrade` | `v3.21.2` | behind |

The ruff hook is the one that had teeth: it sat five minors behind the `requirements.txt` pin, so `pre-commit run` linted with 0.15.22 while CI linted with 0.16.x, and ruff's rules shift between minors. #2337 stalled for a day on exactly that mismatch, and clearing it took a hand-written PR (#2348), which aligned the versions but left the hook with nothing to keep it aligned.

**Why the check as well as the config.** Dependabot treats `pip` and `pre-commit` as independent ecosystems that cannot see each other's pins, so enabling the ecosystem alone does not enforce agreement. In the ordinary case they converge on their own, since `requirements.txt` holds a *range* and the hook lands on the newest in-range release, which is exactly what pip resolves to. The case that does not self-correct is a hook bump past the upper cap, for instance ruff 0.17 against the current `<0.17`: the pre-commit updater cannot see that cap, so the hook would cross it quietly. Combining both entries into a single Dependabot PR is not an option, because groups are per-ecosystem.

### How?
The Dependabot entry matches the schedule the pip entry already uses. The check lives in the lint job because that job already installs ruff from the constraint, so it can compare against the version in hand rather than re-parsing the specifier:

```yaml
hook=$(grep -A2 'astral-sh/ruff-pre-commit' .pre-commit-config.yaml | sed -n 's/^ *rev: *v//p' | head -1)
installed=$(ruff --version | awk '{print $2}')
if [ "$hook" != "$installed" ]; then
  echo "::error::pre-commit ruff hook is v$hook, but requirements.txt resolves to $installed. ..."
  exit 1
fi
```

That is stricter than a range test on purpose: it asserts the hook is exactly the ruff CI lints with, which is the property worth having. Crossing the cap becomes a deliberate decision with a red job and a message naming both versions, instead of something that lands quietly in a hook bump.

### Testing?
Both config files parse, and the Dependabot entries read back correctly:

```
parsed OK, version: 2
  ecosystem: pip | dir: / | interval: daily
  ecosystem: pre-commit | dir: / | interval: daily
```

The check was exercised both ways against the current tree:

- **matching** (hook `v0.16.2`, installed `0.16.2`): passes.
- **mismatched** (simulated hook `v0.17.0` against installed `0.16.2`): fails with the error above.

CI runs the real step on this PR, so the passing path is confirmed in the actual job. Dependabot config is not exercised by CI, so the confirmation there is Dependabot acting on it after merge; if it were rejected, GitHub reports config errors under Insights, Dependency graph, Dependabot.

### Screenshots (if front end is affected)
N/A: CI config only.

### Anything Else?
- **Expect a burst of about three PRs shortly after merge**, since `pre-commit-hooks` and `pyupgrade` are both overdue and ruff may be too. It should be quiet after that. The daily Dependabot auto-review handles the triage, and these are lint tooling only, so CI proves them.
- A ruff hook bump that crosses the `<0.17` cap will now arrive red. That is intended: the fix is to raise the cap in `requirements.txt` in the same breath, or to hold the hook back, whichever is right at the time.
- If the volume turns out to be more than you want later, the natural dials are `interval: "weekly"`, or an `allow` entry scoping the ecosystem to `ruff-pre-commit` alone.

### Review request
@tylerecouture

- Claude Code (Bytedeck - dependancies upgrades)