### PR TITLE
feat: sign out in one click from the navbar

### DIFF
--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -89,6 +89,25 @@ class SignOutNavbarTests(ByteDeckTenantTestCase):
         # The visible link is the no-JS fallback (GET -> allauth's confirmation page).
         self.assertContains(response, f'<a href="{logout_url}" class="js-signout" role="button">Sign Out</a>')
 
+    def test_logout__post_clears_the_session(self):
+        """POSTing the logout view actually signs the user out: the auth session is
+        cleared and the request redirects to the login page. This is the behavior the
+        navbar's one-click sign-out (and its no-JS confirmation button) relies on."""
+        self.assertIn('_auth_user_id', self.client.session)  # signed in from setUp
+        response = self.client.post(reverse('account_logout'))
+        self.assertRedirects(response, reverse(settings.LOGIN_URL))
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    def test_logout__get_does_not_sign_out(self):
+        """A GET to the logout view does NOT sign the user out: it renders allauth's
+        confirmation page while the auth session stays intact. This is what keeps
+        sign-out from being triggered by a GET (a prefetch, an <img>, or a cross-site
+        link), and is the no-JS page the navbar link degrades to."""
+        response = self.client.get(reverse('account_logout'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Are you sure you want to sign out?')
+        self.assertIn('_auth_user_id', self.client.session)  # still signed in
+
 
 class SuspendedDeckSignupTests(ByteDeckTenantTestCase):
     """Sign-up is closed on a suspended deck (#1734 redesign): a suspended deck is

--- a/src/hackerspace_online/tests/test_auth.py
+++ b/src/hackerspace_online/tests/test_auth.py
@@ -60,6 +60,36 @@ class NonPublicOnlyAuthViewTests(ByteDeckTenantTestCase):
         self.assert200('account_reset_password_from_key_done')  # ok
 
 
+class SignOutNavbarTests(ByteDeckTenantTestCase):
+    """The navbar's Sign Out control logs a user out in a single click by POSTing to
+    the logout view.
+
+    allauth logs a user out only on POST (``ACCOUNT_LOGOUT_ON_GET`` is left at its
+    default ``False``), so the navbar carries a hidden POST form that a small JS
+    handler submits on click. The visible link keeps its ``href`` as a no-JS
+    fallback: with JS off it GETs allauth's confirmation page, whose button POSTs
+    the same view. Because sign-out is a POST, it can't be triggered by a GET
+    (a prefetch, an ``<img>``, or a cross-site link)."""
+
+    def setUp(self):
+        """Log in a student so the authenticated navbar (which holds Sign Out) renders."""
+        self.student = User.objects.create_user(username='test_student', password='password')
+        self.client.force_login(self.student)
+
+    def test_navbar__sign_out_posts_to_logout(self):
+        """The authenticated navbar renders a POST form (carrying a CSRF token) that
+        targets the logout view, plus the visible link as a no-JS GET fallback."""
+        logout_url = reverse('account_logout')
+        response = self.client.get(reverse('quest_manager:quests'))
+        self.assertEqual(response.status_code, 200)
+        # A hidden POST form targets the logout view and carries a CSRF token, so one
+        # click signs out and the request can't be forged by a GET.
+        self.assertContains(response, f'<form method="post" action="{logout_url}" class="js-signout-form hidden">')
+        self.assertContains(response, 'name="csrfmiddlewaretoken"')
+        # The visible link is the no-JS fallback (GET -> allauth's confirmation page).
+        self.assertContains(response, f'<a href="{logout_url}" class="js-signout" role="button">Sign Out</a>')
+
+
 class SuspendedDeckSignupTests(ByteDeckTenantTestCase):
     """Sign-up is closed on a suspended deck (#1734 redesign): a suspended deck is
     owner-only, so brand-new accounts must not be able to register and land in a

--- a/src/static/js/custom.js
+++ b/src/static/js/custom.js
@@ -36,6 +36,14 @@ $(document).ready(function() {
        window.location.href = $(this).attr("href");
      });
 
+    // Sign Out posts directly for a one-click sign out, submitting the hidden POST
+    // form beside the link. The link keeps its href as a no-JS fallback: with JS off
+    // it GETs allauth's confirmation page, whose button POSTs the same logout view.
+    $('.js-signout').click(function(e) {
+      e.preventDefault();
+      $(this).siblings('.js-signout-form').submit();
+    });
+
     // #1981: bootstrap-table reformats server-rendered tables on load. The head CSS
     // (custom_common.css) hides each data-toggle="table" until this code adds .bt-reveal, and a
     // "Loading content..." spinner (.bt-loading) is server-rendered right before the table so

--- a/src/templates/navbar-fixed.html
+++ b/src/templates/navbar-fixed.html
@@ -247,7 +247,14 @@
                     </ul>
                 </li>
 
-                <li><a href="{% url 'account_logout' %}">Sign Out</a></li>
+                <li>
+                    <a href="{% url 'account_logout' %}" class="js-signout" role="button">Sign Out</a>
+                    <!-- Sign Out is a POST so it can't be triggered by a GET (prefetch, an <img>, a
+                         cross-site link). The JS handler in custom.js submits this form on click for a
+                         one-click sign out; with JS off the link's href GETs allauth's confirmation page,
+                         whose button POSTs this same view. -->
+                    <form method="post" action="{% url 'account_logout' %}" class="js-signout-form hidden">{% csrf_token %}</form>
+                </li>
                 {% else %}
                 <!-- Unauthenticated -->
                 <li><a href="{% url 'account_signup' %}">Sign Up</a></li>

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1218,19 +1218,23 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         owner = SiteConfig.get().deck_owner
         self.set_deck(stripe_customer_id='cus_9')
 
+        # Match the manage-subscription form by its action, so the shared navbar's own
+        # sign-out POST form (present on every authenticated page) is never miscounted.
+        manage_form = f'<form method="post" action="{reverse("decks:subscription")}">'
+
         # setUp's staff user is NOT the owner: disabled buttons, owner named in the popup
         response = self.get_page()
         self.assertContains(response, 'Manage subscription', count=2)
         self.assertContains(
             response, f'Only the deck owner, {owner.get_username()}, can manage the subscription.', count=2
         )
-        self.assertNotContains(response, '<form method="post"')
+        self.assertNotContains(response, manage_form)
 
         # the owner: two live forms, the help text riding on the buttons' title popups
         self.client.force_login(owner)
         response = self.get_page()
         self.assertContains(response, 'Manage subscription', count=2)
-        self.assertContains(response, '<form method="post"', count=2)
+        self.assertContains(response, manage_form, count=2)
         self.assertNotContains(response, 'disabled')
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')


### PR DESCRIPTION
### What?
Signing out from the navbar is now a single click. Previously "Sign Out" GET the allauth logout view, which rendered an "Are you sure you want to sign out?" confirmation page whose button then POSTed to actually log out: two clicks to sign out. Now the navbar POSTs the logout directly, so one click signs you out.

### Why?
The confirmation page was an extra, unnecessary step for a routine action. It existed only because allauth won't log a user out on a GET (to keep a sign-out from being triggered by a prefetch, an `<img>`, or a cross-site link). We can keep that protection while still POSTing straight from the navbar, so the interstitial isn't needed.

### How?
- `src/templates/navbar-fixed.html`: the Sign Out list item now holds a hidden POST `<form>` (with `{% csrf_token %}`) beside the link. The visible `<a>` keeps its `href` as a no-JS fallback and gains a `js-signout` class; the form is `js-signout-form`.
- `src/static/js/custom.js`: a small jQuery handler intercepts clicks on `.js-signout`, prevents the default navigation, and submits the adjacent `.js-signout-form`, so one click POSTs the logout.
- Keeping the `<a>` a direct child of `<li>` means it retains all of Bootstrap's native navbar-link styling with no new CSS.
- `src/templates/account/logout.html` (the confirmation page) is unchanged and stays the no-JS fallback: with JavaScript off, the link GETs it and its button POSTs the logout, exactly as before.
- `src/tenant/tests/test_views.py`: the subscription-detail test counted "any POST form" as a stand-in for its two manage-subscription forms. Because the navbar now carries a sign-out POST form on every authenticated page, that assertion is retargeted to match the manage-subscription form by its action URL, so it counts only the forms it means to.

Sign-out remains a POST in every path, so the anti-GET-logout protection is preserved.

### Testing?
New `SignOutNavbarTests` in `src/hackerspace_online/tests/test_auth.py`:
- `test_navbar__sign_out_posts_to_logout`: the authenticated navbar renders the hidden POST form (targeting the logout view, carrying a CSRF token) and the no-JS fallback link.
- `test_logout__post_clears_the_session`: a POST to the logout view clears the auth session and redirects to login (the path the one-click sign-out and the no-JS confirmation button both take).
- `test_logout__get_does_not_sign_out`: a GET renders the confirmation page and leaves the session intact (the anti-GET-logout protection / no-JS fallback).

Also:
- Verified end to end in a real running `hackerspace` dev deck (logged in as a student): clicking the navbar Sign Out issued a `POST /accounts/logout/` (confirmed via network capture) and landed straight on the signed-out login page, with no confirmation step.
- Full suite (`python src/manage.py test src`) and `ruff check src` pass, including the retargeted `SubscriptionDetailViewTest`.

### Screenshots (if front end is affected)
Navbar (the Sign Out control, far right):

![navbar](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/one-click-signout/navbar.png)

Before (what one click used to land on: the confirmation interstitial, still the no-JS fallback):

![before: confirmation page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/one-click-signout/before_confirm.png)

After (one click signs you out directly, no interstitial):

![after: signed out](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/one-click-signout/after_signed_out.png)

### Anything Else?
The change degrades gracefully: with JavaScript disabled, the old two-step flow (link to confirmation page to POST) still works, so no user is left unable to sign out.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - integrations and automations`)