### PR TITLE
fix: reject completing a submission you do not own (#2167)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -939,6 +939,40 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
         # log in the student for all tests here
         self.client.force_login(self.test_student)
 
+    def test_complete__another_student_cannot_complete_someone_elses_submission(self):
+        """A student POSTing complete for another student's submission 404s and changes nothing (#2167).
+
+        Completing publishes the submission's comment and question answers as the owner and marks
+        their quest done, so a forged POST would otherwise let one student submit work in another
+        student's name.
+        """
+        other_student = User.objects.create_user('other_student')
+        self.client.force_login(other_student)
+
+        response = self.client.post(
+            reverse('quests:complete', args=[self.sub.id]),
+            data={'complete': True, 'comment_text': "not my submission"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.sub.refresh_from_db()
+        self.assertFalse(self.sub.is_completed)
+        self.assertEqual(self.sub.draft_comment.text, "test draft comment")
+
+    def test_complete__staff_can_complete_another_users_submission(self):
+        """Staff are not blocked by the ownership guard, matching submission() and drop() (#2167)."""
+        self.client.force_login(self.test_teacher)
+
+        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.test_teacher]):
+            response = self.client.post(
+                reverse('quests:complete', args=[self.sub.id]),
+                data={'complete': True, 'comment_text': "marked on the student's behalf"},
+            )
+
+        self.assertNotEqual(response.status_code, 404)
+        self.sub.refresh_from_db()
+        self.assertTrue(self.sub.is_completed)
+
     def test_complete__no_comment_and_not_completed_returns_404(self):
         """POSTing complete for an in-progress submission with no draft comment 404s.
 

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1728,6 +1728,12 @@ def complete(request, submission_id):
 
     # EARLY EXIT CONDITIONS: ####################
 
+    # Completing publishes the submission's comment and question answers under the owner's name
+    # and marks their quest done, so only the owner may do it. Staff act on other students'
+    # submissions through the approve view, not this one. Matches submission() and drop().
+    if submission.user != request.user and not request.user.is_staff:
+        raise Http404("You can only submit your own quests.")
+
     # This view should only be access when a student submits a submission comment form
     if request.method != "POST":
         raise Http404


### PR DESCRIPTION
### What?
Adds an ownership guard to `complete()`, so a student can only submit their own quest.

Closes #2167

### Why?
`complete()` fetched the submission by pk alone:

```python
submission = get_object_or_404(QuestSubmission, pk=submission_id)
```

with no check that it belongs to the requester. Any authenticated user who knew (or guessed) an in-progress submission id could POST to `quests:complete`, which:

- publishes the owner's draft comment and their draft question answers **as the owner**,
- marks the owner's quest completed (and auto-approves it, granting XP, when the quest is set to auto-approve),
- notifies the owner's teacher that the work was submitted,

all without the owner doing anything. The student who owns the submission loses control of when their work is handed in, and can have half-finished answers published.

Confirmed rather than assumed: with the guard reverted, the forged POST from a second student returns **302** (accepted, then redirects), not a 404.

### How?
One guard, placed ahead of the other early-exit checks in `complete()` so it runs before any side effects:

```python
if submission.user != request.user and not request.user.is_staff:
    raise Http404("You can only submit your own quests.")
```

Staff pass through, matching `submission()` and `drop()`, which already use exactly this predicate. Staff act on other students' submissions all over the app (approving, returning, dropping), so blocking them here would be inconsistent, and `quests:approve` is the view they actually use for marking.

**Scope note:** the issue also flags `ajax_save_draft`'s comment branch. That is already fixed on `develop`: the view fetches with `get_object_or_404(QuestSubmission, pk=submission_id, user=request.user)`, which scopes both the comment and the answers branch, and it already has regression tests for both the other-student case (`test_ajax_save_draft__another_students_draft_is_not_overwritten`) and the staff case (`test_ajax_save_draft__staff_cannot_save_a_students_draft`). So no change was needed there, and this PR closes the remaining half.

### Testing?
Two new tests in `SubmissionCompleteViewTest`, covering every branch of the new condition:

- `test_complete__another_student_cannot_complete_someone_elses_submission`: a second student's POST 404s, and the target submission is still not completed with its draft comment untouched.
- `test_complete__staff_can_complete_another_users_submission`: staff are not blocked, pinning the deliberate `is_staff` exemption so a later change cannot silently flip it.

The owner path stays covered by the existing tests in that class.

Verified test-driven: with the `views.py` guard stashed, the first test fails with `AssertionError: 302 != 404`.

Local run on a Python 3.12 venv against Postgres 16:
- `python src/manage.py test quest_manager questions` -> **520 tests, OK**
- `ruff check src` -> All checks passed
- `python src/manage.py check` -> no issues

### Screenshots (if front end is affected)
N/A: no front-end change. This only rejects a request that no legitimate UI ever sends: the submission page renders the `complete` form solely for the submission's owner.

### Anything Else?
One judgment call worth your eye: I let **staff** through, for consistency with `submission()`/`drop()`. The stricter reading is that completing is inherently the owner's action (staff have `approve` for their workflow), which would make this an owner-only check. Say the word and I will drop the `is_staff` exemption; the test that pins it makes the switch a one-line change.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - multiple submission types`)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_