### PR TITLE
test: answer the two commented-out notes in the tenant admin tests

### DIFF
--- a/src/tenant/tests/test_admin.py
+++ b/src/tenant/tests/test_admin.py
@@ -17,10 +17,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sites.models import Site
 from django.core.exceptions import PermissionDenied
+from django.db import connection
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
 from django.test import RequestFactory, override_settings
-# from django.core.exceptions import ValidationError
 from django.urls import path, reverse
 from django.utils import timezone
 
@@ -512,8 +512,13 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
 
         mock_add_message.assert_called()
 
-    def test_save_model__public_tenant_creates_schema(self):
-        """save_model on the public tenant creates a new tenant with a sanitized schema name."""
+    def test_save_model__public_tenant_creates_a_working_deck(self):
+        """save_model on the public tenant creates a deck that is actually usable: the schema name
+        is sanitized, the deck answers on its own subdomain, and a teacher can sign in and load a page.
+
+        A schema and a Tenant row are not enough on their own. Requests are routed by hostname, so a
+        deck is only reachable once it also has a TenantDomain, which the save creates.
+        """
         with tenant_context(self.public_tenant):
             non_public_tenant = Tenant(
                 name="Non-Public",  # Not a valid name, but not validated in this test
@@ -524,44 +529,24 @@ class PublicTenantTestAdminPublic(ByteDeckTenantTestCase):
             self.assertIsInstance(non_public_tenant, Tenant)
             # schema names should be all lower case and dashes converted to underscores
             self.assertEqual(non_public_tenant.schema_name, "non_public")
+            # the subdomain keeps the name as typed (lower cased), so it does not match the schema name
+            self.assertEqual(non_public_tenant.get_primary_domain().domain, f"non-public.{settings.ROOT_DOMAIN}")
 
-        # TODO: Not working, can't figure out why?
-        # When try to use client.get() the context switches back to the public tenant
-        # WHY!?!?
+        with tenant_context(non_public_tenant):
+            new_deck_teacher = User.objects.create_user('test_teacher', password="password", is_staff=True)
 
-        # make sure we can access and sign-in to the new tenant
-        # with tenant_context(non_public_tenant):
-        #     from django.db import connection
-        #     from django.contrib.auth import get_user_model
-        #     from django.urls import reverse
+        # TenantClient sends the deck's primary domain as the Host header, which is what actually
+        # selects the schema: the middleware resets the connection to public and re-resolves the
+        # tenant from that host on every request.
+        client = TenantClient(non_public_tenant)
+        response = client.get(reverse('account_login'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.tenant, non_public_tenant)
 
-        #     client = TenantClient(non_public_tenant)
-        #     connection.set_tenant(non_public_tenant)
-        #     print(connection.schema_name)  # non_public
-        #     response = client.get(reverse('account_login'))
-        #     print(connection.schema_name)  # public
-
-        #     # self.assertEqual(response.status_code, 200)
-        #     print(connection.schema_name)
-
-        #     test_teacher = get_user_model().objects.create_user('test_teacher', password="password", is_staff=True)
-        #     client = TenantClient(non_public_tenant)
-        #     client.force_login(test_teacher)
-        #     response = client.get(reverse('quests:quests'))
-        #     self.assertEqual(response.status_code, 200)
-
-    # FIXME:
-    # def test_public_tenant_admin_save_new_tenant_with_bad_names(self):
-    #
-    #     with tenant_context(self.public_tenant):
-    #         # tenant names with spaces should be rejected:
-    #         with self.assertRaises(ValidationError):
-    #             non_public_tenant_bad_name = Tenant(name="Non Public")
-    #             self.tenant_model_admin.save_model(obj=non_public_tenant_bad_name, request=None, form=None, change=None)
-    #         # also other alpha-numeric characters except dashes and underscores
-    #         with self.assertRaises(ValidationError):
-    #             non_public_tenant_bad_name = Tenant(name="Non*Public")
-    #             self.tenant_model_admin.save_model(obj=non_public_tenant_bad_name, request=None, form=None, change=None)
+        client.force_login(new_deck_teacher)
+        response = client.get(reverse('quests:quests'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(connection.schema_name, non_public_tenant.schema_name)
 
 
 class TenantAdminFormTest(ByteDeckTenantTestCase):
@@ -612,6 +597,26 @@ class TenantAdminFormTest(ByteDeckTenantTestCase):
         form = TenantAdminForm(self.form_data)
         form.instance = Tenant.get()  # test tenant with schema 'test'
         self.assertFalse(form.is_valid())
+
+    def test_clean__rejects_names_that_would_not_work_as_a_subdomain(self):
+        """A deck name that can't be part of a URL is rejected by the admin form, with the reason.
+
+        The name becomes both the schema name and the deck's subdomain, so the rules live on the
+        model field's validator; this is the admin form surfacing them to whoever is typing.
+        """
+        for bad_name, expected_error in [
+            ("Non Public", "The name must begin with a lower-case letter."),
+            ("Non*Public", "The name must begin with a lower-case letter."),
+            ("non public", "Invalid string used for the tenant name."),
+            ("non*public", "Invalid string used for the tenant name."),
+            ("non--public", "The name cannot have two consecutive dashes."),
+            ("non-public-", "The name cannot end in a dash."),
+        ]:
+            with self.subTest(name=bad_name):
+                self.form_data["name"] = bad_name
+                form = TenantAdminForm(self.form_data)
+                self.assertFalse(form.is_valid())
+                self.assertIn(expected_error, form.errors["name"])
 
     def test_clean__cant_create_if_schema_still_exists(self):
         """


### PR DESCRIPTION
### What?

Replaces the two blocks of commented-out test code in `tenant/tests/test_admin.py` with tests that run.

### Why?

**The TODO.** `test_save_model__public_tenant_creates_schema` asserted the schema name and then gave up:

```python
# TODO: Not working, can't figure out why?
# When try to use client.get() the context switches back to the public tenant
# WHY!?!?
```

followed by twenty commented-out lines with a `print(connection.schema_name)  # public` next to them. So the one thing an admin cares about after creating a deck, that the deck actually works, was never checked.

It does work, and the reason for the symptom is worth writing down: requests are routed by **hostname**, not by whatever `connection.set_tenant()` was called before them. `TenantMainMiddleware.process_request` starts with `connection.set_schema_to_public()` and re-resolves the tenant from the `Host` header on every request, which is exactly the "switches back to the public tenant" that was observed. `TenantClient` supplies that header from the deck's primary domain, and `tenant_save_callback` creates that domain on save, so the lookup resolves and the schema sticks. With `SHOW_PUBLIC_IF_NO_TENANT_FOUND = True` a deck whose host does not resolve silently stays on public instead of erroring, which is what makes this fail quietly rather than loudly.

**The FIXME.** A commented-out test expected `save_model` to raise on bad names:

```python
# with self.assertRaises(ValidationError):
#     non_public_tenant_bad_name = Tenant(name="Non Public")
#     self.tenant_model_admin.save_model(obj=non_public_tenant_bad_name, ...)
```

That could never have passed. `ModelAdmin.save_model` calls `obj.save()`, and `check_tenant_name` is a **model field validator**, so it only runs through `full_clean()` (which `Tenant.save` does not call). Bad names are rejected one layer up, by the admin form.

### How?

* `test_save_model__public_tenant_creates_a_working_deck` (renamed from `..._creates_schema`): keeps the schema-name assertion, adds that the subdomain keeps the name as typed while the schema converts the dash to an underscore (`non-public.localhost` vs `non_public`), and then uses a `TenantClient` to load the login page and, as a teacher created in the new schema, the quests page, asserting the request resolved to the new deck and the connection is still on its schema.
* `test_clean__rejects_names_that_would_not_work_as_a_subdomain` (new, in `TenantAdminFormTest`): asserts the admin form rejects the two names from the note plus their lower-case variants and the dash cases, each with the specific message it produces. The validator itself is already covered directly in `test_models.py`; this covers the admin path the note was about.
* Drops the commented-out `ValidationError` import that only the removed FIXME needed.

### Testing?

Full suite serially, matching CI (`python src/manage.py test src`):

```
Ran 2127 tests in 487.594s

OK
```

`ruff check src` passes.

Checked against broken code, not just passing code:

* deriving the deck's subdomain from the schema name instead of the deck name (`non_public.localhost`) fails the working-deck test on the domain assertion.
* removing the consecutive-dashes rule from `check_tenant_name` fails the form test with `'The name cannot have two consecutive dashes.' not found in ['Invalid string used for the tenant name.']`.

Run against a real Postgres 16 + Redis dev environment, not a mocked one. No source file is changed by this PR.

### Screenshots (if front end is affected)

N/A, tests only.

### Anything Else?

Twelfth in the test-suite cleanup after #2306, #2309, #2321, #2322, #2327, #2333, #2334, #2335, #2342, #2350 and #2352. This clears the last of the TODO/FIXME notes I set out to answer in the test suite.

The working-deck test creates a real schema, so it runs the tenant migrations and initial data (about 30s). That cost was already being paid by the existing test; the added client work is a few seconds on top.

### Review request

@tylerecouture

- Claude Code (bytedeck - test suite review)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5mKUNkKpCoHHNHSBJt3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant creation verification to ensure new tenant subdomains route correctly and support login.
  * Confirmed tenant connections remain isolated to the appropriate tenant schema.
  * Added validation for invalid tenant names, including spaces, special characters, and malformed dashes.
  * Improved error messaging for invalid tenant names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->