### PR TITLE
feat: archive one named semester, not "the open one" (#2157 Phase 3)

### DIFF
--- a/src/announcements/tests/test_views.py
+++ b/src/announcements/tests/test_views.py
@@ -476,7 +476,7 @@ class AnnouncementArchivedViewTests(ByteDeckTenantTestCase):
         draft_ann = baker.make(Announcement, archived=False, draft=True)
 
         self.client.force_login(self.test_teacher)
-        self.client.post(reverse('courses:semester_archive'), data={'archive_announcements': 'on'})
+        self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]), data={'archive_announcements': 'on'})
 
         draft_ann.refresh_from_db()
         self.assertFalse(draft_ann.archived)
@@ -487,7 +487,7 @@ class AnnouncementArchivedViewTests(ByteDeckTenantTestCase):
         announcements = [baker.make(Announcement, archived=False, draft=False) for _ in range(5)]
 
         self.client.force_login(self.test_teacher)
-        self.client.post(reverse('courses:semester_archive'), data={'archive_announcements': 'on'})
+        self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]), data={'archive_announcements': 'on'})
 
         for announcement in announcements:
             announcement.refresh_from_db()

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -410,7 +410,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
     def test_create_assertion__no_open_semester_grants_an_unstamped_assertion(self):
         """Staff can still grant a badge between semesters (issue #1177). The assertion isn't
         stamped with a semester, so it doesn't count toward the next one's XP."""
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
 
         new_assertion = BadgeAssertion.objects.create_assertion(
             self.student, baker.make(Badge), issued_by=self.teacher
@@ -421,7 +421,7 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
     def test_get_queryset__active_semester_only_is_empty_with_no_open_semester(self):
         """With no semester open, nothing was earned this semester: the semester-scoped
         queryset is empty rather than matching the unstamped assertions."""
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
         BadgeAssertion.objects.create_assertion(self.student, baker.make(Badge), issued_by=self.teacher)
 
         self.assertFalse(BadgeAssertion.objects.get_queryset(active_semester_only=True).exists())

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -311,11 +311,16 @@ class SemesterManager(models.Manager.from_queryset(SemesterQuerySet)):
                 # passed in: two requests can both load it while it is open, and the config
                 # lock only makes them queue. The second would otherwise recalculate final
                 # marks from XP the first already reset, recording zeroes.
-                semester = self.get_queryset().select_for_update().filter(pk=semester.pk).first()
+                locked = self.get_queryset().select_for_update().filter(pk=semester.pk).first()
+                if locked is None:  # pragma: no cover
+                    # the row would have to be deleted between the caller loading it and
+                    # this lock, and SemesterDelete refuses to delete an open semester
+                    return Semester.NO_OPEN_SEMESTER
+                semester = locked
 
                 # nothing to archive. Only an open semester can be archived, so one that is
                 # already archived (or still upcoming) is refused rather than archived twice.
-                if semester is None or not semester.is_open:
+                if not semester.is_open:
                     return Semester.NO_OPEN_SEMESTER
 
                 # its own students' quests are still awaiting approval, can't close!

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -267,55 +267,71 @@ class SemesterManager(models.Manager.from_queryset(SemesterQuerySet)):
         else:
             return active_semester
 
-    def complete_active_semester(self, clamp_negative_xp=False):
-        """Archive the open semester and leave the deck with no open semester, or return a
-        Semester error sentinel.
+    def complete_semester(self, semester=None, clamp_negative_xp=False):
+        """Archive one semester: record its students' final XP, free their seats, and make
+        it read-only.
 
-        clamp_negative_xp: record a negative final XP as zero instead of refusing
-        to close (the deck-suspension auto-close uses this, #1734 redesign B2;
-        the staff-driven close keeps the refusal so a teacher can investigate).
+        Everything it touches is scoped to that semester (issue #2157 Phase 3), so a deck
+        running a second one alongside keeps its registrations, its in-progress
+        submissions, and its pending approvals: archiving one cohort's term must not
+        disturb the other's.
+
+        Args:
+            semester: the Semester to archive. None means the deck's open semester, which
+                is what the archive page passes when there is only one.
+            clamp_negative_xp (bool): record a negative final XP as zero instead of
+                refusing to archive (the deck-suspension auto-close uses this, #1734
+                redesign B2; the staff-driven archive keeps the refusal so a teacher can
+                investigate first).
+
+        Returns:
+            Semester: the semester just archived, or one of the Semester.NO_OPEN_SEMESTER
+            / QUEST_AWAITING_APPROVAL / STUDENTS_WITH_NEGATIVE_XP sentinels when it was
+            refused.
         """
         # Atomic so a failure partway leaves nothing half-closed: calc_semester_grades()
         # saves each registration as it iterates and raises on a negative-XP student,
         # so without the transaction the students processed before it would stay finalized.
         try:
             with transaction.atomic():
-                # Lock the config row before reading which semester is open, the same lock
-                # set_active_semester() takes. Without it an activation running alongside this
-                # could open its semester and then have this archive clear the pointer,
-                # leaving a semester open that the deck no longer points at (so students
-                # couldn't use it).
+                # Lock the config row for the duration, the same lock set_active_semester()
+                # takes. Without it an activation running alongside this could open its
+                # semester and then have this archive clear the pointer, leaving a semester
+                # open that the deck no longer points at (so students couldn't use it).
                 SiteConfig.objects.select_for_update().get(pk=SiteConfig.get().pk)
 
-                active_sem = self.get_current()
+                if semester is None:
+                    semester = self.get_current()
 
-                # nothing to archive: the deck is already between semesters. get_current() is
-                # None for a pointer at a semester that isn't open, so an archived (or
-                # upcoming) one can't be archived through here either.
-                if active_sem is None:
+                # nothing to archive: the deck is already between semesters. Only an open
+                # semester can be archived, so an already-archived (or upcoming) one is
+                # refused here too rather than being archived twice.
+                if semester is None or not semester.is_open:
                     return Semester.NO_OPEN_SEMESTER
 
-                # There are still quests awaiting approval, can't close!
-                if QuestSubmission.objects.all_awaiting_approval():
+                # its own students' quests are still awaiting approval, can't close!
+                if QuestSubmission.objects.all_awaiting_approval(semester=semester).exists():
                     return Semester.QUEST_AWAITING_APPROVAL
 
                 # need to calculate all user XP and store in their Course
-                CourseStudent.objects.calc_semester_grades(active_sem, clamp_negative_xp=clamp_negative_xp)
+                CourseStudent.objects.calc_semester_grades(semester, clamp_negative_xp=clamp_negative_xp)
 
-                QuestSubmission.objects.remove_in_progress()
+                QuestSubmission.objects.remove_in_progress(semester=semester)
 
-                active_sem.status = Semester.Status.ARCHIVED
-                active_sem.save()
+                semester.status = Semester.Status.ARCHIVED
+                semester.save()
 
-                # the deck now has no open semester (issue #1177): students can't join a
-                # course or earn XP until staff open the next one
+                # clear the pointer only when it named this semester, so archiving one of
+                # two open semesters leaves the deck pointed at the one still running
+                # (issue #1177 for the no-semester-left case)
                 siteconfig = SiteConfig.get()
-                siteconfig.active_semester = None
-                siteconfig.save()
+                if siteconfig.active_semester_id == semester.pk:
+                    siteconfig.active_semester = None
+                    siteconfig.save()
         except ValueError:
             return Semester.STUDENTS_WITH_NEGATIVE_XP
 
-        return active_sem
+        return semester
 
 
 def default_end_date():

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -298,14 +298,23 @@ class SemesterManager(models.Manager.from_queryset(SemesterQuerySet)):
                 # takes. Without it an activation running alongside this could open its
                 # semester and then have this archive clear the pointer, leaving a semester
                 # open that the deck no longer points at (so students couldn't use it).
-                SiteConfig.objects.select_for_update().get(pk=SiteConfig.get().pk)
+                # The locked row is used for the pointer write below rather than
+                # SiteConfig.get(), whose cached copy can be behind the database.
+                siteconfig = SiteConfig.objects.select_for_update().get(pk=SiteConfig.get().pk)
 
                 if semester is None:
                     semester = self.get_current()
+                if semester is None:
+                    return Semester.NO_OPEN_SEMESTER
 
-                # nothing to archive: the deck is already between semesters. Only an open
-                # semester can be archived, so an already-archived (or upcoming) one is
-                # refused here too rather than being archived twice.
+                # Re-read the semester under its own lock rather than trusting the instance
+                # passed in: two requests can both load it while it is open, and the config
+                # lock only makes them queue. The second would otherwise recalculate final
+                # marks from XP the first already reset, recording zeroes.
+                semester = self.get_queryset().select_for_update().filter(pk=semester.pk).first()
+
+                # nothing to archive. Only an open semester can be archived, so one that is
+                # already archived (or still upcoming) is refused rather than archived twice.
                 if semester is None or not semester.is_open:
                     return Semester.NO_OPEN_SEMESTER
 
@@ -324,7 +333,6 @@ class SemesterManager(models.Manager.from_queryset(SemesterQuerySet)):
                 # clear the pointer only when it named this semester, so archiving one of
                 # two open semesters leaves the deck pointed at the one still running
                 # (issue #1177 for the no-semester-left case)
-                siteconfig = SiteConfig.get()
                 if siteconfig.active_semester_id == semester.pk:
                     siteconfig.active_semester = None
                     siteconfig.save()

--- a/src/courses/templates/courses/semester_list.html
+++ b/src/courses/templates/courses/semester_list.html
@@ -78,7 +78,7 @@ directly too.
         </a>
         {% endif %}
         {% if object.is_open %}
-        <a class="btn btn-danger" href="{% url 'courses:semester_archive' %}" role="button"
+        <a class="btn btn-danger" href="{% url 'courses:semester_archive' object.id %}" role="button"
           title="Archive this semester: record all students' final XP and free up their seats.">
           <i class="fa fa-archive"></i>
         </a>

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -152,33 +152,67 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
         """ Gets the current semester object in a queryset  """
         self.assertQuerySetEqual(Semester.objects.get_current(as_queryset=True), [SiteConfig.get().active_semester])
 
-    def test_complete_active_semester__returns_sentinel_when_pointed_at_archived_semester(self):
+    def test_complete_semester__returns_sentinel_when_pointed_at_archived_semester(self):
         """A config left pointing at an archived semester has nothing to archive either."""
         active_sem = Semester.objects.get_current()
         active_sem.status = Semester.Status.ARCHIVED
         active_sem.save()
 
-        self.assertEqual(Semester.objects.complete_active_semester(), Semester.NO_OPEN_SEMESTER)
+        self.assertEqual(Semester.objects.complete_semester(), Semester.NO_OPEN_SEMESTER)
 
-    def test_complete_active_semester__returns_sentinel_when_no_semester_is_open(self):
+    def test_complete_semester__returns_sentinel_when_no_semester_is_open(self):
         """With no active semester (the state archiving leaves behind), there is nothing to
         archive and the sentinel comes back instead of an error."""
         config = SiteConfig.get()
         config.active_semester = None
         config.save()
 
-        self.assertEqual(Semester.objects.complete_active_semester(), Semester.NO_OPEN_SEMESTER)
+        self.assertEqual(Semester.objects.complete_semester(), Semester.NO_OPEN_SEMESTER)
 
-    def test_complete_active_semester__leaves_the_deck_with_no_open_semester(self):
+    def test_complete_semester__leaves_the_deck_with_no_open_semester(self):
         """Archiving clears the active semester, so the deck sits between semesters
         (issue #1177) instead of pointing at an archived one."""
-        archived = Semester.objects.complete_active_semester()
+        archived = Semester.objects.complete_semester()
 
         self.assertTrue(archived.is_archived)
         self.assertIsNone(SiteConfig.get().active_semester)
         self.assertTrue(SiteConfig.get().has_no_open_semester())
 
-    def test_complete_active_semester__returns_awaiting_approval_with_pending_submissions(self):
+    def test_complete_semester__leaves_the_other_open_semester_alone(self):
+        """Archiving one semester is scoped to it (issue #2157 Phase 3): the other cohort's
+        registrations stay active, their in-progress quests survive, and the deck's pointer
+        is left alone because it named the semester still running."""
+        config = SiteConfig.get()
+        archiving = config.active_semester
+        keeping = baker.make(Semester, status=Semester.Status.OPEN)
+        config.active_semester = keeping
+        config.save()
+
+        student_here = baker.make(User)
+        baker.make(CourseStudent, user=student_here, course=baker.make(Course), semester=archiving)
+        student_there = baker.make(User)
+        registration_there = baker.make(CourseStudent, user=student_there, course=baker.make(Course), semester=keeping)
+        in_progress_there = baker.make(QuestSubmission, user=student_there, semester=keeping, is_completed=False)
+
+        self.assertEqual(Semester.objects.complete_semester(archiving), archiving)
+
+        keeping.refresh_from_db()
+        self.assertTrue(keeping.is_open)
+        registration_there.refresh_from_db()
+        self.assertTrue(registration_there.active)  # their seat is not freed
+        self.assertTrue(QuestSubmission.objects.filter(pk=in_progress_there.pk).exists())
+        self.assertEqual(SiteConfig.get().active_semester, keeping)
+
+    def test_complete_semester__is_not_blocked_by_another_semesters_approvals(self):
+        """Quests awaiting approval in the other open semester are that semester's business,
+        so they don't stand in the way of archiving this one."""
+        archiving = SiteConfig.get().active_semester
+        other = baker.make(Semester, status=Semester.Status.OPEN)
+        baker.make(QuestSubmission, semester=other, is_completed=True, is_approved=False)
+
+        self.assertEqual(Semester.objects.complete_semester(archiving), archiving)
+
+    def test_complete_semester__returns_awaiting_approval_with_pending_submissions(self):
         """A semester can't be closed while quests are still awaiting approval."""
         baker.make(
             QuestSubmission,
@@ -186,9 +220,9 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
             is_approved=False,
             semester=SiteConfig.get().active_semester,
         )
-        self.assertEqual(Semester.objects.complete_active_semester(), Semester.QUEST_AWAITING_APPROVAL)
+        self.assertEqual(Semester.objects.complete_semester(), Semester.QUEST_AWAITING_APPROVAL)
 
-    def test_complete_active_semester__clamp_records_negative_xp_as_zero(self):
+    def test_complete_semester__clamp_records_negative_xp_as_zero(self):
         """With clamp_negative_xp on (the deck-suspension auto-close, #1734 B2), a
         student's negative balance is recorded as zero final XP and the semester
         closes; without it the STUDENTS_WITH_NEGATIVE_XP refusal stands."""
@@ -198,8 +232,8 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
         registration = baker.make(CourseStudent, user=student, semester=SiteConfig.get().active_semester)
 
         with patch('profile_manager.models.Profile.xp_per_course', return_value=-50):
-            self.assertEqual(Semester.objects.complete_active_semester(), Semester.STUDENTS_WITH_NEGATIVE_XP)
-            result = Semester.objects.complete_active_semester(clamp_negative_xp=True)
+            self.assertEqual(Semester.objects.complete_semester(), Semester.STUDENTS_WITH_NEGATIVE_XP)
+            result = Semester.objects.complete_semester(clamp_negative_xp=True)
 
         self.assertTrue(result.is_archived)
         registration.refresh_from_db()
@@ -224,7 +258,7 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
         self.assertFalse(
             CourseStudent.objects.filter(semester=SiteConfig.get().active_semester, active=False).exists())
 
-    def test_complete_active_semester__rolls_back_grades_when_a_student_has_negative_xp(self):
+    def test_complete_semester__rolls_back_grades_when_a_student_has_negative_xp(self):
         """A negative-XP student aborts the close atomically: registrations finalized before
         the bad student was reached are rolled back and the semester stays open. Regression
         test for the pre-transaction behavior, where those students kept their recorded
@@ -245,7 +279,7 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
             xp_adjustment=-10,  # makes this student's XP negative
         )
 
-        self.assertEqual(Semester.objects.complete_active_semester(), Semester.STUDENTS_WITH_NEGATIVE_XP)
+        self.assertEqual(Semester.objects.complete_semester(), Semester.STUDENTS_WITH_NEGATIVE_XP)
 
         # the fine student's registration must be untouched, and the semester still open
         fine_registration.refresh_from_db()
@@ -495,7 +529,7 @@ class NoOpenSemesterTest(ByteDeckTenantTestCase):
             CourseStudent, user=self.student, course=baker.make(Course),
             semester=SiteConfig.get().active_semester,
         )
-        self.archived_semester = Semester.objects.complete_active_semester()
+        self.archived_semester = Semester.objects.complete_semester()
 
     def test_archiving__leaves_no_active_semester(self):
         """The state under test: the semester is archived and nothing is pointed at."""
@@ -519,7 +553,7 @@ class NoOpenSemesterTest(ByteDeckTenantTestCase):
         self.assertIsNone(Semester.objects.get_current())
         self.assertFalse(Semester.objects.get_current(as_queryset=True).exists())
 
-    def test_complete_active_semester__will_not_archive_a_semester_that_is_not_open(self):
+    def test_complete_semester__will_not_archive_a_semester_that_is_not_open(self):
         """An upcoming semester has no final marks to record, so archiving refuses rather
         than skipping it straight to the terminal stage."""
         upcoming = baker.make(Semester, status=Semester.Status.UPCOMING)
@@ -527,7 +561,7 @@ class NoOpenSemesterTest(ByteDeckTenantTestCase):
         config.active_semester = upcoming
         config.save()
 
-        self.assertEqual(Semester.objects.complete_active_semester(), Semester.NO_OPEN_SEMESTER)
+        self.assertEqual(Semester.objects.complete_semester(), Semester.NO_OPEN_SEMESTER)
         upcoming.refresh_from_db()
         self.assertTrue(upcoming.is_upcoming)
 
@@ -606,14 +640,14 @@ class StudentOwnSemesterTest(ByteDeckTenantTestCase):
     def test_current_semester__unregistered_user_between_semesters_is_none(self):
         """With nothing open and no registration to fall back on, there is no semester."""
         Semester.objects.filter(pk=self.other_semester.pk).update(status=Semester.Status.ARCHIVED)
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
         self.assertIsNone(CourseStudent.objects.current_semester(self.teacher))
 
     def test_current_semester__archived_registration_is_not_current(self):
         """Archiving the semester a student was in leaves them with no current registration.
         They fall back to the deck's pointer, which archiving cleared, rather than staying
         attached to the archived semester (or being adopted by someone else's open one)."""
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
         self.assertTrue(self.other_semester.is_open)
         self.assertIsNone(CourseStudent.objects.current_semester(self.student))
 
@@ -811,7 +845,7 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
 
     def test_all_users_in_open_semesters__leaves_out_archived_semesters(self):
         """Archiving a semester takes its students off the roster: that is what frees seats."""
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
 
         self.assertEqual(CourseStudent.objects.all_users_in_open_semesters().count(), 0)
 

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -565,6 +565,27 @@ class NoOpenSemesterTest(ByteDeckTenantTestCase):
         upcoming.refresh_from_db()
         self.assertTrue(upcoming.is_upcoming)
 
+    def test_complete_semester__refuses_a_named_semester_that_is_not_open(self):
+        """Naming the semester doesn't get round the rule: an archived one passed straight to
+        the manager is refused rather than having its students' final marks recalculated from
+        the XP the first archive already reset."""
+        archived = baker.make(Semester, status=Semester.Status.ARCHIVED)
+        upcoming = baker.make(Semester, status=Semester.Status.UPCOMING)
+
+        self.assertEqual(Semester.objects.complete_semester(archived), Semester.NO_OPEN_SEMESTER)
+        self.assertEqual(Semester.objects.complete_semester(upcoming), Semester.NO_OPEN_SEMESTER)
+
+    def test_complete_semester__reads_the_semesters_status_from_the_database(self):
+        """The status is re-read under the lock, so a stale in-memory instance saying "open"
+        can't push a second archive through: two requests can both load a semester while it
+        is open, and the config lock only makes them queue."""
+        semester = baker.make(Semester, status=Semester.Status.OPEN)
+        stale = Semester.objects.get(pk=semester.pk)  # loaded while it was still open
+        Semester.objects.complete_semester(semester)
+        self.assertTrue(stale.is_open)  # the caller's copy still says open
+
+        self.assertEqual(Semester.objects.complete_semester(stale), Semester.NO_OPEN_SEMESTER)
+
     def test_current_courses__is_empty(self):
         """Nobody is registered in a current course, so a student has none."""
         self.assertFalse(CourseStudent.objects.current_courses(self.student).exists())

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -648,6 +648,7 @@ class StudentOwnSemesterTest(ByteDeckTenantTestCase):
         They fall back to the deck's pointer, which archiving cleared, rather than staying
         attached to the archived semester (or being adopted by someone else's open one)."""
         Semester.objects.complete_semester()
+        self.other_semester.refresh_from_db()
         self.assertTrue(self.other_semester.is_open)
         self.assertIsNone(CourseStudent.objects.current_semester(self.student))
 

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -372,7 +372,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
 
     def test_SemesterArchive__semester_not_open_get(self):
         """A semester that isn't open has nothing to preview archiving, so staff are sent
-        back to the semester list with a warning."""
+        back to the semester list with an error."""
         self.client.force_login(self.test_teacher)
         semester_id = SiteConfig.get().active_semester.id
         Semester.objects.complete_semester()

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -187,7 +187,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertRedirectsLogin('courses:ranks')
         self.assertRedirectsLogin('courses:my_marks')
         self.assertRedirectsLogin('courses:marks', args=[1])
-        self.assertRedirectsLogin('courses:semester_archive')
+        self.assertRedirectsLogin('courses:semester_archive', args=[1])
 
         self.assertRedirectsLogin('courses:markranges')
         self.assertRedirectsLogin('courses:markrange_create')
@@ -224,7 +224,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
 
         # Staff access only
         self.assert403('courses:join', args=[self.test_student1.id])
-        self.assert403('courses:semester_archive')
+        self.assert403('courses:semester_archive', args=[1])
         self.assert403('courses:coursestudent_delete', args=[1])
 
         self.assert403('courses:markranges')
@@ -256,7 +256,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         # Staff access only
         self.assert200('courses:join', args=[self.test_student1.id])
 
-        self.assert200('courses:semester_archive')
+        self.assert200('courses:semester_archive', args=[SiteConfig.get().active_semester.id])
 
         self.assert200('courses:markranges')
         self.assert200('courses:markrange_create')
@@ -300,7 +300,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         active_sem = SiteConfig.get().active_semester
         self.assertFalse(active_sem.is_archived)
         self.assertRedirects(
-            response=self.client.post(reverse('courses:semester_archive')),
+            response=self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id])),
             expected_url=reverse('courses:semester_list'),
         )
         active_sem.refresh_from_db()
@@ -314,7 +314,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         student = baker.make(User)
         baker.make(CourseStudent, user=student, course=baker.make(Course), semester=active_sem)
 
-        response = self.client.get(reverse('courses:semester_archive'))
+        response = self.client.get(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['semester'], active_sem)
@@ -334,7 +334,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         baker.make(CourseStudent, user=negative_student, course=baker.make(Course),
                    semester=active_sem, xp_adjustment=-10)
 
-        response = self.client.get(reverse('courses:semester_archive'))
+        response = self.client.get(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['blocked'])
@@ -349,7 +349,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         active_sem = SiteConfig.get().active_semester
         baker.make(QuestSubmission, is_completed=True, is_approved=False, semester=active_sem)
 
-        response = self.client.post(reverse('courses:semester_archive'))
+        response = self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
 
         self.assertRedirects(response, reverse('courses:semester_list'))
         self.assertWarningMessage(response)
@@ -358,40 +358,44 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertFalse(active_sem.is_archived)
 
     def test_SemesterArchive__already_archived(self):
-        """POSTing the archive view for an already-archived semester warns and takes no action."""
+        """POSTing the archive view for an already-archived semester is refused and takes no
+        action: its final marks are recorded and must not be recalculated."""
         self.client.force_login(self.test_teacher)
         active_sem = SiteConfig.get().active_semester
         active_sem.status = Semester.Status.ARCHIVED
         active_sem.save()
 
-        response = self.client.post(reverse('courses:semester_archive'))
+        response = self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
 
         self.assertRedirects(response, reverse('courses:semester_list'))
-        self.assertWarningMessage(response)
+        self.assertErrorMessage(response)
 
-    def test_SemesterArchive__no_open_semester_get(self):
-        """With the deck between semesters there is nothing to preview archiving, so staff
-        are sent back to the semester list with a warning."""
+    def test_SemesterArchive__semester_not_open_get(self):
+        """A semester that isn't open has nothing to preview archiving, so staff are sent
+        back to the semester list with a warning."""
         self.client.force_login(self.test_teacher)
-        Semester.objects.complete_active_semester()
+        semester_id = SiteConfig.get().active_semester.id
+        Semester.objects.complete_semester()
         self.assertIsNone(SiteConfig.get().active_semester)
 
-        response = self.client.get(reverse('courses:semester_archive'))
+        response = self.client.get(reverse('courses:semester_archive', args=[semester_id]))
 
         self.assertRedirects(response, reverse('courses:semester_list'))
-        self.assertWarningMessage(response)
+        self.assertErrorMessage(response)
         self.assertIn('nothing to archive', str(self.get_message_list(response)[0]))
 
-    def test_SemesterArchive__no_open_semester_post(self):
-        """The POST is refused the same way, so a resubmitted archive form can't run against
-        a deck that is already between semesters."""
+    def test_SemesterArchive__upcoming_semester_post(self):
+        """An upcoming semester is refused too: nobody has earned anything in it yet, so
+        there are no final marks to record."""
         self.client.force_login(self.test_teacher)
-        Semester.objects.complete_active_semester()
+        upcoming = baker.make(Semester, status=Semester.Status.UPCOMING)
 
-        response = self.client.post(reverse('courses:semester_archive'))
+        response = self.client.post(reverse('courses:semester_archive', args=[upcoming.id]))
 
         self.assertRedirects(response, reverse('courses:semester_list'))
-        self.assertWarningMessage(response)
+        self.assertErrorMessage(response)
+        upcoming.refresh_from_db()
+        self.assertTrue(upcoming.is_upcoming)
 
     def test_SemesterArchive__leaves_the_deck_with_no_open_semester(self):
         """Archiving is how a deck gets to the between-semesters state (issue #1177): the
@@ -399,7 +403,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
         active_sem = SiteConfig.get().active_semester
 
-        self.client.post(reverse('courses:semester_archive'))
+        self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
 
         active_sem.refresh_from_db()
         self.assertTrue(active_sem.is_archived)
@@ -412,7 +416,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         announcement = baker.make(Announcement, archived=False, draft=False)
         self.client.force_login(self.test_teacher)
 
-        response = self.client.post(reverse('courses:semester_archive'))  # no checkbox in POST data
+        response = self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))  # no checkbox in POST data
 
         self.assertRedirects(response, reverse('courses:semester_list'))
         self.assertSuccessMessage(response)
@@ -448,7 +452,7 @@ class CourseViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         """Activating a semester is the way out of the between-semesters state: the deck has
         an open semester again and students can join a course."""
         self.client.force_login(self.test_teacher)
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
         next_semester = baker.make('courses.semester', status=Semester.Status.UPCOMING)
 
         response = self.client.post(reverse('courses:semester_activate', args=[next_semester.pk]))
@@ -939,7 +943,7 @@ class SemesterStatusBannerTests(ByteDeckTenantTestCase):
 
         self.assertContains(response, self.BANNER_ID)
         self.assertContains(response, 'ended on')
-        self.assertContains(response, reverse('courses:semester_archive'))
+        self.assertContains(response, reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
 
     def test_semester_status_banner__no_open_semester(self):
         """When the active semester is archived (the no-open-semester state, #1177),
@@ -1322,7 +1326,7 @@ class SemesterViewTests(ByteDeckTenantTestCase):
         course = baker.make(Course)
         baker.make(CourseStudent, user=student, course=course, semester=semester)
 
-        response = self.client.post(reverse('courses:semester_archive'))
+        response = self.client.post(reverse('courses:semester_archive', args=[SiteConfig.get().active_semester.id]))
         self.assertWarningMessage(response)
         self.assertRedirects(response, reverse('courses:semester_list'))
         message = self.get_message_list(response)[0]
@@ -1633,7 +1637,7 @@ class TestAjax_MarkDistributionChart(ByteDeckTenantTestCase):
         against, so there are no classmates rather than a crash on the missing semester."""
         self.create_student_course(100)
         stranger = baker.make(User)
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
 
         self.client.force_login(self.teacher)
         response = self.client.get(
@@ -1883,7 +1887,7 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
     def test_ajax_xp_data__empty_with_no_open_semester(self):
         """Between semesters there is no semester to chart progress through, so the chart gets
         an empty dataset instead of the page failing."""
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
         self.client.force_login(self.student)
 
         response = self.client.post(

--- a/src/courses/urls.py
+++ b/src/courses/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('semesters/add/', views.SemesterCreate.as_view(), name='semester_create'),
     path('semesters/<pk>/edit/', views.SemesterUpdate.as_view(), name='semester_update'),
     path('semesters/<pk>/delete/', views.SemesterDelete.as_view(), name='semester_delete'),
-    path('semesters/archive/', views.SemesterArchive.as_view(), name='semester_archive'),
+    path('semesters/<pk>/archive/', views.SemesterArchive.as_view(), name='semester_archive'),
     path('semesters/<pk>/activate/', views.SemesterActivate.as_view(), name='semester_activate'),
 
     # Blocks

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -815,49 +815,61 @@ class BlockDelete(NonPublicOnlyViewMixin, DeleteView):
 
 
 @method_decorator(staff_member_required, name='dispatch')
-class SemesterArchive(NonPublicOnlyViewMixin, LoginRequiredMixin, TemplateView):
-    """Staff-only two-step archive (close) of the active semester.
+class SemesterArchive(RefuseSemesterMixin, NonPublicOnlyViewMixin, LoginRequiredMixin, TemplateView):
+    """Staff-only two-step archive (close) of one semester.
+
+    The semester is named in the URL rather than taken from the deck, so a deck running
+    two of them can archive either one (issue #2157 Phase 3). Every count and blocker
+    below belongs to that semester alone.
 
     GET renders a preview of everything archiving will do: how many course registrations
     get their final XP recorded (freeing those students' deck seats), how many in-progress
     quest submissions are deleted, and whether announcements will be archived, along with
     any blockers (submissions still awaiting approval, students with negative XP). POST
-    performs the archive via Semester.objects.complete_active_semester().
+    performs the archive via Semester.objects.complete_semester().
     """
     template_name = 'courses/semester_archive.html'
 
-    NO_OPEN_SEMESTER_ERROR = 'No semester is open, so there is nothing to archive.'
+    NOT_OPEN_ERROR = "That semester isn't open, so there is nothing to archive."
 
-    def dispatch(self, request, *args, **kwargs):
-        """Refuse to serve the view at all (GET or POST) when the deck is between semesters:
-        there is no semester to preview or archive.
+    def get_semester(self):
+        """The semester this page is archiving.
 
         Returns:
-            HttpResponse: a redirect to the semester list with a warning when no semester is
-            open; otherwise the normal response.
+            Semester: the one named by the URL's pk.
         """
-        if SiteConfig.get().has_no_open_semester():
-            messages.warning(request, self.NO_OPEN_SEMESTER_ERROR)
-            return redirect('courses:semester_list')
-        return super().dispatch(request, *args, **kwargs)
+        return get_object_or_404(Semester, pk=self.kwargs['pk'])
+
+    def refusal_message(self):
+        """Whether this semester can be archived at all.
+
+        Returns:
+            str or None: the error message when the target is not open (an upcoming
+            semester has no marks to record, an archived one is already done), otherwise
+            None.
+        """
+        return None if self.get_semester().is_open else self.NOT_OPEN_ERROR
 
     def get_context_data(self, **kwargs):
-        """Assemble the preview counts and blockers for archiving the active semester.
+        """Assemble the preview counts and blockers for archiving this semester.
 
         Returns:
-            dict: template context with the active semester, the counts previewed above,
-            the negative-XP users queryset, and a `blocked` flag when archiving would be
+            dict: template context with the semester, the counts previewed above, the
+            negative-XP users queryset, and a `blocked` flag when archiving would be
             refused (pending approvals or negative XP).
         """
         context = super().get_context_data(**kwargs)
-        semester = SiteConfig.get().open_semester
+        semester = self.get_semester()
         registrations = CourseStudent.objects.all_for_semester(semester)
         context['semester'] = semester
         context['num_registrations'] = registrations.count()
         context['num_seats_freed'] = registrations.get_students_only().count()
-        # matches what QuestSubmission.objects.remove_in_progress() will delete
-        context['num_in_progress'] = QuestSubmission.objects.all_not_completed(active_semester_only=False).count()
-        context['num_awaiting_approval'] = QuestSubmission.objects.all_awaiting_approval().count()
+        # both match what archiving this semester will actually touch: another open
+        # semester's in-progress work and pending approvals are left alone
+        context['num_in_progress'] = QuestSubmission.objects.all_not_completed(
+            active_semester_only=False,
+        ).get_semester(semester).count()
+        context['num_awaiting_approval'] = QuestSubmission.objects.all_awaiting_approval(semester=semester).count()
         # negative final XP comes from a negative xp_cached (final_xp = xp_cached / course count);
         # select_related the profile since the blockers list renders user.profile per row
         context['negative_xp_users'] = User.objects.filter(
@@ -868,20 +880,33 @@ class SemesterArchive(NonPublicOnlyViewMixin, LoginRequiredMixin, TemplateView):
         return context
 
     def post(self, request, *args, **kwargs):
-        """Archive the active semester: record final XP, deactivate registrations, delete
+        """Archive this semester: record final XP, deactivate its registrations, delete its
         in-progress submissions, and (unless opted out via the archive_announcements
         checkbox) archive announcements.
 
+        Args:
+            request: the POST request, whose archive_announcements field opts in to
+                archiving announcements alongside the semester.
+            *args: positional URL arguments.
+            **kwargs: keyword URL arguments, including the semester's pk.
+
         Returns:
-            HttpResponse: a redirect to the semester list with a success message, or a
-            warning message when archiving was refused (no semester open by the time the
-            POST ran, submissions awaiting approval, or students with negative XP).
+            HttpResponse: a redirect to the semester list with a success message, or with
+            a message saying why archiving was refused (the semester is not open, its
+            submissions await approval, or its students have negative XP).
         """
-        sem = Semester.objects.complete_active_semester()
+        # RefuseSemesterMixin.post() is shadowed by this method, so the guard is called
+        # here instead: a POST to a semester that isn't open must be refused the same way
+        # the GET is, rather than falling through to the sentinel below.
+        refused = self._refuse(request)
+        if refused:
+            return refused
+
+        sem = Semester.objects.complete_semester(self.get_semester())
         semester_warnings = {
-            # dispatch() already redirects when nothing is open, so this only comes up when
-            # another request archived the semester between that check and this one
-            Semester.NO_OPEN_SEMESTER: 'No semester is open, so there is nothing to archive.',
+            # refusal_message() already redirects when the target isn't open, so this only
+            # comes up when another request archived it between that check and this one
+            Semester.NO_OPEN_SEMESTER: self.NOT_OPEN_ERROR,
             Semester.QUEST_AWAITING_APPROVAL: "There are still quests awaiting approval. "
                                               "Can't archive the semester until they are approved or returned.",
             Semester.STUDENTS_WITH_NEGATIVE_XP: "There are some students with negative XP. Can't archive the semester until it is fixed.",

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -1008,12 +1008,26 @@ class QuestSubmissionManager(models.Manager):
 
         return qs
 
-    def all_awaiting_approval(self, user=None, teacher=None):
-        if user is None:
-            qs = self.get_queryset(True).not_approved().completed(SiteConfig.get().approve_oldest_first)\
-                .for_teacher_only(teacher)
-            return qs
-        return self.get_queryset(True, user=user).get_user(user).not_approved().completed()
+    def all_awaiting_approval(self, user=None, teacher=None, semester=None):
+        """Submissions handed in and waiting for a teacher.
+
+        Args:
+            user: limit to this student's submissions, in their own semester.
+            teacher: limit to the students this teacher has blocks for.
+            semester: limit to one Semester's submissions, whichever semester it is.
+                Archiving passes the semester being archived so a second semester's
+                pending work doesn't block it (issue #2157 Phase 3).
+
+        Returns:
+            QuestSubmissionQuerySet: the matching submissions awaiting approval.
+        """
+        if user is not None:
+            return self.get_queryset(True, user=user).get_user(user).not_approved().completed()
+
+        qs = self.get_queryset(semester is None).not_approved().completed(SiteConfig.get().approve_oldest_first)
+        if semester is not None:
+            qs = qs.get_semester(semester)
+        return qs.for_teacher_only(teacher)
 
     def all_returned(self, user=None):
         # completion date indicates the quest was submitted, but since completed
@@ -1168,11 +1182,22 @@ class QuestSubmissionManager(models.Manager):
 
         return total_xp
 
-    def remove_in_progress(self):
-        # In Progress Quests
+    def remove_in_progress(self, semester=None):
+        """Delete the submissions students had on the go but never completed.
+
+        Args:
+            semester: delete only the submissions belonging to this Semester. Archiving
+                passes the semester it is archiving, so a deck running a second semester
+                alongside keeps that one's work (issue #2157 Phase 3). None deletes every
+                in-progress submission on the deck, semester or not.
+
+        Returns:
+            tuple: the (count, per-model counts) that QuerySet.delete() returns.
+        """
         qs = self.all_not_completed(active_semester_only=False)
-        num_del = qs.delete()
-        return num_del
+        if semester is not None:
+            qs = qs.get_semester(semester)
+        return qs.delete()
 
 
 class QuestSubmission(models.Model):

--- a/src/templates/semester_status_banner.html
+++ b/src/templates/semester_status_banner.html
@@ -21,7 +21,7 @@ are noise next to the suspension banner.
         <div class="alert alert-warning" id="semester-status-banner">
             <i class="fa fa-fw fa-calendar-o"></i>
             <strong>Semester {{ config.active_semester }} ended on {{ config.active_semester.last_day }}.</strong>
-            <a href="{% url 'courses:semester_archive' config.active_semester.id %}" class="alert-link">Archive it</a>
+            <a href="{% url 'courses:semester_archive' config.open_semester_id %}" class="alert-link">Archive it</a>
             to record final marks and free up your students' seats.
         </div>
     {% endif %}

--- a/src/templates/semester_status_banner.html
+++ b/src/templates/semester_status_banner.html
@@ -21,7 +21,7 @@ are noise next to the suspension banner.
         <div class="alert alert-warning" id="semester-status-banner">
             <i class="fa fa-fw fa-calendar-o"></i>
             <strong>Semester {{ config.active_semester }} ended on {{ config.active_semester.last_day }}.</strong>
-            <a href="{% url 'courses:semester_archive' %}" class="alert-link">Archive it</a>
+            <a href="{% url 'courses:semester_archive' config.active_semester.id %}" class="alert-link">Archive it</a>
             to record final marks and free up your students' seats.
         </div>
     {% endif %}

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -83,16 +83,24 @@ def close_semester_on_new_suspension(deck):
             submission.mark_returned()
             returned += 1
 
-        result = Semester.objects.complete_active_semester(clamp_negative_xp=True)
-        if result == Semester.NO_OPEN_SEMESTER:
+        # every open semester, not just the one the deck points at: suspension stops the
+        # whole deck, so a second cohort's semester has to close with the first
+        open_semesters = list(Semester.objects.open())
+        if not open_semesters:
             # nothing was open; the episode is recorded so this isn't re-checked
             return 'no open semester to close'
-        if result in (Semester.QUEST_AWAITING_APPROVAL, Semester.STUDENTS_WITH_NEGATIVE_XP):
-            # can't happen (submissions were just returned; negative XP is clamped),
-            # but if it ever does, roll everything back and retry next run instead
-            # of recording a close that didn't happen
-            raise RuntimeError(f'semester close failed with sentinel {result}')
-    return f'closed semester "{result}" (returned {returned} awaiting-approval submission(s))'
+
+        closed = []
+        for semester in open_semesters:
+            result = Semester.objects.complete_semester(semester, clamp_negative_xp=True)
+            if result in (Semester.NO_OPEN_SEMESTER, Semester.QUEST_AWAITING_APPROVAL, Semester.STUDENTS_WITH_NEGATIVE_XP):
+                # can't happen (submissions were just returned; negative XP is clamped),
+                # but if it ever does, roll everything back and retry next run instead
+                # of recording a close that didn't happen
+                raise RuntimeError(f'semester close failed with sentinel {result}')
+            closed.append(str(result))
+    names = ', '.join(f'"{name}"' for name in closed)
+    return f'closed semester {names} (returned {returned} awaiting-approval submission(s))'
 
 
 def evaluate_deck_notices(deck):

--- a/src/tenant/notices.py
+++ b/src/tenant/notices.py
@@ -78,11 +78,6 @@ def close_semester_on_new_suspension(deck):
         if not created:
             return 'semester close already handled this episode'
 
-        returned = 0
-        for submission in QuestSubmission.objects.all_awaiting_approval():
-            submission.mark_returned()
-            returned += 1
-
         # every open semester, not just the one the deck points at: suspension stops the
         # whole deck, so a second cohort's semester has to close with the first
         open_semesters = list(Semester.objects.open())
@@ -90,8 +85,16 @@ def close_semester_on_new_suspension(deck):
             # nothing was open; the episode is recorded so this isn't re-checked
             return 'no open semester to close'
 
+        returned = 0
         closed = []
         for semester in open_semesters:
+            # this semester's own pending approvals, cleared before it closes. Returning
+            # only the deck-pointed semester's queue would leave a second open semester
+            # blocked on its own, which rolls the whole suspension close back.
+            for submission in QuestSubmission.objects.all_awaiting_approval(semester=semester):
+                submission.mark_returned()
+                returned += 1
+
             result = Semester.objects.complete_semester(semester, clamp_negative_xp=True)
             if result in (Semester.NO_OPEN_SEMESTER, Semester.QUEST_AWAITING_APPROVAL, Semester.STUDENTS_WITH_NEGATIVE_XP):
                 # can't happen (submissions were just returned; negative XP is clamped),

--- a/src/tenant/tests/test_limits.py
+++ b/src/tenant/tests/test_limits.py
@@ -53,7 +53,7 @@ class CanAddCurrentStudentTest(ByteDeckTenantTestCase):
         occupant = self.fill_the_single_seat()
         self.assertFalse(can_add_current_student(baker.make(User)))
 
-        Semester.objects.complete_active_semester()
+        Semester.objects.complete_semester()
 
         self.assertTrue(can_add_current_student(baker.make(User)))
         self.assertTrue(can_add_current_student(occupant))

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -783,6 +783,36 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
 
         self.assertEqual(self.close(), 'semester close already handled this episode')
 
+    def test_close__closes_every_open_semester(self):
+        """Suspension stops the whole deck, so a second open semester closes with the first
+        (issue #2157 Phase 3). Its own pending approvals are returned first: leaving them
+        would make its close report QUEST_AWAITING_APPROVAL and roll the whole suspension
+        enforcement back."""
+        from django.contrib.auth import get_user_model
+        from model_bakery import baker
+        from courses.models import Semester
+        from quest_manager.models import QuestSubmission
+        from siteconfig.models import SiteConfig
+
+        User = get_user_model()
+        baker.make(User, is_staff=True)  # a teacher must exist before students
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        other_student = baker.make(User)
+        baker.make('courses.CourseStudent', user=other_student, semester=other_semester)
+        baker.make(
+            QuestSubmission, user=other_student, is_completed=True, is_approved=False,
+            semester=other_semester,
+        )
+
+        self.set_deck(trial_end_date=TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None)
+        summary = self.close()
+
+        self.assertIn('closed semester', summary)
+        other_semester.refresh_from_db()
+        self.assertTrue(other_semester.is_archived)
+        self.assertIsNone(SiteConfig.get().active_semester)
+        self.assertFalse(Semester.objects.open().exists())
+
     def test_close__no_op_paths(self):
         """Unsuspended decks are untouched (no ledger row); a suspended deck whose
         semester is already closed records the episode without changes."""

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -832,7 +832,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         from courses.models import Semester
 
         self.set_deck(trial_end_date=TODAY - timedelta(days=GRACE_PERIOD_DAYS + 1), paid_until=None)
-        with patch.object(Semester.objects, 'complete_active_semester', return_value=Semester.QUEST_AWAITING_APPROVAL):
+        with patch.object(Semester.objects, 'complete_semester', return_value=Semester.QUEST_AWAITING_APPROVAL):
             with self.assertRaises(RuntimeError):
                 self.close()
         self.assertFalse(DeckNotice.objects.filter(threshold='semester-close').exists())


### PR DESCRIPTION
### What?
The next step of #2157 Phase 3 (concurrent semesters, #1781). Archiving is now something you do to a **named semester**: the URL is `/semesters/<pk>/archive/`, and everything the archive touches is scoped to that semester rather than to whichever one the deck points at.

### Why?
This is the prerequisite for letting two semesters be open at once. "Archive the open semester" has no meaning when two are open, and worse, the current implementation would take the other one down with it:

* `QuestSubmission.objects.remove_in_progress()` deleted **every** in-progress submission on the deck, so archiving one cohort's semester would have deleted the other cohort's unfinished work;
* the awaiting-approval blocker was deck-wide, so one semester's pending approvals would have blocked a different semester from being archived.

Both are latent today (only one semester can be open) and both become live the moment the next PR lifts that restriction, so they are fixed here, with the guard tests that catch them.

### How?
`Semester.objects.complete_active_semester()` becomes `complete_semester(semester=None)`. It archives the semester it is given, refuses anything that is not open, and scopes each step to that semester: `calc_semester_grades`, `remove_in_progress(semester=...)` and the awaiting-approval check. Passing no semester still means the deck's open one, which is what a single-semester deck does.

The deck's pointer is cleared **only when it named the semester being archived**, so archiving one of two open semesters leaves the deck pointed at the one still running (the no-semester-left case is still #1177's pause state).

`QuestSubmission.objects.remove_in_progress()` and `all_awaiting_approval()` both take an optional `semester`; without one they behave exactly as before, which is what the deck-wide staff approval queue wants.

The deck-suspension auto-close (`tenant/notices.py`) closes **every** open semester rather than the pointed one: suspension stops the whole deck, so a second cohort's semester has to close with the first. Each semester's own pending approvals are returned immediately before that semester closes.

**Concurrency.** `complete_semester()` takes the `SiteConfig` lock and then **re-reads the target semester under `select_for_update()`** rather than trusting the instance it was handed. Two archive requests can both load a semester while it is open; the config lock only makes them queue, so without the re-read the second would recalculate final marks from XP the first had already reset, writing zeroes over marks that had just been recorded. The pointer comparison and write use the locked `SiteConfig` row rather than `SiteConfig.get()`, whose cached copy can trail the database.

Two smaller consequences worth calling out:

* Refusing a semester that is not open now goes through the shared `RefuseSemesterMixin`, so it reports an **error** like the delete and edit refusals rather than a warning. `RefuseSemesterMixin.post()` is shadowed by this view's own `post()`, so the guard is called explicitly there; without that the POST fell through to the sentinel path and reported a warning while the GET reported an error.
* `SemesterArchive` gained a `get_semester()` and lost its `dispatch()` override, for the same MRO reason documented on the mixin: the semester lookup has to happen after `NonPublicOnlyViewMixin` has had its chance to 404 the public schema.

### Testing?
`ruff check src` plus the full suite: **2261 tests, all pass**, with the changed apps at 100% coverage.

Three bugs are covered test-first, verified by reverting the fix:

* `test_complete_semester__leaves_the_other_open_semester_alone` fails on the deleted submission (`AssertionError: False is not true`) when `remove_in_progress()` is left unscoped. It also pins that the other semester stays open, its registrations stay active, and the deck pointer is untouched.
* `test_close__closes_every_open_semester` errors with `RuntimeError: semester close failed with sentinel -2` (QUEST_AWAITING_APPROVAL) when the suspension close returns only the deck-pointed semester's approvals: the sentinel raises inside the `atomic()` block, so the whole suspension enforcement rolls back, ledger row and all, and retries identically on every later run.
* `test_complete_semester__is_not_blocked_by_another_semesters_approvals` covers the blocker half.

`test_complete_semester__reads_the_semesters_status_from_the_database` pins the concurrency fix from the reachable side: a caller holding an instance whose in-memory copy still says "open" is refused, which is the state the losing request of a race is in. The genuinely unreachable arm (the row deleted between load and lock, which `SemesterDelete` refuses for an open semester) carries a `# pragma: no cover` and a note saying why.

The refusal cases cover both not-open states separately: `test_SemesterArchive__already_archived` (archived, POST), `test_SemesterArchive__upcoming_semester_post` (upcoming, POST, and the semester is still upcoming afterwards), the GET, and `test_complete_semester__refuses_a_named_semester_that_is_not_open` for the manager API directly.

### Screenshots (if front end is affected)
Captured from the seeded `hackerspace` dev deck, signed in as the deck owner.

The pages themselves are deliberately unchanged: what changed is which semester the archive button targets. On a deck with one open semester the flow looks exactly as it did, which is the point.

**Semester list**, with the archive button on the open semester's row (it now links to `/courses/semesters/1/archive/` rather than `/courses/semesters/archive/`):

![Semester list](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2435/semester-list.png)

**The archive page reached from that button**, showing the preview counts for that semester's own registrations and submissions:

![Archive semester page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2435/archive-page.png)

### Anything Else?
With this in, the actual flip is small: drop the demotion in `SiteConfig.set_active_semester()` so starting a semester leaves the others open, point the registration form's semester field at every open semester (it already renders a picker as soon as there is more than one choice), enforce the one-open-semester-per-student rule you confirmed, and handle the plural in the semester list heading and the staff banner.

Also open: #2434 (two `students_only` defaults) and #2413 (starting a quest with no semester open).

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)