### PR TITLE
fix: stop the conflict-copy export carrying local row ids into the Library (#2367)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -1,6 +1,7 @@
 from datetime import date
-from copy import deepcopy
 from uuid import uuid4
+
+import tablib
 
 from django_tenants.utils import schema_context
 from quest_manager.admin import QuestResource
@@ -9,6 +10,97 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from .utils import library_schema_context, get_library_conflicting_quests
+
+
+def build_library_clone_name(local_name, taken_names):
+    """Return a name for a clone of `local_name` that is free in the Library.
+
+    Quest names are unique per schema and capped at the model's max_length, so a
+    clone of a quest whose original is already in the Library needs a name of its
+    own. Falls back to numbered suffixes when the dated one is also taken.
+
+    Args:
+        local_name (str): the source quest's name.
+        taken_names (set[str]): every name already spoken for in the Library.
+            Must include archived quests: they still hold their name against the
+            unique constraint even though the default manager hides them.
+
+    Returns:
+        str: a name not in `taken_names`, within the field's max_length.
+    """
+    max_len = Quest._meta.get_field('name').max_length or 50
+    base_suffix = f" (Exported on {date.today()})"
+
+    candidate = local_name[:max_len - len(base_suffix)] + base_suffix
+    counter = 1
+    while candidate in taken_names:
+        full_suffix = f"{base_suffix} #{counter}"
+        candidate = local_name[:max_len - len(full_suffix)] + full_suffix
+        counter += 1
+
+    return candidate
+
+
+def clone_quests_into_library(*, source_schema, quests):
+    """Copy quests into the Library as fresh entries, leaving the originals alone.
+
+    Used when a campaign is shared but some of its quests are already in the
+    Library under the same `import_id`: those get a new copy rather than
+    overwriting what is there.
+
+    The copies travel through `QuestResource`, the same serialization the rest of
+    the export uses, with the `import_id` and `name` columns rewritten per row.
+    Going through the resource is what keeps this safe: `Meta.exclude` drops
+    `editor`, `specific_teacher_to_notify` and `common_data`, which are primary
+    keys that mean something different in the Library's schema and must not
+    travel. It also means the copies pick up campaign and prerequisite handling
+    for free instead of re-implementing a subset of it.
+
+    Args:
+        source_schema (str): the tenant schema holding the quests being copied.
+        quests (list[Quest]): quests loaded from `source_schema`.
+
+    Returns:
+        ImportResult | None: the result of importing the copies, or None when
+        there was nothing to copy.
+    """
+    if not quests:
+        return None
+
+    with schema_context(source_schema):
+        export_data = QuestResource().export(quests)
+
+    with library_schema_context():
+        # Archived quests count: the unique constraint does not care that the
+        # default manager hides them.
+        taken_names = set(Quest.objects.all_including_archived().values_list('name', flat=True))
+
+        rows = export_data.dict
+        visibility_map = {}
+        for row in rows:
+            clone_import_id = str(uuid4())
+            row['import_id'] = clone_import_id
+            row['name'] = build_library_clone_name(row['name'], taken_names)
+            taken_names.add(row['name'])
+            # Copies land unpublished like everything else pushed to the Library
+            visibility_map[clone_import_id] = False
+
+        clone_data = tablib.Dataset()
+        clone_data.headers = export_data.headers
+        for row in rows:
+            clone_data.append([row[header] for header in clone_data.headers])
+
+        try:
+            return QuestResource().import_data(
+                clone_data,
+                dry_run=False,
+                raise_errors=True,
+                use_transactions=True,
+                import_campaign=True,
+                local_visibility_map=visibility_map,
+            )
+        except (ValidationError, IntegrityError) as e:
+            raise ValidationError(f"Failed to copy conflicting quests to library schema: {e}") from e
 
 
 def export_quest_to_library(*, source_schema, quest_import_id):
@@ -131,9 +223,9 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
       - Detect quests in the target library that share an import_id with local quests.
       - Export only the non-conflicting quests (unpublished) and the campaign.
       - Ensure the campaign exists in the library.
-      - For each conflicting local quest, create a new unpublished copy in the
-        library campaign with a fresh import_id and a suffixed name to avoid
-        uniqueness issues.
+      - Copy each conflicting local quest into the library campaign as a new
+        unpublished entry with a fresh import_id and a name of its own, leaving
+        the library's existing version untouched.
 
     Args:
         source_schema (str): Tenant schema that contains the source campaign.
@@ -176,32 +268,10 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
             library_campaign.full_clean()
             library_campaign.save()
 
-        # Step 4: clone only the conflicting quests
-        for local_quest in local_quests:
-            if local_quest.import_id in library_conflicting_ids:
-                clone = deepcopy(local_quest)
-                clone.pk = None
-                clone.import_id = uuid4()
-                clone.campaign = library_campaign
-                clone.published = False
+    # Step 4: copy the conflicting quests in alongside the campaign. They carry
+    # the campaign's import_id in their export data, so they attach to the
+    # campaign ensured above.
+    conflicting_quests = [q for q in local_quests if q.import_id in library_conflicting_ids]
+    clone_quests_into_library(source_schema=source_schema, quests=conflicting_quests)
 
-                # make sure name fits max length
-                max_len = Quest._meta.get_field("name").max_length or 50
-                base_suffix = f" (Exported on {date.today()})"
-                counter = 1
-                base_name = local_quest.name
-
-                # Try the base suffix first
-                potential_name = base_name[:max_len - len(base_suffix)] + base_suffix
-                while Quest.objects.filter(name=potential_name).exists():
-                    counter_suffix = f" #{counter}"
-                    full_suffix = base_suffix + counter_suffix
-                    potential_name = base_name[:max_len - len(full_suffix)] + full_suffix
-                    counter += 1
-
-                clone.name = potential_name
-
-                clone.full_clean()
-                clone.save()
-
-        return library_campaign
+    return library_campaign

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1208,6 +1208,14 @@ class ExporterErrorPathTests(LibraryTenantTestCaseMixin):
             export_quest_to_library(source_schema=self.tenant.schema_name, quest_import_id=uuid.uuid4())
 
     @patch("library.exporter.QuestResource.import_data")
+    def test_clone_quests_into_library__import_failure_wrapped_as_validation_error(self, mock_import_data):
+        """A database error while copying conflicting quests is re-raised with context."""
+        mock_import_data.side_effect = IntegrityError("duplicate key")
+        quest = baker.make(Quest, published=True)
+        with self.assertRaisesMessage(ValidationError, "Failed to copy conflicting quests to library schema"):
+            clone_quests_into_library(source_schema=self.tenant.schema_name, quests=[quest])
+
+    @patch("library.exporter.QuestResource.import_data")
     def test_export_quest_to_library__import_failure_wrapped_as_validation_error(self, mock_import_data):
         """A database error while importing a quest is re-raised as a clearer ValidationError with context."""
         mock_import_data.side_effect = IntegrityError("duplicate key")

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1,5 +1,6 @@
 import uuid
 from copy import deepcopy
+from datetime import date
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
@@ -13,10 +14,16 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.utils import get_library_schema_name, library_schema_context
 from library.views import shared_library_enabled_view
 from library.importer import import_quest_to, import_campaign_to
-from library.exporter import export_campaign_and_copy_quests, export_campaign_to_library, export_quest_to_library
+from library.exporter import (
+    build_library_clone_name,
+    clone_quests_into_library,
+    export_campaign_and_copy_quests,
+    export_campaign_to_library,
+    export_quest_to_library,
+)
 from model_bakery import baker
 from notifications.models import Notification
-from quest_manager.models import Category, Quest
+from quest_manager.models import Category, CommonData, Quest
 from siteconfig.models import SiteConfig
 from tenant.models import Tenant
 from tenant.models import TenantDomain
@@ -1460,3 +1467,143 @@ class LibraryViewsOnPublicSchemaTests(LibraryTenantTestCaseMixin):
 
         with self.assertRaises(Http404):
             wrapped(RequestFactory().get('/'))
+
+
+class ConflictingQuestCloneTests(LibraryTenantTestCaseMixin):
+    """Copying a quest whose original is already in the Library must not carry local row ids.
+
+    The copy used to be built with `deepcopy`, which kept `editor_id`,
+    `specific_teacher_to_notify_id` and `common_data_id`: primary keys that mean
+    something different in the Library's schema. Absent there, the export died on a
+    ValidationError; present, the copy silently adopted a stranger's row.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A local campaign whose quest also exists in the Library, plus local FK targets."""
+        cls.test_teacher = User.objects.create_user('clone_teacher', is_staff=True)
+        cls.local_editor = User.objects.create_user('clone_local_editor', is_staff=False)
+
+    def _make_conflicting_campaign(self, **quest_kwargs):
+        """Build a local campaign with one quest that already exists in the Library.
+
+        Args:
+            **quest_kwargs: extra field values for the local quest.
+
+        Returns:
+            tuple[Category, Quest]: the local campaign and its conflicting quest.
+        """
+        campaign = baker.make(Category, title=f"Conflict Campaign {uuid.uuid4().hex[:6]}")
+        quest = baker.make(
+            Quest, campaign=campaign, published=True, archived=False,
+            name=f"Conflicted Quest {uuid.uuid4().hex[:6]}", **quest_kwargs
+        )
+        with library_schema_context():
+            baker.make(Quest, import_id=quest.import_id, published=False,
+                       name=f"Library copy {uuid.uuid4().hex[:6]}")
+        return campaign, quest
+
+    def _library_clone_of(self, quest):
+        """Return the Library copy of `quest`: same campaign, different import_id.
+
+        Args:
+            quest (Quest): the local quest that was copied.
+
+        Returns:
+            Quest: the copy created in the Library schema.
+        """
+        return Quest.objects.all_including_archived().exclude(import_id=quest.import_id).get(
+            campaign__import_id=quest.campaign.import_id
+        )
+
+    def test_export_campaign_and_copy_quests__succeeds_when_the_quest_has_an_editor(self):
+        """A conflicting quest with local user FKs exports instead of raising ValidationError."""
+        campaign, quest = self._make_conflicting_campaign(
+            editor=self.local_editor, specific_teacher_to_notify=self.test_teacher
+        )
+
+        export_campaign_and_copy_quests(
+            source_schema=self.tenant.schema_name, campaign_import_id=campaign.import_id
+        )
+
+        with library_schema_context():
+            clone = self._library_clone_of(quest)
+            self.assertIsNone(clone.editor)
+            self.assertIsNone(clone.specific_teacher_to_notify)
+
+    def test_export_campaign_and_copy_quests__does_not_adopt_a_library_row_at_the_same_pk(self):
+        """The copy drops common_data rather than pointing at whatever shares that pk."""
+        with library_schema_context():
+            library_common = baker.make(CommonData, title="LIBRARY BLURB")
+
+        local_common = baker.make(CommonData, title="LOCAL BLURB")
+        campaign, quest = self._make_conflicting_campaign(common_data=local_common)
+
+        export_campaign_and_copy_quests(
+            source_schema=self.tenant.schema_name, campaign_import_id=campaign.import_id
+        )
+
+        with library_schema_context():
+            clone = self._library_clone_of(quest)
+            self.assertIsNone(clone.common_data)
+            # the Library's own row is untouched by the export
+            library_common.refresh_from_db()
+            self.assertEqual(library_common.title, "LIBRARY BLURB")
+
+    def test_export_campaign_and_copy_quests__copy_keeps_the_quest_content(self):
+        """Dropping the cross-schema FKs must not gut the copy: its content still travels."""
+        campaign, quest = self._make_conflicting_campaign(
+            xp=42, instructions="<p>Do the thing</p>", short_description="A conflicted quest",
+        )
+
+        export_campaign_and_copy_quests(
+            source_schema=self.tenant.schema_name, campaign_import_id=campaign.import_id
+        )
+
+        with library_schema_context():
+            clone = self._library_clone_of(quest)
+            self.assertEqual(clone.xp, 42)
+            # the quest_manager signal re-indents saved HTML, so match on the content
+            self.assertIn("Do the thing", clone.instructions)
+            self.assertEqual(clone.short_description, "A conflicted quest")
+            self.assertFalse(clone.published)
+            self.assertNotEqual(clone.import_id, quest.import_id)
+            self.assertIn("(Exported on", clone.name)
+
+    def test_clone_quests_into_library__returns_none_when_there_is_nothing_to_copy(self):
+        """A campaign with no conflicts skips the copy step entirely."""
+        self.assertIsNone(clone_quests_into_library(source_schema=self.tenant.schema_name, quests=[]))
+
+    def test_build_library_clone_name__avoids_names_held_by_archived_quests(self):
+        """Archived Library quests still hold their name against the unique constraint."""
+        dated = f"Quest A (Exported on {date.today()})"
+
+        self.assertEqual(build_library_clone_name("Quest A", set()), dated)
+        self.assertEqual(
+            build_library_clone_name("Quest A", {dated}),
+            f"Quest A (Exported on {date.today()}) #1",
+        )
+
+    def test_build_library_clone_name__stays_within_the_field_max_length(self):
+        """A long source name is truncated so the suffixed name still fits."""
+        max_len = Quest._meta.get_field('name').max_length
+
+        name = build_library_clone_name("x" * max_len, set())
+
+        self.assertLessEqual(len(name), max_len)
+        self.assertIn("(Exported on", name)
+
+    def test_export_campaign_and_copy_quests__copy_does_not_collide_with_an_archived_name(self):
+        """The naming loop consults archived Library quests, which the default manager hides."""
+        campaign, quest = self._make_conflicting_campaign()
+        with library_schema_context():
+            # Claim the name the copy would otherwise take, on an archived quest
+            baker.make(Quest, name=build_library_clone_name(quest.name, set()), archived=True)
+
+        export_campaign_and_copy_quests(
+            source_schema=self.tenant.schema_name, campaign_import_id=campaign.import_id
+        )
+
+        with library_schema_context():
+            clone = self._library_clone_of(quest)
+            self.assertTrue(clone.name.endswith("#1"), f"expected a numbered suffix, got {clone.name!r}")

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1582,8 +1582,8 @@ class ConflictingQuestCloneTests(LibraryTenantTestCaseMixin):
         """A campaign with no conflicts skips the copy step entirely."""
         self.assertIsNone(clone_quests_into_library(source_schema=self.tenant.schema_name, quests=[]))
 
-    def test_build_library_clone_name__avoids_names_held_by_archived_quests(self):
-        """Archived Library quests still hold their name against the unique constraint."""
+    def test_build_library_clone_name__falls_back_to_a_numbered_suffix(self):
+        """A taken dated name pushes the next copy on to a numbered suffix."""
         dated = f"Quest A (Exported on {date.today()})"
 
         self.assertEqual(build_library_clone_name("Quest A", set()), dated)


### PR DESCRIPTION
### What?

When a shared campaign contains a quest that is already in the Library under the same `import_id`, that quest gets copied in as a new entry. This rebuilds how that copy is made: it now travels through `QuestResource` like the rest of the export, instead of `deepcopy`.

### Why?

The copy was built with `deepcopy(local_quest)` and `pk = None`, which kept `editor_id`, `specific_teacher_to_notify_id` and `common_data_id`. Those are primary keys that mean something entirely different in the Library's schema, and both outcomes were wrong.

**When the id was absent over there**, `full_clean()` rejected it and the exporting teacher got an unhandled `ValidationError`, so sharing the campaign 500'd:

```
{'specific_teacher_to_notify': ['user instance with id 3 is not a valid choice.'],
 'editor': ['user instance with id 4 is not a valid choice.']}
```

**When the id happened to exist**, nothing complained and the copy silently adopted a stranger's row. A quest whose `CommonData` sat at pk 1 came out attached to the Library's own pk 1:

```
[SM] local CommonData pk 1   = "LOCAL BLURB"
[SM] library CommonData pk 1 = "LIBRARY BLURB"
[SM] clone: Mislink Quest (Exported on 2026-08-12)
       common_data -> LIBRARY BLURB (pk 1)
```

The same applies to `editor` and `specific_teacher_to_notify`, so a shared quest could arrive attributed to a Library user who had never seen it.

### How?

The copies go through `QuestResource().export(...)`, with the `import_id` and `name` columns rewritten per row before importing into the Library. Its `Meta.exclude` drops the three per-deck FKs (`editor`, `specific_teacher_to_notify`, `common_data`), so this path no longer keeps its own list of dangerous FKs in sync as the model grows.

Two things improve as a side effect, because the copies now get the same treatment as every other exported quest:

- they attach to their campaign through the normal `campaign_import_id` column instead of a hand-assigned FK
- they carry their prerequisites, where the hand-rolled version dropped them silently. Prereqs resolve by `import_id`, so a copy links to the Library's existing version of its prerequisite. That is the same matching every other import uses; it is a better answer than the previous "no prerequisites at all", though it is worth knowing it is import-id matching and not deck-aware.

**Correction to an earlier version of this description**, which said `Meta.exclude` covers everything that cannot cross a schema boundary and that tag handling would arrive later with #1792. Both are wrong, and I have since verified it on a real push:

`tags` is not a `Meta.exclude` entry. Taggit's `TaggableManager` reports `get_internal_type() == "ManyToManyField"`, so django-import-export auto-discovers it and builds a `ManyToManyWidget(model=Tag, field='pk')`. Tag primary keys are per-schema, so tags travel as raw pks and get re-resolved against whatever holds those pks in the destination:

```
[setup] tags on the SOURCE deck : {2: 'photography', 3: 'darkroom'}
[setup] tags in the LIBRARY     : {2: 'library-tag-2', 3: 'library-tag-3'}
[RESULT] the quest in the Library is tagged: ['library-tag-2', 'library-tag-3']
```

So tags already "work" in the sense that the column moves, and #1792 is that bug rather than a missing feature. This PR neither causes nor fixes it: the same thing happens on every other push and pull, because the copy path now shares their mechanism. Flagging it because the earlier wording implied this path was clean of cross-schema pk hazards, and it is not.

The naming loop moves out into `build_library_clone_name` and now consults **archived** Library quests. It used `Quest.objects`, whose default manager hides them, while the unique constraint they hold does not care: an archived quest sitting on the candidate name would have tripped the very `IntegrityError` the loop exists to avoid.

### Testing?

Eight new tests. Three of them fail against the old implementation with the exact errors above, verified by temporarily restoring the `deepcopy` behaviour behind the new signature:

```
ERROR: test_export_campaign_and_copy_quests__succeeds_when_the_quest_has_an_editor
       ValidationError: {'specific_teacher_to_notify': ['user instance with id 3 is not a valid choice.'],
                         'editor': ['user instance with id 4 is not a valid choice.']}
FAIL:  test_export_campaign_and_copy_quests__does_not_adopt_a_library_row_at_the_same_pk
       AssertionError:  is not None
ERROR: test_export_campaign_and_copy_quests__copy_does_not_collide_with_an_archived_name
```

The rest cover the copy keeping its content (so dropping the FKs did not gut it), the no-conflicts case being a no-op, `build_library_clone_name` both avoiding taken names and staying inside the field's `max_length`, and the copy path's error wrapping.

The existing test that covers copy naming and publish state across repeat exports still passes unchanged, so the behaviour users see is the same where it was already correct.

```
src/library                                  76 tests   OK
full suite (python src/manage.py test src)   2130 tests  OK (skipped=5)
ruff check src                               clean
```

Coverage: `library/exporter.py` is at 100% branch coverage. It briefly was not, and I said otherwise here before Codecov corrected me: the error-wrapping branch on the copy path had no test, and `226d2cf` adds one to match the equivalent branches on the other two export functions.

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

No front-end change: this is the server-side copy path behind the existing campaign share button. The user-visible outcome is that sharing a campaign with an already-shared quest stops 500ing, which the tests above cover.

### Anything Else?

Step 3 of the Shared Library audit (after #2362 and #2381). Deliberately **not** in this PR:

- **#2372, atomicity.** Both directions still commit the import and then fix visibility in a separate save, so a failure in between can leave unreviewed content published in the Library. It touches every entry point plus the notification and email, so it is cleaner as its own change; that is next.
- **#2364** (name collision on import still 500s), **#2373** (conflicts still raise `PermissionDenied`), **#2369** / **#2370** / **#2371**.

One thing worth a maintainer's eye: the copies now carry prerequisites, which they did not before. If you would rather they arrive with no prerequisites (on the grounds that a copy is a fresh start), say so and I will strip that column for the copy path specifically.

A wider finding, raised separately with @tylerecouture: this PR routes the copy path *through* `QuestResource` on the grounds that the resource is the safe, shared mechanism. A follow-up audit of the whole Library transfer layer found that the resource is itself the source of several content bugs (the tag pk issue above, prerequisites flattened to one `&`-joined string, `common_data` and `Category.map_order` dropped), and that the tablib `Dataset` it builds never leaves the process. That does not change this PR, which fixes a live cross-tenant defect today, but it does mean this code is likely to be rewritten rather than extended. Nothing to do here.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conflicting quests are now copied into the Library with unique names and fresh identifiers.
  * Copied quests remain unpublished and preserve their content.
  * Archived-name conflicts are handled automatically.

* **Bug Fixes**
  * Improved handling of validation and integrity errors during quest imports.
  * Ensured copied quests do not retain invalid references to their original location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->