### PR TITLE
HOTFIX: fix: stop a POST parameter from choosing which deck's schema a request runs against

### DIFF
--- a/src/library/tests/test_utils.py
+++ b/src/library/tests/test_utils.py
@@ -1,6 +1,19 @@
+from django.contrib.auth import get_user_model
 from django.db import connection
-from django.test import SimpleTestCase
-from library.utils import library_schema_context
+from django.test import RequestFactory, SimpleTestCase
+from django.urls import reverse
+
+from library.tests.test_views import LibraryTenantTestCaseMixin
+from library.utils import (
+    get_library_schema_name,
+    is_library_schema_requested,
+    library_schema_context,
+    library_schema_if_requested,
+)
+from model_bakery import baker
+from quest_manager.models import Quest
+
+User = get_user_model()
 
 
 class QuestLibraryUtilsTestCase(SimpleTestCase):
@@ -13,3 +26,121 @@ class QuestLibraryUtilsTestCase(SimpleTestCase):
             self.assertEqual(connection.schema_name, 'library')
 
         self.assertEqual(connection.schema_name, previous_schema)
+
+
+class IsLibrarySchemaRequestedTestCase(SimpleTestCase):
+    """The Library flag is a boolean, and only a boolean."""
+
+    def setUp(self):
+        """Build a request factory for the POSTs each test sends."""
+        self.factory = RequestFactory()
+
+    def test_is_library_schema_requested__truthy_values(self):
+        """Every form-encodable spelling of true asks for the Library."""
+        for value in ('1', 'true', 'True', 'on', 'yes'):
+            with self.subTest(value=value):
+                request = self.factory.post('/', {'use_library_schema': value})
+                self.assertTrue(is_library_schema_requested(request))
+
+    def test_is_library_schema_requested__falsy_and_missing_values(self):
+        """No flag, or a falsy one, means the caller's own deck."""
+        for data in ({}, {'use_library_schema': '0'}, {'use_library_schema': ''}, {'use_library_schema': 'false'}):
+            with self.subTest(data=data):
+                request = self.factory.post('/', data)
+                self.assertFalse(is_library_schema_requested(request))
+
+    def test_is_library_schema_requested__schema_name_is_not_a_flag(self):
+        """Posting a schema name as the flag value is not a request for that schema."""
+        request = self.factory.post('/', {'use_library_schema': 'some_other_deck'})
+        self.assertFalse(is_library_schema_requested(request))
+
+
+class LibrarySchemaIfRequestedTestCase(LibraryTenantTestCaseMixin):
+    """`library_schema_if_requested` resolves the schema itself, never from the request."""
+
+    def setUp(self):
+        """Build a request factory and attach this test's tenant to each request."""
+        self.factory = RequestFactory()
+
+    def _request(self, data):
+        """Return a POST request carrying the current tenant, as the middleware would."""
+        request = self.factory.post('/', data)
+        request.tenant = connection.tenant
+        return request
+
+    def test_library_schema_if_requested__flag_set_switches_to_library(self):
+        """With the flag set, the context manager enters the Library schema."""
+        with library_schema_if_requested(self._request({'use_library_schema': '1'})):
+            self.assertEqual(connection.schema_name, get_library_schema_name())
+
+    def test_library_schema_if_requested__no_flag_stays_on_the_callers_deck(self):
+        """Without the flag, the context manager stays on the requesting tenant's schema."""
+        own_schema = connection.schema_name
+
+        with library_schema_if_requested(self._request({})):
+            self.assertEqual(connection.schema_name, own_schema)
+
+    def test_library_schema_if_requested__arbitrary_schema_name_is_ignored(self):
+        """A schema name posted under the old `use_schema` key does not switch schemas.
+
+        Regression test: `use_schema` used to be read straight off the POST and handed to
+        `schema_context`, so any authenticated user could read another deck's content by
+        posting that deck's schema name. Schema names are the decks' public subdomains.
+        """
+        own_schema = connection.schema_name
+
+        with library_schema_if_requested(self._request({'use_schema': get_library_schema_name()})):
+            self.assertEqual(connection.schema_name, own_schema)
+
+
+class AjaxQuestInfoSchemaIsolationTestCase(LibraryTenantTestCaseMixin):
+    """The quest preview endpoint must not serve content from an arbitrary schema."""
+
+    LIBRARY_MARKER = 'library-only-marker-for-schema-isolation'
+
+    @classmethod
+    def setUpTestData(cls):
+        """Put a uniquely-marked quest in the Library and give the local deck a staff user."""
+        with library_schema_context():
+            cls.library_quest = baker.make(
+                Quest,
+                name='Library Isolation Quest',
+                short_description=cls.LIBRARY_MARKER,
+                published=True,
+                archived=False,
+            )
+        cls.test_teacher = User.objects.create_user('isolation_teacher', is_staff=True)
+
+    def _post_preview(self, data):
+        """POST the quest-preview endpoint for the Library quest's pk with the given data."""
+        return self.client.post(
+            reverse('quests:ajax_quest_info', args=[self.library_quest.id]),
+            data=data,
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+
+    def test_ajax_quest_info__foreign_schema_name_does_not_leak_content(self):
+        """Naming another schema in the POST does not serve that schema's quest.
+
+        Regression test for the `use_schema` POST parameter, which switched the
+        connection to any schema the caller named.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self._post_preview({'use_schema': get_library_schema_name()})
+
+        # Either the pk does not exist on this deck (404) or a local quest is served,
+        # but the other schema's content must never come back.
+        if response.status_code == 200:
+            self.assertNotIn(self.LIBRARY_MARKER, response.json()['quest_info_html'])
+        else:
+            self.assertEqual(response.status_code, 404)
+
+    def test_ajax_quest_info__library_flag_still_serves_library_content(self):
+        """The supported flag still renders the Library preview the accordion needs."""
+        self.client.force_login(self.test_teacher)
+
+        response = self._post_preview({'use_library_schema': 1})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.LIBRARY_MARKER, response.json()['quest_info_html'])

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -8,19 +8,45 @@ def get_library_schema_name():
     return apps.get_app_config('library').TENANT_NAME
 
 
-def from_library_schema_first(request):
+# POST flag the front end sets to ask for a preview out of the shared Library
+# instead of the caller's own deck. It is a boolean: the schema name is never
+# taken from the request (see `library_schema_if_requested`).
+LIBRARY_SCHEMA_POST_FLAG = 'use_library_schema'
+
+# Values jQuery / a plain form can send for a "true" boolean.
+_TRUTHY_POST_VALUES = frozenset(['1', 'true', 'True', 'on', 'yes'])
+
+
+def is_library_schema_requested(request):
+    """Whether this request asked to be served out of the shared Library schema.
+
+    Args:
+        request (HttpRequest): the current request.
+
+    Returns:
+        bool: True if the request carries the Library flag with a truthy value.
     """
-    Function to check if the POST request contains `use_schema` data which will allow us to
-    use the library schema for fetching campaigns or quest data
+    return request.POST.get(LIBRARY_SCHEMA_POST_FLAG) in _TRUTHY_POST_VALUES
+
+
+def library_schema_if_requested(request):
+    """Return a schema context for this request: the Library, or the caller's own deck.
+
+    The request only gets to ask a yes/no question. The schema name itself is
+    resolved here from `get_library_schema_name()`, never read off the request:
+    a request that could name its own schema would let any authenticated user
+    read another deck's content just by POSTing that deck's schema name, since
+    schema names are public (they are the decks' subdomains).
+
+    Args:
+        request (HttpRequest): the current request.
+
+    Returns:
+        context manager: switches the connection to the resolved schema.
     """
+    schema_name = get_library_schema_name() if is_library_schema_requested(request) else request.tenant.schema_name
 
-    current_schema_name = request.tenant.schema_name
-    use_schema_name = request.POST.get('use_schema')
-    schema_name = use_schema_name if use_schema_name else current_schema_name
-
-    force_schema_func = functools.partial(schema_context, schema_name)
-
-    return force_schema_func()
+    return schema_context(schema_name)
 
 
 library_schema_context = functools.partial(schema_context, get_library_schema_name())

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -298,7 +298,6 @@ class ImportCampaignView(View):
             'category_displayed_quests': shared_quests,
             'local_category': local_category,
             'local_quest_import_ids': local_quest_import_ids,
-            'use_schema': get_library_schema_name(),
         }
         return render(request, self.template_name, context)
 
@@ -596,7 +595,6 @@ class CategoryDetailView(TemplateView):
                 - category_total_xp_available (int): Sum of XP from all publsihed quests in the campaign.
                 - category_displayed_quests (list[Quest]): List of quest objects to display.
                 - quest_info (list[dict]): List of dicts with detailed quest info.
-                - use_schema (str): Name of the library schema currently in use.
         """
         campaign_import_id = kwargs.get('campaign_import_id')
         context = super().get_context_data(**kwargs)
@@ -629,7 +627,6 @@ class CategoryDetailView(TemplateView):
                 'category_total_xp_available': category.xp_sum(),
                 'category_displayed_quests': displayed_quests,
                 'quest_info': quest_info,
-                'use_schema': get_library_schema_name(),
             })
 
         return context

--- a/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
+++ b/src/quest_manager/static/quest_manager/js/bootstrap-table-accordion.js
@@ -63,7 +63,10 @@ function loadQuestOrSubmissionContent(id) {
       ajax_url = `${window.contextData.ajax_approval_root}${id}/`;
   } else if (currentURL.includes("/library/")) {
       ajax_url = `${window.contextData.ajax_quest_root}${id}/`;
-      postData.use_schema = "library";
+      // Ask for the preview out of the shared Library. This is a yes/no flag:
+      // the server resolves the Library's schema name itself, so the browser
+      // cannot name the schema the request runs against.
+      postData.use_library_schema = 1;
   } else {
       ajax_url = `${window.contextData.ajax_quest_root}${id}/`; // Default for available quests or drafts
   }

--- a/src/quest_manager/templates/quest_manager/base.html
+++ b/src/quest_manager/templates/quest_manager/base.html
@@ -25,5 +25,5 @@
         ajax_quest_root: "{% url 'quests:ajax_quest_root' %}",
       };
     </script>
-    <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}?v=1.2"></script>
+    <script src="{% static 'quest_manager/js/bootstrap-table-accordion.js' %}?v=1.3"></script>
 {% endblock %}

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -923,6 +923,35 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
 @non_public_only_view
 @login_required
 def ajax_quest_info(request, quest_id=None):
+    """Return the rendered preview panel for one quest, for the accordion tables.
+
+    POST only, and XHR only (see the decorators). The accordion in
+    bootstrap-table-accordion.js calls this when a row is expanded and drops the
+    returned HTML into the row's detail area.
+
+    On a Library page the accordion sets ``use_library_schema=1``, which serves
+    the preview out of the shared Library schema instead of the caller's own
+    deck. That flag is a boolean by design: the schema name is resolved server
+    side from the library app's config, never taken from the request, so a
+    caller cannot name the schema its request runs against (schema names are the
+    decks' public subdomains, so accepting one would let any logged-in user read
+    another deck's content).
+
+    Args:
+        request (HttpRequest): the current request. Reads ``use_library_schema``
+            from POST; everything else comes from the URL and the session.
+        quest_id (int | None): primary key of the quest to preview, in whichever
+            schema the flag above selected. Staff may preview archived quests.
+
+    Returns:
+        JsonResponse: ``{"quest_info_html": "<rendered preview>"}``.
+
+    Raises:
+        Http404: if the request is not a POST, if no ``quest_id`` is given (the
+            "every quest at once" response was an unbounded per-request memory
+            hog with no staff gate, issue #2081), or if no matching quest is
+            visible to this user.
+    """
     if request.method == "POST":
         template = 'quest_manager/preview_content_quests_avail.html'
 

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -32,7 +32,7 @@ from questions.forms import QuestionSubmissionFormsetFactory
 from questions.models import QuestionSubmission, QuestionType
 from questions.utils import sync_draft_question_submissions
 from courses.models import Block, CourseStudent
-from library.utils import from_library_schema_first
+from library.utils import is_library_schema_requested, library_schema_if_requested
 from notifications.signals import notify
 from notifications.models import notify_rank_up
 from prerequisites.views import ObjectPrereqsFormView
@@ -926,8 +926,8 @@ def ajax_quest_info(request, quest_id=None):
     if request.method == "POST":
         template = 'quest_manager/preview_content_quests_avail.html'
 
-        with from_library_schema_first(request):
-            is_library_view = (request.POST.get('use_schema') == 'library')
+        with library_schema_if_requested(request):
+            is_library_view = is_library_schema_requested(request)
             can_export = SiteConfig.get().can_user_export_to_library(request.user)
 
             if quest_id:


### PR DESCRIPTION
### What?

The quest-preview AJAX endpoint let the browser choose which tenant schema the request ran under, via a `use_schema` POST parameter. This replaces that with a boolean flag and resolves the schema name server side.

- `library.utils.from_library_schema_first()` is replaced by `library_schema_if_requested()` + `is_library_schema_requested()`.
- The wire contract changes from `use_schema=<schema name>` to `use_library_schema=1`.
- `bootstrap-table-accordion.js` sends the new flag (cache-buster bumped to `?v=1.3`).
- The `use_schema` template context keys are removed: nothing read them.
- `ajax_quest_info` gains the docstring it was missing.

### Why?

`from_library_schema_first()` read `use_schema` straight off the POST body and handed it to `schema_context()`:

```python
use_schema_name = request.POST.get('use_schema')
schema_name = use_schema_name if use_schema_name else current_schema_name
return functools.partial(schema_context, schema_name)()
```

Its only caller, `ajax_quest_info`, is `@login_required` but not staff-gated. Schema names are the decks' public subdomains and quest primary keys are small and sequential, so an authenticated user on one deck could read another deck's quest content by posting that deck's schema name with a quest pk. I reproduced it with a staff user on one deck pulling a uniquely-marked quest out of a different schema:

```
[PROBE] status: 200
[PROBE] leaked SECRET-MARKER-XYZ: True
```

A student hitting the same request got a 500 instead (their profile lookup runs against the foreign schema and fails), so the practical exposure was staff-to-staff between unrelated schools. A schema name that does not exist gave a 500 and an aborted transaction.

The same change removes a hardcoded `'library'` literal that `is_library_view` compared against, which quietly ignored `LIBRARY_TENANT_NAME`.

This is a hotfix rather than a `develop` PR because it is a tenant isolation break on live decks. There is no issue number: filing a public issue describing a cross-tenant read before the fix shipped would have advertised it. Happy to file one retroactively if you would rather have it tracked.

### How?

The request now only gets to ask a yes/no question. The schema name is resolved from `get_library_schema_name()`, never read off the request:

```python
def library_schema_if_requested(request):
    schema_name = get_library_schema_name() if is_library_schema_requested(request) else request.tenant.schema_name
    return schema_context(schema_name)
```

`is_library_schema_requested()` accepts the spellings a form or jQuery can send (`1`, `true`, `True`, `on`, `yes`) and nothing else, so a posted schema name is simply not a truthy flag.

### Testing?

New tests in `src/library/tests/test_utils.py` (9 tests in that module, all passing):

- flag parsing: truthy values, falsy/missing values, and a posted schema name treated as not-a-flag
- schema resolution: flag set enters the Library schema, no flag stays on the caller's deck, an arbitrary schema name under the old `use_schema` key is ignored
- the endpoint itself: a foreign schema name must not return that schema's content, and the supported flag still renders the Library preview

All four schema-related tests fail against the old behaviour (verified by reverting the resolution line and re-running):

```
FAIL: test_ajax_quest_info__foreign_schema_name_does_not_leak_content
      AssertionError: 'library-only-marker-for-schema-isolation' unexpectedly found in ...
FAIL: test_ajax_quest_info__library_flag_still_serves_library_content
FAIL: test_library_schema_if_requested__arbitrary_schema_name_is_ignored
FAIL: test_library_schema_if_requested__flag_set_switches_to_library
```

Full runs against this branch: `src/library` + `src/quest_manager` = 428 tests, OK. `ruff check src` clean. Codecov reports all modified lines covered. `library/utils.py` was the only uncovered code in the library app (5 statements, exactly this function); it is now covered.

Also verified in the browser, see below.

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

There is **no visual change**: the only front-end edit is the POST key the accordion sends when expanding a row on a Library page, and the rendered preview is byte-for-byte the same. So there is no meaningful before/after to show. What is worth showing is that the preview still loads over the new wire format, captured from the real running app rather than a reproduction:

![Library quest preview loading on the hackerspace dev deck](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2362/library-preview-expanded.png)

Real `hackerspace` dev deck (`initdb` + `generate_content hackerspace`, Shared Library enabled), signed in as a teacher, on the Library tab with the first quest row expanded. The expanded panel is the AJAX response this PR's flag drives: it shows the real seeded Library quest's description, its "Import Quest" button (so `is_library_view` resolved correctly), and its prerequisite chain read from the Library schema. Console clean, no failed requests:

```
expanding row: [Shared Library] - ByteDeck Class Contract 2 Orientation intro
still spinning: False
console errors: none
```

### Anything Else?

This came out of a full audit of the Shared Library import/export system. This PR is the only finding that affects tenant isolation, which is why it was split out first and sent to `staging`. Everything else from the audit is now filed:

**Correctness / access control:** #2363 (unreviewed content importable by URL, bypassing the #1949 review gate), #2364 (name collision on import returns a 500), #2365 (`enable_shared_library` only hides the sidebar link), #2366 (licence agreement is client-side only), #2367 (conflict-clone export drags local FK ids into the Library schema), #2369 (lazy querysets rendered outside the schema context), #2370 (campaign import preview renders a blank heading), #2371 (review email arrives as one run-on paragraph), #2372 (pushes are not atomic), #2373 (conflicts raise `PermissionDenied`, so users get a bare 403).

**User-facing gaps:** #2374 (tell the sharer what does not travel), #2375 (badges cannot be shared, badge prereqs vanish), #2376 (let a sharer push a corrected version, answering an open question from #1546), #2377 (provenance and post-import guidance), #2379 (no pagination or server-side search).

**Code health:** #2378 (move the cross-deck serialization out of `quest_manager.admin`), #2380 (dead template, URL-string branching, wrong docstring, em dashes).

#2381 is now open against `develop` with the first batch of those fixes (#2363, #2365, #2366).

Also added root-cause comments to #1792 (two separate bugs behind the missing tags) and #2163 (the same schema-context mechanism, generalized), and a status comment on #1546 measuring the implementation against its spec.

**Separately found while setting up the dev deck for the screenshot above:** a fresh `initdb` gives the Shared Library deck an unreachable domain. Filed as #2382; unrelated to this diff.

The wire-format change here means a browser holding the old cached JS would stop getting Library previews until it picks up `?v=1.3`. It fails closed (the preview renders from the user's own deck or 404s), never open.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)