### PR TITLE
fix: stop the trailing-whitespace hook rewriting a vendored font

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+        # Leave vendored font files alone. fontawesome-webfont.svg ships with
+        # trailing whitespace on 709 lines, so a `pre-commit run --all-files`
+        # rewrites it and drifts it from upstream for no benefit.
+        exclude: ^src/static/fonts/
       - id: check-yaml
       - id: check-merge-conflict
       - id: debug-statements


### PR DESCRIPTION
### What?
Excludes the vendored font directory from the `trailing-whitespace` hook, alongside the exclusion `check-added-large-files` already carries.

```diff
       - id: trailing-whitespace
+        # Leave vendored font files alone. fontawesome-webfont.svg ships with
+        # trailing whitespace on 709 lines, so a `pre-commit run --all-files`
+        # rewrites it and drifts it from upstream for no benefit.
+        exclude: ^src/static/fonts/
```

### Why?
`src/static/fonts/fontawesome-webfont.svg` arrives from upstream with trailing whitespace on **709 of its lines**. Running `pre-commit run --all-files` therefore rewrites the file and leaves a 709-line diff on a vendored third-party asset, diverging our copy from upstream for no benefit.

It has stayed hidden because pre-commit normally only sees **staged** files, and nobody stages that font, so only a full-repo run reaches it. `pre-commit run` is documented in CLAUDE.md, so it is reachable in normal use.

This is not a consequence of the recent hook bump: the behaviour is identical on the old `v4.3.0` and the current `v6.0.0`, which I checked while reviewing #2354.

### How?
One `exclude` on the hook, scoped to the directory rather than the single file so any other vendored font is covered too. The other four hooks from that repo are untouched: `check-yaml`, `check-merge-conflict`, `debug-statements` and `check-added-large-files` never flagged anything here.

### Testing?
Run against the whole repository with `pre-commit 4.6.2` (the version `requirements.txt` resolves to):

**Before:**
```
trim trailing whitespace.................................................Failed
- files were modified by this hook
Fixing src/static/fonts/fontawesome-webfont.svg
```
with `git diff --stat` showing `1 file changed, 709 insertions(+), 709 deletions(-)`.

**After:**
```
trim trailing whitespace.................................................Passed
```
and `git diff` clean, so the hook now modifies nothing.

Note the repository's CI does not run `pre-commit` at all (the lint workflow invokes ruff directly), so this could only be verified by running the hooks by hand, which is what the results above are.

### Screenshots (if front end is affected)
N/A: tooling config only. The font file itself is unchanged, which is the point.

### Anything Else?
Only that one file currently trips the hook; no other vendored asset in `src/static/` has trailing whitespace today, so the exclusion is deliberately narrow rather than covering all of `src/static/`.

### Review request
@tylerecouture

- Claude Code (Bytedeck - dependancies upgrades)

---
_Generated by [Claude Code](https://claude.ai/code/session_014RwTtNLXvwNkobVYP9kABW)_