### PR TITLE
feat: link the import next steps, and only link deck names for Library staff (#2377)

### DIFF
--- a/src/library/templates/library/category_detail_view.html
+++ b/src/library/templates/library/category_detail_view.html
@@ -7,9 +7,16 @@
 
 {% block content %}
   {% comment %} Attribution: content travels under CC BY-SA, which asks for it (#2377) {% endcomment %}
+  {% comment %}
+    The deck name only links for the Library's own staff: another deck is closed to
+    everyone else, so for them the link would be a dead end.
+  {% endcomment %}
   {% if origin %}
     <p class="text-muted">
-      Shared by {{ origin.shared_by }} of <a href="{{ origin.deck_url }}">{{ origin.deck_name }}</a>
+      Shared by {{ origin.shared_by }} of
+      {% if viewer_is_library_staff %}
+        <a href="{{ origin.deck_url }}">{{ origin.deck_name }}</a>
+      {% else %}{{ origin.deck_name }}{% endif %}
       on {{ origin.shared_on|date:"j M Y" }}.
     </p>
   {% endif %}

--- a/src/library/templates/library/tab_library_quests.html
+++ b/src/library/templates/library/tab_library_quests.html
@@ -75,9 +75,15 @@
           <td class="col-sm-5 col-xs-8">{{q.name}}
             {% if q.editor %}<br><small>Editor: {{ q.editor.username }} - {{ q.editor.profile }}</small>{% endif %}
             {% comment %} Attribution: content travels under CC BY-SA, which asks for it (#2377) {% endcomment %}
+            {% comment %}
+              The deck name only links for the Library's own staff: another deck is closed
+              to everyone else, so for them the link would be a dead end.
+            {% endcomment %}
             {% if q.origin %}
               <br><small class="text-muted">Shared by {{ q.origin.shared_by }} of
-                <a href="{{ q.origin.deck_url }}">{{ q.origin.deck_name }}</a></small>
+                {% if viewer_is_library_staff %}
+                  <a href="{{ q.origin.deck_url }}">{{ q.origin.deck_name }}</a>
+                {% else %}{{ q.origin.deck_name }}{% endif %}</small>
             {% endif %}
           </td>
           <td class="col-sm-1 col-xs-2 text-center">{{q.xp}}{% if q.xp_can_be_entered_by_students %}+{% endif %}</td>

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -13,7 +13,7 @@ from django_tenants.utils import get_public_schema_name, schema_exists
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.utils import get_library_schema_name, library_schema_context
 from library.models import ContentOrigin
-from library.views import LibraryQuestListView, shared_library_enabled_view
+from library.views import LibraryQuestListView, shared_library_enabled_view, viewer_is_library_staff
 from library.importer import import_quest_to, import_campaign_to
 from library.exporter import (
     build_library_clone_name,
@@ -1617,6 +1617,10 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
     recording who had shared what (#2377).
     """
 
+    # what the deck the content is shared from is called, so the attribution has
+    # something distinctive to render
+    DECK_NAME = 'sharing-deck'
+
     @classmethod
     def setUpTestData(cls):
         """Create a local quest and campaign to share, and the staff user who shares them."""
@@ -1626,11 +1630,18 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
         cls.test_teacher = User.objects.create_user('sharing_teacher', is_staff=True)
 
     def setUp(self):
-        """Allow staff to export, and log in as one."""
+        """Allow staff to export, log in as one, and give the deck a recognizable name.
+
+        The test tenant is created without a name, and an empty name would make the
+        rendered attribution ("...of {deck}") impossible to assert on.
+        """
         super().setUp()
         config = SiteConfig.get()
         config.allow_staff_export = True
         config.save()
+        # the middleware re-fetches the tenant per request, so this has to reach the row
+        Tenant.objects.filter(schema_name=connection.schema_name).update(name=self.DECK_NAME)
+        self.tenant.name = self.DECK_NAME
         self.client.force_login(self.test_teacher)
 
     def test_export_quest_post__records_who_shared_it_and_from_where(self):
@@ -1643,8 +1654,8 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
             )
 
         self.assertEqual(origin.shared_by, 'sharing_teacher')
-        self.assertEqual(origin.deck_name, self.tenant.name)
-        self.assertIn(self.tenant.name, origin.deck_url)
+        self.assertEqual(origin.deck_name, self.DECK_NAME)
+        self.assertEqual(origin.deck_url, self.tenant.get_root_url())
 
     def test_export_campaign_post__records_the_campaign_and_each_of_its_quests(self):
         """A campaign push attributes the campaign and every quest that travelled with it.
@@ -1666,8 +1677,22 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
         self.assertEqual(quest_origin.shared_by, 'sharing_teacher')
         self.assertEqual(quest_origin.deck_name, self.tenant.name)
 
+    def _attribution_html(self, response):
+        """The response's HTML with runs of whitespace collapsed to single spaces.
+
+        The attribution is laid out over several template lines, so matching it as it
+        appears in the source needs the indentation flattened first.
+
+        Args:
+            response (HttpResponse): the rendered page.
+
+        Returns:
+            str: the page HTML, whitespace-normalized.
+        """
+        return ' '.join(response.content.decode().split())
+
     def test_library_quest_list__attributes_a_shared_quest(self):
-        """The Library's quest list names who shared each quest and links to their deck."""
+        """The Library's quest list names who shared each quest, and their deck."""
         self.client.post(reverse('library:export_quest', args=[self.local_quest.import_id]), data=AGREED_LICENCE)
         with library_schema_context():
             library_quest = Quest.objects.get(import_id=self.local_quest.import_id)
@@ -1676,11 +1701,17 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
 
         response = self.client.get(reverse('library:quest_list'))
 
-        self.assertContains(response, 'Shared by sharing_teacher of')
-        self.assertContains(response, self.tenant.name)
+        # the deck name follows "of" as plain text, not as a link: this viewer is staff of
+        # their own deck, not of the Library, and other decks are closed to them, so a link
+        # would be a dead end. (The deck's own name and URL appear in the page chrome too,
+        # which is why this looks at the attribution itself rather than the whole page.)
+        self.assertIn(
+            f'Shared by sharing_teacher of {self.DECK_NAME}</small>', self._attribution_html(response)
+        )
+        self.assertFalse(response.context['viewer_is_library_staff'])
 
     def test_library_campaign_detail__attributes_a_shared_campaign(self):
-        """The Library's campaign page carries the same attribution."""
+        """The Library's campaign page carries the same attribution, unlinked."""
         self.client.post(reverse('library:export_category', args=[self.local_campaign.import_id]), data=AGREED_LICENCE)
         with library_schema_context():
             library_campaign = Category.objects.get(import_id=self.local_campaign.import_id)
@@ -1691,7 +1722,10 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
             reverse('library:category_detail_view', args=[self.local_campaign.import_id])
         )
 
-        self.assertContains(response, 'Shared by sharing_teacher of')
+        self.assertIn(
+            f'Shared by sharing_teacher of {self.DECK_NAME} on ', self._attribution_html(response)
+        )
+        self.assertFalse(response.context['viewer_is_library_staff'])
 
     def test_library_quest_list__says_nothing_about_content_with_no_recorded_origin(self):
         """Content shared before origins were recorded is listed without a false attribution."""
@@ -1702,6 +1736,58 @@ class ContentOriginTests(LibraryTenantTestCaseMixin):
 
         self.assertContains(response, 'An older library quest')
         self.assertNotContains(response, 'Shared by')
+
+
+class ViewerIsLibraryStaffTests(LibraryTenantTestCaseMixin):
+    """Who gets the deck name in an attribution rendered as a link (#2377).
+
+    Only the Library's own staff, because every other deck is closed to everyone else and
+    the link would be a dead end for them.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """One staff user and one student, to separate the two conditions the helper checks."""
+        cls.staff = User.objects.create_user('library_admin', is_staff=True)
+        cls.student = User.objects.create_user('a_student')
+
+    def _request_from(self, user, tenant):
+        """Build a bare request from a given user on a given deck.
+
+        Args:
+            user (User): who the request is from.
+            tenant (Tenant): the deck serving the request, as the middleware would set it.
+
+        Returns:
+            HttpRequest: a GET request with `user` and `tenant` attached.
+        """
+        request = RequestFactory().get('/')
+        request.user = user
+        request.tenant = tenant
+        return request
+
+    def test_viewer_is_library_staff__true_for_staff_on_the_library_deck(self):
+        """Staff browsing from the Library deck itself can open the decks they review."""
+        self.assertTrue(viewer_is_library_staff(self._request_from(self.staff, self.library_tenant)))
+
+    def test_viewer_is_library_staff__false_for_a_student_on_the_library_deck(self):
+        """Being on the Library deck is not enough: reviewing content is a staff job."""
+        self.assertFalse(viewer_is_library_staff(self._request_from(self.student, self.library_tenant)))
+
+    def test_viewer_is_library_staff__false_for_staff_on_their_own_deck(self):
+        """A teacher is staff of their own deck, not of the Library, so links stay off."""
+        self.assertFalse(viewer_is_library_staff(self._request_from(self.staff, self.tenant)))
+
+    def test_viewer_is_library_staff__ignores_the_schema_the_content_is_read_from(self):
+        """The answer follows the deck serving the page, not a temporary schema switch.
+
+        Both views ask this while inside `library_schema_context()`, so a connection-based
+        answer would hand every teacher a link to a deck they cannot open.
+        """
+        request = self._request_from(self.staff, self.tenant)
+
+        with library_schema_context():
+            self.assertFalse(viewer_is_library_staff(request))
 
 
 class ImportNextStepsTests(LibraryTenantTestCaseMixin):
@@ -1734,9 +1820,14 @@ class ImportNextStepsTests(LibraryTenantTestCaseMixin):
             reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True
         )
 
+        imported = Quest.objects.get(import_id=self.library_quest.import_id)
         message = str(list(response.context['messages'])[0])
-        self.assertIn('publish it', message)
-        self.assertIn('prerequisite', message)
+        # each step links to the page that performs it, rather than naming it and leaving
+        # the reader to find it
+        self.assertIn(f'href="{reverse("quests:quest_update", args=[imported.id])}">publish it</a>', message)
+        self.assertIn(
+            f'href="{reverse("quests:quest_prereqs_update", args=[imported.id])}">prerequisite</a>', message
+        )
 
     def test_import_campaign_post__tells_the_user_to_publish_and_add_a_prerequisite(self):
         """The campaign import message names both remaining steps."""
@@ -1744,9 +1835,13 @@ class ImportNextStepsTests(LibraryTenantTestCaseMixin):
             reverse('library:import_category', args=[self.library_campaign.import_id]), follow=True
         )
 
+        imported = Category.objects.get(import_id=self.library_campaign.import_id)
         message = str(list(response.context['messages'])[0])
-        self.assertIn('publish the campaign', message)
-        self.assertIn('prerequisite', message)
+        self.assertIn(
+            f'href="{reverse("quests:category_update", args=[imported.id])}">publish the campaign</a>', message
+        )
+        # the prerequisite belongs to one of its quests, so this one points at the campaign
+        self.assertIn(f'href="{imported.get_absolute_url()}">prerequisite</a>', message)
 
 
 class LibraryViewsOnPublicSchemaTests(LibraryTenantTestCaseMixin):

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.generic import TemplateView
@@ -101,6 +102,29 @@ def redirect_awaiting_review(request, content_type, redirect_to):
         f"That {content_type} is not available in the Library yet: a Library admin still has to review and publish it."
     )
     return redirect(redirect_to)
+
+
+def viewer_is_library_staff(request):
+    """Whether this viewer is staff *of the Library deck itself*.
+
+    Attribution names the deck content came from, but a link to that deck is only useful
+    to someone who can actually open it. A teacher on their own deck cannot: other decks
+    are closed to them, so the link would be a dead end. The people it helps are the
+    Library's own staff, who review pushed content and may want to see where it came from,
+    and they are staff of the Library deck, which is only true when the page is being
+    served from it.
+
+    The deck is read from the request rather than from the connection, because the views
+    that ask this read the content itself inside `library_schema_context()`: on the
+    connection every viewer would look like they were on the Library deck.
+
+    Args:
+        request (HttpRequest): the current request.
+
+    Returns:
+        bool: True when the request is being served from the Library deck by a staff user.
+    """
+    return request.tenant.schema_name == get_library_schema_name() and request.user.is_staff
 
 
 def record_push_origin(content_type, import_ids, request, source_deck_url):
@@ -318,6 +342,7 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             'library_quests': page_quests,
             'page_obj': page,
             'search_term': search_term,
+            'viewer_is_library_staff': viewer_is_library_staff(self.request),
             'num_matching_quests': paginator.count,
             'num_quests': num_quests,
             'num_campaigns': num_campaigns,
@@ -454,12 +479,15 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
         link = f'<a href="{quest.get_absolute_url()}">{quest.name}</a>'
         # An imported quest arrives as an unpublished draft with no prerequisite, so it is
         # invisible to students and unreachable on the map. Saying so is the difference
-        # between "imported" and "usable" (#2377).
+        # between "imported" and "usable", and each step links to the page that does it
+        # rather than leaving the reader to find it (#2377).
+        publish_link = f'<a href="{reverse("quests:quest_update", args=[quest.id])}">publish it</a>'
+        prereq_link = f'<a href="{reverse("quests:quest_prereqs_update", args=[quest.id])}">prerequisite</a>'
         messages.success(
             request,
             f"Successfully imported '{link}' to your deck. Two things left to do before "
-            "students can see it: <strong>publish it</strong>, and give it a "
-            "<strong>prerequisite</strong> so it is reachable on the quest map."
+            f"students can see it: <strong>{publish_link}</strong>, and give it a "
+            f"<strong>{prereq_link}</strong> so it is reachable on the quest map."
         )
 
         return redirect('quests:drafts')
@@ -566,12 +594,18 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
         category = get_object_or_404(Category, import_id=campaign_import_id)
         link = f'<a href="{category.get_absolute_url()}">{category.name}</a>'
         # As with a single quest: the campaign and its quests arrive unpublished and
-        # unreachable, so the import is only half the job (#2377).
+        # unreachable, so the import is only half the job (#2377). Publishing is on the
+        # campaign's own edit form; the prerequisite belongs to one of its quests, so that
+        # step links to the campaign, where they are listed.
+        publish_link = (
+            f'<a href="{reverse("quests:category_update", args=[category.id])}">publish the campaign</a>'
+        )
+        prereq_link = f'<a href="{category.get_absolute_url()}">prerequisite</a>'
         messages.success(
             request,
             f"Successfully imported '{link}' to your deck. Two things left to do before "
-            "students can see it: <strong>publish the campaign</strong> (which publishes its "
-            "quests), and give its first quest a <strong>prerequisite</strong> so the campaign "
+            f"students can see it: <strong>{publish_link}</strong> (which publishes its "
+            f"quests), and give its first quest a <strong>{prereq_link}</strong> so the campaign "
             "is reachable on the quest map."
         )
 
@@ -936,6 +970,7 @@ class CategoryDetailView(NonPublicOnlyViewMixin, TemplateView):
 
             context.update({
                 'origin': origins.get(category.import_id),
+                'viewer_is_library_staff': viewer_is_library_staff(self.request),
                 'category': category,
                 'category_id': category.pk,
                 'category_campaign_name': category.title,


### PR DESCRIPTION
### What?

Follow-up to #2414 (merged), from review feedback on it. Three changes:

1. The import success message's two steps ("publish it", give it a "prerequisite") are now **links** to the pages that do them, instead of naming them and leaving the reader to go find them.
2. The attribution's **deck name only renders as a link for staff of the Library deck itself**. Everyone else sees it as plain text.
3. `viewer_is_library_staff()` reads the deck from `request.tenant` rather than the connection.

Follow-up to #2377.

### Why?

**The steps were dead ends.** The message told a teacher what was left to do but not where to do it. Publishing lives on the quest's edit form, and the prerequisite on a separate prerequisites form: neither is obvious to someone who has just landed on the Drafts tab. A link makes the message actionable in one click.

**The deck link was useless to almost everyone.** Attribution names the deck content came from, but another deck is closed to a teacher on their own deck, so following the link just got them a login wall. The people it helps are the Library's own staff, who review pushed content and may want to see where it came from, so they keep the link and nobody else gets one.

**Reading the connection was wrong.** Both views build their context *inside* `library_schema_context()`, so `connection.schema_name` is the library schema for every viewer at that moment: the check would have said "yes, Library staff" to every teacher, and the gate would have done nothing. `request.tenant` is the deck actually serving the page and is unaffected by the temporary schema switch. This is exactly what the new test `test_viewer_is_library_staff__ignores_the_schema_the_content_is_read_from` pins.

### How?

* `ImportQuestView`: `publish it` links to `quests:quest_update`, `prerequisite` to `quests:quest_prereqs_update`.
* `ImportCampaignView`: `publish the campaign` links to `quests:category_update` (which publishes its quests), and `prerequisite` to the campaign page, where its quests are listed, since the prerequisite belongs to one of them.
* New `viewer_is_library_staff(request)` helper in `library/views.py`, added to the context of both `LibraryQuestListView` and `CategoryDetailView`; both templates render the deck name as plain text unless it is true.

### Testing?

New `ViewerIsLibraryStaffTests` covers the helper's three conditions plus the schema-context trap. `ContentOriginTests` now asserts the deck name is rendered *unlinked* on both pages, and `ImportNextStepsTests` asserts each step's `href`.

The deck's own name and root URL appear in the page chrome (the navbar links to it), so "is there a link to this deck anywhere on the page" cannot answer the question. The assertions look at the attribution itself, on whitespace-normalized HTML: `Shared by sharing_teacher of sharing-deck</small>` with no anchor between "of" and the name. The test tenant is created without a name, so `setUp` gives it one, otherwise the attribution renders "...of " with nothing after it and the assertion would pass on an empty string.

Runs:

* `python src/manage.py test src/library` : 122 tests, OK
* `ruff check src` : All checks passed!

### Screenshots

From the running dev deck, seeded with real Library content and origins.

**Library quest list, as a teacher on their own deck (`hackerspace`): the deck name is plain text.**

![list, plain](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2377-followup/after_list_plain.png)

**The same list, served from the Library deck to its own staff: the link stays, because for them it works.**

![list, Library staff](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2377-followup/after_list_library_staff.png)

**Library campaign page, same rule.** On a teacher's own deck:

![campaign, plain](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2377-followup/after_campaign_plain.png)

...and to Library staff:

![campaign, Library staff](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2377-followup/after_campaign_library_staff.png)

**After importing a quest: both steps are now links.**

![quest import message](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2377-followup/after_import_quest_message.png)

**After importing a campaign.**

![campaign import message](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2377-followup/after_import_campaign_message.png)

### Anything Else?

You raised the alternative: point the deck name at "a Library page showing only quests shared by that deck". That is a better destination than the deck itself, and it would work for every viewer rather than only Library staff, but it needs a new filtered view and a route, so this PR does the plain-text version you asked for and I filed the filtered page as its own issue rather than smuggling it in here.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - GitHub issues`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh42cNkXcmY3CM5dvPm7Gi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deck attribution links are now restricted to Library staff.
  * Other viewers see source deck names as plain text, preventing access to unavailable deck links.
  * Import follow-up messages now provide direct links to publishing and prerequisite actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->