### PR TITLE
fix: tidy up a skipped submission's unsubmitted draft (#2164, #2431)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3060,6 +3060,28 @@ class SkipQuestViewTests(ByteDeckTenantTestCase):
         self.assertTrue(self.submission.is_approved)
         self.assertSuccessMessage(response)
 
+    def test_skip__keeps_the_students_draft_comment(self):
+        """Skipping leaves the student's unsubmitted draft comment on the submission (#2431).
+
+        Completing a quest publishes the draft comment, which is why marking a submission
+        completed clears it. Skipping publishes nothing, so clearing it would put the row beyond
+        reach and empty the student's comment box, even though a transferred quest can still be
+        commented on.
+        """
+        draft = Comment.objects.create_comment(
+            user=self.transfer_student, path=self.submission.get_absolute_url(),
+            text="half-written, not sent yet", target=None)
+        self.submission.draft_comment = draft
+        self.submission.save()
+        self.client.force_login(self.test_teacher)
+
+        self.client.post(reverse('quests:skip', args=[self.submission.pk]))
+
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.is_approved)
+        self.assertEqual(self.submission.draft_comment, draft)
+        self.assertEqual(self.submission.draft_comment.text, "half-written, not sent yet")
+
     def test_skip__grants_the_student_no_xp(self):
         """The point of skipping: the quest is approved, but its XP is not added to the student's total."""
         self.client.force_login(self.test_teacher)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2124,9 +2124,19 @@ def skip(request, submission_id):
         with transaction.atomic():
             discard_draft_question_submissions(submission)
 
+            draft_comment = submission.draft_comment
+
             # approve quest automatically, and mark as transfer.
             submission.mark_completed()
             submission.mark_approved(transfer=True)
+
+            # mark_completed() clears the draft comment because completing publishes it first.
+            # Skipping publishes nothing, so hand it back: a transferred quest can still be
+            # commented on, and the student keeps whatever they had typed (with anything attached
+            # to it) ready to post. This is how the staff skip button already leaves it (#2431).
+            if draft_comment:
+                submission.draft_comment = draft_comment
+                submission.save()
 
         messages.success(
             request, ("Transfer Successful.  No XP was granted for this quest.")

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1351,9 +1351,12 @@ class ApproveView(NonPublicOnlyViewMixin, View):
             )
             # Matches the skip view: waiving the quest drops the answers the student drafted but
             # never submitted, so they don't linger as rows nothing will ever show (#2164). The
-            # answers of any cycle they did submit stay published with their own comment.
-            discard_draft_question_submissions(self.submission)
-            self.submission.mark_approved(transfer=True)
+            # answers of any cycle they did submit stay published with their own comment. Both
+            # steps share a transaction so a failure in the approval (which also grants badges
+            # and recalculates XP) takes the deletion back with it.
+            with transaction.atomic():
+                discard_draft_question_submissions(self.submission)
+                self.submission.mark_approved(transfer=True)
 
         notification_kwargs.update({
             'verb': note_verb,
@@ -2115,11 +2118,15 @@ def skip(request, submission_id):
 
         # The quest is being waived, so any answers the student drafted will never be submitted
         # and nothing renders them; drop them rather than leave invisible rows behind (#2164).
-        discard_draft_question_submissions(submission)
+        # In one transaction with the approval that justifies it, so a failure part way through
+        # (marking approved also grants badges and recalculates XP) cannot leave the answers
+        # deleted on a submission that was never transferred.
+        with transaction.atomic():
+            discard_draft_question_submissions(submission)
 
-        # approve quest automatically, and mark as transfer.
-        submission.mark_completed()
-        submission.mark_approved(transfer=True)
+            # approve quest automatically, and mark as transfer.
+            submission.mark_completed()
+            submission.mark_approved(transfer=True)
 
         messages.success(
             request, ("Transfer Successful.  No XP was granted for this quest.")

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -32,7 +32,7 @@ from comments.sanitize import sanitize_comment_html
 from comments.utils import save_draft_attachments
 from questions.forms import QuestionSubmissionFormsetFactory
 from questions.models import QuestionSubmission, QuestionType
-from questions.utils import save_draft_file_answers, sync_draft_question_submissions
+from questions.utils import discard_draft_question_submissions, save_draft_file_answers, sync_draft_question_submissions
 from courses.models import Block, CourseStudent
 from library.utils import is_library_schema_requested, library_schema_if_requested
 from notifications.signals import notify
@@ -1349,6 +1349,10 @@ class ApproveView(NonPublicOnlyViewMixin, View):
             blank_comment_text = (
                 "<p>(Skipped - You were not granted XP for this quest)</p>"
             )
+            # Matches the skip view: waiving the quest drops the answers the student drafted but
+            # never submitted, so they don't linger as rows nothing will ever show (#2164). The
+            # answers of any cycle they did submit stay published with their own comment.
+            discard_draft_question_submissions(self.submission)
             self.submission.mark_approved(transfer=True)
 
         notification_kwargs.update({
@@ -2108,6 +2112,10 @@ def skip(request, submission_id):
         #     text=comment_text,
         #     target=submission,
         # )
+
+        # The quest is being waived, so any answers the student drafted will never be submitted
+        # and nothing renders them; drop them rather than leave invisible rows behind (#2164).
+        discard_draft_question_submissions(submission)
 
         # approve quest automatically, and mark as transfer.
         submission.mark_completed()

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -613,3 +613,74 @@ class CompleteSecurityTest(QuestionSubmissionFlowTestBase):
         self.assertRedirects(response, self.submission.get_absolute_url())
         self.submission.refresh_from_db()
         self.assertFalse(self.submission.is_completed)
+
+
+class SkipDiscardsDraftAnswersTest(QuestionSubmissionFlowTestBase):
+    """Skipping a submission clears the answers the student drafted but never submitted (#2164)."""
+
+    def draft_some_answers(self):
+        """Put content in the submission's draft answer rows, as autosaving a draft would."""
+        rows = list(sync_draft_question_submissions(self.submission))
+        for row in rows:
+            row.response_text = "drafted but never submitted"
+            row.save()
+        return rows
+
+    def draft_rows(self):
+        """The submission's unpublished draft answer rows."""
+        return QuestionSubmission.objects.filter(quest_submission=self.submission, comment__isnull=True)
+
+    def test_skip__discards_the_students_draft_answers(self):
+        """A student who is not earning XP skips their own in-progress submission, and their
+        drafted answers go with it.
+
+        Nothing renders unpublished answers, and a skipped submission is approved for good, so
+        rows left behind here would be permanently invisible data.
+        """
+        self.draft_some_answers()
+        self.assertEqual(self.draft_rows().count(), 2)
+        profile = self.test_student.profile
+        profile.not_earning_xp = True
+        profile.save()
+
+        response = self.client.post(reverse("quests:skip", args=[self.submission.id]))
+
+        self.assertRedirects(response, reverse("quests:quests"), fetch_redirect_response=False)
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.is_approved)
+        self.assertFalse(self.draft_rows().exists())
+
+    def test_skip__leaves_already_published_answers_alone(self):
+        """A teacher skipping a submission the student did complete keeps the published answers.
+
+        Those answers are part of the record of what was handed in, and they still display with
+        their comment; only unpublished drafts are discarded.
+        """
+        self.client.post(
+            reverse("quests:complete", args=[self.submission.id]),
+            data={"complete": True, "comment_text": "", **self.formset_data()})
+        published = QuestionSubmission.objects.filter(quest_submission=self.submission, comment__isnull=False)
+        self.assertEqual(published.count(), 2)
+        self.client.force_login(self.test_teacher)
+
+        self.client.post(reverse("quests:skip", args=[self.submission.id]))
+
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.do_not_grant_xp)
+        self.assertEqual(published.count(), 2)
+
+    def test_approve_skip_button__discards_the_students_draft_answers(self):
+        """A teacher skipping from the submission page discards the drafts too, so both skip
+        paths leave the same state behind."""
+        self.draft_some_answers()
+        self.assertEqual(self.draft_rows().count(), 2)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse("quests:approve", args=[self.submission.id]),
+            data={"skip_button": True, "comment_text": ""})
+
+        self.assertRedirects(response, reverse("quests:approvals"), fetch_redirect_response=False)
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.do_not_grant_xp)
+        self.assertFalse(self.draft_rows().exists())

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -619,7 +619,11 @@ class SkipDiscardsDraftAnswersTest(QuestionSubmissionFlowTestBase):
     """Skipping a submission clears the answers the student drafted but never submitted (#2164)."""
 
     def draft_some_answers(self):
-        """Put content in the submission's draft answer rows, as autosaving a draft would."""
+        """Put content in the submission's draft answer rows, as autosaving a draft would.
+
+        Returns:
+            list: the draft rows, each now carrying answer text.
+        """
         rows = list(sync_draft_question_submissions(self.submission))
         for row in rows:
             row.response_text = "drafted but never submitted"
@@ -627,7 +631,12 @@ class SkipDiscardsDraftAnswersTest(QuestionSubmissionFlowTestBase):
         return rows
 
     def draft_rows(self):
-        """The submission's unpublished draft answer rows."""
+        """The submission's unpublished draft answers.
+
+        Returns:
+            QuerySet: the submission's answer rows that have no comment, so the ones a skip
+            should discard.
+        """
         return QuestionSubmission.objects.filter(quest_submission=self.submission, comment__isnull=True)
 
     def test_skip__discards_the_students_draft_answers(self):
@@ -669,7 +678,7 @@ class SkipDiscardsDraftAnswersTest(QuestionSubmissionFlowTestBase):
         self.assertTrue(self.submission.do_not_grant_xp)
         self.assertEqual(published.count(), 2)
 
-    def test_approve_skip_button__discards_the_students_draft_answers(self):
+    def test_ApproveView__skip_button_discards_the_students_draft_answers(self):
         """A teacher skipping from the submission page discards the drafts too, so both skip
         paths leave the same state behind."""
         self.draft_some_answers()

--- a/src/questions/utils.py
+++ b/src/questions/utils.py
@@ -48,6 +48,29 @@ def save_draft_file_answers(question_formset, uploaded_files):
     return saved
 
 
+def discard_draft_question_submissions(quest_submission):
+    """Delete a submission's unpublished draft answer rows, and return how many were deleted.
+
+    Called when a submission is skipped (approved as a transfer): the student never submitted
+    this work and the quest is being waived, so nothing will ever publish those rows. Only
+    answers attached to a comment are rendered anywhere, so left alone the drafts would be
+    invisible and permanent (#2164).
+
+    Published rows are untouched, so a submission that was completed once, or returned and
+    re-drafted, keeps the answers it already published with their comments.
+
+    Args:
+        quest_submission: the QuestSubmission being skipped.
+
+    Returns:
+        int: how many draft rows were deleted.
+    """
+    deleted, _ = QuestionSubmission.objects.filter(
+        quest_submission=quest_submission, comment__isnull=True
+    ).delete()
+    return deleted
+
+
 def sync_draft_question_submissions(quest_submission):
     """Ensure exactly one draft answer row exists per current question of the submission's
     quest, and return the queryset of draft rows to build the answer formset from.


### PR DESCRIPTION
Closes #2164
Closes #2431

### What?

Skipping a submission (approving it as a transfer) now deals with the draft work the student never submitted, on both skip paths:

* the drafted **answers** are discarded, instead of being left on the submission forever;
* the drafted **comment** is kept, instead of being cut loose by the skip view.

Answers the student did submit stay published with their comment, untouched.

### Why?

**Answers (#2164).** `skip()` marked a submission completed and approved without doing anything about its draft answer rows, so they stayed `comment IS NULL, question IS NOT NULL` forever on a submission that is finished for good. Only published answers are ever rendered (`comment.question_submissions.all`), so those rows were invisible in every view: permanent dead data that grows with every skipped submission on a quest with questions.

Of the two options the issue lists, this takes the discard route rather than publishing the drafts to a skip comment:

* The skip view creates no comment at all, so publishing would mean inventing one, and the student never pressed submit. Showing their half-typed answers as though they had been handed in misrepresents what happened.
* On the `ApproveView` path the only comment available is the *teacher's* skip comment, so the student's drafts would render underneath the teacher's name.
* Discarding keeps both paths consistent, which is what the issue asks for.

**Comment (#2431).** The draft comment is the opposite case: it is still usable, because a transferred quest can still be commented on. The staff skip button already leaves it alone, so the student reopens the submission, finds their text in the comment box, and can post it. The skip view did not, because `mark_completed()` clears `draft_comment` (correct for a real completion, which publishes that comment first). After a skip nothing published it, so the row lost its last reference and became unreachable, and the student's box came up blank.

### How?

* `src/questions/utils.py`: `discard_draft_question_submissions(quest_submission)` deletes the submission's answer rows with no comment and returns the count, alongside the existing `sync_draft_question_submissions()`.
* `src/quest_manager/views.py`: `skip()` calls it before `mark_completed()`, then hands the draft comment back to the submission afterwards; the `skip_button` branch of `ApproveView.handle_form_button()` calls it before `mark_approved(transfer=True)` and needs no comment handling, since it never clears one.
* Each call site wraps the cleanup and the state change it belongs to in a single `transaction.atomic()` block (this project sets no `ATOMIC_REQUESTS`). Marking approved also grants badge assertions and recalculates XP, so a failure there would otherwise leave the answers deleted on a submission that was never transferred.

### Testing?

`quest_manager` + `questions` + `comments` all green (578 tests), `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` clean. `src/questions/utils.py` and `src/quest_manager/views.py` both 100% including branches.

Every behaviour test below fails on `develop` without its fix:

* `questions/tests/test_integration.py`, new `SkipDiscardsDraftAnswersTest`: a not-earning-XP student skipping their own in-progress submission leaves no draft answers behind; a teacher skipping a submission that was completed keeps its published answers; the staff skip button discards the drafts too, so both paths leave the same state.
* `quest_manager/tests/test_views.py`, in `SkipQuestViewTests`: skipping keeps the student's draft comment on the submission, text intact.

### Screenshots (if front end is affected)

N/A: no template changes. Nothing that was visible changes; the answer rows this discards were never rendered anywhere, and the draft comment it keeps is what the comment box already shows on the staff skip path.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)