### PR TITLE
fix: close three missing guards in the Shared Library views (#2363, #2365, #2366)

### DIFF
--- a/src/library/forms.py
+++ b/src/library/forms.py
@@ -1,0 +1,19 @@
+from django import forms
+
+
+class ShareLicenceForm(forms.Form):
+    """Confirms the sharer agrees to the Shared Library's content licence.
+
+    Content pushed to the Shared Library is published to every other deck under
+    CC BY-SA 4.0, and #1546 requires the sharer to agree to that before the push
+    goes through. The confirmation templates mark the checkbox `required`, but
+    that is a browser-side hint only: this form is what actually holds the push.
+    """
+
+    agree_license = forms.BooleanField(
+        required=True,
+        label="I agree to share this content under the Creative Commons Attribution-ShareAlike 4.0 International License.",
+        error_messages={
+            "required": "You need to agree to the Creative Commons license before sharing to the Library.",
+        },
+    )

--- a/src/library/importer.py
+++ b/src/library/importer.py
@@ -54,11 +54,13 @@ def import_quest_to(*, destination_schema, quest_import_id):
         ImportResult: The result of the import operation, including row-level status info.
 
     Raises:
-        ValueError: If the quest with the given import_id does not exist in the source schema
-                    or cannot be found in the destination schema after import.
+        Quest.DoesNotExist: If no *published* quest with the given import_id exists in
+            the library. Content awaiting a Library admin's review is unpublished and
+            must not travel to other decks (#1949), so it is filtered out here as well
+            as in the view.
     """
     with library_schema_context():
-        quest = Quest.objects.get(import_id=quest_import_id)
+        quest = Quest.objects.get(import_id=quest_import_id, published=True)
 
         export_data = QuestResource().export([quest])
 

--- a/src/library/templates/library/confirm_export_campaign.html
+++ b/src/library/templates/library/confirm_export_campaign.html
@@ -38,9 +38,13 @@
     <form method="post" id="export-form">
       {% csrf_token %}
 
+      {% if licence_form.agree_license.errors %}
+        <div class="alert alert-danger">{{ licence_form.agree_license.errors.0 }}</div>
+      {% endif %}
+
       <div class="form-check mb-3">
-        <input type="checkbox" class="form-check-input" id="agreeLicense" name="agreeLicense" required />
-        <label class="form-check-label" for="agreeLicense">
+        <input type="checkbox" class="form-check-input" id="id_agree_license" name="agree_license" required />
+        <label class="form-check-label" for="id_agree_license">
           I agree to share this campaign and all its quests under the Creative Commons Attribution-ShareAlike 4.0 International License.*
         </label>
       </div>

--- a/src/library/templates/library/confirm_export_quest.html
+++ b/src/library/templates/library/confirm_export_quest.html
@@ -31,9 +31,13 @@
     <form method="post" id="export-form">
       {% csrf_token %}
 
+      {% if licence_form.agree_license.errors %}
+        <div class="alert alert-danger">{{ licence_form.agree_license.errors.0 }}</div>
+      {% endif %}
+
       <div class="form-check mb-3">
-        <input type="checkbox" class="form-check-input" id="agreeLicense" name="agreeLicense" required />
-        <label class="form-check-label" for="agreeLicense">
+        <input type="checkbox" class="form-check-input" id="id_agree_license" name="agree_license" required />
+        <label class="form-check-label" for="id_agree_license">
           I agree to share this quest under the Creative Commons Attribution-ShareAlike 4.0 International License.*
         </label>
       </div>

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -5,10 +5,13 @@ from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection
+from django.http import Http404
+from django.test import RequestFactory
 from django.urls import reverse
 from django_tenants.utils import get_public_schema_name, schema_exists
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.utils import get_library_schema_name, library_schema_context
+from library.views import shared_library_enabled_view
 from library.importer import import_quest_to, import_campaign_to
 from library.exporter import export_campaign_and_copy_quests, export_campaign_to_library, export_quest_to_library
 from model_bakery import baker
@@ -1442,3 +1445,18 @@ class LibraryViewsOnPublicSchemaTests(LibraryTenantTestCaseMixin):
             with self.subTest(url_name=url_name):
                 response = self.client.get(reverse(url_name))
                 self.assertEqual(response.status_code, 404)
+
+    @patch('library.views.SiteConfig.get', return_value=None)
+    def test_shared_library_enabled_view__404s_when_there_is_no_site_config(self, mock_get):
+        """With no deck config there is no Shared Library either, so the check 404s.
+
+        `SiteConfig.get()` returns None on the public schema. This check runs ahead
+        of the non-public guard, so it has to handle that itself rather than raising
+        AttributeError on a None config. Exercised against the decorator directly:
+        going through the test client would render the 404 page, which calls
+        `SiteConfig.get()` again and would fail on the patch rather than the guard.
+        """
+        wrapped = shared_library_enabled_view(lambda request: 'reached the view')
+
+        with self.assertRaises(Http404):
+            wrapped(RequestFactory().get('/'))

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -6,7 +6,7 @@ from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection
 from django.urls import reverse
-from django_tenants.utils import schema_exists
+from django_tenants.utils import get_public_schema_name, schema_exists
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.utils import get_library_schema_name, library_schema_context
 from library.importer import import_quest_to, import_campaign_to
@@ -20,6 +20,10 @@ from tenant.models import TenantDomain
 
 
 User = get_user_model()
+
+# What the browser sends when the sharer ticks the licence checkbox on an export
+# confirmation page. The push is refused without it (#2366).
+AGREED_LICENCE = {'agree_license': 'on'}
 
 
 class LibraryTenantTestCaseMixin(ByteDeckTenantTestCase):
@@ -40,6 +44,18 @@ class LibraryTenantTestCaseMixin(ByteDeckTenantTestCase):
             cls._setup_library_tenant()
 
         super().setUpClass()
+
+    def setUp(self):
+        """Turn the Shared Library on for the deck under test.
+
+        Every test in this module exercises a deck that has opted into the feature.
+        The opted-out case has its own class (`SharedLibraryDisabledTests`), so the
+        default here is "enabled" rather than SiteConfig's off-by-default.
+        """
+        super().setUp()
+        config = SiteConfig.get()
+        config.enable_shared_library = True
+        config.save()
 
     @classmethod
     def get_library_tenant_domain(cls):
@@ -76,6 +92,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
 
     def setUp(self):
         """Set up the site config and active semester."""
+        super().setUp()
         self.config = SiteConfig.get()
         self.sem = SiteConfig.get().active_semester
 
@@ -299,7 +316,9 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         # Login as staff
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('library:quest_list'))
+        # The Library pages themselves 404 while the feature is off, so check the
+        # sidebar on a page staff can still reach.
+        response = self.client.get(reverse('quests:quests'))
         # Checks if the html in the sidebar for library is there (shouldn't be)
         self.assertNotContains(response, 'id="lg-menu-library"')
 
@@ -325,7 +344,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse("library:export_quest", kwargs={"quest_import_id": str(self.local_quest.import_id)})
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
 
         self.assertEqual(response.status_code, 403)
 
@@ -398,7 +417,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)  # user performing export
 
         url = reverse('library:export_quest', args=[self.local_quest.import_id])
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
 
         self.assertRedirects(response, reverse('quests:quests'))
 
@@ -439,7 +458,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse('library:export_quest', args=[self.local_quest.import_id])
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
         self.assertRedirects(response, reverse('quests:quests'))
 
         # An email was dispatched asynchronously to the library staff member.
@@ -473,7 +492,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse("library:export_quest", kwargs={"quest_import_id": str(self.shared_quest.import_id)})
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
 
         self.assertEqual(response.status_code, 403)
 
@@ -500,6 +519,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
 
     def setUp(self):
         """Set up the active semester, site config, and deck owner."""
+        super().setUp()
         self.sem = SiteConfig.get().active_semester
 
         self.config = SiteConfig.get()
@@ -870,7 +890,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
         self.assertEqual(response.status_code, 403)
 
     def test_export__permission_allowed_for_owner_staff_export_disabled(self):
@@ -931,7 +951,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse('library:export_category', kwargs={'campaign_import_id': str(self.shared_category.import_id)})
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
         self.assertEqual(response.status_code, 403)
 
     def test_export_get__disables_button_if_no_quests(self):
@@ -966,7 +986,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse('library:export_category', kwargs={'campaign_import_id': str(self.local_category.import_id)})
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
         self.assertRedirects(response, reverse('quests:categories'))
 
         with library_schema_context():
@@ -1005,7 +1025,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse('library:export_category', kwargs={'campaign_import_id': str(self.local_category.import_id)})
-        response = self.client.post(url)
+        response = self.client.post(url, data=AGREED_LICENCE)
         self.assertRedirects(response, reverse('quests:categories'))
 
         # An email was dispatched asynchronously to the library staff member.
@@ -1200,3 +1220,225 @@ class ExporterErrorPathTests(LibraryTenantTestCaseMixin):
         baker.make(Quest, campaign=campaign, published=True)
         with self.assertRaisesMessage(ValidationError, "Failed to import campaign to library schema"):
             export_campaign_to_library(source_schema=self.tenant.schema_name, campaign_import_id=campaign.import_id)
+
+
+class SharedLibraryDisabledTests(LibraryTenantTestCaseMixin):
+    """Every Library view is unreachable on a deck that has the feature turned off.
+
+    `SiteConfig.enable_shared_library` used to hide the sidebar link and nothing
+    else, leaving every Library URL live (and importable) on a deck that had
+    opted out.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create published Library content and a staff user on the local deck."""
+        with library_schema_context():
+            cls.library_campaign = baker.make(Category, published=True)
+            cls.library_quest = baker.make(Quest, campaign=cls.library_campaign, published=True, archived=False)
+
+        cls.local_quest = baker.make(Quest, published=True)
+        cls.local_campaign = baker.make(Category)
+        baker.make(Quest, campaign=cls.local_campaign, published=True)
+        cls.test_teacher = User.objects.create_user('disabled_teacher', is_staff=True)
+
+    def setUp(self):
+        """Turn the Shared Library back off, overriding the base class default."""
+        super().setUp()
+        self.config = SiteConfig.get()
+        self.config.enable_shared_library = False
+        self.config.allow_staff_export = True
+        self.config.save()
+        self.client.force_login(self.test_teacher)
+
+    def test_library_views__return_404_when_shared_library_disabled(self):
+        """Staff hitting any Library URL on an opted-out deck get a 404."""
+        urls = [
+            reverse('library:quest_list'),
+            reverse('library:category_list'),
+            reverse('library:import_quest', args=[self.library_quest.import_id]),
+            reverse('library:import_category', args=[self.library_campaign.import_id]),
+            reverse('library:category_detail_view', args=[self.library_campaign.import_id]),
+            reverse('library:export_quest', args=[self.local_quest.import_id]),
+            reverse('library:export_category', args=[self.local_campaign.import_id]),
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                self.assert404URL(url)
+
+    def test_import_quest_post__does_nothing_when_shared_library_disabled(self):
+        """A POST to the quest import URL cannot pull content onto an opted-out deck."""
+        response = self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(Quest.objects.all_including_archived().filter(import_id=self.library_quest.import_id).exists())
+
+    def test_import_campaign_post__does_nothing_when_shared_library_disabled(self):
+        """A POST to the campaign import URL cannot pull content onto an opted-out deck."""
+        response = self.client.post(reverse('library:import_category', args=[self.library_campaign.import_id]))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(Category.objects.filter(import_id=self.library_campaign.import_id).exists())
+
+    def test_export_quest_post__does_nothing_when_shared_library_disabled(self):
+        """A POST to the quest export URL cannot push content from an opted-out deck."""
+        response = self.client.post(
+            reverse('library:export_quest', args=[self.local_quest.import_id]), data=AGREED_LICENCE
+        )
+
+        self.assertEqual(response.status_code, 404)
+        with library_schema_context():
+            self.assertFalse(Quest.objects.all_including_archived().filter(import_id=self.local_quest.import_id).exists())
+
+
+class UnreviewedLibraryContentTests(LibraryTenantTestCaseMixin):
+    """Content awaiting a Library admin's review must not be importable.
+
+    Pushed content lands unpublished and is invisible until reviewed (#1949).
+    That gate only filtered the listing pages, so a POST straight to an import
+    URL pulled unreviewed content down.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create unpublished (pending review) Library content and a local staff user."""
+        with library_schema_context():
+            cls.pending_quest = baker.make(Quest, published=False, archived=False)
+            cls.pending_campaign = baker.make(Category, published=False)
+            cls.pending_campaign_quest = baker.make(
+                Quest, campaign=cls.pending_campaign, published=True, archived=False
+            )
+        cls.test_teacher = User.objects.create_user('pending_teacher', is_staff=True)
+
+    def setUp(self):
+        """Log in as staff on a deck with the Shared Library enabled."""
+        super().setUp()
+        self.client.force_login(self.test_teacher)
+
+    def test_import_quest_get__redirects_when_quest_awaits_review(self):
+        """The confirmation page for an unpublished Library quest sends the user back with a warning."""
+        response = self.client.get(reverse('library:import_quest', args=[self.pending_quest.import_id]))
+
+        self.assertRedirects(response, reverse('library:quest_list'))
+        self.assertWarningMessage(response)
+
+    def test_import_quest_post__refuses_a_quest_awaiting_review(self):
+        """Posting the import URL for an unpublished Library quest imports nothing."""
+        response = self.client.post(reverse('library:import_quest', args=[self.pending_quest.import_id]))
+
+        self.assertRedirects(response, reverse('library:quest_list'))
+        self.assertFalse(Quest.objects.all_including_archived().filter(import_id=self.pending_quest.import_id).exists())
+
+    def test_import_campaign_get__redirects_when_campaign_awaits_review(self):
+        """The confirmation page for an unpublished Library campaign sends the user back with a warning."""
+        response = self.client.get(reverse('library:import_category', args=[self.pending_campaign.import_id]))
+
+        self.assertRedirects(response, reverse('library:category_list'))
+        self.assertWarningMessage(response)
+
+    def test_import_campaign_post__refuses_a_campaign_awaiting_review(self):
+        """Posting the import URL for an unpublished Library campaign imports nothing, quests included."""
+        response = self.client.post(reverse('library:import_category', args=[self.pending_campaign.import_id]))
+
+        self.assertRedirects(response, reverse('library:category_list'))
+        self.assertFalse(Category.objects.filter(import_id=self.pending_campaign.import_id).exists())
+        self.assertFalse(
+            Quest.objects.all_including_archived().filter(import_id=self.pending_campaign_quest.import_id).exists()
+        )
+
+    def test_category_detail_view__redirects_when_campaign_awaits_review(self):
+        """The Library campaign detail page is not a peephole into unreviewed content."""
+        response = self.client.get(reverse('library:category_detail_view', args=[self.pending_campaign.import_id]))
+
+        self.assertRedirects(response, reverse('library:category_list'))
+        self.assertWarningMessage(response)
+
+    def test_import_quest_to__refuses_a_quest_awaiting_review(self):
+        """The importer itself filters on published, not just the view above it."""
+        with self.assertRaises(Quest.DoesNotExist):
+            import_quest_to(destination_schema=connection.schema_name, quest_import_id=self.pending_quest.import_id)
+
+    def test_import_quest__unknown_import_id_still_404s(self):
+        """An import ID that is in no schema at all is a 404, not a redirect."""
+        self.assert404URL(reverse('library:import_quest', args=[str(uuid.uuid4())]))
+
+
+class ShareLicenceAgreementTests(LibraryTenantTestCaseMixin):
+    """The CC BY-SA agreement holds the push server-side, not just in the browser."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a local quest and campaign to share, and a staff user to share them."""
+        cls.local_quest = baker.make(Quest, published=True, archived=False)
+        cls.local_campaign = baker.make(Category)
+        baker.make(Quest, campaign=cls.local_campaign, published=True, archived=False)
+        cls.test_teacher = User.objects.create_user('licence_teacher', is_staff=True)
+
+    def setUp(self):
+        """Allow staff to export, and log in as one."""
+        super().setUp()
+        config = SiteConfig.get()
+        config.allow_staff_export = True
+        config.save()
+        self.client.force_login(self.test_teacher)
+
+    def test_export_quest_post__refused_without_the_licence_agreement(self):
+        """A quest push with no licence checkbox is re-rendered with an error and shares nothing."""
+        response = self.client.post(reverse('library:export_quest', args=[self.local_quest.import_id]), data={})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'agree to the Creative Commons license')
+        with library_schema_context():
+            self.assertFalse(Quest.objects.all_including_archived().filter(import_id=self.local_quest.import_id).exists())
+
+    def test_export_campaign_post__refused_without_the_licence_agreement(self):
+        """A campaign push with no licence checkbox is re-rendered with an error and shares nothing."""
+        response = self.client.post(reverse('library:export_category', args=[self.local_campaign.import_id]), data={})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'agree to the Creative Commons license')
+        with library_schema_context():
+            self.assertFalse(Category.objects.filter(import_id=self.local_campaign.import_id).exists())
+
+    def test_export_quest_post__succeeds_with_the_licence_agreement(self):
+        """Ticking the box lets the push through, so the guard is not blocking everything."""
+        response = self.client.post(
+            reverse('library:export_quest', args=[self.local_quest.import_id]), data=AGREED_LICENCE
+        )
+
+        self.assertRedirects(response, reverse('quests:quests'))
+        with library_schema_context():
+            self.assertTrue(Quest.objects.all_including_archived().filter(import_id=self.local_quest.import_id).exists())
+
+    def test_export_get__renders_the_licence_checkbox(self):
+        """Both confirmation pages render the field name the form validates."""
+        for url in (
+            reverse('library:export_quest', args=[self.local_quest.import_id]),
+            reverse('library:export_category', args=[self.local_campaign.import_id]),
+        ):
+            with self.subTest(url=url):
+                self.assertContains(self.client.get(url), 'name="agree_license"')
+
+
+class LibraryViewsOnPublicSchemaTests(LibraryTenantTestCaseMixin):
+    """The Library is a per-deck feature and has no meaning on the public schema.
+
+    There is a single urlconf, so `/library/...` resolves on the public tenant too,
+    where `SiteConfig.get()` returns None. These views need the project's standard
+    non-public guard ahead of anything that reads site config.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a staff user to make the request."""
+        cls.test_teacher = User.objects.create_user('public_schema_teacher', is_staff=True)
+
+    @patch('tenant.views.connection', schema_name=get_public_schema_name())
+    def test_library_views__404_on_the_public_schema(self, mock_connection):
+        """Library URLs are not served from the public schema."""
+        self.client.force_login(self.test_teacher)
+
+        for url_name in ('library:quest_list', 'library:category_list'):
+            with self.subTest(url_name=url_name):
+                response = self.client.get(reverse(url_name))
+                self.assertEqual(response.status_code, 404)

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -40,23 +40,18 @@ def shared_library_enabled_view(f):
     reachable (and importable) on a deck that had deliberately opted out. A deck
     with the feature off should behave as though it does not exist, hence 404
     rather than a 403 or an explanatory page.
+
+    `SiteConfig.get()` returns None on the public schema, which has no deck
+    config and so has no Shared Library either: that is treated the same way, so
+    this holds on its own rather than relying on running after a non-public check.
     """
     @functools.wraps(f)
     def wrapper(request, *args, **kwargs):
         config = SiteConfig.get()
-        if not config.enable_shared_library:
+        if config is None or not config.enable_shared_library:
             raise Http404("The Shared Library is not enabled on this deck.")
         return f(request, *args, **kwargs)
     return wrapper
-
-
-class SharedLibraryEnabledMixin:
-    """Class-based-view form of `shared_library_enabled_view`."""
-
-    @method_decorator(shared_library_enabled_view)
-    def dispatch(self, *args, **kwargs):
-        """Apply the Shared Library feature check before handling the request."""
-        return super().dispatch(*args, **kwargs)
 
 
 def get_published_library_object(model, import_id):
@@ -151,8 +146,8 @@ def email_library_staff_of_push(content_type, content_name, exported_obj, sharer
     send_email_message.apply_async(args=[subject, message, recipient_list], queue="default")
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class LibraryQuestListView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, TemplateView):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
     """
     View for displaying a list of active quests from the shared library.
 
@@ -195,8 +190,8 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, Te
         return context
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class LibraryCampaignListView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, TemplateView):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
     """
     View for displaying a list of active campaigns (categories) from the shared library.
 
@@ -243,8 +238,8 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin,
         return context
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class ImportQuestView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, View):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class ImportQuestView(NonPublicOnlyViewMixin, View):
     """
     View for importing a single quest from the shared library into the current deck.
 
@@ -321,8 +316,8 @@ class ImportQuestView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, View):
         return redirect('quests:drafts')
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class ImportCampaignView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, View):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class ImportCampaignView(NonPublicOnlyViewMixin, View):
     """
     View for importing a full campaign (category) from the shared library into the current deck.
 
@@ -445,8 +440,8 @@ class ExportPermissionMixin:
             raise PermissionDenied("Only the deck owner can export unless allow_staff_export is enabled.")
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class ExportQuestView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, ExportPermissionMixin, View):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
     """
     View for exporting a single quest from the current deck into the shared library.
 
@@ -560,8 +555,8 @@ class ExportQuestView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, ExportP
         return redirect('quests:quests')
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class ExportCampaignView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, ExportPermissionMixin, View):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
     """
     View for exporting a full campaign (category) and its quests
     from the current deck into the shared library.
@@ -697,8 +692,8 @@ class ExportCampaignView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, Expo
         return redirect('quests:categories')
 
 
-@method_decorator([login_required, staff_member_required], name='dispatch')
-class CategoryDetailView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, TemplateView):
+@method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
+class CategoryDetailView(NonPublicOnlyViewMixin, TemplateView):
     """
     View the content of a campaign (category) from the shared library.
     """

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -1,6 +1,9 @@
+import functools
+
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.db import connection
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
 from django.utils.decorators import method_decorator
@@ -10,6 +13,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 
 from hackerspace_online.decorators import staff_member_required
+from tenant.views import NonPublicOnlyViewMixin
 
 from quest_manager.models import Quest, Category
 
@@ -21,10 +25,84 @@ from notifications.signals import notify
 
 
 from .exporter import export_quest_to_library, export_campaign_and_copy_quests
+from .forms import ShareLicenceForm
 from .importer import import_campaign_to, import_quest_to
 from .utils import get_library_schema_name, library_schema_context, get_library_conflicting_quests
 
 User = get_user_model()
+
+
+def shared_library_enabled_view(f):
+    """Raise Http404 unless this deck has the Shared Library turned on.
+
+    `SiteConfig.enable_shared_library` is off by default and marked experimental.
+    Without this the flag only hid the sidebar link, so every Library URL stayed
+    reachable (and importable) on a deck that had deliberately opted out. A deck
+    with the feature off should behave as though it does not exist, hence 404
+    rather than a 403 or an explanatory page.
+    """
+    @functools.wraps(f)
+    def wrapper(request, *args, **kwargs):
+        config = SiteConfig.get()
+        if not config.enable_shared_library:
+            raise Http404("The Shared Library is not enabled on this deck.")
+        return f(request, *args, **kwargs)
+    return wrapper
+
+
+class SharedLibraryEnabledMixin:
+    """Class-based-view form of `shared_library_enabled_view`."""
+
+    @method_decorator(shared_library_enabled_view)
+    def dispatch(self, *args, **kwargs):
+        """Apply the Shared Library feature check before handling the request."""
+        return super().dispatch(*args, **kwargs)
+
+
+def get_published_library_object(model, import_id):
+    """Fetch a published object from the Shared Library by its import ID.
+
+    Content lands in the Library unpublished and stays invisible to other decks
+    until a Library admin reviews and publishes it (#1949). That gate used to
+    filter only the listing pages, so a POST straight to an import URL pulled
+    unreviewed content down. Both import paths go through here instead.
+
+    Must be called from within the library schema context.
+
+    Args:
+        model (type[Quest] | type[Category]): the model to fetch.
+        import_id (UUID): the import ID to look up.
+
+    Returns:
+        Quest | Category | None: the published object, or None when it exists in
+        the Library but has not been published yet.
+
+    Raises:
+        Http404: if nothing in the Library has this import ID at all.
+    """
+    obj = model.objects.filter(import_id=import_id).first()
+    if obj is None:
+        raise Http404(f"No {model._meta.verbose_name} in the Library with import ID {import_id}.")
+
+    return obj if obj.published else None
+
+
+def redirect_awaiting_review(request, content_type, redirect_to):
+    """Send the user back to the Library, explaining the content is not published yet.
+
+    Args:
+        request (HttpRequest): the current request, for the message framework.
+        content_type (str): "quest" or "campaign", used in the message.
+        redirect_to (str): the URL name to redirect to.
+
+    Returns:
+        HttpResponseRedirect: a redirect carrying the warning message.
+    """
+    messages.warning(
+        request,
+        f"That {content_type} is not available in the Library yet: a Library admin still has to review and publish it."
+    )
+    return redirect(redirect_to)
 
 
 def email_library_staff_of_push(content_type, content_name, exported_obj, sharer, source_deck_url):
@@ -74,7 +152,7 @@ def email_library_staff_of_push(content_type, content_name, exported_obj, sharer
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class LibraryQuestListView(TemplateView):
+class LibraryQuestListView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, TemplateView):
     """
     View for displaying a list of active quests from the shared library.
 
@@ -118,7 +196,7 @@ class LibraryQuestListView(TemplateView):
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class LibraryCampaignListView(TemplateView):
+class LibraryCampaignListView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, TemplateView):
     """
     View for displaying a list of active campaigns (categories) from the shared library.
 
@@ -166,7 +244,7 @@ class LibraryCampaignListView(TemplateView):
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class ImportQuestView(View):
+class ImportQuestView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, View):
     """
     View for importing a single quest from the shared library into the current deck.
 
@@ -196,7 +274,10 @@ class ImportQuestView(View):
 
         # Fetch the quest from the shared library
         with library_schema_context():
-            quest = get_object_or_404(Quest, import_id=quest_import_id)
+            quest = get_published_library_object(Quest, quest_import_id)
+
+        if quest is None:
+            return redirect_awaiting_review(request, 'quest', 'library:quest_list')
 
         return render(request, self.template_name, {
             'quest': quest,
@@ -226,7 +307,9 @@ class ImportQuestView(View):
             raise PermissionDenied(f'Quest with import_id {quest_import_id} already exists in the current deck.')
 
         with library_schema_context():
-            quest = get_object_or_404(Quest, import_id=quest_import_id)
+            quest = get_published_library_object(Quest, quest_import_id)
+            if quest is None:
+                return redirect_awaiting_review(request, 'quest', 'library:quest_list')
             # Use dest_schema because current schema is library
             import_quest_to(destination_schema=dest_schema, quest_import_id=quest.import_id)
 
@@ -239,7 +322,7 @@ class ImportQuestView(View):
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class ImportCampaignView(View):
+class ImportCampaignView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, View):
     """
     View for importing a full campaign (category) from the shared library into the current deck.
 
@@ -271,7 +354,9 @@ class ImportCampaignView(View):
         local_category = Category.objects.filter(import_id=campaign_import_id).first()
 
         with library_schema_context():
-            library_category = get_object_or_404(Category, import_id=campaign_import_id)
+            library_category = get_published_library_object(Category, campaign_import_id)
+            if library_category is None:
+                return redirect_awaiting_review(request, 'campaign', 'library:category_list')
             category_id = library_category.pk
             category_name = library_category.name
             category_icon = library_category.get_icon_url()
@@ -325,7 +410,9 @@ class ImportCampaignView(View):
             raise PermissionDenied(f'Campaign with import ID {campaign_import_id} already exists in the current deck.')
 
         with library_schema_context():
-            category = get_object_or_404(Category, import_id=campaign_import_id)
+            category = get_published_library_object(Category, campaign_import_id)
+            if category is None:
+                return redirect_awaiting_review(request, 'campaign', 'library:category_list')
             # Collect import IDs for all quests in the campaign
             # Inactive quests are filtered out by the importer
             quest_ids = list(category.quest_set.values_list('import_id', flat=True))
@@ -359,7 +446,7 @@ class ExportPermissionMixin:
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class ExportQuestView(View, ExportPermissionMixin):
+class ExportQuestView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, ExportPermissionMixin, View):
     """
     View for exporting a single quest from the current deck into the shared library.
 
@@ -388,6 +475,7 @@ class ExportQuestView(View, ExportPermissionMixin):
         return render(request, self.template_name, {
             'quest': quest,
             'library_quest': library_quest,
+            'licence_form': ShareLicenceForm(),
         })
 
     def post(self, request, quest_import_id):
@@ -414,6 +502,18 @@ class ExportQuestView(View, ExportPermissionMixin):
         self._require_export_permission(request)
 
         quest = get_object_or_404(Quest.objects.all(), import_id=quest_import_id)
+
+        # The licence checkbox is `required` in the template, but that is a browser
+        # hint only: this is what actually holds the push (#1546, #2366).
+        licence_form = ShareLicenceForm(request.POST)
+        if not licence_form.is_valid():
+            with library_schema_context():
+                library_quest = Quest.objects.all_including_archived().filter(import_id=quest.import_id).first()
+            return render(request, self.template_name, {
+                'quest': quest,
+                'library_quest': library_quest,
+                'licence_form': licence_form,
+            })
 
         source_schema = connection.schema_name
         # Resolve the source deck's URL now, while its schema is active (the email
@@ -461,7 +561,7 @@ class ExportQuestView(View, ExportPermissionMixin):
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class ExportCampaignView(View, ExportPermissionMixin):
+class ExportCampaignView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, ExportPermissionMixin, View):
     """
     View for exporting a full campaign (category) and its quests
     from the current deck into the shared library.
@@ -470,20 +570,21 @@ class ExportCampaignView(View, ExportPermissionMixin):
     """
     template_name = 'library/confirm_export_campaign.html'
 
-    def get(self, request, campaign_import_id):
-        """
-        Display the confirmation page for exporting a campaign and its quests to the shared library.
+    def _render_confirmation(self, request, campaign, licence_form):
+        """Render the campaign export confirmation page.
+
+        Shared by GET and by the POST path that rejects an unagreed licence, so
+        the page a user lands on after a failed submit is the one they started from.
 
         Args:
             request (HttpRequest): The current HTTP request object.
-            campaign_import_id (UUID): The unique import ID of the campaign to be exported.
+            campaign (Category): The local campaign being shared.
+            licence_form (ShareLicenceForm): Blank on GET, bound (and invalid) on
+                a rejected POST so its error renders.
 
         Returns:
-            HttpResponse: The rendered confirmation template with campaign and quest details.
+            HttpResponse: The rendered confirmation template.
         """
-        self._require_export_permission(request)
-
-        campaign = get_object_or_404(Category, import_id=campaign_import_id)
         # evaluate the queryset to render the quests properly and give proper context to get_library_conflicting_quests
         quests = list(campaign.current_quests())
 
@@ -504,8 +605,26 @@ class ExportCampaignView(View, ExportPermissionMixin):
             'category_published': campaign.published,
             'category_displayed_quests': quests,
             'library_quest_import_ids': library_quest_import_ids,
+            'licence_form': licence_form,
         }
         return render(request, self.template_name, context)
+
+    def get(self, request, campaign_import_id):
+        """
+        Display the confirmation page for exporting a campaign and its quests to the shared library.
+
+        Args:
+            request (HttpRequest): The current HTTP request object.
+            campaign_import_id (UUID): The unique import ID of the campaign to be exported.
+
+        Returns:
+            HttpResponse: The rendered confirmation template with campaign and quest details.
+        """
+        self._require_export_permission(request)
+
+        campaign = get_object_or_404(Category, import_id=campaign_import_id)
+
+        return self._render_confirmation(request, campaign, ShareLicenceForm())
 
     def post(self, request, campaign_import_id):
         """
@@ -527,6 +646,13 @@ class ExportCampaignView(View, ExportPermissionMixin):
         self._require_export_permission(request)
 
         campaign = get_object_or_404(Category, import_id=campaign_import_id)
+
+        # The licence checkbox is `required` in the template, but that is a browser
+        # hint only: this is what actually holds the push (#1546, #2366).
+        licence_form = ShareLicenceForm(request.POST)
+        if not licence_form.is_valid():
+            return self._render_confirmation(request, campaign, licence_form)
+
         source_schema = connection.schema_name
         # Resolve the source deck's URL now, while its schema is active (the email
         # is built later inside the library schema context) -- see #1949.
@@ -572,11 +698,31 @@ class ExportCampaignView(View, ExportPermissionMixin):
 
 
 @method_decorator([login_required, staff_member_required], name='dispatch')
-class CategoryDetailView(TemplateView):
+class CategoryDetailView(NonPublicOnlyViewMixin, SharedLibraryEnabledMixin, TemplateView):
     """
     View the content of a campaign (category) from the shared library.
     """
     template_name = 'library/category_detail_view.html'
+
+    def get(self, request, *args, **kwargs):
+        """Render the campaign, or send the user back if it is still awaiting review.
+
+        Args:
+            request (HttpRequest): The current HTTP request.
+            *args: Positional arguments passed through to TemplateView.
+            **kwargs: URL kwargs, including 'campaign_import_id' (UUID).
+
+        Returns:
+            HttpResponse: the campaign detail page, or a redirect to the Library
+            campaign list when the campaign has not been published there yet.
+        """
+        with library_schema_context():
+            category = get_published_library_object(Category, kwargs.get('campaign_import_id'))
+
+        if category is None:
+            return redirect_awaiting_review(request, 'campaign', 'library:category_list')
+
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         """

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3720,6 +3720,7 @@ class AjaxQuestInfoTest(ByteDeckTenantTestCase):
         """
         site_config = SiteConfig.get()
         site_config.allow_staff_export = True
+        site_config.enable_shared_library = True
         site_config.full_clean()
         site_config.save()
         self.client.force_login(self.test_teacher)
@@ -4136,6 +4137,7 @@ class DetailViewTest(ByteDeckTenantTestCase):
 
         site_config = SiteConfig.get()
         site_config.allow_staff_export = True
+        site_config.enable_shared_library = True
         site_config.full_clean()
         site_config.save()
 

--- a/src/siteconfig/models.py
+++ b/src/siteconfig/models.py
@@ -366,6 +366,7 @@ class SiteConfig(models.Model):
 
         Rules:
             - Unauthenticated users cannot export.
+            - Nobody can export from a deck that has the Shared Library turned off.
             - Exports are blocked when on the Library schema.
             - The deck owner can export when not on the Library schema.
             - Staff members can export only if `allow_staff_export` is True.
@@ -380,6 +381,12 @@ class SiteConfig(models.Model):
             current_schema = connection.schema_name
 
         if not user.is_authenticated:
+            return False
+
+        # This decides whether the export buttons render; the views enforce the same
+        # feature flag, so without this a deck with the Shared Library off would show
+        # export buttons that lead straight to a 404.
+        if not self.enable_shared_library:
             return False
 
         if current_schema == get_library_schema_name():

--- a/src/siteconfig/tests/test_models.py
+++ b/src/siteconfig/tests/test_models.py
@@ -201,6 +201,11 @@ class SiteConfigModelTest(ByteDeckTenantTestCase):
         current_schema = "test"
         library_schema = get_library_schema_name()
 
+        # Exporting is part of the Shared Library feature, so the deck has to have it on
+        self.config.enable_shared_library = True
+        self.config.full_clean()
+        self.config.save()
+
         # Owner should always be able to export
         owner = self.config.deck_owner
         self.assertTrue(self.config.can_user_export_to_library(owner, current_schema))
@@ -234,3 +239,18 @@ class SiteConfigModelTest(ByteDeckTenantTestCase):
         # Anonymous users cannot export
         self.assertFalse(self.config.can_user_export_to_library(AnonymousUser(), current_schema))
         self.assertFalse(self.config.can_user_export_to_library(AnonymousUser(), library_schema))
+
+    def test_can_user_export_to_library__false_when_shared_library_disabled(self):
+        """Nobody can export from a deck that has the Shared Library turned off.
+
+        The views 404 in that case, so the buttons this method controls must not render.
+        """
+        self.config.enable_shared_library = False
+        self.config.allow_staff_export = True
+        self.config.full_clean()
+        self.config.save()
+
+        staff_user = baker.make('auth.User', is_staff=True)
+
+        self.assertFalse(self.config.can_user_export_to_library(self.config.deck_owner, "test"))
+        self.assertFalse(self.config.can_user_export_to_library(staff_user, "test"))


### PR DESCRIPTION
### What?

Three ways into the Shared Library that had no server-side check behind them, plus the project's standard non-public guard the Library views were missing.

- **#2365** the `shared_library_enabled_view` check 404s all seven Library views when `enable_shared_library` is off, and `SiteConfig.can_user_export_to_library` requires the flag too.
- **#2363** `get_published_library_object` keeps content that is still awaiting review out of both import views and the campaign detail view.
- **#2366** `ShareLicenceForm` validates the CC BY-SA agreement server-side on both export views.
- `NonPublicOnlyViewMixin` added to all seven views.

### Why?

**The feature flag was decoration (#2365).** `enable_shared_library` was read in exactly one place, `sidebar.html`, so it hid the Library link and nothing else. On a deck that had deliberately opted out of a flag whose label reads "EXPERIMENTAL WIP", every Library URL was still live and an import still completed:

```
library:quest_list           -> 200
library:category_list        -> 200
library:import_quest         -> 200
library:import_category      -> 200
library:category_detail_view -> 200
import_quest POST            -> 302, quest now local: True
```

**Unreviewed content was importable (#2363).** #1949 established that pushed content lands unpublished and stays invisible until a Library admin reviews it. That gate only filtered the listing pages; a POST straight to an import URL pulled it down anyway:

```
[PROBE] import unpublished quest    -> 302, now on local deck: True
[PROBE] import unpublished campaign -> 302, now on local deck: True
```

**The licence agreement was client-side only (#2366).** The checkbox is `required` in the template, which is a browser hint. Neither export view read it:

```
[LIC] export POST with no agreeLicense -> 302
[LIC] quest landed in the library anyway: True
```

#1546 specifies the agreement as part of the share flow ("There should be a confirmation page, that the quest is being shared under Creative Commons Attribution Share Alike license. They need to agree to that."), so as built it was doing nothing.

### How?

**Feature flag.** `shared_library_enabled_view` joins the existing `@method_decorator([...], name='dispatch')` list on all seven views. A deck with the feature off should behave as though it does not exist, so it 404s rather than showing an explanation page. `can_user_export_to_library` gets the same check, because it decides whether the export buttons render and buttons that lead to a 404 are worse than no buttons. Because the decorator runs ahead of the non-public guard, it treats a `None` SiteConfig (the public schema, which has no deck config) as "no Shared Library here" rather than raising `AttributeError`.

**Review gate.** `get_published_library_object(model, import_id)` raises `Http404` when nothing in the Library has that import ID at all, and returns `None` when the content exists but is not published. Callers redirect with a message:

> That campaign is not available in the Library yet: a Library admin still has to review and publish it.

`import_quest_to` filters on `published=True` as well, so the importer does not depend on its caller for that.

**Licence.** A small `ShareLicenceForm` with one required `BooleanField`. `ExportCampaignView`'s confirmation context moved into `_render_confirmation` so GET and a rejected POST render the same page. The checkbox input is renamed `agreeLicense` → `agree_license` to match the field.

**Non-public guard.** There is a single urlconf, so `/library/...` resolves on the public tenant too. CLAUDE.md requires `NonPublicOnlyViewMixin` on all class-based views; these seven never had it.

### Testing?

27 new tests across four classes, each guard tested from both directions so none of them is just "everything 404s now":

- `SharedLibraryDisabledTests` — all seven URLs 404 with the flag off; import and export POSTs move no content
- `UnreviewedLibraryContentTests` — unpublished quest/campaign redirect with a warning on both GET and POST and import nothing; `import_quest_to` raises; an import ID in no schema at all still 404s rather than redirecting
- `ShareLicenceAgreementTests` — a push without the checkbox re-renders with the error and shares nothing, a push with it succeeds, and both confirmation pages render the field name the form validates
- `LibraryViewsOnPublicSchemaTests` — Library URLs 404 on the public schema (fails without the mixin: `AssertionError: 200 != 404`), and the feature check handles a `None` site config

The existing library tests now enable the flag in the shared base class, since every one of them exercises a deck that has opted in.

```
src/library                          68 tests   OK
full suite (python src/manage.py test src)   2119 tests   OK (skipped=5)
ruff check src                       clean
```

Coverage: `library/views.py`, `forms.py`, `importer.py` and `exporter.py` are all at 100% branch coverage. The one uncovered block left in the app is `from_library_schema_first` in `utils.py`, which #2362 removes on `staging`.

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

Captured from a real `hackerspace` dev deck (`initdb` + `generate_content hackerspace`, Shared Library and staff export both enabled), signed in as a teacher, on the quest export confirmation page.

**Before: the page as the sharer first sees it.** Unchanged apart from the checkbox's `name` attribute.

![Export confirmation page, initial state](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2381/export-confirm-before.png)

**After: submitting without agreeing to the licence.** Previously this shared the quest anyway; now the page comes back with the error and the quest stays put.

![Export confirmation page rejecting a submit with no licence agreement](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2381/export-confirm-refused.png)

> You need to agree to the Creative Commons license before sharing to the Library.

To capture that second state I had to strip the checkbox's `required` attribute in the browser first, since Chrome blocks the submit otherwise. That is exactly the point: `required` is a browser courtesy, and anything that is not a browser (curl, a script, a stale page) was never stopped by it.

The other two fixes have no UI: they turn URLs into 404s and redirects, covered by the tests above.

### Anything Else?

This is step 2 of the Shared Library audit that produced #2362 (the tenant-isolation hotfix) and the issue set filed alongside it. Deliberately **not** in this PR, each already tracked:

- #2364 — a name collision on import still 500s. It needs a rename affordance rather than another guard, and the `ShareLicenceForm` added here is the hook that work will hang off.
- #2373 — the four "already exists" conflicts still raise `PermissionDenied`, so they still show a bare 403.
- #2367, #2369, #2370, #2371, #2372 — the rest of the correctness findings.

One behaviour change worth flagging for the Library deck itself: it now needs `enable_shared_library` turned on for its own `/library/` pages to load. Its staff review and publish through the normal quest pages, so I do not think anything depends on this, but it is worth a look before merging.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)