### PR TITLE
fix: require POST for the views that change state (#2383)

### DIFF
--- a/src/announcements/templates/announcements/list.html
+++ b/src/announcements/templates/announcements/list.html
@@ -59,7 +59,17 @@
             <li class="announcement--edit"><a href="{% url 'announcements:update' object.id %}">Edit</a></li>
             <li class="announcement--copy"><a href="{% url 'announcements:copy' object.id %}">Copy</a></li>
             {% if object.draft %}
-              <li><a href="{% url 'announcements:publish' object.id %}" title="Publish and broadcast this announcement to students.">Publish</a></li>
+              {% comment %}
+                Publishing broadcasts and emails the announcement to every student, so it posts
+                rather than links (#2383). .dropdown-post-form keeps the button looking like the
+                other items in the menu.
+              {% endcomment %}
+              <li>
+                <form method="post" action="{% url 'announcements:publish' object.id %}" class="dropdown-post-form">
+                  {% csrf_token %}
+                  <button type="submit" class="btn btn-link" title="Publish and broadcast this announcement to students.">Publish</button>
+                </form>
+              </li>
             {% endif %}
             <li role="separator" class="divider"></li>
             {% endif %}

--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -115,6 +115,17 @@ class AnnouncementViewTests(ByteDeckTenantTestCase):
             expected_url=reverse('announcements:list', args=[self.ann_pk]),
         )
 
+    @patch('announcements.views.publish_announcement.apply_async')
+    def test_publish__get_is_rejected_and_broadcasts_nothing(self, mock_publish):
+        """Publishing broadcasts and emails an announcement to every student, so it must not happen
+        on a GET: a teacher following a link, or a page with an <img> pointing here, would otherwise
+        send it (#2383)."""
+        self.client.force_login(self.test_teacher)
+
+        self.assert405('announcements:publish', args=[self.ann_pk])
+
+        self.assertFalse(mock_publish.called)
+
     def test_archive_button__visible_to_teachers(self):
         """Teachers see the 'Archived' button on the announcements list."""
         self.client.force_login(self.test_teacher)

--- a/src/announcements/views.py
+++ b/src/announcements/views.py
@@ -10,6 +10,7 @@ from django.urls import reverse_lazy
 from django.urls.base import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.views.decorators.http import require_POST
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 
 from hackerspace_online.decorators import staff_member_required
@@ -171,6 +172,7 @@ def copy(request, ann_id):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def publish(request, ann_id):
     publish_announcement.apply_async(args=[request.user.id, ann_id, get_root_url()], queue='default')
 

--- a/src/comments/templates/comments/comments.html
+++ b/src/comments/templates/comments/comments.html
@@ -19,8 +19,11 @@
           {% endif %}
           <a class='btn btn-danger btn-xs' title='Delete this comment'
             href="{% url 'comments:delete' comment.id %}"><i class="fa fa-fw fa-trash-o"></i></a>
-          <a class='btn btn-danger btn-xs' title='Ban this user from public comments'
-            href="{% url 'profiles:comment_ban' comment.user.profile.id %}"><i class="fa fa-fw fa-ban"></i></a>
+          {# Banning changes the student's account, so it posts rather than links (#2383). #}
+          <form method="post" action="{% url 'profiles:comment_ban' comment.user.profile.id %}" class="preview-action-form">
+            {% csrf_token %}
+            <button type="submit" class='btn btn-danger btn-xs' title='Ban this user from public comments'><i class="fa fa-fw fa-ban"></i></button>
+          </form>
         </div>
         {% endif %}
 

--- a/src/djcytoscape/templates/djcytoscape/cytoscape_list.html
+++ b/src/djcytoscape/templates/djcytoscape/cytoscape_list.html
@@ -5,8 +5,12 @@
 {% block heading_inner %}Quest Maps
   {% if request.user.is_staff %}
     <a class="btn btn-primary" href="{% url 'djcytoscape:generate_unseeded' %}" role="button"><i class="fa fa-plus-circle"></i> Create</a>
-    <a class="btn btn-primary" href="{% url 'djcytoscape:regenerate_all' %}" role="button"
-    title = "Recalculate ALL Maps.  This may take a few moments." ><i class="fa fa-refresh"></i></a>
+    {# Regenerating rebuilds every map, so it posts rather than links (#2383). #}
+    <form method="post" action="{% url 'djcytoscape:regenerate_all' %}" class="preview-action-form">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-primary"
+        title="Recalculate ALL Maps.  This may take a few moments."><i class="fa fa-refresh"></i></button>
+    </form>
   {% endif %}
 {% endblock %}
 

--- a/src/djcytoscape/templates/djcytoscape/quest_map.html
+++ b/src/djcytoscape/templates/djcytoscape/quest_map.html
@@ -20,14 +20,22 @@
       <a id="btn-fullscreen" role="button" class="btn btn-default">Fullscreen <i class="fa fa-arrows-alt"></i></a>
       <a class="btn btn-default" href="{% url 'djcytoscape:list' %}" role="button"
         title = "List all maps"><i class="fa fa-list-ul"></i></a>
-      <a class="btn btn-primary" href="{% url 'djcytoscape:regenerate_all' %}" role="button"
-        title = "Recalculate ALL Maps.  This may take a few moments." >
-        <i class="fa fa-refresh"></i>
-      </a>
-      <a class="btn btn-success" href="{% url 'djcytoscape:regenerate' scape.id %}" role="button"
-        title = "Recalculate this Map." >
-        <i class="fa fa-undo"></i>
-      </a>
+      {% comment %}
+        Regenerating rebuilds a map (and removes one whose initial object is gone), so these post
+        rather than link (#2383).
+      {% endcomment %}
+      <form method="post" action="{% url 'djcytoscape:regenerate_all' %}" class="preview-action-form">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-primary" title="Recalculate ALL Maps.  This may take a few moments.">
+          <i class="fa fa-refresh"></i>
+        </button>
+      </form>
+      <form method="post" action="{% url 'djcytoscape:regenerate' scape.id %}" class="preview-action-form">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-success" title="Recalculate this Map.">
+          <i class="fa fa-undo"></i>
+        </button>
+      </form>
       <a class="btn btn-warning" href="{% url 'djcytoscape:update' scape.id %}" role="button"
         title = "Edit the Map" >
         <i class="fa fa-edit"></i>

--- a/src/djcytoscape/tests/test_views.py
+++ b/src/djcytoscape/tests/test_views.py
@@ -313,7 +313,7 @@ class RegenerateViewTests(ByteDeckTenantTestCase):
     def test_regenerate__redirects_to_quest_map(self):
         """Regenerating a good map redirects back to that map's quest_map page."""
         self.assertRedirects(
-            response=self.client.get(reverse('djcytoscape:regenerate', args=[self.map.id])),
+            response=self.client.post(reverse('djcytoscape:regenerate', args=[self.map.id])),
             expected_url=reverse('djcytoscape:quest_map', args=[self.map.id]),
         )
 
@@ -325,22 +325,43 @@ class RegenerateViewTests(ByteDeckTenantTestCase):
             initial_object_id=99999,  # a non-existant object
         )
         self.assertRedirects(
-            response=self.client.get(reverse('djcytoscape:regenerate', args=[bad_map.id])),
+            response=self.client.post(reverse('djcytoscape:regenerate', args=[bad_map.id])),
             expected_url=reverse('djcytoscape:primary'),
         )
 
     def test_regenerate_all__redirects_to_primary(self):
         """Regenerating all maps redirects to the primary map."""
         self.assertRedirects(
-            response=self.client.get(reverse('djcytoscape:regenerate_all')),
+            response=self.client.post(reverse('djcytoscape:regenerate_all')),
             expected_url=reverse('djcytoscape:primary'),
         )
+
+    def test_regenerate__get_is_rejected_and_leaves_the_map_alone(self):
+        """Regenerating rebuilds a map, and removes one whose initial object is gone, so it must
+        not happen on a GET: a staff member following a link (or loading a page with an <img>
+        pointing here) would otherwise delete a map (#2383)."""
+        bad_map = CytoScape.objects.create(
+            name="bad map",
+            initial_content_type=ContentType.objects.get(app_label='quest_manager', model='quest'),
+            initial_object_id=99999,  # a non-existant object, so regenerating would delete this map
+        )
+
+        self.assert405('djcytoscape:regenerate', args=[bad_map.id])
+
+        self.assertTrue(CytoScape.objects.filter(id=bad_map.id).exists())
+
+    @patch('djcytoscape.views.regenerate_all_maps.apply_async')
+    def test_regenerate_all__get_is_rejected_and_dispatches_nothing(self, mock_apply_async):
+        """The same for regenerating every map, which is queued as a background task (#2383)."""
+        self.assert405('djcytoscape:regenerate_all')
+
+        self.assertFalse(mock_apply_async.called)
 
     @patch('djcytoscape.views.regenerate_all_maps.apply_async')
     def test_regenerate_all__always_offloads_to_background_task(self, mock_apply_async):
         """Regeneration is always offloaded to the celery task (no inline loop / count
         threshold), and the user is told it's being processed in the background (#2081)."""
-        response = self.client.get(reverse('djcytoscape:regenerate_all'), follow=True)
+        response = self.client.post(reverse('djcytoscape:regenerate_all'), follow=True)
 
         mock_apply_async.assert_called_once_with(args=[self.staff_user.id], queue='default')
         self.assertTrue(

--- a/src/djcytoscape/views.py
+++ b/src/djcytoscape/views.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.shortcuts import render, redirect, get_object_or_404, reverse
 from django.utils.decorators import method_decorator
+from django.views.decorators.http import require_POST
 from django.views.generic import ListView
 from django.views.generic.edit import UpdateView, DeleteView, FormView
 from django.urls import reverse_lazy
@@ -215,6 +216,7 @@ class ScapeGenerateMap(NonPublicOnlyViewMixin, FormView):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def regenerate(request, scape_id):
     scape = get_object_or_404(CytoScape, id=scape_id)
     try:
@@ -228,6 +230,7 @@ def regenerate(request, scape_id):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def regenerate_all(request):
     # Offload to celery: regenerating maps builds each map's full graph JSON in memory, so
     # doing it in the request would scale a single web request's memory with the number and

--- a/src/hackerspace_online/tests/utils.py
+++ b/src/hackerspace_online/tests/utils.py
@@ -191,6 +191,22 @@ class ViewTestUtilsMixin():
         )
         return response
 
+    def assert405(self, url_name, *args, **kwargs):
+        """
+        Assert that a GET response to reverse(url_name, *args, **kwargs) is rejected: 405 Method Not Allowed.
+        For a view decorated with `require_POST`, i.e. one that changes state and so must not be
+        reachable by following a link or loading an image (issue #2383).
+        Provide any url and path parameters as args or kwargs.
+
+        Returns the response object.
+        """
+        response = self.client.get(reverse(url_name, *args, **kwargs))
+        self.assertEqual(
+            response.status_code,
+            405
+        )
+        return response
+
     def get_message_list(self, response):
         """ Django messages missing from context of redirected views, so get another way
         https://stackoverflow.com/questions/2897609/how-can-i-unit-test-django-messages

--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -36,24 +36,30 @@
     </div>
 
     {# Archive / restore / delete get their own button group, separate from the profile actions above (#2182). #}
+    {% comment %}
+      Archiving and restoring change the student's account, so they post rather than link (#2383).
+      One form wraps the whole group and each button names its own action, which keeps the buttons
+      direct children of the .btn-group so Bootstrap still joins them into one control.
+    {% endcomment %}
     {% if request.user.is_staff and not object.user.is_staff %}
-      <div class="btn-group" role="group">
-        {% if object.user.is_active %}
-          {# Archiving deactivates the student (reversible) instead of deleting outright. #}
-          <a class="btn btn-default" title="Archive this student (deactivates their account; can be restored or deleted later)"
-            href="{% url 'profiles:profile_archive' object.id %}"
-            role="button"><i class="fa fa-archive"></i></a>
-        {% else %}
-          {# Archived student: restore (dark up-arrow inside the archive box, kept 1em via fa-stack-inline) reactivates; delete is available here too. #}
-          <a class="btn btn-success" title="Restore this student (reactivates their account)"
-            href="{% url 'profiles:profile_restore' object.id %}"
-            role="button"><span class="fa-stack fa-stack-inline"><i class="fa fa-archive fa-stack-1x"></i><i class="fa fa-arrow-up fa-stack-1x"></i></span></a>
+      <form method="post" class="preview-action-form">
+        {% csrf_token %}
+        <div class="btn-group" role="group">
+          {% if object.user.is_active %}
+            {# Archiving deactivates the student (reversible) instead of deleting outright. #}
+            <button type="submit" class="btn btn-default" title="Archive this student (deactivates their account; can be restored or deleted later)"
+              formaction="{% url 'profiles:profile_archive' object.id %}"><i class="fa fa-archive"></i></button>
+          {% else %}
+            {# Archived student: restore (dark up-arrow inside the archive box, kept 1em via fa-stack-inline) reactivates; delete is available here too. #}
+            <button type="submit" class="btn btn-success" title="Restore this student (reactivates their account)"
+              formaction="{% url 'profiles:profile_restore' object.id %}"><span class="fa-stack fa-stack-inline"><i class="fa fa-archive fa-stack-1x"></i><i class="fa fa-arrow-up fa-stack-1x"></i></span></button>
 
-          <a class="btn btn-danger" title="Delete this User permanently"
-            href="{% url 'profiles:profile_delete' object.id %}"
-            role="button"><i class="fa fa-trash-o"></i></a>
-        {% endif %}
-      </div>
+            <a class="btn btn-danger" title="Delete this User permanently"
+              href="{% url 'profiles:profile_delete' object.id %}"
+              role="button"><i class="fa fa-trash-o"></i></a>
+          {% endif %}
+        </div>
+      </form>
     {% endif %}
 {% endblock %}
 

--- a/src/profile_manager/templates/profile_manager/profile_list.html
+++ b/src/profile_manager/templates/profile_manager/profile_list.html
@@ -235,25 +235,33 @@ data-classes="table table-no-bordered table-hover"
                     {#      Admin buttons #}
                     {% if view_type != VIEW_TYPES.STAFF %}
                         <td>
+                            {% comment %}
+                              The ban and skipping toggles change the student, so they post rather than link
+                              (#2383). One form wraps the group and each button names its own action, so the
+                              buttons stay direct children of the .btn-group and Bootstrap still joins them.
+                            {% endcomment %}
+                            <form method="post">
+                            {% csrf_token %}
                             <div class="btn-group action-btn-group">
-                                <a href="{% url 'profiles:comment_ban_toggle' object.id %}"
+                                <button type="submit" formaction="{% url 'profiles:comment_ban_toggle' object.id %}"
                                     title="{% if object.banned_from_comments %}Remove comment ban
                                 {% else %}Ban student from public comments{% endif %}"
                                     class="btn btn-sm {% if object.banned_from_comments %}btn-success{% else %}btn-default{% endif %}">
                                     <i class="fa fa-commenting-o"></i>
-                                </a>
-                                <a href="{% url 'profiles:xp_toggle' object.id %}"
+                                </button>
+                                <button type="submit" formaction="{% url 'profiles:xp_toggle' object.id %}"
                                     title="{% if object.not_earning_xp %}Turn quest skipping off
                                 {% else %}Allow user to skip quests. Gives user a button allowing them skip quests without approval. Skipped quests count as completed for prerequisite purposes but don't grant XP.{% endif %}"
                                     class="btn btn-sm
                             {% if object.not_earning_xp %}btn-success{% else %}btn-default{% endif %}">
                                     <i class="fa fa-magic"></i>
-                                </a>
+                                </button>
                                 <a href="{% url 'profiles:change_password' object.user.pk %}" class="btn btn-sm btn-default"
                                     title="Reset this student's password">
                                     <i class="fa fa-key"></i>
                                 </a>
                             </div>
+                            </form>
                         </td>
                     {% endif %}
                 {% endif %}

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -108,9 +108,11 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.assert200('profiles:profile_list_inactive')
         self.assert200('profiles:tag_chart', args=[s_pk])
         self.assert200('profiles:profile_delete', args=[s_pk])
-        self.assert302('profiles:comment_ban', args=[s_pk])
-        self.assert302('profiles:comment_ban_toggle', args=[s_pk])
-        self.assert302('profiles:xp_toggle', args=[s_pk])
+        # POST-only, so a GET is rejected rather than performed (#2383); each view's staff
+        # behaviour is covered by its own test below
+        self.assert405('profiles:comment_ban', args=[s_pk])
+        self.assert405('profiles:comment_ban_toggle', args=[s_pk])
+        self.assert405('profiles:xp_toggle', args=[s_pk])
 
     def test_recalculate_current_xp__requires_staff(self):
         """Only staff can trigger the current-semester XP recalculation: an anonymous visitor is sent
@@ -128,11 +130,11 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         profile = self.test_student1.profile
         self.assertFalse(profile.not_earning_xp)
 
-        self.client.get(reverse('profiles:xp_toggle', args=[profile.pk]))
+        self.client.post(reverse('profiles:xp_toggle', args=[profile.pk]))
         profile.refresh_from_db()
         self.assertTrue(profile.not_earning_xp)
 
-        self.client.get(reverse('profiles:xp_toggle', args=[profile.pk]))
+        self.client.post(reverse('profiles:xp_toggle', args=[profile.pk]))
         profile.refresh_from_db()
         self.assertFalse(profile.not_earning_xp)
 
@@ -141,7 +143,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
         previous_page = reverse('profiles:profile_list')
 
-        response = self.client.get(
+        response = self.client.post(
             reverse('profiles:xp_toggle', args=[self.test_student1.profile.pk]),
             HTTP_REFERER=previous_page,
         )
@@ -154,7 +156,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         profile = self.test_student1.profile
         self.assertFalse(profile.banned_from_comments)
 
-        response = self.client.get(reverse('profiles:comment_ban', args=[profile.pk]))
+        response = self.client.post(reverse('profiles:comment_ban', args=[profile.pk]))
         profile.refresh_from_db()
         self.assertTrue(profile.banned_from_comments)
         self.assertWarningMessage(response)
@@ -162,7 +164,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.assertIn(self.test_student1.username, message)
         self.assertIn('banned from commenting publicly', message)
 
-        self.client.get(reverse('profiles:comment_ban', args=[profile.pk]))
+        self.client.post(reverse('profiles:comment_ban', args=[profile.pk]))
         profile.refresh_from_db()
         self.assertTrue(profile.banned_from_comments)
 
@@ -171,11 +173,11 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
         profile = self.test_student1.profile
 
-        self.client.get(reverse('profiles:comment_ban_toggle', args=[profile.pk]))
+        self.client.post(reverse('profiles:comment_ban_toggle', args=[profile.pk]))
         profile.refresh_from_db()
         self.assertTrue(profile.banned_from_comments)
 
-        self.client.get(reverse('profiles:comment_ban_toggle', args=[profile.pk]))
+        self.client.post(reverse('profiles:comment_ban_toggle', args=[profile.pk]))
         profile.refresh_from_db()
         self.assertFalse(profile.banned_from_comments)
 
@@ -186,7 +188,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         profile.save()
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('profiles:comment_ban_toggle', args=[profile.pk]))
+        response = self.client.post(reverse('profiles:comment_ban_toggle', args=[profile.pk]))
 
         self.assertSuccessMessage(response)
         message = self.get_message_list(response)[0].message
@@ -197,7 +199,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         """A banned student is told they were banned, so the ban is not silent to them."""
         self.client.force_login(self.test_teacher)
 
-        self.client.get(reverse('profiles:comment_ban', args=[self.test_student1.profile.pk]))
+        self.client.post(reverse('profiles:comment_ban', args=[self.test_student1.profile.pk]))
 
         notification = Notification.objects.all_for_user(self.test_student1).first()
         self.assertIsNotNone(notification)
@@ -219,7 +221,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         # The view must NOT recompute in-request; it must dispatch the celery task instead.
         with patch('profile_manager.views.invalidate_profile_xp_cache_on_schema.apply_async') as mock_dispatch, \
                 patch.object(Profile, 'xp_invalidate_cache') as mock_invalidate:
-            response = self.client.get(reverse('profiles:recalculate_xp_current'))
+            response = self.client.post(reverse('profiles:recalculate_xp_current'))
 
         self.assertEqual(response.status_code, 302)
         mock_dispatch.assert_called_once()
@@ -875,7 +877,7 @@ class ProfileArchiveTests(ByteDeckTenantTestCase):
     def test_profile_archive__staff_deactivates_student(self):
         """A staff request to profile_archive deactivates the student (is_active=False) and redirects."""
         self.client.force_login(self.teacher)
-        response = self.client.get(self.archive_url)
+        response = self.client.post(self.archive_url)
         self.student.refresh_from_db()
         self.assertFalse(self.student.is_active)
         self.assertEqual(response.status_code, 302)
@@ -885,7 +887,7 @@ class ProfileArchiveTests(ByteDeckTenantTestCase):
         self.student.is_active = False
         self.student.save()
         self.client.force_login(self.teacher)
-        response = self.client.get(self.restore_url)
+        response = self.client.post(self.restore_url)
         self.student.refresh_from_db()
         self.assertTrue(self.student.is_active)
         self.assertEqual(response.status_code, 302)
@@ -894,14 +896,14 @@ class ProfileArchiveTests(ByteDeckTenantTestCase):
         """Archiving a staff account is refused, leaving that account active."""
         staff_target = self.User.objects.create_user('other_teacher', is_staff=True)
         self.client.force_login(self.teacher)
-        self.client.get(reverse("profiles:profile_archive", args=[staff_target.profile.pk]))
+        self.client.post(reverse("profiles:profile_archive", args=[staff_target.profile.pk]))
         staff_target.refresh_from_db()
         self.assertTrue(staff_target.is_active)
 
     def test_profile_archive__non_staff_forbidden(self):
         """A non-staff user cannot archive: access is forbidden and the target stays active."""
         self.client.force_login(self.other_student)
-        response = self.client.get(self.archive_url)
+        response = self.client.post(self.archive_url)
         self.student.refresh_from_db()
         self.assertEqual(response.status_code, 403)
         self.assertTrue(self.student.is_active)
@@ -911,7 +913,7 @@ class ProfileArchiveTests(ByteDeckTenantTestCase):
         self.student.is_active = False
         self.student.save()
         self.client.force_login(self.other_student)
-        response = self.client.get(self.restore_url)
+        response = self.client.post(self.restore_url)
         self.student.refresh_from_db()
         self.assertEqual(response.status_code, 403)
         self.assertFalse(self.student.is_active)
@@ -1034,3 +1036,64 @@ class OAuthMergeAccountViewTests(ByteDeckTenantTestCase):
         404 before any POST handling — which is why the view's own ``if not merge_with_user_id``
         guard can never be reached."""
         self.assert404('profiles:oauth_merge_account')
+
+
+class StateChangingProfileViewsRequirePostTests(ByteDeckTenantTestCase):
+    """The profile views that change a student's account must not act on a GET (#2383).
+
+    Django's CSRF protection deliberately does not cover GET, so a view that mutates on GET can
+    be triggered by a teacher following a link or merely loading a page with an <img> pointing at
+    it. Each of these now answers 405 and leaves the student alone.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a teacher and the student these views would act on."""
+        User = get_user_model()
+        cls.teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.student = User.objects.create_user('test_student')
+
+    def setUp(self):
+        """Log the teacher in, so only the request method decides the outcome."""
+        self.client.force_login(self.teacher)
+
+    def test_profile_archive__get_is_rejected_and_leaves_the_student_active(self):
+        """Loading the archive url can't deactivate a student."""
+        self.assert405('profiles:profile_archive', args=[self.student.profile.pk])
+        self.student.refresh_from_db()
+        self.assertTrue(self.student.is_active)
+
+    def test_profile_restore__get_is_rejected_and_leaves_the_student_archived(self):
+        """Loading the restore url can't reactivate an archived student."""
+        self.student.is_active = False
+        self.student.save()
+
+        self.assert405('profiles:profile_restore', args=[self.student.profile.pk])
+
+        self.student.refresh_from_db()
+        self.assertFalse(self.student.is_active)
+
+    def test_xp_toggle__get_is_rejected_and_leaves_xp_earning_alone(self):
+        """Loading the xp toggle url can't stop a student earning XP."""
+        self.assert405('profiles:xp_toggle', args=[self.student.profile.pk])
+        self.student.profile.refresh_from_db()
+        self.assertFalse(self.student.profile.not_earning_xp)
+
+    def test_comment_ban__get_is_rejected_and_leaves_the_student_unbanned(self):
+        """Loading the ban url can't ban a student from commenting."""
+        self.assert405('profiles:comment_ban', args=[self.student.profile.pk])
+        self.student.profile.refresh_from_db()
+        self.assertFalse(self.student.profile.banned_from_comments)
+
+    def test_comment_ban_toggle__get_is_rejected_and_leaves_the_student_unbanned(self):
+        """The toggle form of the ban is closed the same way."""
+        self.assert405('profiles:comment_ban_toggle', args=[self.student.profile.pk])
+        self.student.profile.refresh_from_db()
+        self.assertFalse(self.student.profile.banned_from_comments)
+
+    def test_recalculate_current_xp__get_is_rejected_and_dispatches_nothing(self):
+        """Loading the recalculate url can't queue the all-student XP recompute."""
+        with patch('profile_manager.views.invalidate_profile_xp_cache_on_schema.apply_async') as mock_dispatch:
+            self.assert405('profiles:recalculate_xp_current')
+
+        self.assertFalse(mock_dispatch.called)

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -577,6 +577,20 @@ def profile_restore(request, profile_id):
 @staff_member_required
 @require_POST
 def comment_ban_toggle(request, profile_id):
+    """Toggle whether a student is banned from commenting publicly.
+
+    The toggling form of :func:`comment_ban`: where that view only applies a ban, this one
+    lifts a ban that is already in place. Staff-only, and POST-only because it changes the
+    student's account (#2383).
+
+    Args:
+        request: the HttpRequest; must be a POST from a staff user.
+        profile_id: the id of the Profile to ban or unban.
+
+    Returns:
+        The HttpResponseRedirect from :func:`comment_ban`, back to the page the toggle was
+        clicked from.
+    """
     return comment_ban(request, profile_id, toggle=True)
 
 

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html
+from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import UpdateView, FormView, DeleteView
 
@@ -491,6 +492,7 @@ def oauth_merge_account(request):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def recalculate_current_xp(request):
     # Recalculating XP for every current student invalidates and recomputes a cache per
     # profile; on a busy deck that is hundreds of profiles in one request, which has grown a
@@ -509,6 +511,7 @@ def recalculate_current_xp(request):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def xp_toggle(request, profile_id):
     profile = get_object_or_404(Profile, id=profile_id)
     profile.not_earning_xp = not profile.not_earning_xp
@@ -518,6 +521,7 @@ def xp_toggle(request, profile_id):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def profile_archive(request, profile_id):
     """Archive a student by deactivating their account (``User.is_active = False``).
 
@@ -549,6 +553,7 @@ def profile_archive(request, profile_id):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def profile_restore(request, profile_id):
     """Restore an archived student by reactivating their account (``User.is_active = True``).
 
@@ -570,12 +575,14 @@ def profile_restore(request, profile_id):
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def comment_ban_toggle(request, profile_id):
     return comment_ban(request, profile_id, toggle=True)
 
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def comment_ban(request, profile_id, toggle=False):
     profile = get_object_or_404(Profile, id=profile_id)
     if toggle:

--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -83,8 +83,12 @@
         </a>
 
         {% if request.user.profile.not_earning_xp %}
-          <a title="Skip Quest: mark this quest as completed, but you won't get XP for it."
-             class="btn btn-warning" href="{% url 'quests:skip_for_quest' q.id %}" role="button">Skip Quest</a>
+          {# Skipping starts and approves the quest, so it posts rather than links (#2383). #}
+          <form method="post" action="{% url 'quests:skip_for_quest' q.id %}" class="preview-action-form">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-warning"
+              title="Skip Quest: mark this quest as completed, but you won't get XP for it.">Skip Quest</button>
+          </form>
         {% endif %}
 
         {% if q|is_hidden:request.user %}

--- a/src/quest_manager/templates/quest_manager/preview_content_submissions.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_submissions.html
@@ -28,7 +28,11 @@
       </a>
 
       {% if request.user.profile.not_earning_xp %}
-        <a class="btn btn-warning" href="{% url 'quests:skip' s.id %}" role="button">Skip</a>
+        {# Skipping completes and approves the submission, so it posts rather than links (#2383). #}
+        <form method="post" action="{% url 'quests:skip' s.id %}" class="preview-action-form">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-warning">Skip</button>
+        </form>
       {% endif %}
     {% else %}
       <a title="View Details: view the content of this quest or add to the submission."

--- a/src/quest_manager/templates/quest_manager/preview_content_submissions.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_submissions.html
@@ -31,7 +31,8 @@
         {# Skipping completes and approves the submission, so it posts rather than links (#2383). #}
         <form method="post" action="{% url 'quests:skip' s.id %}" class="preview-action-form">
           {% csrf_token %}
-          <button type="submit" class="btn btn-warning">Skip</button>
+          <button type="submit" class="btn btn-warning"
+            title="Skip Quest: mark this quest as completed, but you won't get XP for it.">Skip</button>
         </form>
       {% endif %}
     {% else %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -131,7 +131,8 @@ class QuestViewQuickTests(ByteDeckTenantTestCase):
         self.assert302('quests:start', args=[q2_pk])
         self.assert302('quests:hide', args=[q_pk])
         self.assert302('quests:unhide', args=[q_pk])
-        self.assert404('quests:skip_for_quest', args=[q_pk])
+        # skip_for_quest is POST-only (#2383); posting still 404s for a student who may not skip
+        self.assertEqual(self.client.post(reverse('quests:skip_for_quest', args=[q_pk])).status_code, 404)
         self.assert403('quests:unarchive', args=[archived_quest_pk])
 
         self.assert403('quests:quest_prereqs_update', args=[q_pk])
@@ -158,7 +159,7 @@ class QuestViewQuickTests(ByteDeckTenantTestCase):
         self.assert200('quests:quest_prereqs_update', args=[q_pk])
         # unarchiving unpublishes the quest, so it lands on the Drafts tab where the quest now is
         self.assertRedirects(
-            response=self.client.get(reverse('quests:unarchive', args=[archived_quest_pk])),
+            response=self.client.post(reverse('quests:unarchive', args=[archived_quest_pk])),
             expected_url=reverse('quests:drafts'),
         )
 
@@ -397,8 +398,9 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         # Students shouldn't have access to these
         self.assert403('quests:flagged')
 
-        # Student's own submission
-        self.assert404('quests:skip', args=[s1_pk])
+        # Student's own submission. skip is POST-only (#2383), so post to reach the view's own
+        # 404 for a student who isn't allowed to skip.
+        self.assertEqual(self.client.post(reverse('quests:skip', args=[s1_pk])).status_code, 404)
         self.assert403('quests:approve', args=[s1_pk])
         self.assert200('quests:submission_past', args=[s1_pk])
         self.assert403('quests:flag', args=[s1_pk])
@@ -408,14 +410,14 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         # Not this student's submission: sent back to their own quests page, not shown someone else's work
         self.assertRedirectsQuests('quests:submission', args=[s2_pk])
         self.assertRedirectsQuests('quests:drop', args=[s2_pk])
-        self.assert404('quests:skip', args=[s2_pk])
+        self.assertEqual(self.client.post(reverse('quests:skip', args=[s2_pk])).status_code, 404)
         self.assertRedirectsQuests('quests:submission_past', args=[s2_pk])
         self.assert404('quests:complete', args=[s2_pk])
 
         # Non existent submissions
         self.assert404('quests:submission', args=[0])
         self.assert404('quests:drop', args=[0])
-        self.assert404('quests:skip', args=[0])
+        self.assertEqual(self.client.post(reverse('quests:skip', args=[0])).status_code, 404)
         self.assert404('quests:submission_past', args=[0])
         self.assert404('quests:complete', args=[0])
 
@@ -665,14 +667,14 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         # Non existent submissions
         self.assert404('quests:submission', args=[0])
         self.assert404('quests:drop', args=[0])
-        self.assert404('quests:skip', args=[0])
+        self.assertEqual(self.client.post(reverse('quests:skip', args=[0])).status_code, 404)
         self.assert404('quests:submission_past', args=[0])
 
         # These Needs to be completed via POST
         # self.assertEqual(self.client.get(reverse('quests:complete', args=[s1_pk])).status_code, 404)
         # skipping is a staff transfer, so it returns the teacher to the approvals queue
         self.assertRedirects(
-            response=self.client.get(reverse('quests:skip', args=[s1_pk])),
+            response=self.client.post(reverse('quests:skip', args=[s1_pk])),
             expected_url=reverse('quests:approvals'),
         )
         self.assert404('quests:approve', args=[s1_pk])
@@ -961,7 +963,7 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
         profile.not_earning_xp = True
         profile.save()
 
-        response = self.client.get(reverse('quests:skip', args=[self.sub.id]))
+        response = self.client.post(reverse('quests:skip', args=[self.sub.id]))
 
         self.assertRedirects(response, reverse('quests:quests'), fetch_redirect_response=False)
         self.sub.refresh_from_db()
@@ -2859,11 +2861,30 @@ class SkipQuestViewTests(ByteDeckTenantTestCase):
             QuestSubmission, user=cls.transfer_student, quest=cls.quest, semester=cls.semester,
         )
 
+    def test_skip__get_is_rejected_and_leaves_the_submission_unapproved(self):
+        """Skipping approves a submission outright, so it must not happen on a GET: a teacher
+        following a link, or a page with an <img> pointing here, would otherwise approve a
+        student's quest for them (#2383)."""
+        self.client.force_login(self.test_teacher)
+
+        self.assert405('quests:skip', args=[self.submission.pk])
+
+        self.submission.refresh_from_db()
+        self.assertFalse(self.submission.is_approved)
+
+    def test_skip_for_quest__get_is_rejected_and_starts_nothing(self):
+        """The same for the url that starts the quest before approving it: nothing is created."""
+        self.client.force_login(self.test_teacher)
+
+        self.assert405('quests:skip_for_quest', args=[self.quest.pk])
+
+        self.assertFalse(QuestSubmission.objects.filter(user=self.test_teacher, quest=self.quest).exists())
+
     def test_skip__teacher_approves_the_submission_as_a_transfer(self):
         """A teacher skipping a submission marks it completed and approved, and back to the approvals queue."""
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('quests:skip', args=[self.submission.pk]))
+        response = self.client.post(reverse('quests:skip', args=[self.submission.pk]))
 
         self.assertRedirects(response, reverse('quests:approvals'), fetch_redirect_response=False)
         self.submission.refresh_from_db()
@@ -2876,7 +2897,7 @@ class SkipQuestViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
         xp_before = self.transfer_student.profile.xp_cached
 
-        self.client.get(reverse('quests:skip', args=[self.submission.pk]))
+        self.client.post(reverse('quests:skip', args=[self.submission.pk]))
 
         self.submission.refresh_from_db()
         self.assertTrue(self.submission.do_not_grant_xp)
@@ -2891,7 +2912,7 @@ class SkipQuestViewTests(ByteDeckTenantTestCase):
         """
         self.client.force_login(self.transfer_student)
 
-        self.assert404('quests:skip', args=[self.submission.pk])
+        self.assertEqual(self.client.post(reverse('quests:skip', args=[self.submission.pk])).status_code, 404)
 
         self.submission.refresh_from_db()
         self.assertFalse(self.submission.is_approved)
@@ -2904,7 +2925,7 @@ class SkipQuestViewTests(ByteDeckTenantTestCase):
         self.client.force_login(self.test_student)
         self.assertFalse(QuestSubmission.objects.filter(user=self.test_student, quest=self.quest).exists())
 
-        response = self.client.get(reverse('quests:skip_for_quest', args=[self.quest.pk]))
+        response = self.client.post(reverse('quests:skip_for_quest', args=[self.quest.pk]))
 
         self.assertRedirects(response, reverse('quests:quests'), fetch_redirect_response=False)
         submission = QuestSubmission.objects.get(user=self.test_student, quest=self.quest)
@@ -2915,7 +2936,7 @@ class SkipQuestViewTests(ByteDeckTenantTestCase):
         """A skip url for a missing quest 404s rather than creating a submission for nothing."""
         self.client.force_login(self.test_teacher)
 
-        self.assert404('quests:skip_for_quest', args=[0])
+        self.assertEqual(self.client.post(reverse('quests:skip_for_quest', args=[0])).status_code, 404)
 
         self.assertFalse(QuestSubmission.objects.filter(user=self.test_teacher).exists())
 
@@ -5105,6 +5126,16 @@ class QuestArchiveViewTest(ByteDeckTenantTestCase):
         self.assertFalse(Quest.objects.all_including_archived().filter(id=nonexistent_id).exists())
         url = reverse('quests:quest_archive', args=[nonexistent_id])
         self.assertEqual(self.client.post(url).status_code, 404)
+
+    def test_unarchive__get_is_rejected_and_leaves_the_quest_archived(self):
+        """Unarchiving changes the quest, so it must not happen on a GET (#2383). The button in
+        the template already posts; this closes the url itself."""
+        archived_quest = baker.make(Quest, archived=True)
+
+        self.assert405('quests:unarchive', args=[archived_quest.id])
+
+        archived_quest.refresh_from_db()
+        self.assertTrue(archived_quest.archived)
 
     def test_unarchive__nonexistent_quest_returns_404(self):
         """Unarchiving a quest id that does not exist 404s cleanly (#1856).

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -20,6 +20,7 @@ from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import Http404, get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
+from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, View
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 
@@ -1623,6 +1624,7 @@ def approvals(request, quest_id=None, template="quest_manager/quest_approval.htm
 
 @non_public_only_view
 @staff_member_required
+@require_POST
 def unarchive(request, quest_id):
     """
     Unarchive a quest by setting `archived=False` and ensure it is unpublished
@@ -2002,6 +2004,7 @@ def unhide(request, quest_id):
 
 
 @login_required
+@require_POST
 def skip(request, submission_id):
     submission = get_object_or_404(QuestSubmission, pk=submission_id)
     # student can only do this if the button is turned on by a teacher
@@ -2036,6 +2039,7 @@ def skip(request, submission_id):
 
 @non_public_only_view
 @login_required
+@require_POST
 def skipped(request, quest_id):
     """A combination of the start and complete views, but automatically approved
     regardless, and do_not_grant_xp = True

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2006,6 +2006,22 @@ def unhide(request, quest_id):
 @login_required
 @require_POST
 def skip(request, submission_id):
+    """Approve a submission as a transfer: complete and approved, but worth no XP.
+
+    Limited to staff and to a student marked as not earning XP acting on their own
+    submission, so a student cannot skip a quest by guessing the url. POST-only, because it
+    approves the quest outright (#2383).
+
+    Args:
+        request: the HttpRequest; must be a POST.
+        submission_id: the id of the QuestSubmission to transfer.
+
+    Returns:
+        An HttpResponseRedirect to the approvals queue for staff, or to the student's quests.
+
+    Raises:
+        Http404: when the requester may not skip this submission.
+    """
     submission = get_object_or_404(QuestSubmission, pk=submission_id)
     # student can only do this if the button is turned on by a teacher
     # prevent students form skipping by guessing correct url
@@ -2041,8 +2057,18 @@ def skip(request, submission_id):
 @login_required
 @require_POST
 def skipped(request, quest_id):
-    """A combination of the start and complete views, but automatically approved
-    regardless, and do_not_grant_xp = True
+    """Skip a quest the student never started: start it, then transfer it.
+
+    A combination of the start and complete views, but automatically approved regardless,
+    and do_not_grant_xp = True. POST-only, since it both creates a submission and approves
+    it (#2383).
+
+    Args:
+        request: the HttpRequest; must be a POST.
+        quest_id: the id of the Quest to start and transfer.
+
+    Returns:
+        The HttpResponseRedirect from :func:`skip`, which handles the approval.
     """
     quest = get_object_or_404(Quest, pk=quest_id)
     # create_submission always returns a submission: a new in-progress one, or the

--- a/src/static/css/custom.css
+++ b/src/static/css/custom.css
@@ -192,3 +192,16 @@ a.list-group-item-muted {
 .announcement-dropdown a{
     color: #777;
 }
+
+/* A dropdown item that posts instead of linking (e.g. Publish an announcement) takes the colours
+   this theme gives `.dropdown-menu > li > a`; its layout comes from .dropdown-post-form in
+   custom_common.css. */
+.dropdown-menu > li > .dropdown-post-form > .btn-link{
+    color: #333;
+}
+
+.dropdown-menu > li > .dropdown-post-form > .btn-link:hover,
+.dropdown-menu > li > .dropdown-post-form > .btn-link:focus{
+    color: #262626;
+    background-color: #f5f5f5;
+}

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -923,6 +923,30 @@ div.btn-group.action-btn-group {
     display: inline-block;
 }
 
+/* A dropdown item that posts instead of linking (e.g. Publish an announcement) is a button in a
+   form, so give it the layout Bootstrap gives `.dropdown-menu > li > a`. Colours are theme
+   specific, so they live in custom.css and custom_slate.css beside this rule. */
+.dropdown-menu > li > .dropdown-post-form {
+    margin: 0;
+}
+
+.dropdown-menu > li > .dropdown-post-form > .btn-link {
+    display: block;
+    width: 100%;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 1.42857143;
+    text-align: left;
+    white-space: nowrap;
+    text-decoration: none;
+}
+
+.dropdown-menu > li > .dropdown-post-form > .btn-link:hover,
+.dropdown-menu > li > .dropdown-post-form > .btn-link:focus {
+    text-decoration: none;
+}
+
 /*Make the container act like container-fluid at small and medium sizes*/
 
 /*LESS to mimic Bootstrap without importing the less files.*/

--- a/src/static/css/custom_slate.css
+++ b/src/static/css/custom_slate.css
@@ -295,3 +295,16 @@ input, textarea {
 .announcement-dropdown a{
     color: rgb(200, 200, 200);
 }
+
+/* A dropdown item that posts instead of linking (e.g. Publish an announcement) takes the colours
+   this theme gives `.dropdown-menu > li > a`; its layout comes from .dropdown-post-form in
+   custom_common.css. */
+.dropdown-menu > li > .dropdown-post-form > .btn-link{
+    color: #c8c8c8;
+}
+
+.dropdown-menu > li > .dropdown-post-form > .btn-link:hover,
+.dropdown-menu > li > .dropdown-post-form > .btn-link:focus{
+    color: #ffffff;
+    background-color: #272b30;
+}

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -20,11 +20,11 @@
 
 <!-- Custom site-wide styles -->
 {% if request.user.profile.dark_theme %}
-<link href="{{ STATIC_PREFIX }}css/custom_slate.css?v=1.6" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_slate.css?v=1.7" rel="stylesheet">
 {% else %}
-<link href="{{ STATIC_PREFIX }}css/custom.css?v=1.6" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom.css?v=1.7" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.3" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.4" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->


### PR DESCRIPTION
### What?
The views that change state now answer only to POST, and the buttons that reach them post instead of linking. Closes #2383.

### Why?
Django's CSRF protection deliberately does not cover GET, so a view that mutates on a GET runs whenever a teacher follows a link, or merely loads a page containing an image tag pointing at it. Archiving a student, banning them from commenting, publishing an announcement to the whole deck, regenerating (and sometimes deleting) a quest map, and approving a quest as a skip were all reachable that way. They are staff-gated, so this is not an anonymous hole: the realistic cases are a student getting a teacher to open a link, and a browser or scanner prefetching a url it found.

### How?
`require_POST` on each view, and the template call site becomes an inline post form. Two shapes, no new JavaScript, so the pages render exactly as before:

- **Loose buttons** (quest map toolbar, map list, comment actions, Skip) use the `.preview-action-form` class the codebase already uses for Unarchive: an inline-block form around the button.
- **Button groups** (profile detail, student list) keep one form around the whole `.btn-group`, with each button naming its own `formaction`. That leaves the buttons as direct children of the group, so Bootstrap still joins them into a single control.
- **The dropdown item** (Publish) needed a style: `.dropdown-post-form` gives the button the layout Bootstrap gives `.dropdown-menu > li > a` in `custom_common.css`, with the colours beside each theme's existing dropdown rules in `custom.css` / `custom_slate.css`. Cache-busters bumped.

Each converted button keeps its native `title` tooltip, per the front-end convention; the Skip button in the in-progress preview gains one it never had, matching the wording on its sibling Skip Quest button. The three views whose signatures this PR touches (`comment_ban_toggle`, `skip`, `skipped`) gained full docstrings.

### Triage
The issue asked for triage rather than one bucket, and three of the sixteen listed views should not change:

| View | Verdict |
|---|---|
| `profiles`: `profile_archive`, `profile_restore`, `xp_toggle`, `comment_ban`, `comment_ban_toggle`, `recalculate_current_xp` | POST only |
| `djcytoscape`: `regenerate`, `regenerate_all` | POST only |
| `announcements`: `publish` | POST only |
| `quests`: `unarchive`, `skip`, `skipped` (`skip_for_quest`) | POST only |
| `announcements.copy`, `badges.badge_copy` | **left alone**: these are form views. A GET renders the pre-filled copy form and only a POST saves (`AnnouncementForm(request.POST or None, ...)`), so the scan caught the `form.save()` inside the POST branch. `require_POST` would break the Copy button outright. |
| `notifications`: `read`, `read_all` | **left alone**: self-only and harmless, as the issue says. `read` in particular is the click-through target of every notification link, so it has to stay a GET. |
| `quests`: `flag`, `unflag` | **split out into #2389**: staff-only follow-up markers, and neither has a plain call site (`flag` has none at all; the flag button already posts through `ajax_flag`). `unflag` lives in `submission_buttons_other.html`, which is included both inside an existing form and outside one, so it wants the same ajax treatment rather than a nested form. |

Two of the converted views (`recalculate_current_xp` and `flag`) have no template link at all today, so nothing rendered changes for them.

### Testing?
`python src/manage.py test src` passes (2137 tests). `ruff check src` clean.

- New tests, one per converted view, assert the GET is refused **and** that nothing changed: the student stays active, the ban is not applied, the map still exists, the announcement task is never queued, the submission stays unapproved. All 11 fail on `develop`.
- `assert405` added beside the existing `assert200` / `assert403` helpers in the shared test mixin, since four apps needed it.
- Existing tests that documented the old behaviour now post. Where a test asserted the view's own 404 (a student guessing a skip url, a missing quest id), it posts so it still reaches that branch rather than stopping at the method check.

### Screenshots (if front end is affected)
Captured from the running `hackerspace` dev deck (seeded with `initdb` + `generate_content`), as the deck owner and as a student. Every pair is before on top, after below. The point of each is that nothing moved:

**Student list row** (ban and skipping toggles, `formaction` inside the `.btn-group`):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_student_list_row.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_student_list_row.png)

**Profile detail** (archive button, inline form so the group stays on the heading line):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_profile_detail.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_profile_detail.png)

**Announcement menu** (Publish, the one that needed the new style):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_announcement_menu.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_announcement_menu.png)

**Quest map toolbar** (regenerate all, regenerate this map):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_quest_map_toolbar.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_quest_map_toolbar.png)

**Quest map list heading**:

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_map_list_heading.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_map_list_heading.png)

**Comment actions** (the ban button, beside flag and delete):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_comment_buttons.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_comment_buttons.png)

**Student Skip Quest button** (a student marked as not earning XP):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/before_student_quest_buttons.png)
![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2383/after_student_quest_buttons.png)

I also clicked the new buttons on the running deck rather than trusting the tests: the XP toggle returned to the student list with the flag flipped, Archive deactivated the student and showed its message, Publish redirected to the announcement, and Regenerate All redirected to the primary map.

### Anything Else?
Two things worth knowing:

- The Publish menu item first rendered link-blue against its dark neighbours, because `.btn-link` takes the theme's link colour while the other items take Bootstrap's `.dropdown-menu > li > a` colour. That is what the screenshots above are for; it is fixed by the theme rules, not by inline CSS.
- The archive button initially wrapped onto its own line, because a `<form>` is block level. `.preview-action-form` (already in the codebase for exactly this) puts it back inline.

Follow-up filed: #2389 for `flag` / `unflag`.

This PR sat red on an unrelated lint failure until #2392 fixed a repo-wide ruff pin drift; it is rebased past that now.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)