### PR TITLE
fix: show the second cohort's work to their teacher, and chart each student's own term (#2157 Phase 3)

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1997,6 +1997,32 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {'days_in_semester': 0, 'xp_data': []})
 
+    @freeze_time('2024-02-01')
+    def test_ajax_xp_data__charts_the_students_own_semester(self):
+        """A deck can run two cohorts on different calendars (#1781), and the chart is drawn over
+        the semester's class days. Charting a student against the deck's default semester would
+        give the other cohort someone else's term: the wrong length, and the wrong first day to
+        count their XP from."""
+        their_semester = baker.make(
+            Semester, status=Semester.Status.OPEN,
+            first_day=datetime.date(2024, 1, 15), last_day=datetime.date(2024, 3, 15),
+        )
+        their_student = baker.make(User)
+        baker.make(
+            CourseStudent, user=their_student, semester=their_semester,
+            course=baker.make(Course), block=baker.make(Block),
+        )
+        self.client.force_login(their_student)
+
+        response = self.client.post(
+            reverse('courses:ajax_progress_chart', args=[their_student.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        data = json.loads(response.content)
+        self.assertEqual(data['days_in_semester'], their_semester.num_days())
+        self.assertNotEqual(their_semester.num_days(), self.semester.num_days())
+        # their term started Jan 15, so only its class days are plotted, not the deck semester's
+        self.assertEqual(len(data['xp_data']), their_semester.days_so_far())
+
     def test_ajax_xp_data__correct_xp_current_day(self):
         """ tests if xp_data from ajax request holds the correct xp on different days of the week.
         uses freeze_time to test the current day as Fri, Sat, Sun, and Mon

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1998,7 +1998,7 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
         self.assertEqual(json.loads(response.content), {'days_in_semester': 0, 'xp_data': []})
 
     @freeze_time('2024-02-01')
-    def test_ajax_xp_data__charts_the_students_own_semester(self):
+    def test_ajax_progress_chart__charts_the_students_own_semester(self):
         """A deck can run two cohorts on different calendars (#1781), and the chart is drawn over
         the semester's class days. Charting a student against the deck's default semester would
         give the other cohort someone else's term: the wrong length, and the wrong first day to

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -953,10 +953,10 @@ def ajax_progress_chart(request, user_id=0):
         user_id (int): the student to chart, or 0 for the logged-in user.
 
     Returns:
-        HttpResponse: JSON with `days_in_semester` (the semester's total class days) and
-        `xp_data` (a point per class day so far, as {'x': day, 'y': xp}). Both are empty
-        when there is nothing to chart: no semester is open, or the open one has no class
-        days behind it yet.
+        HttpResponse: JSON with `days_in_semester` (the student's semester's total class days)
+        and `xp_data` (a point per class day so far, as {'x': day, 'y': xp}). Both are empty
+        when there is nothing to chart: the student is in no open semester, or theirs has no
+        class days behind it yet.
 
     Raises:
         Http404: for any method other than POST.
@@ -967,11 +967,15 @@ def ajax_progress_chart(request, user_id=0):
         user = get_object_or_404(User, pk=user_id)
 
     if request.method == "POST":
-        sem = SiteConfig.get().open_semester
+        # the student's own semester, not the deck's default (issue #2157 Phase 3): two
+        # cohorts running on different calendars have different first days and different
+        # class days, so charting one student against the other's term is the wrong graph
+        # (issue #1781).
+        sem = semester_for(user)
 
         if sem is None or sem.days_so_far() <= 0:
-            # Nothing to plot: either the deck is between semesters, or the open semester has
-            # no class days behind it yet (a semester with no dates set has none at all). Hand
+            # Nothing to plot: either the student is in no open semester, or theirs has no
+            # class days behind it yet (a semester with no dates set has none at all). Hand
             # the chart an empty dataset rather than building one from an empty date list,
             # which the weekend adjustment below would then index into.
             return HttpResponse(json.dumps({"days_in_semester": 0, "xp_data": []}), content_type='application/json')

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -852,6 +852,21 @@ class QuestSubmissionQuerySet(models.query.QuerySet):
             return self.none()
         return self.filter(semester=semester)
 
+    def in_open_semesters(self):
+        """Submissions made in any semester that is open right now.
+
+        What a deck-wide staff view of "current" work should filter on: a deck can run
+        several semesters at once (issue #2157 Phase 3, #1781), and scoping to the deck's
+        default would hide everything the other cohort hands in.
+
+        Returns:
+            QuestSubmissionQuerySet: the submissions whose semester is open, empty between
+            semesters.
+        """
+        from courses.models import Semester  # locally, since courses imports this module
+
+        return self.filter(semester__status=Semester.Status.OPEN)
+
     def get_not_semester(self, semester):
         """Submissions made outside `semester`.
 
@@ -916,8 +931,9 @@ class QuestSubmissionManager(models.Manager):
             exclude_quests_not_published (bool): drop submissions of draft quests.
             include_related (bool): join the related objects the templates almost always need.
             user (User): whose semester to limit to. Their registration names it (issue #2157
-                Phase 3). Without a user this is a deck-wide staff view, which uses the deck's
-                open semester.
+                Phase 3). Without a user this is a deck-wide staff view, which covers every
+                open semester: a deck can run two cohorts on different calendars, and a
+                teacher's queues have to hold both cohorts' work, not one semester's.
 
         Returns:
             QuestSubmissionQuerySet: the matching submissions.
@@ -926,7 +942,7 @@ class QuestSubmissionManager(models.Manager):
 
         qs = QuestSubmissionQuerySet(self.model, using=self._db)
         if active_semester_only:
-            qs = qs.get_semester(semester_for(user))
+            qs = qs.get_semester(semester_for(user)) if user is not None else qs.in_open_semesters()
         if exclude_archived_quests:
             qs = qs.exclude_archived_quests()
         if exclude_quests_not_published:

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -874,19 +874,24 @@ class QuestSubmissionQuerySet(models.query.QuerySet):
         :param teacher: a User model
         :return: qs filtered for submissions of students in the current teacher's blocks
         """
+        from courses.models import Semester  # locally, since courses imports this module
+
         if teacher is None:
             return self
         else:
-            # The student's "current teachers" are the teachers of the blocks of their
-            # course registrations in the active semester (Profile.teachers()), so the
-            # block filter must be scoped to the active semester to match. With no open
-            # semester nobody has a current teacher, leaving only the quests this teacher
-            # asked to be notified about.
-            active_semester_id = SiteConfig.get().open_semester_id
-            teacher_filter = Q(quest__specific_teacher_to_notify=teacher)
-            if active_semester_id is not None:
-                teacher_filter |= Q(user__coursestudent__semester=active_semester_id,
-                                    user__coursestudent__block__current_teacher=teacher)
+            # A student's "current teachers" are the teachers of the blocks of the course
+            # registrations they hold in the semester they are in (Profile.teachers()), and
+            # a deck can run several semesters at once (issue #2157 Phase 3), so this matches
+            # a registration in any open semester. Scoping it to the deck's default instead
+            # would empty the approval queue of a teacher whose group runs in the other one.
+            # Both conditions sit in one Q so they match the same registration, rather than
+            # any open-semester registration plus any block this teacher happens to teach.
+            # With no semester open nobody has a current teacher, leaving only the quests
+            # this teacher asked to be notified about.
+            teacher_filter = Q(quest__specific_teacher_to_notify=teacher) | Q(
+                user__coursestudent__semester__status=Semester.Status.OPEN,
+                user__coursestudent__block__current_teacher=teacher,
+            )
             return self.filter(teacher_filter).distinct()
 
     def exclude_archived_quests(self):

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -885,26 +885,38 @@ class QuestSubmissionQuerySet(models.query.QuerySet):
         return self.filter(time_approved__lte=date)
 
     def for_teacher_only(self, teacher):
-        """
-        :param teacher: a User model
-        :return: qs filtered for submissions of students in the current teacher's blocks
+        """The submissions one teacher is responsible for, as their approval queues show them.
+
+        A submission is theirs on either of two counts: the student who made it is in a group
+        this teacher currently teaches, or the quest itself names this teacher to notify
+        whoever hands it in.
+
+        "Currently teaches" is read from the student's own registration rather than from the
+        deck's default semester, since a deck can run several semesters at once (issue #2157
+        Phase 3): scoping it to the default would empty the queue of a teacher whose group
+        runs in the other one. The registration has to be the one that produced the submission
+        (its semester matches the submission's), so a teacher only ever sees the work of the
+        term they teach that student in. With no semester open nobody has a current teacher,
+        leaving only the quests this teacher asked to be notified about.
+
+        Args:
+            teacher (User): the teacher whose queue this is. None means a deck-wide view of
+                every teacher's submissions, so the queryset comes back unfiltered.
+
+        Returns:
+            QuestSubmissionQuerySet: the submissions belonging to this teacher, without
+            duplicates when a student holds several registrations that match.
         """
         from courses.models import Semester  # locally, since courses imports this module
 
         if teacher is None:
             return self
         else:
-            # A student's "current teachers" are the teachers of the blocks of the course
-            # registrations they hold in the semester they are in (Profile.teachers()), and
-            # a deck can run several semesters at once (issue #2157 Phase 3), so this matches
-            # a registration in any open semester. Scoping it to the deck's default instead
-            # would empty the approval queue of a teacher whose group runs in the other one.
-            # Both conditions sit in one Q so they match the same registration, rather than
-            # any open-semester registration plus any block this teacher happens to teach.
-            # With no semester open nobody has a current teacher, leaving only the quests
-            # this teacher asked to be notified about.
+            # all three conditions sit in one Q so they match a single registration, rather
+            # than pairing any open-semester registration with any block this teacher teaches
             teacher_filter = Q(quest__specific_teacher_to_notify=teacher) | Q(
                 user__coursestudent__semester__status=Semester.Status.OPEN,
+                user__coursestudent__semester=F('semester'),
                 user__coursestudent__block__current_teacher=teacher,
             )
             return self.filter(teacher_filter).distinct()

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -716,6 +716,28 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
 
         self.assertIn(their_sub, QuestSubmission.objects.all().for_teacher_only(self.teacher))
 
+    def test_for_teacher_only__matches_the_registration_the_submission_belongs_to(self):
+        """A teacher sees the work of the term they teach that student in, not every term the
+        student has open. CourseStudent.clean() refuses a second open-semester registration,
+        but one can still reach the database (a hand edit in the admin, or two registrations
+        racing, #2438), and a teacher's queue must not start showing another cohort's work
+        because of it."""
+        their_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        other_teacher = baker.make(User, username='other_teacher', is_staff=True)
+        baker.make(
+            'courses.CourseStudent', user=self.student, semester=their_semester,
+            block=baker.make('courses.Block', current_teacher=self.teacher),
+        )
+        baker.make(
+            'courses.CourseStudent', user=self.student, semester=other_semester,
+            block=baker.make('courses.Block', current_teacher=other_teacher),
+        )
+        submission = baker.make(QuestSubmission, user=self.student, quest=baker.make(Quest), semester=their_semester)
+
+        self.assertIn(submission, QuestSubmission.objects.all().for_teacher_only(self.teacher))
+        self.assertNotIn(submission, QuestSubmission.objects.all().for_teacher_only(other_teacher))
+
     def test_for_teacher_only__leaves_out_a_registration_in_a_semester_that_is_not_open(self):
         """A registration in a semester still being set up, or already archived, does not make
         its student one of this teacher's current students, so the block half of the filter

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -791,6 +791,7 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         """Between semesters nothing was earned "this semester", so the semester-scoped
         queryset is empty instead of matching submissions whose semester was deleted."""
         orphaned = baker.make(QuestSubmission, user=self.student, quest__published=True, quest__archived=False, semester=None)
+        Semester.objects.update(status=Semester.Status.ARCHIVED)
         config = SiteConfig.get()
         config.active_semester = None
         config.save()
@@ -799,6 +800,20 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
 
         self.assertFalse(qs.exists())
         self.assertNotIn(orphaned, qs)
+
+    def test_get_queryset__active_semester_only_spans_every_open_semester(self):
+        """A deck-wide staff view covers both cohorts when a deck runs two semesters at once
+        (#2157 Phase 3). Scoping it to the deck's default would hide everything the other
+        cohort hands in, so their work would never reach a teacher's approval queue."""
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        their_submission = baker.make(
+            QuestSubmission, user=self.student, quest__published=True, quest__archived=False,
+            semester=other_semester,
+        )
+
+        qs = QuestSubmission.objects.get_queryset(active_semester_only=True)
+
+        self.assertIn(their_submission, qs)
 
     def test_create_submission__is_not_stamped_when_no_semester_is_open(self):
         """A quest started between semesters belongs to no semester, so its XP counts toward

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -704,35 +704,39 @@ class QuestSubmissionQuerysetTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.all()
         self.assertQuerySetEqual(qs.for_teacher_only(self.teacher), [self.sub, sub2], ordered=False)
 
-    def test_for_teacher_only__ignores_a_pointer_at_a_semester_that_is_not_open(self):
-        """A pointer left on a semester that isn't open means no open semester, so nobody has a
-        current teacher and the block-based half of the filter drops out."""
-        semester = baker.make(Semester)
-        SiteConfig.get().set_active_semester(semester.id)
+    def test_for_teacher_only__spans_every_open_semester(self):
+        """A teacher's group in the deck's other open semester is still their group (#2157 Phase
+        3). A deck can run two cohorts on different calendars, and scoping this to the deck's
+        default semester would empty the approval queue of whichever teacher's group is not in
+        it, while their students still list them as their teacher."""
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        block = baker.make('courses.Block', current_teacher=self.teacher)
+        baker.make('courses.CourseStudent', user=self.student, block=block, semester=other_semester)
+        their_sub = baker.make(QuestSubmission, user=self.student, quest=baker.make(Quest), semester=other_semester)
+
+        self.assertIn(their_sub, QuestSubmission.objects.all().for_teacher_only(self.teacher))
+
+    def test_for_teacher_only__leaves_out_a_registration_in_a_semester_that_is_not_open(self):
+        """A registration in a semester still being set up, or already archived, does not make
+        its student one of this teacher's current students, so the block half of the filter
+        drops it."""
+        semester = baker.make(Semester, status=Semester.Status.UPCOMING)
         block = baker.make('courses.Block', current_teacher=self.teacher)
         baker.make('courses.CourseStudent', user=self.student, block=block, semester=semester)
         block_sub = baker.make(QuestSubmission, user=self.student, quest=baker.make(Quest), semester=semester)
 
-        semester.status = Semester.Status.UPCOMING
-        semester.save()
-
         self.assertNotIn(block_sub, QuestSubmission.objects.all().for_teacher_only(self.teacher))
 
-    def test_for_teacher_only__no_open_semester_keeps_only_notify_submissions(self):
-        """With no open semester nobody has a current teacher, so a teacher's queue holds only
-        the quests they asked to be notified about, not students whose registration has no
-        semester left."""
-        semester = baker.make(Semester)
-        SiteConfig.get().set_active_semester(semester.id)
+    def test_for_teacher_only__a_registration_with_no_semester_keeps_only_notify_submissions(self):
+        """A registration left behind by a deleted semester belongs to no semester, so its
+        student is nobody's current student and the teacher's queue holds only the quests they
+        asked to be notified about."""
+        semester = SiteConfig.get().active_semester
         block = baker.make('courses.Block', current_teacher=self.teacher)
         # a registration with no semester, as deleting a semester leaves behind
         baker.make('courses.CourseStudent', user=self.student, block=block, semester=None)
         block_sub = baker.make(QuestSubmission, user=self.student, quest=baker.make(Quest), semester=semester)
         notify_sub = baker.make(QuestSubmission, semester=semester, quest__specific_teacher_to_notify=self.teacher)
-
-        config = SiteConfig.get()
-        config.active_semester = None
-        config.save()
 
         qs = QuestSubmission.objects.all().for_teacher_only(self.teacher)
 


### PR DESCRIPTION
### What?

#2437 let a deck run two semesters at once. Sweeping the rest of the code for the same pattern found three places that still answered from the deck's default semester, and on a two-cohort deck all three are wrong. Part of #2157 (Phase 3), following #1781.

* **The staff submission queues covered one semester.** Everything the second cohort handed in was invisible in all four approval tabs, under **My groups** and **All** alike. Nobody could approve their work.
* **A teacher's own students didn't match.** Even within one semester's worth of results, `for_teacher_only()` matched students through the deck's default semester, so a teacher whose group runs in the other one matched nobody.
* **The XP progress chart was drawn over the wrong term.** A student in the second cohort got a graph of the deck's default semester: the wrong length, counted from the wrong first day. This is the wrong-graph problem #1781 describes for M/W/F vs T/Th/F cohorts.

### Why?

Phase 3 inverted semester reads one at a time, so what is left is a scattering of call sites that still ask "the deck's semester" where they mean either "this student's semester" or "every semester that is running". #2437 fixed two of those (the student list and the quest status page's group scope) and this finishes the sweep for submissions and charts.

The submission-queue one is the most serious of the set: it is not a display detail, it is work handed in that never reaches a teacher. It sits deeper than the others too, in `QuestSubmissionManager.get_queryset()`, which is why fixing `for_teacher_only()` alone left the queue empty. Both needed fixing, and the screenshots below are from the app with both in place.

### How?

**Deck-wide staff views cover every open semester.** `get_queryset(active_semester_only=True)` with no `user` is the deck-wide staff view, and it now filters through a new `QuestSubmissionQuerySet.in_open_semesters()` instead of the deck's default semester. That one change fixes all four approval tabs at once, since `all_awaiting_approval`, `all_not_completed`, `all_completed`, `all_approved` and `all_returned` all route through it. Passing a `user` is unchanged: that is a particular student's view and stays scoped to their own semester through `semester_for()`.

**A teacher's students come from the registration that produced the submission.** `for_teacher_only()` matches a registration whose semester is open, whose block this teacher teaches, and whose semester is the submission's own:

```python
teacher_filter = Q(quest__specific_teacher_to_notify=teacher) | Q(
    user__coursestudent__semester__status=Semester.Status.OPEN,
    user__coursestudent__semester=F('semester'),
    user__coursestudent__block__current_teacher=teacher,
)
```

All three conditions sit in one `Q` so they land on a single registration, rather than pairing any open-semester registration with any block this teacher happens to teach. Binding to the submission's own semester means the filter does not depend on the one-semester-per-student rule holding: `CourseStudent.clean()` refuses a second open-semester registration, but that runs on save, so a row can still reach the database around it (a hand edit in the admin, which is how `Semester.status` is set today, or the concurrent-write window in #2438). This also puts the method back in step with `Profile.teachers()`, which has read the student's own registration since #2424; the two had quietly drifted apart.

**The progress chart uses the student's own semester.** `ajax_progress_chart` already had the student in hand, so it now charts `semester_for(user)`. The page was contradicting itself before: the mark explanation above the chart is computed from `CourseStudent.semester` (the student's own) and said "50% of the way through the semester", while the chart underneath was drawn over a different semester's calendar entirely.

### Testing?

Full suite green (2300 tests) plus `ruff check src`, and 100% line and branch coverage on both changed modules (`quest_manager/models.py`, `courses/views.py`).

New tests:

* `test_get_queryset__active_semester_only_spans_every_open_semester`: the deck-wide staff view holds the other cohort's submission.
* `test_for_teacher_only__spans_every_open_semester`: a teacher's group in the other open semester is still their group.
* `test_for_teacher_only__matches_the_registration_the_submission_belongs_to`: with one student holding registrations in two open semesters under two different teachers, each teacher sees only the work of their own term.
* `test_ajax_progress_chart__charts_the_students_own_semester`: the chart's length and its number of plotted days come from the student's own semester, and that semester is a different length from the deck's.

Each fails against the unfixed code:

```
AssertionError: <QuestSubmission: ...> not found in <QuestSubmissionQuerySet []>
AssertionError: <QuestSubmission: ...> unexpectedly found in <QuestSubmissionQuerySet [<QuestSubmission: ...>]>
AssertionError: 98 != 45
```

Two existing tests changed meaning rather than breaking, both because they were pinning the pointer where they meant the semester's own status:

* `test_get_queryset__active_semester_only_is_empty_with_no_open_semester` cleared `SiteConfig.active_semester` but left the semester itself open. That used to read as "between semesters"; now that the query asks the database, being between semesters means no semester is open, so the test archives them.
* `test_for_teacher_only__ignores_a_pointer_at_a_semester_that_is_not_open` and its sibling are renamed and rewritten around what actually drives the filter now: the registration's own semester status, and a registration left with no semester at all.

Verified by hand on a seeded `hackerspace` dev deck running two cohorts: Spring 2026 (the deck's default, Mar to Jun, ended) and Summer 2026 (Jul to Sep, mid-term), with a student and teacher in the summer cohort.

### Screenshots (if front end is affected)

**A teacher's approval queue.** Nadia hands in a quest in the summer cohort's semester. Her teacher Ada teaches that group.

| Before | After |
| --- | --- |
| ![Before: the queue reads None](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1781/p6-before-02-approvals.png) | ![After: the submission is there, awaiting approval](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1781/p6-after-02-approvals.png) |

Before, the queue says **None.** and the sidebar shows no pending count: her submission does not exist as far as the deck is concerned. After, it is there with the group, the student and how long it has been waiting, and the sidebar count reads 1.

**A student's XP progress chart.** Nadia's own term runs July 1 to September 30, and she is about halfway through it.

| Before | After |
| --- | --- |
| ![Before: 85 days of class, a flat line pinned to the end](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1781/p6-before-01-chart.png) | ![After: 66 days of class, her XP rising across her term](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1781/p6-after-01-chart.png) |

Before, the x-axis runs to 85 days (Spring 2026's length, not hers) and all her work is squashed into a flat line at the far right, as though she had earned nothing until the last day. After, the axis runs to her semester's 66 days and her XP climbs across it, ending around the halfway mark, which is what the explanation above the chart says. Note the text above the chart is identical in both: it was already reading her own semester, so the page was disagreeing with itself.

### Anything Else?

The remaining `SiteConfig.open_semester` reads in the codebase are the deliberate ones: the registration form's default, the registration gates, `SemesterDelete`'s `PROTECT` match, and `semester_for()`'s own fallback for someone with no registration. Each is documented where it sits.

**A design question worth settling before this merges:** a teacher's approval queue now spans both cohorts rather than gaining a semester filter. That seems right for a school running two calendars (one queue, everything waiting on you), but if teachers should be able to narrow the queue by semester, that is a different design and easier to decide now than after.

**Still ahead in #2157 Phase 3:** XP caching is still per-profile rather than per-registration, and `SiteConfig.active_semester` can eventually go once nothing needs a deck-wide default.

### Review request
@tylerecouture

- Claude Code (bytedeck - semester workflow redesign)
