### PR TITLE
ci: sync the pre-commit ruff pin with the version requirements resolves

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   # Keep this rev in step with the ruff pin in requirements.txt, so the hook and
   # CI lint with the same version and cannot disagree about what passes.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [ "--fix" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-debug-toolbar>=7.0.0,<8.0
 
 # CLI
 coveralls>=4.1.0,<5.0  # includes coverage
-ruff>=0.16.2,<0.17  # 0.x lint tool: cap at the next 0.minor so a new rule set can't land unpinned
+ruff>=0.16.3,<0.17  # 0.x lint tool: cap at the next 0.minor so a new rule set can't land unpinned
 pipdeptree>=4.2.0,<5.0
 pre-commit>=4.6.0,<5.0
 


### PR DESCRIPTION
### What?
Bumps the ruff pre-commit hook to `v0.16.3` and the requirement floor to `>=0.16.3,<0.17`, so the two agree again.

### Why?
**`develop` is currently red for every pull request.** The lint workflow guards against the hook and the requirement drifting apart:

```
##[error]pre-commit ruff hook is v0.16.2, but requirements.txt resolves to 0.16.3.
Update .pre-commit-config.yaml and the ruff pin in requirements.txt together.
```

#2337 raised the floor to `>=0.16.2,<0.17`, which was in sync at the time. ruff 0.16.3 has since been released, so the unpinned upper part of that range now resolves to 0.16.3 while `.pre-commit-config.yaml` still pinned `v0.16.2`. Nothing in the codebase changed; the guard simply started failing when upstream published a new patch release.

Caught on #2388, whose "Lint with ruff" job failed on a diff that touches no Python style at all.

### How?
- `.pre-commit-config.yaml`: `rev: v0.16.2` → `v0.16.3`
- `requirements.txt`: `ruff>=0.16.2,<0.17` → `ruff>=0.16.3,<0.17`, keeping the `<0.17` cap and its comment (a new 0.minor could land a new rule set unpinned).

### Testing?
`ruff check src` is clean under 0.16.3 (installed the exact version CI resolves and ran it), so this is only a version bump: no new findings to fix.

### Screenshots (if front end is affected)
N/A: CI configuration only.

### Anything Else?
This will recur the next time ruff publishes a patch release, because the requirement's upper bound is open while the hook is pinned exactly. Filed #2393 with the options (pin `ruff==` and let Dependabot bump both, or derive the hook rev from the requirement) rather than deciding it inside this unblocking fix.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)