### PR TITLE
feat: show the semester lifecycle in the list, and make archiving truly one-way (#2157 Phase 2, part 3)

### DIFF
--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -14,14 +14,14 @@
 <p>This page is visible to staff only.</p>
 
 {% if config.open_semester %}
-<h3>Current Active Semester: {{ config.open_semester }}</h3>
+<h3>Open semester: {{ config.open_semester }}</h3>
 
-<p>When students join a course it will be connected to the active semester.
-  When a semester is over, archive it to record final marks and free up your students' seats.</p>
+<p>Students join a course in the open semester and earn XP in it.
+  When it is over, archive it to record final marks and free up your students' seats.</p>
 {% else %}
 <h3>No semester is open</h3>
 
-<p>Students can't join a course or earn XP between semesters. Activate a semester below to start
+<p>Students can't join a course or earn XP between semesters. Start a semester below to begin
   the next one, or create a new one first.</p>
 {% endif %}
 <p>The first and last day of the semester are only relevant if you are using the
@@ -30,6 +30,12 @@
   <a href="{% url 'config:site_config_update_own' %}">site configuration</a>.
 </p>
 
+{% comment %}
+Every row's Status and actions come from the semester's own lifecycle stage (#2157 Phase 2):
+Upcoming (being set up) -> Open (students earn XP in it) -> Archived (final marks recorded,
+terminal). Archived rows deliberately offer no actions at all, and the views refuse those URLs
+directly too.
+{% endcomment %}
 <table class="table table-striped">
   <thead>
     <tr>
@@ -45,7 +51,7 @@
   </thead>
   <tbody>
     {% for object in object_list %}
-    <tr {% if object == config.open_semester %}class="success" title="This is your currently active semester."{% endif %}>
+    <tr {% if object.is_open %}class="success" title="This is the semester your students are in."{% endif %}>
       <td>{{ object }}</td>
       <td>{{ object.first_day }}</td>
       <td>{{ object.last_day }}</td>
@@ -54,15 +60,15 @@
       <td>{{ object.coursestudent_set.count }}</td>
       <td>
         {% if object.is_archived %}
-        <span class="label label-default">Archived</span>
-        {% elif object == config.open_semester %}
+        <span class="label label-default" title="Final marks have been recorded. An archived semester can't be edited, started again or deleted.">Archived</span>
+        {% elif object.is_open %}
           {% if object.has_ended %}
-          <span class="label label-success" title="This semester's last day has passed. Archive it to record final marks and free up student seats.">Active - ended</span>
+          <span class="label label-success" title="This semester's last day has passed. Archive it to record final marks and free up student seats.">Open - ended</span>
           {% else %}
-          <span class="label label-success">Active</span>
+          <span class="label label-success">Open</span>
           {% endif %}
         {% else %}
-        <span class="label label-info" title="Students can't join this semester unless you activate it.">Inactive</span>
+        <span class="label label-info" title="Still being set up. Students can't join it until you start it.">Upcoming</span>
         {% endif %}
       </td>
       <td>
@@ -71,15 +77,15 @@
           <i class="fa fa-edit"></i>
         </a>
         {% endif %}
-        {% if not object.is_archived and object == config.open_semester %}
+        {% if object.is_open %}
         <a class="btn btn-danger" href="{% url 'courses:semester_archive' %}" role="button"
           title="Archive this semester: record all students' final XP and free up their seats.">
           <i class="fa fa-archive"></i>
         </a>
         {% endif %}
-        {% if not object.is_archived and object != config.open_semester %}
+        {% if not object.is_archived and not object.is_open %}
         <form class="preview-action-form" action="{% url 'courses:semester_activate' object.id %}" method="post">{% csrf_token %}
-          <button type="submit" class="btn btn-success" title="Activate this semester">
+          <button type="submit" class="btn btn-success" title="Start this semester: students can join a course in it and earn XP">
             <i class="fa fa-calendar-check-o"></i>
           </button>
         </form>

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.db import connection
 from django.shortcuts import reverse
 from django.test.utils import CaptureQueriesContext
+from django_tenants.utils import get_public_schema_name
 from django.utils import timezone
 
 from model_bakery import baker
@@ -11,7 +12,7 @@ from freezegun import freeze_time
 
 from courses.forms import CourseStudentStaffForm, ExcludedDateFormset, SemesterForm
 from courses.models import Block, Course, CourseStudent, MarkRange, Semester, Rank, ExcludedDate
-from courses.views import SemesterActivate
+from courses.views import SemesterActivate, SemesterUpdate
 from quest_manager.models import Quest, QuestSubmission
 from badges.models import Badge, BadgeAssertion
 from notifications.models import Notification, notify_rank_up
@@ -1123,18 +1124,71 @@ class SemesterViewTests(ByteDeckTenantTestCase):
         from, so the edit view refuses it (GET and POST alike) rather than rewriting a
         finished record. The list hides the button, but the URL is still reachable."""
         self.client.force_login(self.test_teacher)
-        archived = baker.make(Semester, status=Semester.Status.ARCHIVED, first_day=datetime.date(2020, 1, 1))
+        archived = baker.make(
+            Semester, status=Semester.Status.ARCHIVED,
+            first_day=datetime.date(2020, 1, 1), last_day=datetime.date(2020, 6, 1),
+        )
         post_data = {
             'first_day': '2021-10-16',
             'last_day': '2021-12-16',
             **generate_formset_data(ExcludedDateFormset, quantity=0)
         }
 
-        for response in (self.client.get(reverse('courses:semester_update', args=[archived.pk])),
-                         self.client.post(reverse('courses:semester_update', args=[archived.pk]), data=post_data)):
-            self.assertRedirects(response, reverse('courses:semester_list'))
+        get_response = self.client.get(reverse('courses:semester_update', args=[archived.pk]))
+        self.assertRedirects(get_response, reverse('courses:semester_list'))
+        self.assertErrorMessage(get_response)
+
+        post_response = self.client.post(reverse('courses:semester_update', args=[archived.pk]), data=post_data)
+        self.assertRedirects(post_response, reverse('courses:semester_list'))
+        self.assertIn(SemesterUpdate.ARCHIVED_SEMESTER_ERROR,
+                      [str(message) for message in self.get_message_list(post_response)])
+
         archived.refresh_from_db()
         self.assertEqual(archived.first_day, datetime.date(2020, 1, 1))
+        self.assertEqual(archived.last_day, datetime.date(2020, 6, 1))
+
+    def test_SemesterUpdate_view__archive_race_does_not_modify_archived_semester(self):
+        """A semester archived while an edit was open can't be written by that edit.
+
+        The form carries the semester as it was when the page loaded, so saving it would write
+        the whole row back, dates and the stale open status alike. The re-read under a row lock
+        catches the archive that committed first; here the view is handed that stale instance
+        to stand in for the race.
+        """
+        self.client.force_login(self.test_teacher)
+        semester = baker.make(
+            Semester, status=Semester.Status.ARCHIVED,
+            first_day=datetime.date(2020, 1, 1), last_day=datetime.date(2020, 6, 1),
+        )
+        # what the view loaded before the archive committed
+        stale = Semester.objects.get(pk=semester.pk)
+        stale.status = Semester.Status.OPEN
+        post_data = {
+            'first_day': '2021-10-16',
+            'last_day': '2021-12-16',
+            **generate_formset_data(ExcludedDateFormset, quantity=0)
+        }
+
+        with patch.object(SemesterUpdate, 'get_object', return_value=stale):
+            response = self.client.post(reverse('courses:semester_update', args=[semester.pk]), data=post_data)
+
+        self.assertRedirects(response, reverse('courses:semester_list'))
+        self.assertErrorMessage(response)
+        semester.refresh_from_db()
+        self.assertTrue(semester.is_archived)
+        self.assertEqual(semester.first_day, datetime.date(2020, 1, 1))
+        self.assertEqual(semester.last_day, datetime.date(2020, 6, 1))
+
+    @patch('tenant.views.connection', schema_name=get_public_schema_name())
+    def test_SemesterUpdate_view__public_schema_is_404(self, mock_connection):
+        """The semester views are tenant-only, so a public-schema request gets the
+        NonPublicOnlyViewMixin's 404. The archived check has to run after that mixin, or it
+        would query a tenant-only table on a schema that doesn't have it."""
+        self.client.force_login(self.test_teacher)
+        archived = baker.make(Semester, status=Semester.Status.ARCHIVED)
+
+        self.assert404('courses:semester_update', args=[archived.pk])
+        self.assert404('courses:semester_delete', args=[archived.pk])
 
     def test_SemesterList_view__status_column_names_each_lifecycle_stage(self):
         """The status column shows the semester's own lifecycle stage, so a semester being set
@@ -1148,6 +1202,18 @@ class SemesterViewTests(ByteDeckTenantTestCase):
         self.assertContains(response, '>Upcoming<')
         self.assertContains(response, '>Open<')
         self.assertContains(response, '>Archived<')
+
+    def test_SemesterList_view__open_semester_past_its_last_day_is_flagged(self):
+        """An open semester whose last day has passed reads as Open - ended, the nudge to
+        archive it and free the students' seats."""
+        self.client.force_login(self.test_teacher)
+        open_semester = SiteConfig.get().open_semester
+        open_semester.last_day = datetime.date.today() - datetime.timedelta(days=1)
+        open_semester.save()
+
+        response = self.client.get(reverse('courses:semester_list'))
+
+        self.assertContains(response, '>Open - ended<')
 
     def test_SemesterUpdate__add_data__view(self):
         """

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1118,6 +1118,37 @@ class SemesterViewTests(ByteDeckTenantTestCase):
         self.assertRedirects(response, reverse('courses:semester_list'))
         self.assertEqual(Semester.objects.get(id=1).first_day.strftime('%Y-%m-%d'), post_data['first_day'])
 
+    def test_SemesterUpdate_view__archived_semester_is_blocked(self):
+        """An archived semester's dates are what its students' final marks were calculated
+        from, so the edit view refuses it (GET and POST alike) rather than rewriting a
+        finished record. The list hides the button, but the URL is still reachable."""
+        self.client.force_login(self.test_teacher)
+        archived = baker.make(Semester, status=Semester.Status.ARCHIVED, first_day=datetime.date(2020, 1, 1))
+        post_data = {
+            'first_day': '2021-10-16',
+            'last_day': '2021-12-16',
+            **generate_formset_data(ExcludedDateFormset, quantity=0)
+        }
+
+        for response in (self.client.get(reverse('courses:semester_update', args=[archived.pk])),
+                         self.client.post(reverse('courses:semester_update', args=[archived.pk]), data=post_data)):
+            self.assertRedirects(response, reverse('courses:semester_list'))
+        archived.refresh_from_db()
+        self.assertEqual(archived.first_day, datetime.date(2020, 1, 1))
+
+    def test_SemesterList_view__status_column_names_each_lifecycle_stage(self):
+        """The status column shows the semester's own lifecycle stage, so a semester being set
+        up reads as Upcoming instead of being lumped in with everything that isn't active."""
+        self.client.force_login(self.test_teacher)
+        baker.make(Semester, status=Semester.Status.UPCOMING)
+        baker.make(Semester, status=Semester.Status.ARCHIVED)
+
+        response = self.client.get(reverse('courses:semester_list'))
+
+        self.assertContains(response, '>Upcoming<')
+        self.assertContains(response, '>Open<')
+        self.assertContains(response, '>Archived<')
+
     def test_SemesterUpdate__add_data__view(self):
         """
              Test for SemesterUpdate with correct/valid post data.

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -575,7 +575,7 @@ class SemesterDelete(RefuseSemesterMixin, NonPublicOnlyViewMixin, LoginRequiredM
 
     def form_valid(self, form):
         """Delete the semester, converting a ProtectedError from the delete itself into the
-        same redirect + error: the dispatch() pre-check can race a concurrent activation
+        same redirect + error: the refusal_message() pre-check can race a concurrent activation
         (another request making this semester active between the check and the delete).
         The success message is added here, after the delete succeeds, because Django calls
         get_success_url() before deleting.

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -30,6 +30,7 @@ from djcytoscape.views import UpdateMapMessageMixin
 from .forms import BlockForm, CourseStudentForm, CourseStudentStaffForm, MarkRangeForm, SemesterForm, ExcludedDateFormset, ExcludedDateFormsetHelper
 from .models import Block, Course, CourseStudent, Rank, Semester, MarkRange
 
+from django.db import transaction
 from django.db.models import ProtectedError, Q
 from django.db.models.functions import Greatest
 
@@ -477,8 +478,68 @@ class SemesterDetail(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
     model = Semester
 
 
+class RefuseSemesterMixin:
+    """Refuse GET and POST alike when the semester they target is off limits.
+
+    Subclasses implement refusal_message(), returning the message to show, or None to let
+    the request through. The check lives in the handlers rather than in dispatch() on
+    purpose: a dispatch() override runs *before* NonPublicOnlyViewMixin's, so looking the
+    semester up there would query a tenant-only table on the public schema instead of
+    letting that mixin raise its 404.
+    """
+
+    def refusal_message(self):
+        """The reason this semester can't be acted on, or None when it can.
+
+        Returns:
+            str or None: the error message to show the user, or None to allow the request.
+        """
+        raise NotImplementedError
+
+    def _refuse(self, request):
+        """Turn a refusal into a redirect, or return None to let the handler run.
+
+        Args:
+            request: the request being served, to attach the message to.
+
+        Returns:
+            HttpResponse or None: a redirect to the semester list when refused.
+        """
+        message = self.refusal_message()
+        if message is None:
+            return None
+        messages.error(request, message)
+        return redirect('courses:semester_list')
+
+    def get(self, request, *args, **kwargs):
+        """Refuse the semester or render the page.
+
+        Args:
+            request: the incoming request.
+            *args: positional URL arguments.
+            **kwargs: keyword URL arguments.
+
+        Returns:
+            HttpResponse: the redirect from _refuse(), or the normal response.
+        """
+        return self._refuse(request) or super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        """Refuse the semester or perform the action.
+
+        Args:
+            request: the incoming request.
+            *args: positional URL arguments.
+            **kwargs: keyword URL arguments.
+
+        Returns:
+            HttpResponse: the redirect from _refuse(), or the normal response.
+        """
+        return self._refuse(request) or super().post(request, *args, **kwargs)
+
+
 @method_decorator(staff_member_required, name='dispatch')
-class SemesterDelete(NonPublicOnlyViewMixin, LoginRequiredMixin, DeleteView):
+class SemesterDelete(RefuseSemesterMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, DeleteView):
     """Staff-only confirm-and-delete view for a Semester.
 
     Two semesters are off limits, and both are refused for GET and POST alike (the delete
@@ -496,22 +557,21 @@ class SemesterDelete(NonPublicOnlyViewMixin, LoginRequiredMixin, DeleteView):
     ACTIVE_SEMESTER_ERROR = "The active semester can't be deleted. Activate a different semester first."
     ARCHIVED_SEMESTER_ERROR = "An archived semester can't be deleted: it holds your students' final marks."
 
-    def dispatch(self, request, *args, **kwargs):
-        """Refuse to serve the view at all (GET or POST) for the active or an archived semester.
+    def refusal_message(self):
+        """Whether this semester is one of the two that can't be deleted.
 
         Returns:
-            HttpResponse: a redirect to the semester list with an error message when the
-            target can't be deleted; otherwise the normal DeleteView response.
+            str or None: the error message when the target is archived or is the active
+            semester, otherwise None.
         """
-        if self.get_object().is_archived:
-            messages.error(request, self.ARCHIVED_SEMESTER_ERROR)
-            return redirect('courses:semester_list')
+        semester = self.get_object()
+        if semester.is_archived:
+            return self.ARCHIVED_SEMESTER_ERROR
         # the raw pointer, not open_semester: PROTECT blocks deleting whatever active_semester
         # references, whatever its status, so this check has to match the constraint
-        if self.get_object() == SiteConfig.get().active_semester:
-            messages.error(request, self.ACTIVE_SEMESTER_ERROR)
-            return redirect('courses:semester_list')
-        return super().dispatch(request, *args, **kwargs)
+        if semester == SiteConfig.get().active_semester:
+            return self.ACTIVE_SEMESTER_ERROR
+        return None
 
     def form_valid(self, form):
         """Delete the semester, converting a ProtectedError from the delete itself into the
@@ -612,7 +672,7 @@ class SemesterCreate(SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, L
 
 
 @method_decorator(staff_member_required, name='dispatch')
-class SemesterUpdate(SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, UpdateView):
+class SemesterUpdate(RefuseSemesterMixin, SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, UpdateView):
     """Staff-only edit view for a Semester.
 
     An archived semester is refused: its dates and excluded days are what its students' final
@@ -626,17 +686,37 @@ class SemesterUpdate(SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, L
     ARCHIVED_SEMESTER_ERROR = ("An archived semester can't be edited: its dates are what your students' "
                                "final marks were calculated from.")
 
-    def dispatch(self, request, *args, **kwargs):
-        """Refuse to serve the view at all (GET or POST) for an archived semester.
+    def refusal_message(self):
+        """Whether this semester is archived, and so can't be edited.
 
         Returns:
-            HttpResponse: a redirect to the semester list with an error message when the
-            target is archived; otherwise the normal UpdateView response.
+            str or None: the error message when the target is archived, otherwise None.
         """
-        if self.get_object().is_archived:
-            messages.error(request, self.ARCHIVED_SEMESTER_ERROR)
-            return redirect('courses:semester_list')
-        return super().dispatch(request, *args, **kwargs)
+        return self.ARCHIVED_SEMESTER_ERROR if self.get_object().is_archived else None
+
+    def form_valid(self, form, formset):
+        """Save the semester and its excluded dates, unless it was archived in the meantime.
+
+        The form holds the semester as it was when the page was loaded, so saving it writes
+        every field back, including a status that is no longer current. Re-reading under a row
+        lock closes that window: an archive committing first is seen here (and refused), and
+        one arriving later waits for this save rather than being undone by it.
+
+        Args:
+            form: the validated SemesterForm.
+            formset: the validated ExcludedDateFormset.
+
+        Returns:
+            HttpResponse: a redirect to the semester list, with an error message when the
+            semester was archived while this edit was open.
+        """
+        with transaction.atomic():
+            if Semester.objects.select_for_update().filter(
+                pk=self.object.pk, status=Semester.Status.ARCHIVED,
+            ).exists():
+                messages.error(self.request, self.ARCHIVED_SEMESTER_ERROR)
+                return redirect('courses:semester_list')
+            return super().form_valid(form, formset)
 
     def get_context_data(self, **kwargs):
         kwargs['heading'] = 'Update Semester'

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -613,9 +613,30 @@ class SemesterCreate(SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, L
 
 @method_decorator(staff_member_required, name='dispatch')
 class SemesterUpdate(SemesterCreateUpdateFormsetMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, UpdateView):
+    """Staff-only edit view for a Semester.
+
+    An archived semester is refused: its dates and excluded days are what its students' final
+    marks were calculated from, so editing them would rewrite a finished record. The list hides
+    the edit button for archived semesters, but the URL is still reachable directly.
+    """
     model = Semester
     form_class = SemesterForm
     success_url = reverse_lazy('courses:semester_list')
+
+    ARCHIVED_SEMESTER_ERROR = ("An archived semester can't be edited: its dates are what your students' "
+                               "final marks were calculated from.")
+
+    def dispatch(self, request, *args, **kwargs):
+        """Refuse to serve the view at all (GET or POST) for an archived semester.
+
+        Returns:
+            HttpResponse: a redirect to the semester list with an error message when the
+            target is archived; otherwise the normal UpdateView response.
+        """
+        if self.get_object().is_archived:
+            messages.error(request, self.ARCHIVED_SEMESTER_ERROR)
+            return redirect('courses:semester_list')
+        return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         kwargs['heading'] = 'Update Semester'


### PR DESCRIPTION
### What?
The last step of #2157 Phase 2, and it is small: the semester list now names each semester's own lifecycle stage, and the final edit path that could still reach an archived semester is closed.

* **Status column**: `Upcoming` / `Open` / `Open - ended` / `Archived`, driven by the semester's `status` field.
* **`SemesterUpdate` refuses an archived semester**, GET and POST alike, and can't be raced by a concurrent archive.
* The action button for a semester that isn't running says **Start** rather than Activate.

### Why?
The column read Active / Active - ended / **Inactive** / Archived, which described the deck's pointer rather than the semester. "Inactive" covered exactly the stage part 1 added: a semester created in advance for next term is **Upcoming**, and saying so is the point of having the field. Now that each row reads its own status, the list can't disagree with the staff banner above it.

Archiving is one-way, but `SemesterUpdate` still served an archived semester to anyone with the URL (sharp edge #4 in the issue). Its dates and excluded days are what its students' final marks were calculated from, so editing them rewrites a finished record. The activate and delete paths were closed in #2412; this is the last one.

### How?
Every row's status and actions come from `object.status` (via `is_open` / `is_archived`) instead of comparing against `config.open_semester`, so there is one source for what stage a semester is in.

The refusal itself lives in the request handlers, behind a small `RefuseSemesterMixin` that the update and delete views share, **not** in a `dispatch()` override. A `dispatch()` override sits ahead of `NonPublicOnlyViewMixin`'s in the MRO, so it would look the semester up in a tenant-only table on the public schema instead of letting that mixin raise its 404. `SemesterDelete` has had that ordering since #2412, so its guards move too.

`SemesterUpdate.form_valid()` re-reads the semester with `select_for_update()` inside the transaction that wraps the form and formset writes. The bound form carries the semester as it was when the page loaded, so `ModelForm.save()` writes the whole row back, including a `status` that may no longer be current: without the re-read, an archive committing mid-edit would be silently undone. Now the archive that commits first is seen and refused, and one arriving later waits on the row lock.

### Testing?
`ruff check src` plus the **full suite: 2214 tests, all pass**.

New tests: the update view refuses an archived semester for GET and POST (error message shown, both dates untouched); an archive that commits mid-edit can't be undone (`test_semester_update__archive_race_does_not_modify_archived_semester`); the update and delete URLs 404 on the public schema; and the status column renders each stage, including `Open - ended`.

### Screenshots (if front end is affected)
The same seeded dev deck in both, with one semester at each stage: Fall 2026 being set up, Spring 2026 running (and past its last day), Fall 2025 archived.

**Before**: Fall 2026 reads "Inactive", which tells a teacher what it *isn't*. The heading names the pointer.

![Semester list before: Fall 2026 labelled Inactive, heading reads Current Active Semester](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2157-lifecycle-ui/semester-list-before.png)

**After**: Fall 2026 reads "Upcoming", the running one reads "Open - ended" (still nudging toward archiving), and the archived row offers no actions at all.

![Semester list after: Fall 2026 labelled Upcoming, Spring 2026 Open - ended, heading reads Open semester](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2157-lifecycle-ui/semester-list-after.png)

### Anything Else?
This finishes Phase 2. What remains on #2157 is **Phase 3** (concurrent semesters, #1781): per-registration XP scoping, submissions stamped from the student's own registration rather than the deck, per-semester marks and graphs, and seat counting across every open semester. That is where `SiteConfig.active_semester` finally disappears.

Also still open from the part 2 review: #2413, whether a student should be able to start a quest at all while no semester is open.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)