### PR TITLE
fix: give the Shared Library a reachable domain on a fresh initdb (#2382)

### DIFF
--- a/src/hackerspace_online/management/commands/initdb.py
+++ b/src/hackerspace_online/management/commands/initdb.py
@@ -35,9 +35,16 @@ class Command(BaseCommand):
             defaults={'name': 'Shared Library'},
         )
 
-        if not created and not library_tenant.domains.filter(domain='library.' + settings.ROOT_DOMAIN).exists():
+        # Set the domain whether or not the tenant was just created. A new tenant already has
+        # one, because the post_save signal derives a domain from the tenant's *name*, and
+        # 'Shared Library' contains a space, so that domain can never be reached: on a fresh
+        # database the Library deck was unreachable at library.<ROOT_DOMAIN> until initdb was
+        # run a second time (#2382).
+        library_domain = 'library.' + settings.ROOT_DOMAIN
+        if not library_tenant.domains.filter(domain=library_domain).exists():
+            library_tenant.domains.all().delete()
             library_tenant.domains.create(
-                domain='library.' + settings.ROOT_DOMAIN,
+                domain=library_domain,
                 is_primary=True
             )
         from django.db import models

--- a/src/hackerspace_online/management/commands/initdb.py
+++ b/src/hackerspace_online/management/commands/initdb.py
@@ -25,6 +25,15 @@ class Command(BaseCommand):
             '\nThis should only be run on a fresh db')
 
     def setup_shared_library(self):
+        """Create the Shared Library deck, give it its domain, and label its quests.
+
+        The Library is the tenant whose schema holds the cross-deck library of quests and
+        campaigns. This gets (or creates) that tenant, makes `library.<ROOT_DOMAIN>` its one
+        and only domain, and prefixes the names of any quests already in its schema with
+        `[Shared Library] - ` so they are recognisable wherever they are listed.
+
+        Takes no arguments and returns nothing; it writes its progress to the command's stdout.
+        """
         self.stdout.write('\n** Setting up shared library...')
         # Look up by the unique schema_name only (name is set on create). Matching
         # on name too would miss an existing 'library' tenant created with a
@@ -41,12 +50,12 @@ class Command(BaseCommand):
         # database the Library deck was unreachable at library.<ROOT_DOMAIN> until initdb was
         # run a second time (#2382).
         library_domain = 'library.' + settings.ROOT_DOMAIN
-        if not library_tenant.domains.filter(domain=library_domain).exists():
-            library_tenant.domains.all().delete()
-            library_tenant.domains.create(
-                domain=library_domain,
-                is_primary=True
-            )
+        library_tenant.domains.exclude(domain=library_domain).delete()
+        domain, _ = library_tenant.domains.get_or_create(domain=library_domain)
+        # A domain that already existed may not be the primary one (the signal-derived domain
+        # was), and a tenant with no primary domain has no root URL, so claim it either way.
+        domain.is_primary = True
+        domain.save()
         from django.db import models
         from django.db.models.functions import Concat
         from quest_manager.models import Quest

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -170,6 +170,33 @@ class InitDbTest(TestCase, CommandMixin):
         self.assertEqual(domain_after.domain, 'library.' + settings.ROOT_DOMAIN)
         self.assertEqual(library.domains.count(), 1)
 
+    def test_initdb__setup_shared_library_drops_a_stale_domain_beside_the_correct_one(self):
+        """setup_shared_library removes any other domain on the library tenant, so the deck
+        answers on library.<ROOT_DOMAIN> and nothing else.
+
+        A tenant can end up with a second domain because the post_save signal derives one from
+        the tenant's name; leaving it in place would keep the Library reachable on a host nobody
+        intended (#2382).
+        """
+        from hackerspace_online.management.commands.initdb import Command
+
+        self.call_command()
+        library_schema = apps.get_app_config('library').TENANT_NAME
+        library = Tenant.objects.get(schema_name=library_schema)
+        library.domains.create(domain='stale.' + settings.ROOT_DOMAIN, is_primary=True)
+
+        # As above: patch out the non-idempotent library quest re-labelling, which would
+        # re-prefix names and overflow Quest.name on a second run.
+        with patch('quest_manager.models.Quest'):
+            Command().setup_shared_library()
+
+        self.assertEqual(
+            list(library.domains.values_list('domain', flat=True)),
+            [f'library.{settings.ROOT_DOMAIN}'],
+        )
+        # and the survivor is the primary, even though the stale one held that flag
+        self.assertEqual(library.get_primary_domain().domain, f'library.{settings.ROOT_DOMAIN}')
+
     def test_initdb__notes_when_public_tenant_already_existed(self):
         """When the public tenant already exists, initdb reports that (a not-created notice)
         instead of failing.

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -147,6 +147,29 @@ class InitDbTest(TestCase, CommandMixin):
 
         self.assertTrue(library.domains.filter(domain='library.' + settings.ROOT_DOMAIN).exists())
 
+    def test_initdb__setup_shared_library_leaves_a_correct_domain_alone(self):
+        """setup_shared_library leaves the library tenant's domain untouched when it is already
+        the intended one, rather than deleting and re-creating it on every run.
+
+        The domain row's pk is the tell: a delete-and-recreate would hand out a new one.
+        """
+        from hackerspace_online.management.commands.initdb import Command
+
+        self.call_command()
+        library_schema = apps.get_app_config('library').TENANT_NAME
+        library = Tenant.objects.get(schema_name=library_schema)
+        domain_before = library.get_primary_domain()
+
+        # As above: patch out the non-idempotent library quest re-labelling, which would
+        # re-prefix names and overflow Quest.name on a second run.
+        with patch('quest_manager.models.Quest'):
+            Command().setup_shared_library()
+
+        domain_after = library.get_primary_domain()
+        self.assertEqual(domain_after.pk, domain_before.pk)
+        self.assertEqual(domain_after.domain, 'library.' + settings.ROOT_DOMAIN)
+        self.assertEqual(library.domains.count(), 1)
+
     def test_initdb__notes_when_public_tenant_already_existed(self):
         """When the public tenant already exists, initdb reports that (a not-created notice)
         instead of failing.

--- a/src/hackerspace_online/tests/test_management_commands.py
+++ b/src/hackerspace_online/tests/test_management_commands.py
@@ -81,6 +81,26 @@ class InitDbTest(TestCase, CommandMixin):
 
             Tenant.objects.get(schema_name=apps.get_app_config('library').TENANT_NAME)  # no assert, but will throw exception if doesn't exist
 
+    def test_initdb__gives_the_shared_library_a_reachable_domain(self):
+        """A single initdb run leaves the Library deck reachable at library.<ROOT_DOMAIN> (#2382).
+
+        The tenant post_save signal derives a domain from the tenant's name, and the Library
+        tenant is named 'Shared Library', so the derived domain contains a space and can never
+        be reached. initdb has to set the intended domain itself, on the first run rather than
+        only on a re-run against a database where the tenant already exists.
+        """
+        self.call_command()
+
+        library_tenant = Tenant.objects.get(schema_name=apps.get_app_config('library').TENANT_NAME)
+        primary_domain = library_tenant.get_primary_domain().domain
+
+        self.assertEqual(primary_domain, f'library.{settings.ROOT_DOMAIN}')
+        # no leftover unreachable domain beside it, or the deck answers on a host nobody can type
+        self.assertEqual(
+            list(library_tenant.domains.values_list('domain', flat=True)),
+            [f'library.{settings.ROOT_DOMAIN}'],
+        )
+
     def test_initdb__bails_when_database_is_unreachable(self):
         """If the initial DB connectivity check raises OperationalError, initdb reports it and
         bails without creating a superuser."""


### PR DESCRIPTION
### What?

`initdb` now leaves the Shared Library deck reachable at `library.<ROOT_DOMAIN>`, and reachable at nothing else, on the **first** run rather than only on a re-run against a database where the library tenant already exists.

Closes #2382

### Why?

On a fresh database, the Library deck came out unreachable. `initdb` only set the intended domain in the "tenant already exists" branch; when it created the tenant itself, it left the domain to `tenant.signals.tenant_save_callback`, which derives the domain from the tenant's **name**:

```python
domain = f'{instance.name.lower()}.{settings.ROOT_DOMAIN}'
```

The library tenant is named `Shared Library`, so the derived domain was `shared library.localhost`: a hostname with a space in it, which no browser can request. So after a first-time setup, `http://library.localhost:8000` 404'd, and the only way to get a working Library deck was to run `initdb` a second time (which then took the "already exists" branch and fixed the domain).

### How?

`Command.setup_shared_library` now settles the domain unconditionally, with no branch:

```python
library_domain = 'library.' + settings.ROOT_DOMAIN
library_tenant.domains.exclude(domain=library_domain).delete()
domain, _ = library_tenant.domains.get_or_create(domain=library_domain)
# A domain that already existed may not be the primary one (the signal-derived domain
# was), and a tenant with no primary domain has no root URL, so claim it either way.
domain.is_primary = True
domain.save()
```

That covers every starting state in one path: a freshly created tenant carrying the unusable signal-derived domain, a tenant missing its domain entirely, a tenant that already has the right domain (left in place, same row), and a tenant carrying a stale extra domain beside the right one (the stale one goes, and the survivor is made primary even if the stale one held that flag).

`setup_shared_library` also picked up the docstring it was missing.

### Testing?

Test-driven: `test_initdb__gives_the_shared_library_a_reachable_domain` runs `initdb` **once** and asserts the library tenant's primary domain is `library.<ROOT_DOMAIN>`, and that it is the tenant's only domain. Without the fix it fails with:

```
AssertionError: 'shared library.localhost' != 'library.localhost'
```

Two more tests cover the other starting states, so no path through the new code is untested:

* `test_initdb__setup_shared_library_leaves_a_correct_domain_alone`: an already-correct domain keeps its row (same pk) rather than being deleted and re-created.
* `test_initdb__setup_shared_library_drops_a_stale_domain_beside_the_correct_one`: a stale domain seeded as the primary alongside the correct one is removed, and the correct one ends up primary.

Runs:

* `python src/manage.py test src/hackerspace_online src/library src/tenant` : 675 tests, OK
* full suite `python src/manage.py test src` : OK
* `ruff check src` : All checks passed!

### Screenshots (if front end is affected)

N/A: management command only.

### Anything Else?

The underlying sharp edge is that `tenant_save_callback` builds a domain out of a free-text tenant name, so any tenant whose name isn't already a valid hostname gets an unreachable domain. Decks created through the request flow are constrained, so this bites the Library (created directly by `initdb`) rather than regular decks. Fixing that generally is out of scope here; filed as #2404.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the shared Library is consistently available at the canonical library domain.
  * Removed stale or duplicate Library domains during database setup.
  * Preserved the correct primary domain when setup is run repeatedly.

* **Tests**
  * Added coverage for initial setup, repeated setup, and cleanup of outdated domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->