### PR TITLE
perf: prefetch what the comments template reads off every comment (#2168)

### DIFF
--- a/src/comments/models.py
+++ b/src/comments/models.py
@@ -48,7 +48,6 @@ class CommentManager(models.Manager):
         Returns:
             QuerySet[Comment]: the comments targeting the object, excluding replies.
         """
-        # local import: questions.models imports this module, so importing it up top is circular
         from questions.models import QuestionSubmission
 
         return self.get_queryset().get_object_target(object).get_no_parents().prefetch_related(

--- a/src/comments/models.py
+++ b/src/comments/models.py
@@ -34,7 +34,30 @@ class CommentManager(models.Manager):
         return qs.select_related('user')
 
     def all_with_target_object(self, object):
-        return self.get_queryset().get_object_target(object).get_no_parents()
+        """Return the target's top-level comments, ready for the comments template.
+
+        That template reads each comment's attached documents and its published question answers
+        (with their questions), so both are prefetched here rather than left to each caller.
+        Without it every rendered comment costs two extra queries, and an announcements page
+        showing a hundred comments pays two hundred of them (#2168).
+
+        Args:
+            object: the model instance the comments target, such as a QuestSubmission or an
+                Announcement.
+
+        Returns:
+            QuerySet[Comment]: the comments targeting the object, excluding replies.
+        """
+        # local import: questions.models imports this module, so importing it up top is circular
+        from questions.models import QuestionSubmission
+
+        return self.get_queryset().get_object_target(object).get_no_parents().prefetch_related(
+            "document_set",
+            models.Prefetch(
+                "question_submissions",
+                queryset=QuestionSubmission.objects.select_related("question"),
+            ),
+        )
 
     # def all(self):
     #     return self.get_queryset.get_active().get_no_parents()

--- a/src/comments/tests/test_models.py
+++ b/src/comments/tests/test_models.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from model_bakery import baker
 from model_bakery.recipe import Recipe
 
+from announcements.models import Announcement
 from comments.models import Comment, Document, clean_html
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 
@@ -276,3 +277,41 @@ class DocumentModelTest(ByteDeckTenantTestCase):
         self.assertTrue(Document(docfile=SimpleUploadedFile("art.png", b"x")).is_valid_portfolio_type())
         self.assertTrue(Document(docfile=SimpleUploadedFile("clip.mp4", b"x")).is_valid_portfolio_type())
         self.assertFalse(Document(docfile=SimpleUploadedFile("notes.txt", b"x")).is_valid_portfolio_type())
+
+
+class CommentManagerPrefetchTest(ByteDeckTenantTestCase):
+    """The comments template reads each comment's attached documents and published question
+    answers, so all_with_target_object() prefetches both: a page with a long comment thread
+    must not cost a query per comment (#2168)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """An announcement with three commenting students: the announcements list renders these
+        threads and its comments carry no answers, the case that made the N+1 cost pure waste."""
+        cls.announcement = baker.make(Announcement)
+        cls.students = [User.objects.create_user(f"student{i}") for i in range(3)]
+
+    def setUp(self):
+        """Comment on the announcement as each student, one with a file attached."""
+        for student in self.students:
+            comment = Comment.objects.create_comment(
+                user=student, path="/announcements/", text="Nice announcement.", target=self.announcement)
+            if student is self.students[0]:
+                baker.make(Document, comment=comment,
+                           docfile=SimpleUploadedFile("notes.txt", b"file_content"))
+
+    def test_all_with_target_object__prefetches_documents_and_answers(self):
+        """Reading every comment's documents and answers costs no further queries.
+
+        Announcement comments never have question answers, so before the prefetch each one ran an
+        always-empty query for them, plus another for its documents.
+        """
+        comments = list(self.announcement.get_comments())
+        self.assertEqual(len(comments), 3)
+
+        with self.assertNumQueries(0):
+            attached = [document for comment in comments for document in comment.document_set.all()]
+            answers = [answer for comment in comments for answer in comment.question_submissions.all()]
+
+        self.assertEqual(len(attached), 1)
+        self.assertEqual(answers, [])

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -1328,26 +1328,16 @@ class QuestSubmission(models.Model):
         return self.time_completed is not None and not self.is_completed
 
     def get_comments(self):
-        """Return this submission's comments, each with its published question answers prefetched.
+        """Return this submission's comments, ready to render.
 
-        The answers (and their questions) are prefetched so the comments template can render
-        every comment's answer table without running a query per comment.
+        The manager prefetches what the comments template reads off each comment (its attached
+        documents and its published question answers), so a submission with a long comment
+        thread does not cost a query per comment.
 
         Returns:
             QuerySet[Comment]: the comments targeting this submission.
         """
-        # local import: questions.models FKs onto this app's models (by string reference),
-        # so importing it at module level here would be circular
-        from questions.models import QuestionSubmission
-
-        # prefetch each comment's published question answers (and their questions) so the
-        # comments template doesn't run a query per comment to render them
-        return Comment.objects.all_with_target_object(self).prefetch_related(
-            models.Prefetch(
-                "question_submissions",
-                queryset=QuestionSubmission.objects.select_related("question"),
-            )
-        )
+        return Comment.objects.all_with_target_object(self)
 
     def _fix_ordinal(self):
         # NOTE: There is a rare bug that we are unable to reproduce as of the moment where a QuestSubmission has the same ordinal.


### PR DESCRIPTION
Closes #2168

### What?

`CommentManager.all_with_target_object()` now prefetches each comment's attached documents and its published question answers, so every consumer of `get_comments()` gets them. `QuestSubmission.get_comments()` drops its own answer prefetch, which this replaces.

### Why?

`comments/comments.html` reads two related sets off every comment it renders: `comment.document_set.all` and `comment.question_submissions.all`. Only quest submissions prefetched anything, and only the answers, so:

* **Announcements** paid two extra queries per comment. Their comments never have question answers, so one of the two was always an empty result. An announcements page shows up to 20 announcements with unbounded threads, so around a hundred visible comments cost around two hundred queries that return nothing useful.
* **Submissions** still ran one query per comment for the documents, which the answer prefetch never covered.

Putting both in the manager fixes all four consumers at once and keeps the prefetch next to the queryset it belongs to, rather than asking each caller to remember it.

### How?

* `src/comments/models.py`: `all_with_target_object()` adds `prefetch_related("document_set", Prefetch("question_submissions", queryset=QuestionSubmission.objects.select_related("question")))`. The `questions` import is local, since `questions.models` imports this module.
* `src/quest_manager/models.py`: `QuestSubmission.get_comments()` becomes a plain call to the manager.

### Testing?

`comments` + `announcements` + `quest_manager` + `questions` + `portfolios` all green (658 tests), plus `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run`.

New `CommentManagerPrefetchTest` in `comments/tests/test_models.py`: three students comment on an announcement (one with a file attached), and reading every comment's documents and answers afterwards issues no further queries. On `develop` the same test reports 12 queries instead of 0.

### Screenshots (if front end is affected)

N/A: no template or visible change, only the queries behind the same page.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved comment loading to reduce database queries when displaying attached documents and published question answers.
  * Streamlined comment retrieval for quest submissions while preserving existing results.

* **Bug Fixes**
  * Ensured related comment content is available without triggering additional database queries during access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->