### PR TITLE
fix: refuse a registration that loses the race into a second open semester (#2438)

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 
 from courses.forms import CourseStudentStaffForm, ExcludedDateFormset, SemesterForm
 from courses.models import Block, Course, CourseStudent, MarkRange, Semester, Rank, ExcludedDate
-from courses.views import SemesterActivate, SemesterUpdate
+from courses.views import SemesterActivate, SemesterUpdate, SerializedRegistrationMixin
 from quest_manager.models import Quest, QuestSubmission
 from badges.models import Badge, BadgeAssertion
 from notifications.models import Notification, notify_rank_up
@@ -650,6 +650,34 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         # Now try acessing page a second time, should give 403 permission denied:
         response = self.client.post(reverse('courses:create'), data=self.valid_form_data)
         self.assertEqual(response.status_code, 403)
+
+    def test_CourseAddStudent_view__refuses_a_registration_that_lost_the_race(self):
+        """Two registrations for one student submitted at the same instant both validate clean,
+        because CourseStudent.clean() reads before either has written (#2438). The loser has to
+        notice on the way out and be refused, or the student ends up in two open semesters.
+
+        The race is staged by having the lock land the other registration, which is what waiting
+        for that lock and then getting it actually looks like. Since the staged row shares this
+        request's transaction, it rolls back along with the refusal, so what this pins is the
+        half that matters: the losing request is told why and writes nothing of its own. A true
+        two-thread test needs TransactionTestCase, and this suite deliberately has none: it
+        shares one schema across classes and nothing may commit.
+        """
+        self.client.force_login(self.test_teacher)
+        other_semester = baker.make(Semester, status=Semester.Status.OPEN)
+
+        def land_the_other_registration(view_self, user_id):
+            """Stand in for the request that got there first while this one waited."""
+            baker.make(CourseStudent, user_id=user_id, semester=other_semester, course=baker.make(Course))
+
+        with patch.object(SerializedRegistrationMixin, 'lock_student', land_the_other_registration):
+            response = self.client.post(
+                reverse('courses:join', args=[self.test_student1.id]), data=self.valid_form_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'only be in one semester at a time')
+        self.assertContains(response, str(other_semester))
+        self.assertEqual(self.test_student1.coursestudent_set.count(), 0)
 
     def test_CourseStudentCreate_view__active_registration_in_old_semester_does_not_block(self):
         """A student with an active registration left over in an old (not-yet-closed) semester can

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.db import connection
+from django.db import connection, transaction
 from django.shortcuts import reverse
 from django.test.utils import CaptureQueriesContext
 from django_tenants.utils import get_public_schema_name
@@ -650,6 +650,22 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         # Now try acessing page a second time, should give 403 permission denied:
         response = self.client.post(reverse('courses:create'), data=self.valid_form_data)
         self.assertEqual(response.status_code, 403)
+
+    def test_lock_student__selects_the_student_row_for_update(self):
+        """The refusal above only helps if the two requests actually queue up, and what makes
+        them queue is this lock. The row locked has to be the student's own: locking their
+        registrations would lock nothing for a student registering for the first time, which is
+        exactly when two requests can race.
+        """
+        view = SerializedRegistrationMixin()
+
+        with transaction.atomic(), CaptureQueriesContext(connection) as queries:
+            view.lock_student(self.test_student1.id)
+
+        locking = [q['sql'] for q in queries.captured_queries if 'FOR UPDATE' in q['sql']]
+        self.assertEqual(len(locking), 1)
+        self.assertIn('auth_user', locking[0])
+        self.assertIn(str(self.test_student1.id), locking[0])
 
     def test_CourseAddStudent_view__refuses_a_registration_that_lost_the_race(self):
         """Two registrations for one student submitted at the same instant both validate clean,

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages.views import SuccessMessageMixin
+from django.core.exceptions import ValidationError
 from django.shortcuts import Http404, HttpResponse, get_object_or_404, redirect, render, reverse
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
@@ -265,8 +266,52 @@ class ArchiveStudentsHelp(NonPublicOnlyViewMixin, TemplateView):
     template_name = 'courses/archive_students_help.html'
 
 
+class SerializedRegistrationMixin:
+    """Save a registration with the one-semester rule re-checked under a lock (issue #2438).
+
+    `CourseStudent.clean()` reads the student's other registrations while the form validates,
+    which leaves a window: two registrations for the same student submitted at the same instant
+    both look clean and both save, landing them in two open semesters at once, which is the
+    state the rule exists to prevent.
+
+    Locking the student's own row makes the two queue up instead, and re-running the rule after
+    the lock is taken means the second one sees what the first wrote. It is refused the same
+    way it would have been had it arrived a moment later: as a form error naming the semester
+    the student is already in, not a crash.
+    """
+
+    def lock_student(self, user_id):
+        """Take the lock that serializes this student's registrations.
+
+        The student's own row is what has to be locked: locking their existing registrations
+        would lock nothing at all for a student registering for the first time, which is
+        exactly when two requests can race.
+
+        Args:
+            user_id (int): the student being registered.
+        """
+        User.objects.select_for_update().get(pk=user_id)
+
+    def form_valid(self, form):
+        """Save the registration, refusing it if another one beat us to this student.
+
+        Returns:
+            HttpResponse: the usual redirect on success, or the re-rendered form carrying the
+            one-semester error when a registration landed while this one waited for the lock.
+        """
+        try:
+            with transaction.atomic():
+                self.lock_student(form.instance.user_id)
+                form.instance.clean()
+                return super().form_valid(form)
+        except ValidationError as error:
+            # keyed on 'semester' by CourseStudent.clean(), so it renders on that field
+            form.add_error(None, error)
+            return self.form_invalid(form)
+
+
 @method_decorator(staff_member_required, name='dispatch')
-class CourseAddStudent(NonPublicOnlyViewMixin, CreateView):
+class CourseAddStudent(SerializedRegistrationMixin, NonPublicOnlyViewMixin, CreateView):
     model = CourseStudent
     form_class = CourseStudentForm
     template_name = 'courses/coursestudent_form.html'
@@ -302,7 +347,9 @@ class CourseAddStudent(NonPublicOnlyViewMixin, CreateView):
         return super().post(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        ctx = super().get_context_data()
+        # kwargs carries the validated form from form_invalid(); dropping it rebuilds an
+        # unvalidated one, losing any error added to the form after it was validated
+        ctx = super().get_context_data(**kwargs)
         ctx['heading'] = 'Add student to course'
         ctx['submit_btn_value'] = 'Add'
         return ctx
@@ -323,7 +370,9 @@ class CourseStudentUpdate(NonPublicOnlyViewMixin, UpdateView):
         return kwargs
 
     def get_context_data(self, **kwargs):
-        ctx = super().get_context_data()
+        # kwargs carries the validated form from form_invalid(); dropping it rebuilds an
+        # unvalidated one, losing any error added to the form after it was validated
+        ctx = super().get_context_data(**kwargs)
         ctx['heading'] = f'Update {self.object.user.username}\'s course'
         ctx['submit_btn_value'] = 'Update'
         return ctx
@@ -333,7 +382,8 @@ class CourseStudentUpdate(NonPublicOnlyViewMixin, UpdateView):
 
 
 # Student Course Registration View
-class CourseStudentCreate(NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequiredMixin, UserPassesTestMixin, CreateView):
+class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequiredMixin,
+                          UserPassesTestMixin, CreateView):
 
     def test_func(self):
         """Allow the registration view only when the student is not already actively registered
@@ -452,7 +502,9 @@ class CourseStudentCreate(NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequ
         return kwargs
 
     def get_context_data(self, **kwargs):
-        ctx = super().get_context_data()
+        # kwargs carries the validated form from form_invalid(); dropping it rebuilds an
+        # unvalidated one, losing any error added to the form after it was validated
+        ctx = super().get_context_data(**kwargs)
 
         ctx['submit_btn_value'] = 'Join'
         ctx['heading'] = 'Join a course'


### PR DESCRIPTION
### What?

Closes #2438.

Two registrations for the same student, submitted at the same instant, could both pass the one-semester-per-student check and both save, leaving the student in two open semesters at once. They now queue up behind a lock, and the second one is refused with the same message it would have got had it arrived a moment later.

Fixing that surfaced a second defect it depends on: all three registration views were discarding the form `form_invalid()` hands them, so an error added to a form after validation never reached the page.

### Why?

`CourseStudent.clean()` enforces the rule (added in #2437) by reading the student's other open-semester registrations. Like any `clean()`-based check, the read and the write are not serialized, so two requests can both read nothing, both conclude they are clean, and both write. The result is the exact state the rule exists to prevent, and it is the state the whole of #2157 Phase 3 depends on: a student in two open semesters makes "which semester did they earn this in?" ambiguous again.

The window is narrow (a student would have to open the join page in two tabs and pick different semesters, or a teacher would have to add them at the same instant they self-register), which is why #2437 deferred it rather than bolting it on. It is worth closing properly now.

### How?

**`SerializedRegistrationMixin`** wraps `form_valid()`: take a lock, re-run the rule while holding it, then save. Both registration views use it (`CourseAddStudent` for staff, `CourseStudentCreate` for a student joining).

The lock is on the **student's own row**, not on their registrations. Locking the registrations would lock nothing at all for a student registering for the first time, which is precisely when two requests can race. Locking `auth_user` gives the two requests something that always exists to queue on, and it introduces no deadlock cycle: the other lock in this area is on the `SiteConfig` singleton (`set_active_semester()` and `complete_semester()`), and no path takes both.

A refusal comes back as a form error naming the semester the student is already in, not an exception, so the loser sees the same page they would have seen had they submitted a second later.

**The `get_context_data()` defect.** `CourseAddStudent`, `CourseStudentUpdate` and `CourseStudentCreate` all called `super().get_context_data()` without passing `**kwargs`. `form_invalid()` passes the validated form that way, so it was dropped and `ModelFormMixin` built a fresh, unvalidated one in its place. Errors raised *during* validation survived by accident, because the rebuilt bound form re-validates itself and reproduces them; anything added to the form *after* validation was silently lost. That is exactly what the new refusal does, so it rendered a blank-looking form until this was fixed. All three now pass `**kwargs` through.

### Testing?

Full suite green (2301 tests) plus `ruff check src`, with 100% line and branch coverage on `courses/views.py`.

`test_CourseAddStudent_view__refuses_a_registration_that_lost_the_race` stages the race by having the lock itself land the other registration, which is what waiting for a lock and then acquiring it actually looks like. Against the unfixed code the racing registration is accepted:

```
AssertionError: 302 != 200
```

The staged row shares the request's transaction, so it rolls back along with the refusal. What the test pins is therefore the half that matters: the losing request is told why, and writes nothing of its own. A true two-thread test needs `TransactionTestCase`, and this suite deliberately has none, since it shares one schema across classes and nothing may commit (documented in `hackerspace_online/tests/utils.py`). Introducing the first committing tenant test to cover this would put that shared-schema optimisation at risk for the whole suite, which is a poor trade for a window this narrow; the deterministic staging exercises the same code path.

Also verified by walking a two-cohort term through a seeded `hackerspace` dev deck (two semesters on different calendars, a teacher and students in each, approving and then archiving one while the other kept running). That walk is what turned up #2441, filed separately.

### Screenshots (if front end is affected)

No visual change. The refusal reuses the existing field-error styling on the registration form, which #2437 already showed:

![The registration is refused, naming the semester the student is already in](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1781/after-04-one-semester-rule.png)

The difference this PR makes is that the message now also appears when the clash is detected at save time rather than at validation time. Before the `get_context_data()` fix it would have rendered as an empty form with no explanation at all.

### Anything Else?

**Filed while working on this, not fixed here:**

* #2441 — a student whose semester was archived earns XP into the other cohort's semester. Found by the dev-deck walk. Reachable in the common case because #2437 keeps the deck pointer on a semester that is still running, and it needs the same decision #2413 is waiting on, so it should be settled with that one rather than patched here.
* #2440 — XP is split evenly between a student's courses rather than attributed to the one it was earned in. I have written up the four ways to model it in that issue with what each costs; it needs a product decision before any code.

**On `CourseStudentUpdate`**: it gets the `get_context_data()` fix for consistency, though nothing currently adds an error to its form after validation, so the change is not separately observable there. Leaving one of the three with the latent defect seemed worse than fixing all three.

### Review request
@tylerecouture

- Claude Code (bytedeck - semester workflow redesign)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XCf7tPxvnsM34aMhk6fMHz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate or invalid course registrations when multiple registration requests occur at the same time.
  * Registration attempts that lose a concurrent update now receive a clear explanation without creating an enrollment.
  * Improved error handling and form display when registration rules are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->