### PR TITLE
fix: keep comment attachments when a submission fails validation (#2427)

### DIFF
--- a/src/comments/tests/test_utils.py
+++ b/src/comments/tests/test_utils.py
@@ -1,0 +1,72 @@
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils.datastructures import MultiValueDict
+
+from model_bakery import baker
+
+from comments.models import Comment
+from comments.utils import save_draft_attachments
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from quest_manager.forms import SubmissionForm, SubmissionQuickReplyFormStudent
+
+User = get_user_model()
+
+
+class SaveDraftAttachmentsTest(ByteDeckTenantTestCase):
+    """Tests for comments.utils.save_draft_attachments(), which keeps a submission's uploaded
+    attachments on its draft comment when the submission fails validation (#2427)."""
+
+    def setUp(self):
+        """A draft comment to hang attachments off, built the way the submission view builds it."""
+        self.draft_comment = Comment.objects.create_comment(
+            user=baker.make(User), path="/some/path/", text="", target=None)
+
+    def bound_form(self, uploads, form_class=SubmissionForm):
+        """Return a validated submission form bound to the given uploads, the way complete()
+        binds it to request.POST and request.FILES."""
+        form = form_class(data={"comment_text": ""}, files=MultiValueDict({"attachments": uploads}))
+        form.is_valid()  # the helper runs on an already-validated form, valid or not
+        return form
+
+    def test_save_draft_attachments__attaches_validated_uploads(self):
+        """Every upload that passed validation becomes a Document on the draft comment."""
+        uploads = [
+            SimpleUploadedFile("notes.txt", b"file_content", content_type="text/plain"),
+            SimpleUploadedFile("diagram.png", b"file_content", content_type="image/png"),
+        ]
+
+        saved = save_draft_attachments(self.bound_form(uploads), self.draft_comment)
+
+        self.assertEqual(saved, 2)
+        names = [document.docfile.name for document in self.draft_comment.document_set.all()]
+        self.assertEqual(len(names), 2)
+        self.assertTrue(any("notes" in name for name in names), names)
+        self.assertTrue(any("diagram" in name for name in names), names)
+
+    def test_save_draft_attachments__skips_an_upload_that_failed_validation(self):
+        """An upload over the form's size limit is not kept, so its error still applies on the retry.
+
+        Storing a rejected file would let the student submit again without fixing it, and it would
+        then publish with their comment despite never having been accepted.
+        """
+        too_big = SimpleUploadedFile("huge.png", b"file_content", content_type="image/png")
+        # claim a size over the form field's 16MB limit without allocating 16MB in the test
+        too_big.size = 16777217
+
+        form = self.bound_form([too_big])
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(save_draft_attachments(form, self.draft_comment), 0)
+        self.assertEqual(self.draft_comment.document_set.count(), 0)
+
+    def test_save_draft_attachments__form_without_an_attachments_field(self):
+        """A form that has no attachments field (the quick reply form) contributes nothing.
+
+        complete() uses the quick reply form when the POST carries no files at all, so the helper
+        has to cope with a form that never had the field.
+        """
+        form = SubmissionQuickReplyFormStudent(data={"comment_text": "just a comment"})
+        form.is_valid()
+
+        self.assertEqual(save_draft_attachments(form, self.draft_comment), 0)
+        self.assertEqual(self.draft_comment.document_set.count(), 0)

--- a/src/comments/tests/test_utils.py
+++ b/src/comments/tests/test_utils.py
@@ -59,6 +59,25 @@ class SaveDraftAttachmentsTest(ByteDeckTenantTestCase):
         self.assertEqual(save_draft_attachments(form, self.draft_comment), 0)
         self.assertEqual(self.draft_comment.document_set.count(), 0)
 
+    def test_save_draft_attachments__keeps_the_good_files_of_a_mixed_selection(self):
+        """One oversized file does not cost the student the files chosen alongside it.
+
+        The field validates the whole selection at once, so a single rejected file leaves
+        `attachments` out of cleaned_data entirely; the acceptable files still have to be kept,
+        or a student who attached five files and one too-large one loses all six.
+        """
+        good = SimpleUploadedFile("notes.txt", b"file_content", content_type="text/plain")
+        too_big = SimpleUploadedFile("huge.png", b"file_content", content_type="image/png")
+        # claim a size over the form field's 16MB limit without allocating 16MB in the test
+        too_big.size = 16777217
+
+        form = self.bound_form([good, too_big])
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(save_draft_attachments(form, self.draft_comment), 1)
+        kept = self.draft_comment.document_set.get()
+        self.assertIn("notes", kept.docfile.name)
+
     def test_save_draft_attachments__form_without_an_attachments_field(self):
         """A form that has no attachments field (the quick reply form) contributes nothing.
 

--- a/src/comments/utils.py
+++ b/src/comments/utils.py
@@ -1,4 +1,39 @@
+from django.core.exceptions import ValidationError
+
 from .models import Document
+
+
+def accepted_attachments(form):
+    """Return the uploads from a submission form's ``attachments`` field that passed validation.
+
+    ``cleaned_data`` holds them when the field as a whole validated. When it did not, the field
+    is absent from ``cleaned_data`` entirely: its ``clean()`` validates the selection as a unit,
+    so a single file over the size limit takes the rest of that selection down with it. Running
+    the field's own clean on each file individually recovers the ones that were fine, leaving
+    only the rejected file for the student to choose again.
+
+    Args:
+        form: the bound, already-validated submission form.
+
+    Returns:
+        list: the accepted uploads, empty if the form has no ``attachments`` field or none of
+        the files were acceptable.
+    """
+    uploads = form.cleaned_data.get("attachments")
+    if uploads is not None:
+        return uploads
+
+    field = form.fields.get("attachments")
+    if field is None:
+        return []  # a form without the field at all, such as the quick reply form
+
+    accepted = []
+    for upload in form.files.getlist("attachments"):
+        try:
+            accepted.append(field.clean(upload))
+        except ValidationError:
+            continue  # this one file is the reason the field failed; its error stands
+    return accepted
 
 
 def save_draft_attachments(form, draft_comment):
@@ -12,8 +47,9 @@ def save_draft_attachments(form, draft_comment):
     comment when the submission finally goes through, exactly as they would have on a first-try
     submit.
 
-    Files that failed their own validation (over the size limit) never reach ``cleaned_data``,
-    so nothing is stored for them and their error still applies on the retry.
+    Only files that passed validation are kept (see ``accepted_attachments``): one rejected for
+    being over the size limit is dropped so its error still applies on the retry, while the files
+    it was chosen alongside are kept all the same.
 
     Args:
         form: the bound, already-validated submission form (valid or not). Forms without an
@@ -30,7 +66,7 @@ def save_draft_attachments(form, draft_comment):
     if draft_comment is None:  # pragma: no cover
         return 0
 
-    uploads = form.cleaned_data.get("attachments") or []
+    uploads = accepted_attachments(form)
     for upload in uploads:
         document = Document(docfile=upload, comment=draft_comment)
         document.full_clean()

--- a/src/comments/utils.py
+++ b/src/comments/utils.py
@@ -1,0 +1,38 @@
+from .models import Document
+
+
+def save_draft_attachments(form, draft_comment):
+    """Attach a submission form's validated file uploads to the draft comment, and return how
+    many were attached.
+
+    A browser never repopulates a file input, so when a submission fails validation the
+    re-rendered page comes back with the "Attach files" input empty: without this the student's
+    uploads are gone with nothing to say so, and they submit again believing the files went with
+    it (#2427). Attaching them to the draft comment keeps them, and they publish with that
+    comment when the submission finally goes through, exactly as they would have on a first-try
+    submit.
+
+    Files that failed their own validation (over the size limit) never reach ``cleaned_data``,
+    so nothing is stored for them and their error still applies on the retry.
+
+    Args:
+        form: the bound, already-validated submission form (valid or not). Forms without an
+            ``attachments`` field (the quick-reply form) contribute nothing.
+        draft_comment: the submission's unpublished draft comment, which holds the attachments
+            until the submission is completed.
+
+    Returns:
+        int: how many files were attached.
+    """
+    # Defensive: an already-completed submission has no draft comment to hold attachments, but
+    # its form can only fail validation on the upload itself, and a rejected upload is dropped
+    # here anyway. Guarded so a future caller cannot hit an AttributeError.
+    if draft_comment is None:  # pragma: no cover
+        return 0
+
+    uploads = form.cleaned_data.get("attachments") or []
+    for upload in uploads:
+        document = Document(docfile=upload, comment=draft_comment)
+        document.full_clean()
+        document.save()
+    return len(uploads)

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -146,6 +146,23 @@
         {% endif %}
         <div id="main-comment-form">
           {{ submission_form | crispy }}
+          {% comment %} Files kept from an earlier submit that failed validation: the "Attach files"
+             input above always renders empty (browsers never repopulate it), so without this the
+             student has no way to tell their uploads survived, and would choose them again (#2427).
+             Only the student sees it: these are their pending attachments, and staff post this form
+             to the approve view, where their own files are handled separately. {% endcomment %}
+          {% if request.user == submission.user %}
+            {% with submission.draft_comment.document_set.all as draft_documents %}
+              {% if draft_documents %}
+                <p class="help-block">
+                  <i class="fa fa-paperclip fa-fw"></i> Attached:
+                  {% for document in draft_documents %}<a href="{{ document.docfile.url }}"
+                     target="_blank">{{ document.docfile|filename|safe }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
+                  <small>(already saved: only choose files above if you want to attach more)</small>
+                </p>
+              {% endif %}
+            {% endwith %}
+          {% endif %}
         </div>
         <div class='form-group form-group-summernote'>
         {% if request.user.is_staff %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -16,6 +16,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext
@@ -986,6 +987,91 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
         self.assertIsNone(sub.draft_comment)
         response = self.client.post(reverse('quests:complete', args=[sub.id]), data={'complete': True})
         self.assertEqual(response.status_code, 404)
+
+    def custom_xp_submission(self):
+        """Return a fresh in-progress submission (with its draft comment) of a quest whose XP the
+        student enters: POSTing it without an XP value is the simplest way to fail form validation."""
+        quest = baker.make(Quest, xp=5, xp_can_be_entered_by_students=True)
+        sub = baker.make(QuestSubmission, user=self.test_student, quest=quest, semester=self.semester)
+        sub.draft_comment = Comment.objects.create_comment(
+            user=self.test_student, path=sub.get_absolute_url(), text="", target=None)
+        sub.save()
+        return sub
+
+    def test_complete__attached_file_survives_a_failed_submit(self):
+        """A file attached alongside a missing XP value is kept, not silently dropped (#2427).
+
+        Browsers never repopulate a file input, so without saving the upload the student's file
+        vanishes on the re-render with nothing to say so, and they submit again believing the
+        file went with it.
+        """
+        sub = self.custom_xp_submission()
+        upload = SimpleUploadedFile("my-work.png", b"file_content", content_type="image/png")
+
+        # no xp_requested, which the custom-XP form requires, so the page re-renders with errors
+        response = self.client.post(
+            reverse('quests:complete', args=[sub.id]),
+            data={'complete': True, 'comment_text': "<p>my work is attached</p>", 'attachments': upload},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        sub.refresh_from_db()
+        documents = list(sub.draft_comment.document_set.all())
+        self.assertEqual(len(documents), 1, "the attachment was dropped on re-render")
+        self.assertIn("my-work", documents[0].docfile.name)
+        # the re-rendered page lists it, so the student can see it was kept
+        self.assertContains(response, "my-work")
+        self.assertIn(
+            "Your attached file was saved, so you don't need to choose it again. "
+            "Fix the problems below and submit the quest again.",
+            [str(message) for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_complete__several_attached_files_survive_a_failed_submit(self):
+        """Every attachment is kept, and the notice reads for more than one file (#2427)."""
+        sub = self.custom_xp_submission()
+        uploads = [
+            SimpleUploadedFile("first-file.png", b"file_content", content_type="image/png"),
+            SimpleUploadedFile("second-file.png", b"file_content", content_type="image/png"),
+        ]
+
+        response = self.client.post(
+            reverse('quests:complete', args=[sub.id]),
+            data={'complete': True, 'comment_text': "<p>both attached</p>", 'attachments': uploads},
+        )
+
+        sub.refresh_from_db()
+        self.assertEqual(sub.draft_comment.document_set.count(), 2)
+        self.assertContains(response, "first-file")
+        self.assertContains(response, "second-file")
+        self.assertIn(
+            "Your attached files were saved, so you don't need to choose them again. "
+            "Fix the problems below and submit the quest again.",
+            [str(message) for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_complete__kept_attachment_publishes_with_the_comment_on_the_retry(self):
+        """The file kept from a failed submit publishes with the comment when the student submits
+        again, without re-choosing it and without it being attached twice (#2427).
+
+        The second attempt only fixes the XP, leaving the file input empty as browsers force the
+        student to; that must neither lose the kept file nor duplicate it.
+        """
+        sub = self.custom_xp_submission()
+        url = reverse('quests:complete', args=[sub.id])
+        upload = SimpleUploadedFile("my-work.png", b"file_content", content_type="image/png")
+
+        self.client.post(url, data={'complete': True, 'comment_text': "<p>attached</p>", 'attachments': upload})
+        sub.refresh_from_db()
+        kept_comment = sub.draft_comment
+
+        with patch('profile_manager.models.Profile.current_teachers', return_value=[self.test_teacher]):
+            self.client.post(url, data={'complete': True, 'comment_text': "<p>attached</p>", 'xp_requested': 5})
+
+        sub.refresh_from_db()
+        self.assertTrue(sub.is_completed)
+        self.assertEqual(kept_comment.document_set.count(), 1)
+        self.assertIn(kept_comment, sub.get_comments())
 
     def test_skip__student_not_earning_xp_transfers_their_own_submission(self):
         """A student who is not earning XP can skip their own submission: it is approved as a transfer.

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -29,6 +29,7 @@ from hackerspace_online.decorators import staff_member_required, xml_http_reques
 from badges.models import BadgeAssertion
 from comments.models import Comment, Document
 from comments.sanitize import sanitize_comment_html
+from comments.utils import save_draft_attachments
 from questions.forms import QuestionSubmissionFormsetFactory
 from questions.models import QuestionSubmission, QuestionType
 from questions.utils import save_draft_file_answers, sync_draft_question_submissions
@@ -1805,12 +1806,17 @@ def complete(request, submission_id):
         # on a quest that has `xp_can_be_entered_by_student`; re-rendering shows the full form
         # so they can enter XP. The formset path re-renders with each question's errors visible.
 
-        # Keep any file answers that did validate, since the re-rendered file inputs come back
-        # empty and the student would otherwise lose the upload with no warning (#2165).
-        if question_formset and save_draft_file_answers(question_formset, request.FILES):
+        # Keep the uploads that did validate, both the comment's attachments and the file
+        # answers, since the re-rendered file inputs come back empty and the student would
+        # otherwise lose them with no warning (#2165, #2427).
+        kept_files = save_draft_attachments(form, submission.draft_comment)
+        if question_formset:
+            kept_files += save_draft_file_answers(question_formset, request.FILES)
+        if kept_files:
+            noun, verb, pronoun = ("file", "was", "it") if kept_files == 1 else ("files", "were", "them")
             messages.info(
                 request,
-                "Your attached file was saved, so you don't need to choose it again. "
+                f"Your attached {noun} {verb} saved, so you don't need to choose {pronoun} again. "
                 "Fix the problems below and submit the quest again.",
             )
 


### PR DESCRIPTION
Closes #2427

### What?

Files a student attaches under **Attach files** on the quest submission form are now kept when the submission fails validation, instead of being silently dropped. They are saved on the submission's draft comment, listed under the field on the re-rendered page, and publish with the comment when the submission finally goes through.

This is the same fix #2425 made for question file answers (#2165), applied to the submission form's own attachments.

### Why?

A browser never repopulates a file input, so when a submit bounces back with errors (a blank required question, a missing XP value on a custom-XP quest) the "Attach files" box comes back empty and the upload is gone. Nothing on the page says so: the student either notices and re-attaches, or fixes the error and submits again believing the file went with it. Since the attachment is often the work being handed in, losing it silently is the worse of those two outcomes.

### How?

* `src/comments/utils.py` (new):
  * `accepted_attachments(form)` returns the uploads that passed validation. Normally that is `cleaned_data["attachments"]`, but the field validates the whole selection as a unit, so one file over the 16MB limit errors the field and drops every file chosen with it from `cleaned_data`. In that case each file is re-run through the field's own `clean()` individually, so only the rejected file is lost (its error still applies on the retry) and the acceptable ones are still kept.
  * `save_draft_attachments(form, draft_comment)` attaches those uploads to the draft comment as `Document` rows and returns how many it saved. Forms with no `attachments` field (the quick reply form) contribute nothing.
* `src/quest_manager/views.py`: `complete()`'s invalid branch calls it alongside the existing `save_draft_file_answers()`, and the "your file was saved" notice now counts both kinds of kept upload, so a student who kept more than one is told so in the plural.
* `src/quest_manager/templates/quest_manager/submission.html`: lists the draft comment's saved attachments under the field, so the student can see the upload survived. Student only: staff post this form to the approve view, where their files are handled separately.

Because attachments are a multi-file field, the kept files are additive: choosing more files on the retry adds to them rather than replacing them, which is what the notice says.

### Testing?

Full suite green locally (2225 tests, `python src/manage.py test src`), plus `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` all clean. Under coverage, `src/comments/utils.py` and `src/quest_manager/views.py` both report 100% including branches (the helper's one defensive guard carries a `# pragma: no cover` with the reason in the code).

New tests, and each fails without the corresponding fix:

* `comments/tests/test_utils.py` (new): validated uploads are attached; an upload that failed validation is not; **a valid file chosen alongside an oversized one is still kept** (fails with `0 != 1` on the first commit); a form without an `attachments` field contributes nothing.
* `quest_manager/tests/test_views.py`: an attached file survives a failed submit and is listed on the re-render with the notice; several files are all kept and the notice reads in the plural; the kept file publishes with the comment on the retry, exactly once, without being re-chosen. All three fail on `develop` with `0 != 1 : the attachment was dropped on re-render`.

### Screenshots (if front end is affected)

Captured from the running `hackerspace` dev deck as `student1`, attaching `my-portfolio.png` to a quest whose required question is left blank, then submitting for approval.

**Before** (the attachment is gone, with nothing to say so):

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2427/before.png)

**After** (the file is kept and listed under the field):

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2427/after.png)

And the notice at the top of the page:

![notice](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2427/notice.png)

### Anything Else?

One upload path is still not covered: when a teacher changes the quest's questions while a student has the submission page open, `complete()` redirects with "This quest's questions have changed since you opened this page" before the form is validated, so neither this fix nor #2165's can keep the files there. Filed as #2428.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)