### PR TITLE
ci: bump the ruff pre-commit hook to v0.16.3 to match the requirements pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   # Keep this rev in step with the ruff pin in requirements.txt, so the hook and
   # CI lint with the same version and cannot disagree about what passes.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [ "--fix" ]


### PR DESCRIPTION
### What?

One line: `.pre-commit-config.yaml`'s ruff hook goes from `rev: v0.16.2` to `v0.16.3`.

### Why?

**"Lint with ruff" is currently failing on every open PR**, including ones whose diffs are clean. ruff 0.16.3 was released upstream; `requirements.txt` asks for `ruff>=0.16.2,<0.17`, so CI now installs 0.16.3 while the pre-commit hook was still pinned to v0.16.2, and the workflow's drift guard trips:

```
Installing ruff>=0.16.2,<0.17
Successfully installed ruff-0.16.3
##[error]pre-commit ruff hook is v0.16.2, but requirements.txt resolves to 0.16.3.
Update .pre-commit-config.yaml and the ruff pin in requirements.txt together.
```

Nothing in the repo changed: the same mismatch is present on `develop`, so this is not specific to any branch.

```
$ git show origin/develop:.pre-commit-config.yaml | grep -A1 ruff-pre-commit
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.16.2
$ git show origin/develop:requirements.txt | grep -m1 '^ruff'
ruff>=0.16.2,<0.17
```

The guard is doing exactly what it was added for: the hook and CI must lint with the same version so they cannot disagree about what passes. The fix is to move the hook to the version the pin already resolves to.

### How?

Bumped the hook rev only. The `requirements.txt` pin is left as-is: `>=0.16.2,<0.17` already permits 0.16.3, and the comment on it explains the cap is there so a new rule set cannot land unpinned, which a patch release does not do.

### Testing?

Checked that 0.16.3 does not find anything new in this codebase, so this really is version alignment and not a lint change in disguise:

```
$ pip install ruff==0.16.3 && ruff check src
All checks passed!
```

Full suite is unaffected; nothing outside the pre-commit config changes.

### Screenshots (if front end is affected)

N/A, CI configuration only.

### Anything Else?

Found while driving #2387 to green: its "Lint with ruff" job failed on a commit that only renamed a test, which is what surfaced the drift. #2385 and every other open PR will hit the same thing until this lands, so this is worth merging ahead of them.

If you would rather the two versions could never drift again, the alternative is pinning `requirements.txt` to an exact `ruff==` and bumping both together on purpose, which trades the automatic patch pickup for never seeing this failure. Happy to open an issue for that if it is the direction you want; I have not filed one since the current setup is a deliberate choice and this is its intended failure mode working correctly.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code-quality checks to use the latest Ruff pre-commit revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->