### PR TITLE
fix: keep file answers when a submission fails validation (#2165)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load crispy_forms_tags %}
 {% load question_tags %}
+{% load comment_tags %}
 
 {% block head %}
     {{ submission_form.media }}
@@ -123,6 +124,16 @@
                 {{ form.question.instructions|unwrap_p }}
               </div>
               {% crispy form %}
+              {% comment %} A file kept from an earlier submit that failed validation: the file input
+                 above always renders empty (browsers never repopulate it), so without this the
+                 student has no way to tell their upload survived, and would re-attach it (#2165). {% endcomment %}
+              {% if form.instance.response_file %}
+                <p class="help-block">
+                  <i class="fa fa-paperclip fa-fw"></i> Attached:
+                  <a href="{{ form.instance.response_file.url }}" target="_blank">{{ form.instance.response_file|filename|safe }}</a>
+                  <small>(already saved: only choose a file above if you want to replace it)</small>
+                </p>
+              {% endif %}
             </div>
           {% endfor %}
           </div>

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -31,7 +31,7 @@ from comments.models import Comment, Document
 from comments.sanitize import sanitize_comment_html
 from questions.forms import QuestionSubmissionFormsetFactory
 from questions.models import QuestionSubmission, QuestionType
-from questions.utils import sync_draft_question_submissions
+from questions.utils import save_draft_file_answers, sync_draft_question_submissions
 from courses.models import Block, CourseStudent
 from library.utils import is_library_schema_requested, library_schema_if_requested
 from notifications.signals import notify
@@ -1804,6 +1804,16 @@ def complete(request, submission_id):
         # The main form path should only occur if a student tries to use the quick reply form
         # on a quest that has `xp_can_be_entered_by_student`; re-rendering shows the full form
         # so they can enter XP. The formset path re-renders with each question's errors visible.
+
+        # Keep any file answers that did validate, since the re-rendered file inputs come back
+        # empty and the student would otherwise lose the upload with no warning (#2165).
+        if question_formset and save_draft_file_answers(question_formset, request.FILES):
+            messages.info(
+                request,
+                "Your attached file was saved, so you don't need to choose it again. "
+                "Fix the problems below and submit the quest again.",
+            )
+
         context = {
             "heading": submission.quest.name,
             "submission": submission,

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -1,6 +1,7 @@
 import json
 
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from model_bakery import baker
@@ -57,6 +58,13 @@ class QuestionSubmissionFlowTestBase(ByteDeckTenantTestCase):
             data[f"question_submissions-{i}-id"] = str(row.id)
             data[f"question_submissions-{i}-response_text"] = texts.get(row.question_id, "")
         return data
+
+    def file_field_name(self, question):
+        """The formset field name of the given question's file input, found by the question's
+        position among the submission's draft rows (the order the formset is built in)."""
+        rows = list(sync_draft_question_submissions(self.submission))
+        index = next(i for i, row in enumerate(rows) if row.question_id == question.id)
+        return f"question_submissions-{index}-response_file"
 
 
 class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
@@ -143,6 +151,87 @@ class CompleteWithQuestionsTest(QuestionSubmissionFlowTestBase):
         self.assertFalse(self.submission.is_completed)
         self.assertFalse(QuestionSubmission.objects.filter(
             quest_submission=self.submission, comment__isnull=False).exists())
+
+    def test_complete__uploaded_file_survives_a_failed_submit(self):
+        """A file attached alongside a blank required answer is kept, not silently dropped (#2165).
+
+        Browsers never repopulate a file input, so without saving the upload the student's file
+        would vanish on the re-render with no notice: the required file error would reappear
+        even though they did attach one, or an optional answer would publish as empty.
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload", required=False,
+            instructions="<p>Attach your work.</p>", allowed_file_type="image",
+        )
+        upload = SimpleUploadedFile("my-work.png", b"file_content", content_type="image/png")
+
+        # short answer left blank, so the formset is invalid and the page re-renders
+        data = {"complete": True, "comment_text": "<p>a comment</p>", **self.formset_data(short_text="")}
+        data[self.file_field_name(file_question)] = upload
+        response = self.client.post(self.complete_url(), data=data)
+
+        self.assertEqual(response.status_code, 200)
+
+        file_row = QuestionSubmission.objects.get(
+            quest_submission=self.submission, question=file_question, comment__isnull=True)
+        self.assertTrue(file_row.response_file, "the attached file was dropped on re-render")
+        self.assertIn("my-work", file_row.response_file.name)
+        # and the re-rendered page shows it, so the student can see it was kept
+        self.assertContains(response, "my-work")
+
+    def test_complete__rejected_file_is_not_saved(self):
+        """A file rejected for its type is not kept, so its error still applies on the retry (#2165).
+
+        Only uploads that pass the question's own file-type check are worth keeping; storing a
+        rejected one would let the student submit again without fixing it.
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload", required=False,
+            instructions="<p>Attach an image.</p>", allowed_file_type="image",
+        )
+        not_an_image = SimpleUploadedFile("notes.txt", b"file_content", content_type="text/plain")
+
+        data = {"complete": True, "comment_text": "<p>a comment</p>", **self.formset_data()}
+        data[self.file_field_name(file_question)] = not_an_image
+        response = self.client.post(self.complete_url(), data=data)
+
+        self.assertEqual(response.status_code, 200)
+        file_row = QuestionSubmission.objects.get(
+            quest_submission=self.submission, question=file_question, comment__isnull=True)
+        self.assertFalse(file_row.response_file)
+
+    def test_complete__file_field_left_alone_keeps_the_saved_file(self):
+        """Re-submitting without re-choosing a file keeps the one already saved (#2165).
+
+        The student's second attempt only fixes the text answer, leaving the file input empty
+        as browsers force them to; that must not wipe the file kept from the first attempt.
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload", required=True,
+            instructions="<p>Attach your work.</p>", allowed_file_type="image",
+        )
+
+        # first attempt: file attached, required text answer blank, so it bounces back
+        first = {"complete": True, "comment_text": "<p>a comment</p>", **self.formset_data(short_text="")}
+        first[self.file_field_name(file_question)] = SimpleUploadedFile(
+            "my-work.png", b"file_content", content_type="image/png")
+        self.client.post(self.complete_url(), data=first)
+
+        file_row = QuestionSubmission.objects.get(
+            quest_submission=self.submission, question=file_question, comment__isnull=True)
+        kept_name = file_row.response_file.name
+        self.assertTrue(kept_name)
+
+        # second attempt: text answer fixed, file input left empty
+        response = self.client.post(
+            self.complete_url(),
+            data={"complete": True, "comment_text": "<p>a comment</p>", **self.formset_data()})
+        self.assertRedirects(response, reverse("quests:quests"))
+
+        file_row.refresh_from_db()
+        self.assertEqual(file_row.response_file.name, kept_name)
+        # and it published with the completion, rather than as an empty answer
+        self.assertIsNotNone(file_row.comment_id)
 
     def test_complete__quest_without_questions_unchanged(self):
         """A quest with no questions completes exactly as before when a comment is left."""

--- a/src/questions/utils.py
+++ b/src/questions/utils.py
@@ -1,6 +1,53 @@
 from .models import QuestionSubmission
 
 
+def save_draft_file_answers(question_formset, uploaded_files):
+    """Persist the file answers of an invalid formset onto their draft rows, and return how
+    many were saved.
+
+    A browser never repopulates a file input, so when the answer formset fails validation the
+    re-rendered page comes back with every file field empty. Without this the student's upload
+    is gone with nothing to say so: a required file question demands a file they did attach,
+    and an optional one publishes empty (#2165). Keeping the upload on the draft row means it
+    survives the round trip, exactly as autosaved text answers already do.
+
+    Only rows whose own file validated are saved: a file rejected for type or size never
+    reaches ``cleaned_data``, so its error stands and nothing is stored. Rows the student did
+    not upload to this time are skipped, so an earlier file is never overwritten by a
+    re-submit that left the field alone.
+
+    Args:
+        question_formset: the bound, invalid answer formset.
+        uploaded_files: the request's ``FILES``, used to tell a fresh upload from an untouched
+            field (the field is absent from ``FILES`` when nothing new was chosen).
+
+    Returns:
+        int: how many draft rows had a file saved.
+    """
+    saved = 0
+    for form in question_formset.forms:
+        if form.add_prefix("response_file") not in uploaded_files:
+            continue
+        # cleaned_data is missing entirely if the form never ran validation, and omits
+        # response_file when the upload itself was rejected for type or size
+        upload = getattr(form, "cleaned_data", {}).get("response_file")
+        if not upload:
+            continue
+
+        row = form.instance
+        # Defensive: the formset is only ever built over this submission's own unpublished
+        # draft rows, so a saved-but-published row cannot reach here. Guarded anyway so that
+        # widening the caller's queryset can never overwrite a finished cycle's answer.
+        if not row.pk or row.comment_id is not None:  # pragma: no cover
+            continue
+
+        row.response_file = upload
+        row.full_clean()
+        row.save()
+        saved += 1
+    return saved
+
+
 def sync_draft_question_submissions(quest_submission):
     """Ensure exactly one draft answer row exists per current question of the submission's
     quest, and return the queryset of draft rows to build the answer formset from.


### PR DESCRIPTION
### What?
Keeps a student's uploaded file answer when the answer formset fails validation, instead of silently dropping it.

Closes #2165

### Why?
File answers upload only at submit (autosave handles text only), and a browser never repopulates a file input. So if the formset failed validation for *any* reason, most commonly a different question's required text answer being blank, the page came back with every file field empty and nothing to say the upload was gone:

- **Required file question:** a second-round "You must upload a file for this type of question" error, even though the student did attach one.
- **Optional file question:** nothing flags it at all. The student fixes the text answer, resubmits, and the answer publishes empty while they believe their file went with it.

The second case is the quiet one: the work is marked with a missing attachment and neither the student nor the marker knows why.

### How?
- **`questions/utils.py`**: new `save_draft_file_answers(question_formset, uploaded_files)`, which persists the file answers that validated onto their draft rows and returns how many it saved. Text answers already survive a round trip via autosave; this gives files the same treatment. Deliberately narrow:
  - only fields present in `request.FILES` this time, so a later attempt that leaves the input alone (as browsers force it to) cannot wipe the file already kept;
  - only uploads that reached `cleaned_data`, so a file rejected for type or size is not stored and its error still stands on the retry;
  - never a published row, guarded defensively with a `# pragma: no cover` and a note, since the formset is only ever built over this submission's own draft rows.
- **`quest_manager/views.py`**: call it on the invalid path before re-rendering, and tell the student their file was kept so they know not to re-attach it.
- **`submission.html`**: show the file currently held against a question, linked, using the same `filename` filter the marking display uses. The input itself still renders empty (nothing can change that), so without this the student has no way to tell the upload survived.

### Testing?
Three new tests in `CompleteWithQuestionsTest`, covering each branch of the new helper:

- `test_complete__uploaded_file_survives_a_failed_submit`: file kept on the draft row and shown on the re-rendered page.
- `test_complete__rejected_file_is_not_saved`: a `.txt` sent to an image-only question is not stored.
- `test_complete__file_field_left_alone_keeps_the_saved_file`: the second attempt fixes the text, leaves the file input empty, and the kept file survives and publishes with the completion.

Verified test-driven: with the fix reverted, the first test fails with `<FieldFile: None> is not true : the attached file was dropped on re-render`.

Local run on a Python 3.12 venv against Postgres 16:
- `python src/manage.py test quest_manager questions` -> **523 tests, OK**
- `ruff check src`, `manage.py check`, `makemigrations --check --dry-run` -> all clean
- `coverage` on `src/questions/utils.py` -> **100%**, branches included

### Screenshots (if front end is affected)
Captured from the real `hackerspace` dev deck as `student1`, on a quest with a required short answer, a required long answer, and an optional image question. The student attaches a file, leaves the required answers blank, and submits.

**Before** (the file is gone, with nothing to indicate it)

![before, file question after a failed submit](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2165/before-file-question.png)

**After** (the file is held against the question, and the input is clearly optional now)

![after, file question after a failed submit](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2165/after-file-question.png)

**After** (the notice at the top of the page)

![after, kept-file notice](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2165/after-kept-file-notice.png)

### Anything Else?
The issue also notes that the main `attachments` field on the comment form has the same underlying browser behaviour. That is pre-existing and outside the question flow, so I left it alone here rather than widening the change; happy to take it as a follow-up if you want the comment attachments kept too.

While setting the dev deck up for these screenshots I had to run `migrate_schemas`, since the seeded `hackerspace` schema predated several `develop` migrations. Nothing to do with this PR, just noting it in case other sessions hit the same thing.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - multiple submission types`)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Previously saved response files are now shown with download links and filenames.
  * Clear guidance explains that selecting a new file replaces the existing upload.

* **Bug Fixes**
  * Valid file uploads are preserved when another answer prevents submission.
  * Previously saved files remain intact when the file field is left unchanged.
  * Rejected uploads are no longer saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->