### PR TITLE
fix: don't bind the fields TAQuestForm hides from a TA (#2384)

### DIFF
--- a/src/quest_manager/forms.py
+++ b/src/quest_manager/forms.py
@@ -16,6 +16,39 @@ from tags.forms import BootstrapTaggitSelect2Widget
 from .models import Category, Quest, CommonData
 
 
+#: Quest fields a student TA may not set. A TA works on drafts, so whether a quest is
+#: visible to students (``published``), who may keep editing it (``editor``), whether it is
+#: filed away (``archived``) and whether it escapes course enrolment
+#: (``available_outside_course``) all stay with the teacher.
+TA_RESTRICTED_QUEST_FIELDS = ('published', 'editor', 'archived', 'available_outside_course')
+
+
+def remove_layout_fields(layout_object, field_names):
+    """Remove the named fields from a crispy-forms layout tree, in place.
+
+    Used when a form subclass drops fields the shared layout still names, so crispy is
+    never asked to render a field the form does not have.
+
+    Args:
+        layout_object: a crispy ``Layout`` (or any nested layout object). Objects without
+            a ``fields`` list, such as ``HTML``, are left alone.
+        field_names: an iterable of field names to drop wherever they appear in the tree.
+
+    Returns:
+        None. The layout is modified in place.
+    """
+    fields = getattr(layout_object, 'fields', None)
+    if fields is None:
+        return
+
+    layout_object.fields = [
+        field for field in fields
+        if not (isinstance(field, str) and field in field_names)
+    ]
+    for child in layout_object.fields:
+        remove_layout_fields(child, field_names)
+
+
 class BadgeLabel:
     def label_from_instance(self, obj):
         return f"{str(obj)} ({obj.xp} XP)"
@@ -248,14 +281,28 @@ class QuestForm(forms.ModelForm):
 
 
 class TAQuestForm(QuestForm):
-    """ Modified QuestForm that removes some fields TAs should not be able to set. """
+    """QuestForm for a student TA, with the fields a TA may not set left off the form entirely.
+
+    Those fields (``TA_RESTRICTED_QUEST_FIELDS``) are not bound, so a hand-made POST cannot
+    reach them: an unbound field is one a ``ModelForm`` never writes to its instance. Editing
+    therefore leaves whatever the teacher set in place, and creating falls back to the model
+    defaults. ``QuestFormViewMixin.form_valid`` still forces ``published`` and ``editor`` for a
+    TA, which keeps a TA's quest a draft of their own no matter which form or view saved it.
+    """
+
+    class Meta(QuestForm.Meta):
+        fields = tuple(f for f in QuestForm.Meta.fields if f not in TA_RESTRICTED_QUEST_FIELDS)
+
     def __init__(self, *args, **kwargs):
+        """Build the TA form, then drop the restricted fields from the inherited layout.
+
+        Args:
+            *args: positional arguments passed through to ``QuestForm``.
+            **kwargs: keyword arguments passed through to ``QuestForm``.
+        """
         super().__init__(*args, **kwargs)
-        # SET published here to?
-        self.fields['published'].widget = forms.HiddenInput()
-        self.fields['available_outside_course'].widget = forms.HiddenInput()
-        self.fields['archived'].widget = forms.HiddenInput()
-        self.fields['editor'].widget = forms.HiddenInput()
+        # QuestForm's layout names fields this form doesn't have, so take them back out
+        remove_layout_fields(self.helper.layout, TA_RESTRICTED_QUEST_FIELDS)
 
 
 class SubmissionForm(forms.Form):

--- a/src/quest_manager/tests/test_forms.py
+++ b/src/quest_manager/tests/test_forms.py
@@ -1,13 +1,21 @@
+from django.contrib.auth import get_user_model
 from django.utils import timezone
+
+from crispy_forms.utils import render_crispy_form
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 from quest_manager.forms import (
+    TA_RESTRICTED_QUEST_FIELDS,
     QuestForm,
     SubmissionQuickReplyForm,
     SubmissionQuickReplyFormStudent,
     SubmissionReplyForm,
+    TAQuestForm,
 )
+from quest_manager.models import Quest
+
+User = get_user_model()
 
 
 class QuestFormTest(ByteDeckTenantTestCase):
@@ -92,6 +100,101 @@ class QuestFormTest(ByteDeckTenantTestCase):
 
         form = QuestForm(data=form_data)
         self.assertTrue(form.is_valid())
+
+    def test_QuestForm__still_binds_the_TA_restricted_fields(self):
+        """A teacher's quest form keeps the fields TAQuestForm drops: restricting a TA
+        must not take those settings away from the teachers who are meant to have them."""
+        form = QuestForm()
+        for field_name in TA_RESTRICTED_QUEST_FIELDS:
+            with self.subTest(field=field_name):
+                self.assertIn(field_name, form.fields)
+
+
+class TAQuestFormTest(ByteDeckTenantTestCase):
+    """A student TA's quest form must not carry the fields only a teacher may set (#2384)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Provide minimal valid quest form data and the users a TA form needs."""
+        cls.minimal_valid_data = {
+            "name": "Test Quest",
+            "xp": 0,
+            "max_repeats": 0,
+            "max_xp": -1,
+            "hours_between_repeats": 0,
+            "sort_order": 0,
+            "date_available": str(timezone.now().date()),
+            "time_available": "0:00:00",
+            "tags": "",
+        }
+        cls.teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.ta = User.objects.create_user('test_ta')
+        cls.ta.profile.is_TA = True
+        cls.ta.profile.save()
+
+    def test_TAQuestForm__does_not_bind_the_restricted_fields(self):
+        """The restricted fields are absent from the form, not merely hidden: a hidden widget
+        still binds whatever is posted, so hiding them only removed the control from the page."""
+        form = TAQuestForm()
+        rendered = str(form)
+        for field_name in TA_RESTRICTED_QUEST_FIELDS:
+            with self.subTest(field=field_name):
+                self.assertNotIn(field_name, form.fields)
+                self.assertNotIn(f'name="{field_name}"', rendered)
+
+    def test_TAQuestForm__crispy_layout_drops_the_restricted_fields_and_keeps_the_rest(self):
+        """The form renders through its crispy layout, which QuestForm builds naming fields this
+        form no longer has. Those are taken back out, and everything a TA may edit still renders."""
+        rendered = render_crispy_form(TAQuestForm())
+
+        for field_name in TA_RESTRICTED_QUEST_FIELDS:
+            with self.subTest(dropped=field_name):
+                self.assertNotIn(f'name="{field_name}"', rendered)
+
+        # fields from the layout's top level and from inside its Advanced accordion, so a
+        # too-eager removal that emptied a nested group would be caught
+        for field_name in ('name', 'xp', 'instructions', 'sort_order', 'blocking'):
+            with self.subTest(kept=field_name):
+                self.assertIn(f'name="{field_name}"', rendered)
+
+    def test_TAQuestForm__posted_restricted_fields_cannot_change_a_quest(self):
+        """A TA's POST claiming every restricted field leaves all of them as the teacher set
+        them: an unbound field is one a ModelForm never writes to its instance."""
+        quest = Quest.objects.create(
+            name="Teacher's Quest",
+            published=False,
+            archived=True,
+            available_outside_course=True,
+            editor=self.ta,
+        )
+
+        form = TAQuestForm(
+            data={
+                **self.minimal_valid_data,
+                'published': True,
+                'archived': False,
+                'available_outside_course': False,
+                'editor': self.teacher.id,
+            },
+            instance=quest,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        saved = form.save()
+
+        self.assertFalse(saved.published)
+        self.assertTrue(saved.archived)
+        self.assertTrue(saved.available_outside_course)
+        self.assertEqual(saved.editor, self.ta)
+
+    def test_TAQuestForm__saves_the_editable_fields(self):
+        """The restrictions don't stop a TA from doing their job: an ordinary edit still saves."""
+        quest = Quest.objects.create(name="Draft", published=False, editor=self.ta)
+
+        form = TAQuestForm(data={**self.minimal_valid_data, 'name': "Renamed by the TA"}, instance=quest)
+        self.assertTrue(form.is_valid(), form.errors)
+        saved = form.save()
+
+        self.assertEqual(saved.name, "Renamed by the TA")
 
 
 class QuickReplyFormsSanitizeHTMLTest(ByteDeckTenantTestCase):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2157,6 +2157,54 @@ class QuestCRUDViewsTest(ByteDeckTenantTestCase):
         self.assertFalse(quest.published)
         self.assertEqual(quest.editor, test_ta)
 
+    def test_quest_create__TA_cannot_set_the_restricted_fields_by_post(self):
+        """A TA who hand-posts the fields their form leaves off gets none of them: the new quest
+        is an ordinary draft of their own, not archived and not available outside a course (#2384).
+        """
+        test_ta = self._make_TA()
+        self.client.force_login(test_ta)
+
+        form_data = {
+            **self.minimal_valid_form_data,
+            'published': True,
+            'editor': self.test_teacher.id,
+            'archived': True,
+            'available_outside_course': True,
+        }
+        response = self.client.post(reverse('quests:quest_create'), data=form_data)
+
+        # an archived quest drops out of the default manager, so look it up either way and let
+        # the assertions below name what actually went wrong
+        new_quest = Quest.objects.all_including_archived().latest('datetime_created')
+        self.assertFalse(new_quest.published)
+        self.assertEqual(new_quest.editor, test_ta)
+        self.assertFalse(new_quest.archived)
+        self.assertFalse(new_quest.available_outside_course)
+        self.assertRedirects(response, new_quest.get_absolute_url())
+
+    def test_quest_update__TA_post_leaves_the_teachers_settings_alone(self):
+        """A TA editing a draft can't clear the settings a teacher made, whether by posting a new
+        value or by omitting the field: neither is bound to their form, so both are left alone (#2384).
+        """
+        test_ta = self._make_TA()
+        quest = Quest.objects.create(**self.minimal_valid_form_data)
+        quest.editor = test_ta
+        quest.published = False
+        quest.available_outside_course = True  # a teacher's setting, absent from the TA's form
+        quest.save()
+        self.client.force_login(test_ta)
+
+        # 'available_outside_course' is omitted entirely, which for a bound BooleanField would
+        # read as False; 'archived' is posted as True to show a claimed value is ignored too.
+        form_data = {**self.minimal_valid_form_data, 'name': "Edited by the TA", 'archived': True}
+        response = self.client.post(reverse('quests:quest_update', args=[quest.pk]), data=form_data)
+
+        self.assertRedirects(response, quest.get_absolute_url())
+        quest.refresh_from_db()
+        self.assertEqual(quest.name, "Edited by the TA")
+        self.assertTrue(quest.available_outside_course)
+        self.assertFalse(quest.archived)
+
     def test_quest_update__teacher_publishing_removes_the_editor(self):
         """When a teacher publishes a TA's draft, the TA's editor access is removed with it, so
         they can no longer edit a quest students are now working on.


### PR DESCRIPTION
### What?
`TAQuestForm` no longer binds the quest fields a student TA may not set. They are dropped from the form entirely instead of being swapped for hidden widgets. Closes #2384.

### Why?
A hidden input still binds posted data, so the widget only hid the control in the browser. Nothing stopped a TA from posting those fields by hand.

`published` and `editor` were safe in practice, because `QuestFormViewMixin.form_valid` overrides both for a TA. The other two fields the form hides were not:

| Field | Hidden by `TAQuestForm` | View backstop | A TA's POST could... |
|---|---|---|---|
| `published` | yes | yes | (overridden) |
| `editor` | yes | yes | (overridden) |
| `archived` | yes | **no** | archive a quest |
| `available_outside_course` | yes | **no** | make a quest available with no course enrolment |

So this is not only about moving the guard next to the form that expresses the restriction: two of the four were genuinely settable. The new view tests fail on `develop` for exactly that reason (`archived` came back `True`, and the update case redirected to the quest list because `QuestUpdate.get_success_url` follows the now-archived quest).

### How?
- `TA_RESTRICTED_QUEST_FIELDS` names the four fields, and `TAQuestForm.Meta.fields` is `QuestForm.Meta.fields` minus that set. An unbound field is one a `ModelForm` never writes to its instance, so a posted value cannot reach the quest even in principle.
- `QuestForm.__init__` builds a crispy layout that names three of them, so `TAQuestForm.__init__` removes them from the inherited layout with a small `remove_layout_fields` helper (recursive, since two sit inside the Advanced accordion). Without that, crispy would be asked to render fields the form does not have.
- `QuestFormViewMixin.form_valid` is untouched and still forces `published` and `editor` for a TA, as the belt-and-braces backstop the issue asks for.

On the round-tripping question in the issue: nothing relied on it. Editing keeps whatever the teacher set (an unbound field is left alone), and creating falls back to the model defaults, which is what the hidden inputs were submitting anyway.

### Testing?
`python src/manage.py test src/quest_manager` passes (261 tests in the touched modules). `ruff check src` clean. `src/quest_manager/forms.py` is at 100% statement and branch coverage.

New tests, all of which fail on `develop`:
- `test_TAQuestForm__does_not_bind_the_restricted_fields`: none of the four are on the form
- `test_TAQuestForm__crispy_layout_drops_the_restricted_fields_and_keeps_the_rest`: rendered through the real crispy layout, so a too-eager removal that emptied a nested accordion group would be caught
- `test_TAQuestForm__posted_restricted_fields_cannot_change_a_quest`: a POST claiming all four leaves all four as the teacher set them
- `test_TAQuestForm__saves_the_editable_fields`: an ordinary TA edit still saves
- `test_quest_create__TA_cannot_set_the_restricted_fields_by_post`
- `test_quest_update__TA_post_leaves_the_teachers_settings_alone`: covers both a claimed value and an omitted one (for a bound `BooleanField`, omitting it reads as `False`, which would silently clear a teacher's setting)
- `test_QuestForm__still_binds_the_TA_restricted_fields`: the teacher's form is unaffected

The two pre-existing tests from #2350 that pin the view override still pass unchanged.

### Screenshots (if front end is affected)
No visual change, so there is nothing to show: all four fields rendered as `<input type="hidden">` for a TA, so removing them changes no pixel of the form. That is asserted rather than assumed: the crispy-render test above checks the restricted inputs are gone and that the fields a TA edits (including ones inside the Advanced accordion) still render.

### Anything Else?
The issue names `published` and `editor`; this covers all four fields the form was hiding, since the reasoning is identical for each and the two unnamed ones were the ones actually exposed. Happy to narrow it to two if you would rather keep the change to the letter of the issue.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_