### PR TITLE
refactor: give the Shared Library its own quest serialization (#2378)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -4,11 +4,11 @@ from uuid import uuid4
 import tablib
 
 from django_tenants.utils import schema_context
-from quest_manager.admin import QuestResource
 from quest_manager.models import Quest, Category
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
+from .resources import LibraryQuestResource
 from .utils import library_schema_context, get_library_conflicting_quests
 
 
@@ -48,7 +48,7 @@ def clone_quests_into_library(*, source_schema, quests):
     Library under the same `import_id`: those get a new copy rather than
     overwriting what is there.
 
-    The copies travel through `QuestResource`, the same serialization the rest of
+    The copies travel through `LibraryQuestResource`, the same serialization the rest of
     the export uses, with the `import_id` and `name` columns rewritten per row.
     Going through the resource is what keeps this safe: `Meta.exclude` drops
     `editor`, `specific_teacher_to_notify` and `common_data`, which are primary
@@ -68,7 +68,7 @@ def clone_quests_into_library(*, source_schema, quests):
         return None
 
     with schema_context(source_schema):
-        export_data = QuestResource().export(quests)
+        export_data = LibraryQuestResource().export(quests)
 
     with library_schema_context():
         # Archived quests count: the unique constraint does not care that the
@@ -91,7 +91,7 @@ def clone_quests_into_library(*, source_schema, quests):
             clone_data.append([row[header] for header in clone_data.headers])
 
         try:
-            return QuestResource().import_data(
+            return LibraryQuestResource().import_data(
                 clone_data,
                 dry_run=False,
                 raise_errors=True,
@@ -127,11 +127,11 @@ def export_quest_to_library(*, source_schema, quest_import_id):
             quest = Quest.objects.get(import_id=quest_import_id)
         except ObjectDoesNotExist as e:
             raise Quest.DoesNotExist(f"Quest with import_id={quest_import_id} not found in schema {source_schema}") from e
-        export_data = QuestResource().export([quest])
+        export_data = LibraryQuestResource().export([quest])
 
     with library_schema_context():
         try:
-            result = QuestResource().import_data(
+            result = LibraryQuestResource().import_data(
                 export_data,
                 dry_run=False,
                 raise_errors=True,
@@ -186,14 +186,14 @@ def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import
 
         if not quests.exists() and not skip_import_ids:
             raise ValidationError("Cannot export a campaign without any published quests.")
-        export_data = QuestResource().export(quests)
+        export_data = LibraryQuestResource().export(quests)
 
     # Prepare visibility map for library: all quests unpublished
     exported_visibility_map = {str(q.import_id): False for q in quests}
 
     with library_schema_context():
         try:
-            result = QuestResource().import_data(
+            result = LibraryQuestResource().import_data(
                 export_data,
                 dry_run=False,
                 raise_errors=True,

--- a/src/library/importer.py
+++ b/src/library/importer.py
@@ -1,7 +1,7 @@
 from django_tenants.utils import schema_context
-from quest_manager.admin import QuestResource
 from quest_manager.models import Quest, Category
 
+from .resources import LibraryQuestResource
 from .utils import library_schema_context
 
 
@@ -20,7 +20,7 @@ def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_
 
     with library_schema_context():
         quests = Quest.objects.select_related('campaign').filter(published=True, import_id__in=quest_import_ids)
-        export_data = QuestResource().export(quests)
+        export_data = LibraryQuestResource().export(quests)
 
     dry_run = False
     with schema_context(destination_schema):
@@ -29,7 +29,7 @@ def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_
         local_visibility_map = {str(q.import_id): q.published for q in existing_quests}
 
         # Explicitly import the campaign as well
-        result = QuestResource().import_data(export_data, dry_run=dry_run, import_campaign=True, local_visibility_map=local_visibility_map)
+        result = LibraryQuestResource().import_data(export_data, dry_run=dry_run, import_campaign=True, local_visibility_map=local_visibility_map)
 
         category = Category.objects.filter(import_id=campaign_import_id).first()
         if category:
@@ -62,10 +62,10 @@ def import_quest_to(*, destination_schema, quest_import_id):
     with library_schema_context():
         quest = Quest.objects.get(import_id=quest_import_id, published=True)
 
-        export_data = QuestResource().export([quest])
+        export_data = LibraryQuestResource().export([quest])
 
     with schema_context(destination_schema):
-        result = QuestResource().import_data(
+        result = LibraryQuestResource().import_data(
             export_data,
             dry_run=False,
             raise_errors=True,

--- a/src/library/resources.py
+++ b/src/library/resources.py
@@ -1,0 +1,40 @@
+"""The serialization the Shared Library uses to move quests between decks.
+
+Sharing a quest to the Library, and importing one back down into a deck, both work by
+serializing the quest in one schema and deserializing it in another. That contract is
+the Library's, and it lives here so that improving it is a change to the Library rather
+than a change to the Django admin (#2378).
+
+The two features that serialize quests want different things:
+
+* The **admin's** CSV export is a table dump for a human to read, so it deliberately
+  drops the bulky summernote HTML columns (`QuestAdminExportResource`, for the
+  per-request memory reasons in #2081).
+* The **Library** is copying the quest itself, so those same columns are the point: a
+  quest that arrives without its instructions is not the quest.
+
+Keeping them apart means the fidelity work queued up for the Library (tags, #1792;
+submission questions, #2162; competency links, #1915) lands in the library app instead
+of in `quest_manager.admin`, where it would be coupled to a feature that wants the
+opposite.
+"""
+
+from quest_manager.admin import QuestResource
+
+
+class LibraryQuestResource(QuestResource):
+    """Full-fidelity quest serialization for cross-deck sharing.
+
+    Subclasses the admin's `QuestResource` because the base contract (match rows on
+    `import_id`, exclude the local-only foreign keys `editor`,
+    `specific_teacher_to_notify` and `common_data`, carry the campaign and simple
+    prerequisites as import_ids) is genuinely shared, and duplicating it would leave two
+    definitions to keep in step.
+
+    What this class exists for is the *other* direction: it is the seam the Library's own
+    fidelity requirements attach to. Anything the Library needs to carry that the admin's
+    CSV round-trip does not (or must not) belongs here rather than on the base class.
+
+    Every quest field this resource exports must survive the round trip, so it never
+    inherits from `QuestAdminExportResource`, whose whole purpose is to leave fields out.
+    """

--- a/src/library/tests/test_resources.py
+++ b/src/library/tests/test_resources.py
@@ -1,0 +1,91 @@
+from django.test import SimpleTestCase
+
+from library.resources import LibraryQuestResource
+from library.tests.test_views import LibraryTenantTestCaseMixin
+from library.utils import library_schema_context
+from model_bakery import baker
+from quest_manager.admin import QUEST_EXPORT_EXCLUDED_HTML_FIELDS, QuestAdminExportResource, QuestResource
+from quest_manager.models import Quest
+
+
+class LibraryQuestResourceTest(SimpleTestCase):
+    """The Library's serialization contract, as distinct from the admin's.
+
+    These are the properties the cross-deck sharing feature depends on, pinned here in the
+    library app so that a change to the admin's CSV export can't quietly take them away
+    (#2378).
+    """
+
+    def test_LibraryQuestResource__exports_the_full_quest_content(self):
+        """The Library carries the summernote HTML fields the admin's export drops.
+
+        The admin export omits them on purpose, to bound the memory a table dump costs
+        (#2081). A quest shared to the Library without its instructions would not be the
+        quest, so the Library's resource must keep exporting them.
+        """
+        library_columns = [field.column_name for field in LibraryQuestResource().get_export_fields()]
+        admin_columns = [field.column_name for field in QuestAdminExportResource().get_export_fields()]
+
+        for column in QUEST_EXPORT_EXCLUDED_HTML_FIELDS:
+            self.assertIn(column, library_columns)
+            self.assertNotIn(column, admin_columns)
+
+    def test_LibraryQuestResource__does_not_export_the_local_only_fields(self):
+        """Fields whose values mean something different in another schema stay behind.
+
+        `editor` and `specific_teacher_to_notify` are local user ids and `common_data` a
+        local row id, so carrying them across decks would point the imported quest at
+        whoever happens to hold those ids there.
+        """
+        columns = [field.column_name for field in LibraryQuestResource().get_export_fields()]
+
+        for column in ('id', 'editor', 'specific_teacher_to_notify', 'common_data'):
+            self.assertNotIn(column, columns)
+
+    def test_LibraryQuestResource__visibility_map_is_per_instance(self):
+        """Each resource starts with its own empty visibility map.
+
+        The map is what preserves a deck's own published/unpublished choice when it
+        re-imports a quest it already has, and it is filled in per import. Were the empty
+        default shared between instances, one import could be read as another's default.
+        """
+        first, second = LibraryQuestResource(), LibraryQuestResource()
+
+        first.local_visibility_map['some-import-id'] = True
+
+        self.assertEqual(second.local_visibility_map, {})
+        # and the class itself is not carrying the state either
+        self.assertFalse(hasattr(QuestResource, 'local_visibility_map'))
+
+
+class LibraryQuestResourceRoundTripTest(LibraryTenantTestCaseMixin):
+    """What actually survives a trip through the Library's serialization."""
+
+    def test_LibraryQuestResource__round_trip_keeps_the_quest_content(self):
+        """Exporting a quest in one schema and importing it in another keeps its content.
+
+        This is the property the whole feature rests on: the deck that imports a quest
+        gets the instructions, submission details and instructor notes that the deck which
+        shared it wrote.
+        """
+        content = {
+            'instructions': '<p>Do the thing, then <b>show your work</b>.</p>',
+            'submission_details': '<p>Paste a link to your repository.</p>',
+            'instructor_notes': '<p>Watch for the off-by-one.</p>',
+        }
+        with library_schema_context():
+            baker.make(Quest, name='A quest worth importing', published=True, **content)
+            export_data = LibraryQuestResource().export(Quest.objects.filter(name='A quest worth importing'))
+
+        # back on the deck's own schema, which is where a real import lands
+        LibraryQuestResource().import_data(export_data, dry_run=False, raise_errors=True)
+
+        imported = Quest.objects.get(name='A quest worth importing')
+        # compared by their text, not byte for byte: saving a quest re-indents its HTML
+        expected_text = {
+            'instructions': 'Do the thing, then <b>show your work</b>.',
+            'submission_details': 'Paste a link to your repository.',
+            'instructor_notes': 'Watch for the off-by-one.',
+        }
+        for field, text in expected_text.items():
+            self.assertIn(text, ' '.join(getattr(imported, field).split()))

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -1227,7 +1227,7 @@ class ExporterErrorPathTests(LibraryTenantTestCaseMixin):
         with self.assertRaises(Quest.DoesNotExist):
             export_quest_to_library(source_schema=self.tenant.schema_name, quest_import_id=uuid.uuid4())
 
-    @patch("library.exporter.QuestResource.import_data")
+    @patch("library.exporter.LibraryQuestResource.import_data")
     def test_clone_quests_into_library__import_failure_wrapped_as_validation_error(self, mock_import_data):
         """A database error while copying conflicting quests is re-raised with context."""
         mock_import_data.side_effect = IntegrityError("duplicate key")
@@ -1235,7 +1235,7 @@ class ExporterErrorPathTests(LibraryTenantTestCaseMixin):
         with self.assertRaisesMessage(ValidationError, "Failed to copy conflicting quests to library schema"):
             clone_quests_into_library(source_schema=self.tenant.schema_name, quests=[quest])
 
-    @patch("library.exporter.QuestResource.import_data")
+    @patch("library.exporter.LibraryQuestResource.import_data")
     def test_export_quest_to_library__import_failure_wrapped_as_validation_error(self, mock_import_data):
         """A database error while importing a quest is re-raised as a clearer ValidationError with context."""
         mock_import_data.side_effect = IntegrityError("duplicate key")
@@ -1250,7 +1250,7 @@ class ExporterErrorPathTests(LibraryTenantTestCaseMixin):
         with self.assertRaisesMessage(ValidationError, "Cannot export a campaign without any published quests."):
             export_campaign_to_library(source_schema=self.tenant.schema_name, campaign_import_id=campaign.import_id)
 
-    @patch("library.exporter.QuestResource.import_data")
+    @patch("library.exporter.LibraryQuestResource.import_data")
     def test_export_campaign_to_library__import_failure_wrapped_as_validation_error(self, mock_import_data):
         """A validation error while importing a campaign is re-raised as a clearer ValidationError with context."""
         mock_import_data.side_effect = ValidationError("bad data")

--- a/src/quest_manager/admin.py
+++ b/src/quest_manager/admin.py
@@ -99,8 +99,6 @@ class QuestResource(resources.ModelResource):
     Related behavior like prerequisites and tags are handled by associated mixins
     on the Quest model, not directly by this class.
     """
-    local_visibility_map = {}
-
     prereq_import_ids = Field(column_name='prereq_import_ids')
     campaign_title = Field()
     campaign_icon = Field()
@@ -111,6 +109,21 @@ class QuestResource(resources.ModelResource):
         model = Quest
         import_id_fields = ('import_id',)
         exclude = ('id', 'editor', 'specific_teacher_to_notify', 'campaign', 'common_data')
+
+    def __init__(self, *args, **kwargs):
+        """Build the resource with its own empty visibility map.
+
+        `local_visibility_map` (a `{import_id: published}` mapping that keeps a deck's
+        own show/hide choice when re-importing a quest it already has) is filled in per
+        import by `after_import`, from `import_data(local_visibility_map=...)`. It is set
+        here, per instance, so one import can never be read as another's default.
+
+        Args:
+            *args: positional arguments passed through to `ModelResource`.
+            **kwargs: keyword arguments passed through to `ModelResource`.
+        """
+        super().__init__(*args, **kwargs)
+        self.local_visibility_map = {}
 
     def dehydrate_prereq_import_ids(self, quest):
         """


### PR DESCRIPTION
### What?

Adds `src/library/resources.py` with `LibraryQuestResource`, and points the Library's exporter and importer at it instead of at `quest_manager.admin.QuestResource`.

Closes #2378

### Why?

#1546 set the constraint plainly: the Library should be its own app, and existing apps shouldn't need to be aware of it. The serialization that cross-deck sharing depends on was living in `quest_manager/admin.py`, shared with the admin's CSV import/export, and the two features want opposite things from it:

* the **admin's** export is a table dump for a human, so `QuestAdminExportResource` deliberately drops `instructions`, `submission_details` and `instructor_notes` to bound per-request memory (#2081);
* the **Library** is copying the quest itself, so those columns are the whole point. A quest that arrives without its instructions isn't the quest.

Every fidelity change queued up for the Library (tags #1792, submission questions #2162, competency links #1915, and the conflict-clone path in #2367) would otherwise be written into the admin module, coupled to a feature pulling the other way. Doing this now means that work lands in the library app rather than being written into `admin.py` and moved later.

### How?

`LibraryQuestResource` **subclasses** `QuestResource` rather than replacing it. The base contract is genuinely shared (match rows on `import_id`; exclude the local-only `editor`, `specific_teacher_to_notify` and `common_data`; carry campaign and simple prerequisites as import_ids), and duplicating it would leave two definitions to keep in step. What the subclass provides is the **seam**: the place the Library's own requirements attach, so they don't have to attach to the admin's class.

The dependency direction is deliberate and stays one-way: `library` imports from `quest_manager`, never the reverse. Moving the class outright into `library/` would have made `quest_manager.admin` import from `library`, which is the coupling #1546 rules out.

Callers updated: `library/exporter.py` (4 call sites) and `library/importer.py` (4 call sites). No behaviour change is intended: the resource is the same serialization, under the Library's own name.

Also, the smaller item from the issue: `QuestResource.local_visibility_map = {}` was a mutable class attribute shared across instances. It's now set in `__init__`, so the empty default is per instance. There's no live bug today (every code path assigns it before reading it, and assignment shadows the class attribute anyway), but it's a footgun in a class two features instantiate.

### Testing?

New `src/library/tests/test_resources.py` pins the Library's side of the contract, which is what a change to the admin's export could otherwise take away silently:

* `..._exports_the_full_quest_content`: the three summernote HTML columns are in the Library resource's export fields and **not** in the admin export resource's. This is the test that fails if someone later trims the shared base class.
* `..._does_not_export_the_local_only_fields`: `id`, `editor`, `specific_teacher_to_notify` and `common_data` stay behind, since those ids mean someone else in the destination schema.
* `..._visibility_map_is_per_instance`: two resources don't share the map, and the class isn't carrying the state.
* `..._round_trip_keeps_the_quest_content`: an actual export in the library schema and import in the deck's schema, asserting the instructions, submission details and instructor notes arrive (compared by text, since saving a quest re-indents its HTML).

Three existing tests in `ExporterErrorPathTests` patched `library.exporter.QuestResource.import_data`; they now patch `library.exporter.LibraryQuestResource.import_data`. That is the only test change the rename required, which is itself evidence the refactor didn't move behaviour.

Runs:

* `python src/manage.py test src/library src/quest_manager` : 488 tests, OK
* full suite `python src/manage.py test src` : 2171 tests, OK
* `ruff check src` : All checks passed!

### Screenshots (if front end is affected)

N/A: no user-visible change. This is the serialization layer behind the existing share/import buttons, which behave exactly as before.

### Anything Else?

The issue lists #2367 (the conflict-clone path re-implementing a subset of the resource) as related. `clone_quests_into_library` already routes through the resource, so nothing to do here; whatever #2367 needs now has a Library-owned class to hang it on.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library quest exports and imports now preserve the full quest content, including HTML.
  * Cross-schema quest and campaign transfers retain content while excluding local-only identifiers.

* **Bug Fixes**
  * Visibility settings are now isolated per export/import operation, preventing state from carrying between resources.

* **Tests**
  * Added coverage for full-fidelity exports, visibility handling, and export/import round trips.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->