### PR TITLE
feat: count the deck's students across every open semester (#2157 Phase 3)

### DIFF
--- a/src/announcements/tasks.py
+++ b/src/announcements/tasks.py
@@ -23,7 +23,7 @@ User = get_user_model()
 def send_notifications(user_id, announcement_id):
     announcement = get_object_or_404(Announcement, pk=announcement_id)
     sending_user = User.objects.get(id=user_id)
-    affected_users = CourseStudent.objects.all_users_for_active_semester()
+    affected_users = CourseStudent.objects.all_users_in_open_semesters()
     notify.send(
         sending_user,
         # action=new_announcement,

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -269,7 +269,7 @@ class Badge(IsAPrereqMixin, HasPrereqsMixin, TagsModelMixin, models.Model):
 
         # students_only=True: the grant-check is for students, so exclude staff/test accounts that
         # happen to be enrolled in a course (issue #2061). The grant task filters the same way.
-        students = CourseStudent.objects.all_users_for_active_semester(students_only=True)
+        students = CourseStudent.objects.all_users_in_open_semesters(students_only=True)
         return [user for user in students if self.student_qualifies_ungranted(user)]
 
     def get_icon_url(self):
@@ -388,7 +388,7 @@ class BadgeAssertionManager(models.Manager):
         """
         from profile_manager.models import Profile
         if active_semester_only:
-            users = User.objects.filter(profile__in=Profile.objects.all_for_active_semester())
+            users = User.objects.filter(profile__in=Profile.objects.all_in_open_semesters())
         else:
             users = User.objects.filter(profile__in=Profile.objects.all_students())
 

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -381,13 +381,21 @@ class BadgeAssertionManager(models.Manager):
     def all_for_user_badge(self, user, badge, active_semester_only):
         return self.get_queryset(active_semester_only, user=user).get_user(user).get_badge(badge)
 
-    def user_badge_assertion_count(self, badge, active_semester_only=False):
-        """Returns a queryset of users with each user's number of assertions of `badge` annotated as assertion_count.
-        If active_semester_only is True, only users with active profiles in the active semester will be returned.
-        Otherwise, all users with active profiles will be returned.
+    def user_badge_assertion_count(self, badge, current_students_only=False):
+        """Users with their number of assertions of `badge` annotated as assertion_count.
+
+        Args:
+            badge: the Badge being counted.
+            current_students_only (bool): limit to students taking a course right now, in
+                any semester that is open. Otherwise every student with an active profile
+                is counted, including those from past semesters.
+
+        Returns:
+            QuerySet[User]: the users who hold at least one assertion of the badge, most
+            assertions first, each annotated with assertion_count.
         """
         from profile_manager.models import Profile
-        if active_semester_only:
+        if current_students_only:
             users = User.objects.filter(profile__in=Profile.objects.all_in_open_semesters())
         else:
             users = User.objects.filter(profile__in=Profile.objects.all_students())

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.validators import validate_comma_separated_integer_list
-from django.db import models, transaction
+from django.db import connection, models, transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.urls import reverse
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 import numpy
 from colorful.fields import RGBColorField
+from django_tenants.utils import get_public_schema_name
 
 from prerequisites.models import IsAPrereqMixin
 from quest_manager.models import QuestSubmission
@@ -504,10 +505,24 @@ class Semester(models.Model):
         Profile.objects.bulk_update(profiles, ['xp_cached'])
 
     def get_student_mark_list(self, students_only=False):
+        """The cached mark of every student registered in this semester.
+
+        Read from this semester's own registrations, so a mark distribution describes the
+        semester it is drawn for even when another one is open alongside it.
+
+        Args:
+            students_only (bool): leave out staff and test accounts.
+
+        Returns:
+            list: each registered student's mark_cached, including None for the unmarked.
+        """
         # select_related the profile since we read profile.mark_cached for every
         # student below; without it that is a query per student.
-        students = CourseStudent.objects.all_users_for_active_semester(
-            students_only=students_only
+        students = User.objects.filter(
+            id__in=CourseStudent.objects.all_for_semester(
+                self, students_only=students_only,
+            ).values_list('user', flat=True),
+            is_active=True,
         ).select_related('profile')
         mark_list = []
         for student in students:
@@ -724,22 +739,32 @@ class CourseStudentManager(models.Manager):
             return registration.semester
         return SiteConfig.get().open_semester
 
-    def all_users_for_active_semester(self, students_only=False, active_only=False):
-        """
-        :return: queryset of all Users who are enrolled in a course during the active semester (doubles removed)
+    def all_users_in_open_semesters(self, students_only=False, active_only=False):
+        """Every user registered in a course in a semester that is open right now.
 
-        active_only limits enrollment to registrations still active, so a closed
-        (e.g. suspension-closed) semester contributes no users.
+        The deck's roster is the union across its open semesters rather than the contents of
+        one of them (issue #2157 Phase 3): with two cohorts running on different calendars,
+        both are equally current, and a student appears once however many courses they hold.
+
+        Args:
+            students_only (bool): leave out staff and test accounts.
+            active_only (bool): leave out registrations that are no longer active, so a
+                semester closed by a suspension contributes no users.
+
+        Returns:
+            QuerySet[User]: the matching active users, without duplicates.
         """
-        try:
-            courses = self.all_for_semester(SiteConfig.get().open_semester, students_only=students_only, active_only=active_only)
-            user_list = courses.values_list('user', flat=True)
-            user_list = set(user_list)  # removes doubles
-            return User.objects.filter(id__in=user_list, is_active=True)
-        except AttributeError:
-            # The code will run on the public tenant when booting up, throwing an exception because
-            # the public tenant doesn't have a SiteConfig object.
+        if connection.schema_name == get_public_schema_name():
+            # the public tenant has no courses tables to read: this runs there while booting
             return User.objects.none()
+
+        courses = self.get_queryset().filter(semester__status=Semester.Status.OPEN)
+        if students_only:
+            courses = courses.get_students_only()
+        if active_only:
+            courses = courses.filter(active=True)
+        user_list = set(courses.values_list('user', flat=True))  # a set removes doubles
+        return User.objects.filter(id__in=user_list, is_active=True)
 
     # @cached(60*60*12)
     def get_current_teacher_list(self, user):

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -686,15 +686,20 @@ class CourseStudentManager(models.Manager):
                 coursestudent.active = False
                 coursestudent.save()
 
-    def all_for_semester(self, semester, students_only=False, active_only=False):
-        """All registrations for `semester`; optionally students only, and
-        optionally only registrations still active (a closed semester deactivates
-        its registrations, so active_only excludes them: #1734 redesign B2)."""
+    def all_for_semester(self, semester, students_only=False):
+        """The registrations in one particular semester.
+
+        Args:
+            semester: the Semester wanted, or None for no semester at all.
+            students_only (bool): leave out staff and test accounts.
+
+        Returns:
+            CourseStudentQuerySet: that semester's registrations, active or not. The
+            roster of the deck as a whole is all_users_in_open_semesters() instead.
+        """
         qs = self.get_queryset().get_semester(semester)
         if students_only:
             qs = qs.get_students_only()
-        if active_only:
-            qs = qs.filter(active=True)
         return qs
 
     # pick one of the courses...for now
@@ -763,8 +768,12 @@ class CourseStudentManager(models.Manager):
             courses = courses.get_students_only()
         if active_only:
             courses = courses.filter(active=True)
-        user_list = set(courses.values_list('user', flat=True))  # a set removes doubles
-        return User.objects.filter(id__in=user_list, is_active=True)
+        # the registrations stay a subquery rather than a set of ids read into python: the
+        # callers that only count the roster then never load it. IN (subquery) yields each
+        # user once, so a student in several courses is still one user
+        return User.objects.filter(
+            id__in=courses.values_list('user_id', flat=True), is_active=True,
+        )
 
     # @cached(60*60*12)
     def get_current_teacher_list(self, user):

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.db.models import ProtectedError
 
+from django_tenants.utils import get_public_schema_name
 from freezegun import freeze_time
 from unittest.mock import patch
 from model_bakery import baker
@@ -535,12 +536,12 @@ class NoOpenSemesterTest(ByteDeckTenantTestCase):
         self.assertFalse(CourseStudent.objects.current_courses(self.student).exists())
         self.assertIsNone(CourseStudent.objects.current_course(self.student))
 
-    def test_all_users_for_active_semester__is_empty(self):
+    def test_all_users_in_open_semesters__is_empty(self):
         """No user is in the active semester, so staff lists and task recipients come back
         empty instead of picking up registrations whose semester was deleted."""
         orphaned = baker.make(CourseStudent, user=baker.make(User), semester=None)
 
-        users = CourseStudent.objects.all_users_for_active_semester()
+        users = CourseStudent.objects.all_users_in_open_semesters()
 
         self.assertFalse(users.exists())
         self.assertNotIn(orphaned.user, users)
@@ -770,23 +771,49 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         self.assertRaises(ValueError, CourseStudent.objects.calc_semester_grades,
                           Semester.objects.get_current())
 
-    def test_all_users_for_active_semester__returns_empty_on_attribute_error(self):
-        """On the public tenant there is no SiteConfig, so resolving the active semester raises
-        AttributeError; the manager swallows it and returns an empty queryset instead of crashing."""
-        with patch('courses.models.SiteConfig.get', side_effect=AttributeError):
-            result = CourseStudent.objects.all_users_for_active_semester()
+    def test_all_users_in_open_semesters__is_empty_on_the_public_schema(self):
+        """The public tenant has no courses tables, and this runs there while booting, so it
+        returns an empty queryset rather than querying a table that isn't there."""
+        with patch('courses.models.connection') as mock_connection:
+            mock_connection.schema_name = get_public_schema_name()
+            result = CourseStudent.objects.all_users_in_open_semesters()
         self.assertEqual(result.count(), 0)
 
-    def test_all_users_for_active_semester__excludes_inactive(self):
-        """all_users_for_active_semester() counts active-semester students, excluding inactive users."""
-        # There should be 1 student in the active semester
-        self.assertEqual(CourseStudent.objects.all_users_for_active_semester().count(), 1)
+    def test_all_users_in_open_semesters__excludes_inactive(self):
+        """The deck's roster counts students in an open semester, leaving out inactive users."""
+        # There should be 1 student in the open semester
+        self.assertEqual(CourseStudent.objects.all_users_in_open_semesters().count(), 1)
 
-        # Makef the student inactiveo
+        # Make the student inactive
         self.student.is_active = False
         self.student.save()
 
-        self.assertEqual(CourseStudent.objects.all_users_for_active_semester(students_only=True).count(), 0)
+        self.assertEqual(CourseStudent.objects.all_users_in_open_semesters(students_only=True).count(), 0)
+
+    def test_all_users_in_open_semesters__spans_every_open_semester(self):
+        """Two cohorts on different calendars are both current, so the deck's roster is the
+        union of them rather than whichever one the deck's pointer names (issue #2157 Phase 3)."""
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        other_student = baker.make(User)
+        baker.make(CourseStudent, user=other_student, course=baker.make(Course), semester=other_semester)
+
+        users = CourseStudent.objects.all_users_in_open_semesters()
+
+        self.assertIn(self.student, users)
+        self.assertIn(other_student, users)
+
+    def test_all_users_in_open_semesters__counts_a_student_in_two_courses_once(self):
+        """A student registered in several courses within their semester is one user, not one
+        per registration."""
+        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=SiteConfig.get().active_semester)
+
+        self.assertEqual(CourseStudent.objects.all_users_in_open_semesters().count(), 1)
+
+    def test_all_users_in_open_semesters__leaves_out_archived_semesters(self):
+        """Archiving a semester takes its students off the roster: that is what frees seats."""
+        Semester.objects.complete_active_semester()
+
+        self.assertEqual(CourseStudent.objects.all_users_in_open_semesters().count(), 0)
 
 
 class CourseStudentModelTest(ByteDeckTenantTestCase):

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1607,6 +1607,27 @@ class TestAjax_MarkDistributionChart(ByteDeckTenantTestCase):
         # Charting against the whole deck instead would add the other cohort's 7 as well.
         self.assertEqual(sum(json_response['data']['students']), len(cohort))
 
+    def test_histogram_values__unmarked_classmate_does_not_break_the_chart(self):
+        """A classmate who has never had a mark calculated has mark_cached None, and numpy
+        can't clip None against a number, so leaving it in returned a 500 to everyone in
+        that semester. Unmarked classmates are left out of the distribution instead."""
+        marked = self.create_student_course(100)
+        marked.user.profile.mark_cached = 60
+        marked.user.profile.save()
+        unmarked = self.create_student_course(50)
+        unmarked.user.profile.mark_cached = None
+        unmarked.user.profile.save()
+
+        self.client.force_login(self.teacher)
+        response = self.client.get(
+            reverse('courses:mark_distribution_chart', args=[marked.user.id]),
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        # the marked student's own bar; the unmarked classmate contributes nothing
+        self.assertEqual(sum(json.loads(response.content)['data']['students']), 1)
+
     def test_histogram_values__empty_class_between_semesters(self):
         """Between semesters an unregistered viewer has no semester at all to be charted
         against, so there are no classmates rather than a crash on the missing semester."""

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1520,16 +1520,16 @@ class TestAjax_MarkDistributionChart(ByteDeckTenantTestCase):
         self.create_student_course(50)
         self.create_student_course(60)
         # warm SiteConfig/content-type caches so only the student marks matter
-        Semester.get_student_mark_list(Semester, students_only=True)
+        self.semester.get_student_mark_list(students_only=True)
 
         with CaptureQueriesContext(connection) as few_queries:
-            Semester.get_student_mark_list(Semester, students_only=True)
+            self.semester.get_student_mark_list(students_only=True)
 
         for _ in range(4):
             self.create_student_course(70)
 
         with CaptureQueriesContext(connection) as many_queries:
-            Semester.get_student_mark_list(Semester, students_only=True)
+            self.semester.get_student_mark_list(students_only=True)
 
         # without select_related('profile') each extra student adds a query
         self.assertEqual(len(many_queries.captured_queries), len(few_queries.captured_queries))
@@ -1583,6 +1583,46 @@ class TestAjax_MarkDistributionChart(ByteDeckTenantTestCase):
         total_students = sum(json_response['data']['students'])
         self.assertNotEqual(total_students, len(inactive_sem_students))
         self.assertEqual(total_students, len(active_sem_students))
+
+    def test_histogram_values__compare_against_the_students_own_semester(self):
+        """A student is charted against their own classmates rather than every current
+        student on the deck (issue #2157 Phase 3), so two cohorts on different calendars
+        each see their own distribution."""
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        [self.create_student_course(100) for _ in range(7)]  # the deck's other cohort
+        cohort = [self.create_student_course(100) for _ in range(3)]
+        for course_student in cohort:
+            course_student.semester = other_semester
+            course_student.save()
+
+        self.client.force_login(self.teacher)
+        response = self.client.get(
+            reverse('courses:mark_distribution_chart', args=[cohort[0].user.id]),
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        json_response = json.loads(response.content)
+        # their 2 classmates plus their own bar, which is added back into this histogram.
+        # Charting against the whole deck instead would add the other cohort's 7 as well.
+        self.assertEqual(sum(json_response['data']['students']), len(cohort))
+
+    def test_histogram_values__empty_class_between_semesters(self):
+        """Between semesters an unregistered viewer has no semester at all to be charted
+        against, so there are no classmates rather than a crash on the missing semester."""
+        self.create_student_course(100)
+        stranger = baker.make(User)
+        Semester.objects.complete_active_semester()
+
+        self.client.force_login(self.teacher)
+        response = self.client.get(
+            reverse('courses:mark_distribution_chart', args=[stranger.id]),
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        # only the viewer's own bar, which is always added into this histogram
+        self.assertEqual(sum(json.loads(response.content)['data']['students']), 1)
 
     def test_histogram_values__exclude_test_users(self):
         """ test users should not show up in histogram values """

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -1019,13 +1019,13 @@ class Ajax_MarkDistributionChart(NonPublicOnlyViewMixin, LoginRequiredMixin, Vie
         # grab dataset
         user_mark = self.user.profile.mark_cached or 0  # can be nonetype
         semester = semester_for(self.user)
-        if semester is None:
-            return min(user_mark, 100), numpy.clip([], 0, 100)
-
-        student_marks = semester.get_student_mark_list(students_only=True)
+        student_marks = semester.get_student_mark_list(students_only=True) if semester else []
+        # a student whose mark has never been calculated has mark_cached None, which has no
+        # place on a distribution and which numpy can't clip against a number
+        student_marks = [mark for mark in student_marks if mark is not None]
         # the user's own mark is drawn in the other histogram, so take it out of this one.
-        # Only when it is actually there: an unmarked student's mark_cached is None while
-        # user_mark reads 0, and remove() raises on a value the list doesn't hold.
+        # Only when it is there: theirs may be one of the Nones just dropped, and remove()
+        # raises on a value the list doesn't hold.
         if user_mark in student_marks:
             student_marks.remove(user_mark)
 

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -28,7 +28,7 @@ from tenant.views import NonPublicOnlyViewMixin, non_public_only_view
 from djcytoscape.views import UpdateMapMessageMixin
 
 from .forms import BlockForm, CourseStudentForm, CourseStudentStaffForm, MarkRangeForm, SemesterForm, ExcludedDateFormset, ExcludedDateFormsetHelper
-from .models import Block, Course, CourseStudent, Rank, Semester, MarkRange
+from .models import Block, Course, CourseStudent, Rank, Semester, MarkRange, semester_for
 
 from django.db import transaction
 from django.db.models import ProtectedError, Q
@@ -1008,14 +1008,25 @@ class Ajax_MarkDistributionChart(NonPublicOnlyViewMixin, LoginRequiredMixin, Vie
     def get_datasets(self):
         """query datasets for both histograms ( marks over 100% will be capped at 100% )
 
+        The comparison group is this student's own semester, so a deck running two cohorts
+        on different calendars shows each of them their own classmates' marks rather than
+        both cohorts mixed together.
+
         Returns:
-            tuple[int, list[ints]]: queried user's mark and all students in active semester's mark
+            tuple[int, list[ints]]: queried user's mark, and the marks of the other students
+            in their semester (empty when they are in none).
         """
         # grab dataset
         user_mark = self.user.profile.mark_cached or 0  # can be nonetype
-        student_marks = Semester.get_student_mark_list(Semester, students_only=True)
-        # only remove user's mark from student_marks if user is part of active sem
-        if CourseStudent.objects.all_users_for_active_semester(students_only=True).filter(id=self.user.id).exists():
+        semester = semester_for(self.user)
+        if semester is None:
+            return min(user_mark, 100), numpy.clip([], 0, 100)
+
+        student_marks = semester.get_student_mark_list(students_only=True)
+        # the user's own mark is drawn in the other histogram, so take it out of this one.
+        # Only when it is actually there: an unmarked student's mark_cached is None while
+        # user_mark reads 0, and remove() raises on a value the list doesn't hold.
+        if user_mark in student_marks:
             student_marks.remove(user_mark)
 
         # limit marks, so marks > 100 can show on histogram

--- a/src/prerequisites/tasks.py
+++ b/src/prerequisites/tasks.py
@@ -64,7 +64,7 @@ def update_conditions_for_quest(self, quest_id, start_from_user_id):
     if quest.available_outside_course:
         users = User.objects.all()
     else:
-        users = CourseStudent.objects.all_users_for_active_semester()
+        users = CourseStudent.objects.all_users_in_open_semesters()
 
     users = users.order_by('id').filter(id__gte=start_from_user_id)[:settings.CELERY_TASKS_BUNCH_SIZE]
     user = None
@@ -144,7 +144,7 @@ def grant_badge_assertions_for_badge(self, badge_id, start_from_user_id):
 
     # students_only=True to match the grant-check preview (Badge.students_who_qualify_ungranted):
     # the grant is for students, so staff/test accounts enrolled in a course are excluded (#2061).
-    users = CourseStudent.objects.all_users_for_active_semester(students_only=True)
+    users = CourseStudent.objects.all_users_in_open_semesters(students_only=True)
     users = users.order_by('id').filter(id__gte=start_from_user_id)[:settings.CELERY_TASKS_BUNCH_SIZE]
 
     user = None
@@ -210,7 +210,7 @@ def update_quest_conditions_all_users(self, start_from_user_id):
     cache.set('update_conditions_all_task_waiting', True, settings.CONDITIONS_UPDATE_COUNTDOWN)
 
     # only cycle through users currently in a course
-    users = CourseStudent.objects.all_users_for_active_semester()
+    users = CourseStudent.objects.all_users_in_open_semesters()
     users = users.order_by('id').filter(id__gte=start_from_user_id)
 
     users = list(users.values_list('id', flat=True)[:settings.CELERY_TASKS_BUNCH_SIZE])  # noqa

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -55,9 +55,14 @@ class ProfileManager(models.Manager):
     def all_students(self):
         return self.get_queryset().students_only()
 
-    def all_for_active_semester(self):
-        """:return: a queryset of student profiles with a course this semester"""
-        courses_user_list = CourseStudent.objects.all_users_for_active_semester()
+    def all_in_open_semesters(self):
+        """Student profiles for everyone currently taking a course.
+
+        Returns:
+            QuerySet[Profile]: the profiles of active students registered in any semester
+            that is open right now, across all of them when several are.
+        """
+        courses_user_list = CourseStudent.objects.all_users_in_open_semesters()
         qs = self.all_students().filter(user__in=courses_user_list, user__is_active=True)
         return qs
 
@@ -86,7 +91,7 @@ class ProfileManager(models.Manager):
         verified_emails = models.Q(emailaddress__verified=True, emailaddress__primary=True, emailaddress__email__iexact=models.F('email'))
 
         students_to_email = (
-            CourseStudent.objects.all_users_for_active_semester()
+            CourseStudent.objects.all_users_in_open_semesters()
                                  .filter(verified_emails)
                                  .exclude(empty_emails)
                                  .filter(email_filter)

--- a/src/profile_manager/tasks.py
+++ b/src/profile_manager/tasks.py
@@ -29,7 +29,7 @@ def invalidate_profile_xp_cache_on_schema():
     DB error while saving) is logged and skipped rather than aborting the whole
     schema's refresh, so a single bad row can't leave every later profile stale.
     """
-    profiles_qs = Profile.objects.all_for_active_semester()
+    profiles_qs = Profile.objects.all_in_open_semesters()
 
     invalidated = 0
     failed = 0

--- a/src/profile_manager/tests/test_managers.py
+++ b/src/profile_manager/tests/test_managers.py
@@ -50,9 +50,9 @@ class ProfileManagerTest(ByteDeckTenantTestCase):
                 semester=cls.active_semester
             )
 
-    def test_all_for_active_semester__returns_active_students(self):
-        """all_for_active_semester() returns only active students registered in the active semester."""
-        qs = Profile.objects.all_for_active_semester().values_list('user__username', flat=True)
+    def test_all_in_open_semesters__returns_active_students(self):
+        """all_in_open_semesters() returns only active students registered in the active semester."""
+        qs = Profile.objects.all_in_open_semesters().values_list('user__username', flat=True)
         expected_qs = self.active_active_semester_students
         expected_qs = [user.username for user in expected_qs]
 

--- a/src/profile_manager/tests/test_managers.py
+++ b/src/profile_manager/tests/test_managers.py
@@ -6,7 +6,7 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
 from profile_manager.models import Profile
 from siteconfig.models import SiteConfig
-from courses.models import CourseStudent, Course
+from courses.models import CourseStudent, Course, Semester
 
 User = get_user_model()
 
@@ -51,12 +51,25 @@ class ProfileManagerTest(ByteDeckTenantTestCase):
             )
 
     def test_all_in_open_semesters__returns_active_students(self):
-        """all_in_open_semesters() returns only active students registered in the active semester."""
+        """all_in_open_semesters() returns only active students registered in an open semester."""
         qs = Profile.objects.all_in_open_semesters().values_list('user__username', flat=True)
         expected_qs = self.active_active_semester_students
         expected_qs = [user.username for user in expected_qs]
 
         self.assertEqual(set(qs), set(expected_qs))
+
+    def test_all_in_open_semesters__includes_a_second_open_semester(self):
+        """A student in another open semester is taking a course too, so they belong in the
+        current-students list rather than only the cohort the deck's pointer names."""
+        other_student = baker.make(User, username='second_cohort')
+        baker.make(
+            CourseStudent, user=other_student, course=self.course,
+            semester=baker.make(Semester, status=Semester.Status.OPEN),
+        )
+
+        usernames = Profile.objects.all_in_open_semesters().values_list('user__username', flat=True)
+
+        self.assertIn('second_cohort', usernames)
 
     def test_all_active__returns_active_users(self):
         """all_active() returns every active user, including staff, regardless of semester."""

--- a/src/profile_manager/tests/test_tasks.py
+++ b/src/profile_manager/tests/test_tasks.py
@@ -52,7 +52,7 @@ class ProfleTasksTests(ByteDeckTenantTestCase):
         # Run the task for recalculating the current xp
         invalidate_profile_xp_cache_in_all_schemas.apply()
 
-        for profile in Profile.objects.all_for_active_semester():
+        for profile in Profile.objects.all_in_open_semesters():
             self.assertEqual(profile.xp_cached, 0)
             self.assertEqual(profile.mark_cached, 0)
 

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from django_tenants.utils import get_public_schema_name, schema_context
 from model_bakery import baker
 
-from courses.models import Block, CourseStudent
+from courses.models import Block, CourseStudent, Semester
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from notifications.models import Notification
 from siteconfig.models import SiteConfig
@@ -608,8 +608,42 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('profiles:profile_list_block', args=[testblock.pk]))
         testblock_queryset = response.context['object_list']
         self.assertEqual(testblock_queryset.count(), 2)
-        # queryset specifications: profile objects that are: part of active semester, a part of a coursestudent object that's in the desired block
-        self.assertQuerySetEqual(testblock_queryset, Profile.objects.all_in_open_semesters().filter(user__coursestudent__block=testblock))
+        # queryset specifications: profile objects that are: in an open semester, and a part of a coursestudent object that's in the desired block
+        self.assertQuerySetEqual(
+            testblock_queryset,
+            Profile.objects.filter(user__in=[cs.user for cs in CourseStudent.objects.filter(block=testblock, semester=self.active_sem)]),
+            ordered=False,
+        )
+
+    def test_profile_list_block__block_and_semester_match_the_same_registration(self):
+        """A student currently taking a course, whose registration in *this* block was in a
+        semester that has since been archived, is not in this block now. Matching the block
+        and the open semester on separate registrations would list them anyway."""
+        self.client.force_login(self.test_teacher)
+        testblock = baker.make(Block)
+        student = baker.make(get_user_model())
+        # in this block last year...
+        baker.make(CourseStudent, user=student, block=testblock, semester=baker.make(Semester, status=Semester.Status.ARCHIVED))
+        # ...and taking a course now, in a different block
+        baker.make(CourseStudent, user=student, block=baker.make(Block), semester=self.active_sem)
+
+        response = self.client.get(reverse('profiles:profile_list_block', args=[testblock.pk]))
+
+        self.assertNotIn(student.profile, response.context['object_list'])
+
+    def test_profile_list_block__spans_every_open_semester(self):
+        """A block can hold students from more than one open semester once a deck runs two
+        cohorts, and the list shows all of them."""
+        self.client.force_login(self.test_teacher)
+        testblock = baker.make(Block)
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        here_now = baker.make(CourseStudent, user=baker.make(get_user_model()), block=testblock, semester=self.active_sem)
+        other_cohort = baker.make(CourseStudent, user=baker.make(get_user_model()), block=testblock, semester=other_semester)
+
+        response = self.client.get(reverse('profiles:profile_list_block', args=[testblock.pk]))
+
+        self.assertIn(here_now.user.profile, response.context['object_list'])
+        self.assertIn(other_cohort.user.profile, response.context['object_list'])
 
     def test_profile_update__email_confirmation_flow(self):
         """

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -210,12 +210,12 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         rather than looping over every active-semester profile synchronously in the request,
         which had grown a web worker large enough to be OOM-killed (issue #2081).
         """
-        # a student registered in the active semester so all_for_active_semester() is non-empty
+        # a student registered in the active semester so all_in_open_semesters() is non-empty
         baker.make(
             'courses.CourseStudent', user=self.test_student1,
             semester=self.active_sem, course=baker.make('courses.Course'),
         )
-        self.assertTrue(Profile.objects.all_for_active_semester().exists())
+        self.assertTrue(Profile.objects.all_in_open_semesters().exists())
         self.client.force_login(self.test_teacher)
 
         # The view must NOT recompute in-request; it must dispatch the celery task instead.
@@ -609,7 +609,7 @@ class ProfileViewTests(ByteDeckTenantTestCase):
         testblock_queryset = response.context['object_list']
         self.assertEqual(testblock_queryset.count(), 2)
         # queryset specifications: profile objects that are: part of active semester, a part of a coursestudent object that's in the desired block
-        self.assertQuerySetEqual(testblock_queryset, Profile.objects.all_for_active_semester().filter(user__coursestudent__block=testblock))
+        self.assertQuerySetEqual(testblock_queryset, Profile.objects.all_in_open_semesters().filter(user__coursestudent__block=testblock))
 
     def test_profile_update__email_confirmation_flow(self):
         """

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -108,7 +108,7 @@ class ProfileListCurrent(ProfileList):
         return self.request.user.is_authenticated
 
     def get_queryset(self):
-        profiles_qs = Profile.objects.all_for_active_semester()
+        profiles_qs = Profile.objects.all_in_open_semesters()
         return self.queryset_append(profiles_qs)
 
 
@@ -123,7 +123,7 @@ class ProfileListBlock(ProfileList):
         block_pk = self.kwargs['pk']
         self.block_object = get_object_or_404(Block, pk=block_pk)
         # queryset specifications: profile objects that are: part of active semester, a part of a coursestudent object that's in the desired block
-        profiles_qs = Profile.objects.all_for_active_semester().filter(user__coursestudent__block=self.block_object)
+        profiles_qs = Profile.objects.all_in_open_semesters().filter(user__coursestudent__block=self.block_object)
         return self.queryset_append(profiles_qs)
 
     def get_context_data(self, **kwargs):
@@ -499,7 +499,7 @@ def recalculate_current_xp(request):
     # Recalculating XP for every current student invalidates and recomputes a cache per
     # profile; on a busy deck that is hundreds of profiles in one request, which has grown a
     # uwsgi worker large enough to get OOM-killed and time out the page (issue #2081). Hand it
-    # to the existing background task instead -- it does the same all_for_active_semester()
+    # to the existing background task instead -- it does the same all_in_open_semesters()
     # recompute (with per-profile error handling) and, dispatched from this request, runs in
     # this tenant's schema via tenant-schemas-celery.
     invalidate_profile_xp_cache_on_schema.apply_async(queue='default')

--- a/src/profile_manager/views.py
+++ b/src/profile_manager/views.py
@@ -21,7 +21,7 @@ from .models import Profile
 from .forms import ProfileForm, UserForm
 from .tasks import invalidate_profile_xp_cache_on_schema
 from badges.models import BadgeAssertion
-from courses.models import CourseStudent, Block
+from courses.models import CourseStudent, Block, Semester
 from notifications.signals import notify
 from quest_manager.models import QuestSubmission
 from tags.models import get_user_tags_and_xp
@@ -119,11 +119,22 @@ class ProfileListBlock(ProfileList):
     block_object = None
 
     def get_queryset(self):
-        """block object is queried via pk kwarg in request from block list view, then a queryset of profiles is generated via relatedmanager"""
+        """The profiles of the students currently in this block.
+
+        The block and the semester have to be matched on the same registration: filtering
+        profiles by block separately would also list a student who is in an open semester
+        for one course and in this block only through an archived one.
+
+        Returns:
+            QuerySet[Profile]: the student profiles registered in this block in a semester
+            that is open right now, each appearing once.
+        """
         block_pk = self.kwargs['pk']
         self.block_object = get_object_or_404(Block, pk=block_pk)
-        # queryset specifications: profile objects that are: part of active semester, a part of a coursestudent object that's in the desired block
-        profiles_qs = Profile.objects.all_in_open_semesters().filter(user__coursestudent__block=self.block_object)
+        registered_in_block = CourseStudent.objects.filter(
+            block=self.block_object, semester__status=Semester.Status.OPEN,
+        ).values_list('user_id', flat=True)
+        profiles_qs = Profile.objects.all_in_open_semesters().filter(user_id__in=registered_in_block)
         return self.queryset_append(profiles_qs)
 
     def get_context_data(self, **kwargs):

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1134,7 +1134,7 @@ def quest_user_status(request, quest_id):
     active_profiles = list(Profile.objects.all_active().students_only().select_related('user'))
     active_ids = {profile.user_id for profile in active_profiles}
     current_ids = set(
-        CourseStudent.objects.all_users_for_active_semester(students_only=True).values_list('id', flat=True)
+        CourseStudent.objects.all_users_in_open_semesters(students_only=True).values_list('id', flat=True)
     ) & active_ids
     my_block_ids = set(
         CourseStudent.objects.get_queryset().get_semester(active_semester).filter(

--- a/src/tenant/limits.py
+++ b/src/tenant/limits.py
@@ -30,8 +30,8 @@ def can_add_current_student(user):
     * the deck's cap is unlimited (-1, admin-set);
     * the user never counts toward the cap -- staff, superusers, and test
       accounts (current-students-only counting, maintainer decision on #2047);
-    * the user is already current (registered this semester, e.g. joining a
-      second course) -- that's not a new seat;
+    * the user is already current (registered in the semester they are taking a
+      course in, e.g. joining a second course) -- that's not a new seat;
     * the live current-student count is below the effective cap.
 
     Refused only when granting a brand-new seat would exceed the cap.

--- a/src/tenant/limits.py
+++ b/src/tenant/limits.py
@@ -19,8 +19,6 @@ current, so they recount LIVE to avoid racing the cache.
 """
 from django.apps import apps
 
-from siteconfig.models import SiteConfig
-
 from tenant.utils import get_current_deck
 
 
@@ -56,11 +54,9 @@ def can_add_current_student(user):
         return True
 
     CourseStudent = apps.get_model('courses', 'CourseStudent')
-    # all_for_user_semester() is empty when no semester is open, so nobody holds a seat then
-    already_current = CourseStudent.objects.all_for_user_semester(
-        user, SiteConfig.get().open_semester
-    ).get_active().exists()
-    if already_current:
+    # someone already holding a seat keeps it when they add another course. current_courses()
+    # is empty when they are in no open semester, so nobody holds a seat between semesters
+    if CourseStudent.objects.current_courses(user).get_active().exists():
         return True
 
     return deck.get_active_user_count() < cap

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -669,6 +669,12 @@ class Tenant(TenantMixin):
         active_only=True further excludes registrations deactivated by a semester
         close (e.g. the suspension auto-close, #1734 redesign B2), so a closed
         semester contributes zero current students.
+
+        The count spans every semester that is open, so a deck running two cohorts on
+        different calendars pays for both (issue #2157 Phase 3).
+
+        Returns:
+            int: how many distinct current students the deck has.
         """
         CourseStudent = apps.get_model('courses', 'CourseStudent')
         return (

--- a/src/tenant/models.py
+++ b/src/tenant/models.py
@@ -672,7 +672,7 @@ class Tenant(TenantMixin):
         """
         CourseStudent = apps.get_model('courses', 'CourseStudent')
         return (
-            CourseStudent.objects.all_users_for_active_semester(students_only=True, active_only=True)
+            CourseStudent.objects.all_users_in_open_semesters(students_only=True, active_only=True)
             .exclude(is_superuser=True)
             .count()
         )

--- a/src/tenant/tests/test_limits.py
+++ b/src/tenant/tests/test_limits.py
@@ -58,6 +58,18 @@ class CanAddCurrentStudentTest(ByteDeckTenantTestCase):
         self.assertTrue(can_add_current_student(baker.make(User)))
         self.assertTrue(can_add_current_student(occupant))
 
+    def test_can_add_current_student__seat_is_held_in_whichever_semester_they_joined(self):
+        """A student in the open semester the deck's pointer does not name still holds their
+        seat, so adding a second course does not ask for another one (issue #2157 Phase 3).
+        Reading the deck's pointer instead would treat them as a newcomer and refuse them
+        once the deck is full."""
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        occupant = baker.make(User)
+        baker.make('courses.CourseStudent', user=occupant, active=True, semester=other_semester)
+
+        self.assertTrue(can_add_current_student(occupant))
+        self.assertFalse(can_add_current_student(baker.make(User)))  # the deck is full because of them
+
     def test_can_add_current_student__staff_superusers_and_test_accounts_never_blocked(self):
         """Users who never count toward the cap (students-only counting, #2047) are
         never refused, even at the cap."""


### PR DESCRIPTION
### What?
The next step of #2157 Phase 3 (concurrent semesters, #1781). #2424 gave each student their own semester; this does the same for the reads that are about the deck as a whole rather than one student.

* `CourseStudent.objects.all_users_for_active_semester()` becomes `all_users_in_open_semesters()` and reads the semesters' own status, so the deck's roster is the union of every open semester. `Profile.objects.all_for_active_semester()` follows it as `all_in_open_semesters()`.
* The seat check (`tenant/limits.py`) asks whether the student already holds an active registration in *their* semester, rather than in the one the deck's pointer names.
* `Semester.get_student_mark_list()` is scoped to its own semester, and the mark distribution chart charts a student against their own classmates.

Three defects came out of review along the way; they are described under How.

### Why?
These are the last reads that treated "the deck's current students" as "the students in one particular semester". With two cohorts running on different calendars both are equally current, so a roster or seat count drawn from one of them is simply wrong: half the deck's students would be invisible to the nightly deck-status refresh, the mailing list, the prerequisite-recalculation tasks and the student list, and their seats would not be counted against the deck's cap.

### How?
The roster query filters `semester__status=OPEN` instead of resolving the deck's pointer, so it no longer reads `SiteConfig` at all. That removed the `AttributeError` guard that used to catch "the public tenant has no SiteConfig", so there is an explicit public-schema check in its place: without it the first thing the method would do on the public schema is query a `courses_*` table that does not exist there. The registrations stay a subquery rather than a list of ids in Python, so callers that only count the roster never load it.

The seat check reuses `CourseStudent.objects.current_courses(user)`, which is already "their registrations in an open semester", so the answer to "do they already hold a seat?" no longer depends on which semester the deck points at.

**Three bugs fixed, all pre-existing:**

1. **`Semester.get_student_mark_list()` never used its own semester.** It was called as `Semester.get_student_mark_list(Semester, students_only=True)`, passing the class itself as `self`, which only worked because the method ignored its instance and read the deck's semester. So a semester's mark distribution was never actually that semester's. It now reads `self`, and `Ajax_MarkDistributionChart` passes the semester of the student being charted.

2. **An unmarked classmate returned a 500 for everyone in that semester.** `mark_cached` is `None` until a mark is calculated, and `numpy.clip` cannot compare `None` to a number (`TypeError: '>=' not supported between instances of 'NoneType' and 'int'`). Unmarked students are now left out of the distribution, which is where they belong anyway.

3. **The block student list could show a student who is not in that block now.** `Profile.objects.all_in_open_semesters().filter(user__coursestudent__block=...)` let the two conditions match *different* registrations, so a student taking a course now, whose registration in this block was in a semester since archived, still appeared. The block and the open semester are now matched on the same row.

Also renamed `user_badge_assertion_count()`'s `active_semester_only` parameter to `current_students_only`, since after this change it selects students in any open semester rather than one particular semester, and dropped `all_for_semester()`'s `active_only` parameter, whose last caller went with the roster change.

### Testing?
`ruff check src` plus the full suite: **2256 tests, all pass**, with the changed apps at 100% coverage.

Both bug fixes are test-driven, verified by reverting the fix:

* `test_histogram_values__unmarked_classmate_does_not_break_the_chart` errors with the `TypeError` above without the `None` filtering.
* `test_profile_list_block__block_and_semester_match_the_same_registration` fails with `<Profile: ...> unexpectedly found in <ProfileQuerySet [...]>` without the block fix.

The scope change itself is covered by the roster spanning two open semesters, a student in several courses counting once, archived semesters dropping off it (which is what frees seats), and the public-schema guard. For the cap, a student registered in the open semester the deck's pointer does not name still holds their seat, and still fills the deck. For the chart, a student is compared against their own cohort rather than the whole deck (the assertion would be 10 instead of 3 if it charted deck-wide), and the between-semesters case gives an empty class.

The second open semester in these tests is built directly, since starting one the normal way still demotes the others until that restriction is lifted later in the phase.

### Screenshots (if front end is affected)
N/A: on a deck with one open semester, which is every deck until later in this phase, all of these read exactly the rows they did before. The two visible fixes (the chart no longer erroring on an unmarked classmate, and the block list no longer listing a student from an archived registration) are both cases where the old behaviour was a bug rather than a look.

### Anything Else?
#2434 tracks two `students_only` defaults that came up in review: `get_mailing_list()` can send announcement email to an enrolled test account, and the prerequisites quest-cache task disagrees with the badge-grant task next to it. Both predate this PR, and the mailing-list one changes who receives email, so it wants its own change and test rather than riding along here.

Remaining in Phase 3: allowing more than one semester to be OPEN at once (dropping the demotion in `set_active_semester`), the registration UI for choosing among them, per-registration XP caching and per-semester marks. That is where `SiteConfig.active_semester` finally disappears (#2157, #1781).

Still open from Phase 2: #2413, whether a student should be able to start a quest at all while no semester is open.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)