### PR TITLE
refactor: tidy up the library app's code health (#2380)

### DIFF
--- a/src/library/templates/library/library_quests.html
+++ b/src/library/templates/library/library_quests.html
@@ -1,1 +1,0 @@
-{% include "quest_manager/quests.html" with view_type=-1%}

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -701,6 +701,26 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.assertContains(response, f'<span class="badge">{quest_count}</span>', html=True)
         self.assertContains(response, f'<span class="badge">{campaign_count}</span>', html=True)
 
+    def test_campaigns_tab__shows_the_library_actions_not_the_local_ones(self):
+        """The Library's campaign list offers the import action, not the deck's own campaign
+        actions (edit, export, delete), and carries the Library's introductory blurb.
+
+        This page and the deck's own campaign list share
+        `quest_manager/tab_campaigns_list.html`, which tells them apart by the
+        `is_library_view` context flag, so this guards the flag being set here (issue #2380).
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:category_list'))
+
+        self.assertTrue(response.context['is_library_view'])
+        self.assertContains(response, reverse('library:import_category', args=[self.library_category.import_id]))
+        self.assertContains(response, 'Import this Campaign into your Deck')
+        self.assertContains(response, 'EXPERIMENTAL!')
+        # the local campaign actions act on the deck's own campaigns, which aren't what's listed here
+        self.assertNotContains(response, 'Edit this campaign')
+        self.assertNotContains(response, 'Export this Campaign to the Library')
+
     def test_campaigns_tab__only_shows_library_campaigns(self):
         """
         Ensure the campaigns tab only displays campaigns from the library schema.
@@ -791,13 +811,13 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
             # Make a library campaign that should be excluded because the quest isn't active (draft)
             excluded_invisible = baker.make(Category, title='Invisible Only')
 
-            # Make a current quest on the library and put it in a campaign — should be included
+            # Make a current quest on the library and put it in a campaign: should be included
             baker.make(Quest, campaign=included, published=True, archived=False)
 
-            # Make an archived quest on the library and put it in a campaign — should not count
+            # Make an archived quest on the library and put it in a campaign: should not count
             baker.make(Quest, campaign=excluded_archived, published=True, archived=True)
 
-            # Make and invisible quest (draft) on the library and put it in a campaign — should not count
+            # Make and invisible quest (draft) on the library and put it in a campaign: should not count
             baker.make(Quest, campaign=excluded_invisible, published=False, archived=False)
 
         # Go to the list on the local deck
@@ -1199,7 +1219,7 @@ class LibraryOverviewTestsCase(LibraryTenantTestCaseMixin):
 
 
 class ExporterErrorPathTests(LibraryTenantTestCaseMixin):
-    """Error-handling branches of ``library.exporter`` — the cases where a quest or
+    """Error-handling branches of ``library.exporter``: the cases where a quest or
     campaign export can't complete and the exporter re-raises a clearer exception."""
 
     def test_export_quest_to_library__unknown_import_id_raises_does_not_exist(self):

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -54,14 +54,16 @@ library_schema_context = functools.partial(schema_context, get_library_schema_na
 
 def get_library_conflicting_quests(local_quests):
     """
-    Given a list of local Quest objects, return any quests in the library
-    that share the same import_id (i.e., conflicts).
+    Given a list of local Quest objects, return the import_ids of any quests in
+    the library that share an import_id with them (i.e., conflicts).
 
     Args:
         local_quests (List[Quest]): Local quests to check.
 
     Returns:
-        list[Quest]: List of conflicting Quest objects from the library.
+        list[UUID]: The import_ids that already exist in the library. Callers use
+            these to tell which of the local quests would collide, so this is a
+            list of ids rather than of the library's Quest objects.
     """
     from quest_manager.models import Quest
     quest_import_ids = [q.import_id for q in local_quests]

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -206,6 +206,9 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
         """
         Populate context with active campaigns from the shared library.
 
+        Args:
+            **kwargs: keyword arguments passed through to `TemplateView.get_context_data`.
+
         Returns:
             dict: Template context including:
                 - heading (str): Page title.

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -210,7 +210,7 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
             dict: Template context including:
                 - heading (str): Page title.
                 - tab (str): Active tab identifier.
-                - library_campaigns (QuerySet[Category]): A queryset of active campaigns
+                - library_categories (QuerySet[Category]): A queryset of active campaigns
                     (categories) from the shared library. Each campaign includes at least one
                     quest that is:
                         - published=True
@@ -218,6 +218,8 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
                 - num_campaigns (int): Number of campaigns in the displayed list, used for the UI badge.
                 - num_quests (int): Total number of visible (published and not archived) quests,
                     used for the UI badge in the quest tab.
+                - is_library_view (bool): True, so the campaign table shared with the deck's own
+                    campaign list shows the Library's import action instead of the local ones.
         """
         context = super().get_context_data(**kwargs)
 
@@ -234,6 +236,7 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
             'library_categories': campaigns,
             'num_campaigns': num_campaigns,
             'num_quests': quests_count,
+            'is_library_view': True,
         })
         return context
 
@@ -548,7 +551,7 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         link = f'<a href="{quest.get_absolute_url()}">{quest.name}</a>'
         messages.success(
             request,
-            f"'{link}' has been shared to the Library. A Library admin has been notified — "
+            f"'{link}' has been shared to the Library. A Library admin has been notified: "
             "it will appear in the Library once they review and publish it."
         )
         return redirect('quests:quests')
@@ -685,7 +688,7 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         link = f'<a href="{campaign.get_absolute_url()}">{campaign.name}</a>'
         messages.success(
             request,
-            f"'{link}' has been shared to the Library. A Library admin has been notified — "
+            f"'{link}' has been shared to the Library. A Library admin has been notified: "
             "it will appear in the Library once they review and publish it."
         )
         return redirect('quests:categories')

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -1,4 +1,4 @@
-{% if '/library/' in request.path %}
+{% if is_library_view %}
   <p>
     <span class="text-danger">EXPERIMENTAL!</span>
     The Library contains quests created and shared by Bytedeck and its community, for you to use by importing them into your own deck.
@@ -32,7 +32,7 @@
         <td>{{ object.quest_count }}</td>
         <td>{{ object.xp_sum }}</td>
         <td>
-          {% if not '/library/' in request.path %}
+          {% if not is_library_view %}
             <a class="btn btn-info"
                href="{% url 'quests:category_detail' object.id %}"
                role="button"

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3584,6 +3584,27 @@ class CategoryViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:categories'))
         self.assertNotContains(response, reverse('quests:category_publish', args=[published_campaign.id]))
 
+    def test_CategoryList_view__shows_the_decks_own_campaign_actions(self):
+        """The deck's campaign list offers the local actions (details, edit, delete), not the
+        Library's import action, and doesn't carry the Library's introductory blurb.
+
+        This page and the Library's campaign list share
+        `quest_manager/tab_campaigns_list.html`, which tells them apart by the
+        `is_library_view` context flag, so this guards the flag being set here (issue #2380).
+        """
+        campaign = baker.make(Category, published=True)
+        baker.make(Quest, campaign=campaign, published=True)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:categories'))
+
+        self.assertFalse(response.context['is_library_view'])
+        self.assertContains(response, reverse('quests:category_update', args=[campaign.id]))
+        self.assertContains(response, 'Edit this campaign')
+        # the Library's import action and its blurb belong to the Library's copy of this table
+        self.assertNotContains(response, 'Import this Campaign into your Deck')
+        self.assertNotContains(response, 'EXPERIMENTAL!')
+
     def test_CategoryDetail_view__staff_see_unpublished_quests_of_unpublished_campaign(self):
         """Staff must see a campaign's unpublished quests on the campaign detail page
         regardless of whether the campaign itself is published; only archived quests

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -104,6 +104,22 @@ class CategoryList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
         return queryset
 
     def get_context_data(self, *args, **kwargs):
+        """Add the tab state and the campaign table's flags to the deck's campaign list.
+
+        Args:
+            *args: positional arguments passed through to `ListView.get_context_data`.
+            **kwargs: keyword arguments passed through to `ListView.get_context_data`.
+
+        Returns:
+            dict: the template context, with
+                - available_tab_active (bool): the Available tab is the one being shown.
+                - inactive_tab_active (bool): the Inactive tab is the one being shown.
+                - can_export (bool): this user may push a campaign to the Shared Library,
+                    so the export action is offered.
+                - is_library_view (bool): False. The campaign table is shared with the
+                    Library's campaign list, and this is the deck's own copy, so it shows
+                    the local actions rather than the Library's import action.
+        """
         context_data = super().get_context_data(*args, **kwargs)
 
         can_export = SiteConfig.get().can_user_export_to_library(self.request.user)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -111,6 +111,9 @@ class CategoryList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
         context_data['available_tab_active'] = self.available_tab_active
         context_data['inactive_tab_active'] = self.inactive_tab_active
         context_data['can_export'] = can_export
+        # these are the deck's own campaigns, so the shared campaign table shows the
+        # local actions (edit, publish, export, delete) rather than the Library's import action
+        context_data['is_library_view'] = False
 
         return context_data
 


### PR DESCRIPTION
### What?

The small code-health items found during the Shared Library audit, swept in one pass:

1. **Dead template deleted.** `src/library/templates/library/library_quests.html` (a one-line include of `quest_manager/quests.html`) was referenced by nothing. The Library's quest tab renders `library/tab_library_quests.html`.
2. **The shared campaign table decides Library vs local from a context flag, not the URL.** `quest_manager/tab_campaigns_list.html` branched on `{% if '/library/' in request.path %}`. It now branches on `is_library_view`, which `LibraryCampaignListView` sets to `True` and `quest_manager.views.CategoryList` sets to `False`.
3. **Three docstrings corrected or completed.** `get_library_conflicting_quests` said it returns `list[Quest]`; it returns the conflicting `import_id`s. `LibraryCampaignListView.get_context_data` documented a `library_campaigns` context key the view never sets (it sets `library_categories`) and was missing its `Args` entry. `CategoryList.get_context_data` had no docstring at all.
4. **Em dashes removed** from the two "shared to the Library" success messages and from the library tests, per the project's no-em-dash convention.

Closes #2380

### Why?

The URL-string branching was the item with real risk. The same question ("is this the Library's copy of the campaign table or the deck's own?") was answered two different ways in two templates: `quest_manager/buttons.html` reads the server-set `is_library_view` flag, while `tab_campaigns_list.html` sniffed `request.path` for the substring `/library/`. A substring test on a URL is fragile in a way the flag isn't: it depends on the Library URLs never moving and on no other URL happening to contain that segment, and it puts a routing decision in a template instead of in the view that already knows the answer. One mechanism, set server-side, is the right number.

The rest are papercuts: a dead file that shows up in searches, docstrings that state the opposite of what the code does (`get_library_conflicting_quests` returning ids rather than objects is exactly the kind of thing a caller reads the docstring for), and copy that violates a documented convention.

### How?

* `LibraryCampaignListView.get_context_data` adds `'is_library_view': True`; `CategoryList.get_context_data` adds `context_data['is_library_view'] = False`.
* The two branches in `tab_campaigns_list.html` become `{% if is_library_view %}` / `{% if not is_library_view %}`. `library_overview.html` includes the template without `only`, so the flag reaches it through the `with object_list=...` include.
* No behaviour change is intended anywhere: both pages must render exactly what they rendered before.

### Testing?

Two regression tests, one per page, that pin the new mechanism (each fails with `KeyError: 'is_library_view'` if its view stops setting the flag, and would fail on wrong content if the flag were set to the wrong value):

* `library.tests.test_views.CampaignLibraryTestCases.test_campaigns_tab__shows_the_library_actions_not_the_local_ones`
* `quest_manager.tests.test_views.CategoryViewTests.test_CategoryList_view__shows_the_decks_own_campaign_actions`

Runs:

* `python src/manage.py test src/library src/quest_manager` : 484 tests, OK
* full suite `python src/manage.py test src` : 2164 tests, OK
* `ruff check src` : All checks passed!

### Screenshots (if front end is affected)

Captured from the running dev deck (`http://hackerspace.localhost:8000`, seeded with `generate_content` plus two campaigns pushed into the library schema), logged in as the deck owner.

Because this is a behaviour-preserving refactor, the interesting result is that **the before and after captures are byte-identical**: the same script was run with the changes stashed and unstashed, and the resulting PNGs have the same md5 (`b02af6bb...` for the deck page, `65bf3556...` for the Library page). So one capture of each page serves as both.

The deck's own campaigns (`/quests/campaigns/`): local actions (details, edit, export, delete), no Library blurb.

![Deck campaigns list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2380/deck_campaigns.png)

The Library's campaigns (`/library/campaign-list/`): the Library blurb, and only the details and import actions.

![Library campaigns list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2380/library_campaigns.png)

### Anything Else?

Three items are deliberately left alone:

* The em dash in `library/email/content_pushed.txt` belongs to #2371, which is rewriting that template.
* The empty app scaffolding (`library/models.py`, `library/admin.py`, the migration-less `migrations/`) stays as the issue suggests, since #2377 may give the app a real model.
* Docstrings on methods this PR doesn't touch (e.g. `LibraryQuestListView.get_context_data`, which is also missing its `Args` entry) are left for a separate pass, tracked in #2406, rather than widening this diff.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)