### PR TITLE
fix: stop the Library hiding content behind the sharing deck's timetable

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2056,23 +2056,27 @@ class LibraryListingWindowTests(LibraryTenantTestCaseMixin):
 
         cls.test_teacher = User.objects.create_user('listing_window_teacher', is_staff=True)
 
-    def test_library_overview__lists_a_quest_whose_availability_date_has_not_arrived(self):
-        """A quest the sharing deck scheduled for a future date is still in the catalogue."""
+    def test_LibraryQuestListView__lists_a_quest_whose_availability_date_has_not_arrived(self):
+        """A quest the sharing deck scheduled for a future date is still in the catalogue.
+
+        Searched for by name rather than read off the first page: the list is paginated and
+        unordered, so which page a quest lands on is not something the test should assume.
+        """
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('library:quest_list'))
+        response = self.client.get(reverse('library:quest_list'), {'q': 'Not Yet Available'})
 
         self.assertIn(self.not_yet, response.context['library_quests'])
 
-    def test_library_overview__lists_a_quest_whose_expiry_date_has_passed(self):
+    def test_LibraryQuestListView__lists_a_quest_whose_expiry_date_has_passed(self):
         """A quest that expired on the sharing deck is still in the catalogue."""
         self.client.force_login(self.test_teacher)
 
-        response = self.client.get(reverse('library:quest_list'))
+        response = self.client.get(reverse('library:quest_list'), {'q': 'Already Expired'})
 
         self.assertIn(self.expired, response.context['library_quests'])
 
-    def test_library_overview__quest_badge_counts_every_quest_the_list_shows(self):
+    def test_LibraryQuestListView__quest_badge_counts_every_quest_the_list_shows(self):
         """The Quests badge agrees with the list beneath it, all three new quests included."""
         self.client.force_login(self.test_teacher)
 
@@ -2080,7 +2084,7 @@ class LibraryListingWindowTests(LibraryTenantTestCaseMixin):
 
         self.assertEqual(response.context['num_quests'], self.quests_already_in_library + 3)
 
-    def test_library_campaign_list__quest_badge_agrees_with_the_quests_tab(self):
+    def test_LibraryCampaignListView__quest_badge_agrees_with_the_quests_tab(self):
         """The Quests badge shows the same total whichever tab the user is on."""
         self.client.force_login(self.test_teacher)
 
@@ -2088,7 +2092,7 @@ class LibraryListingWindowTests(LibraryTenantTestCaseMixin):
 
         self.assertEqual(response.context['num_quests'], self.quests_already_in_library + 3)
 
-    def test_library_overview__search_finds_a_quest_outside_the_sharing_deck_window(self):
+    def test_LibraryQuestListView__search_finds_a_quest_outside_the_sharing_deck_window(self):
         """Search reaches an expired quest, so it can be found rather than only imported by link."""
         self.client.force_login(self.test_teacher)
 

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2021,3 +2021,78 @@ class ConflictingQuestCloneTests(LibraryTenantTestCaseMixin):
         with library_schema_context():
             clone = self._library_clone_of(quest)
             self.assertTrue(clone.name.endswith("#1"), f"expected a numbered suffix, got {clone.name!r}")
+
+
+class LibraryListingWindowTests(LibraryTenantTestCaseMixin):
+    """The Library lists what it holds, not what the sharing deck's timetable allows.
+
+    `date_available` and `date_expired` cross the schema boundary with the quest, so they
+    describe the term of the deck that shared it. A catalogue that honoured those dates
+    would drop a quest the day its original term ended, while leaving it importable
+    through its campaign and by direct link, so the same quest would be missing from one
+    tab and offered in the other.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Add three published quests to the Library: ordinary, not yet available, expired.
+
+        The Library tenant is seeded with quests of its own, so the counts below are
+        measured against a baseline taken before these three are added.
+        """
+        with library_schema_context():
+            cls.quests_already_in_library = Quest.objects.get_queryset().published().active_or_no_campaign().count()
+
+            cls.library_campaign = baker.make(Category, published=True)
+            cls.ordinary = baker.make(Quest, name="Ordinary Quest", campaign=cls.library_campaign, published=True)
+            cls.not_yet = baker.make(
+                Quest, name="Not Yet Available", campaign=cls.library_campaign, published=True,
+                date_available=date(2099, 1, 1),
+            )
+            cls.expired = baker.make(
+                Quest, name="Already Expired", campaign=cls.library_campaign, published=True,
+                date_expired=date(2020, 1, 1),
+            )
+
+        cls.test_teacher = User.objects.create_user('listing_window_teacher', is_staff=True)
+
+    def test_library_overview__lists_a_quest_whose_availability_date_has_not_arrived(self):
+        """A quest the sharing deck scheduled for a future date is still in the catalogue."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:quest_list'))
+
+        self.assertIn(self.not_yet, response.context['library_quests'])
+
+    def test_library_overview__lists_a_quest_whose_expiry_date_has_passed(self):
+        """A quest that expired on the sharing deck is still in the catalogue."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:quest_list'))
+
+        self.assertIn(self.expired, response.context['library_quests'])
+
+    def test_library_overview__quest_badge_counts_every_quest_the_list_shows(self):
+        """The Quests badge agrees with the list beneath it, all three new quests included."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:quest_list'))
+
+        self.assertEqual(response.context['num_quests'], self.quests_already_in_library + 3)
+
+    def test_library_campaign_list__quest_badge_agrees_with_the_quests_tab(self):
+        """The Quests badge shows the same total whichever tab the user is on."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:category_list'))
+
+        self.assertEqual(response.context['num_quests'], self.quests_already_in_library + 3)
+
+    def test_library_overview__search_finds_a_quest_outside_the_sharing_deck_window(self):
+        """Search reaches an expired quest, so it can be found rather than only imported by link."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:quest_list'), {'q': 'Already Expired'})
+
+        self.assertIn(self.expired, response.context['library_quests'])
+        self.assertEqual(response.context['num_matching_quests'], 1)

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -52,6 +52,26 @@ def library_schema_if_requested(request):
 library_schema_context = functools.partial(schema_context, get_library_schema_name())
 
 
+def library_listable_quests():
+    """The quests the Library offers to other decks.
+
+    A quest carries `date_available` and `date_expired` across the schema boundary, so in
+    the Library those dates describe the timetable of the deck that shared it. The Library
+    is a catalogue rather than a feed of what a student can start right now, so it lists by
+    what it holds: published, not archived, and not sitting behind an unpublished campaign.
+    That matches how the Campaigns tab already counts importable quests, so the two tabs
+    agree on what the Library contains.
+
+    Must be called from within the library schema context.
+
+    Returns:
+        QuerySet[Quest]: the listable quests, unordered.
+    """
+    from quest_manager.models import Quest
+
+    return Quest.objects.get_queryset().published().active_or_no_campaign()
+
+
 def get_library_conflicting_quests(local_quests):
     """
     Given a list of local Quest objects, return the import_ids of any quests in

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -207,8 +207,9 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
     """
     View for displaying a list of the quests the shared library holds.
 
-    Only quests that are both published and not archived
-    will be shown. Access is restricted to logged-in staff users.
+    A quest is listed when it is published, not archived, and not sitting behind an
+    unpublished campaign (see `library_listable_quests`). Access is restricted to logged-in
+    staff users.
     """
     # Shared template, tab context determines which section is shown
     template_name = 'library/library_overview.html'
@@ -245,7 +246,7 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             return requested
 
     def get_library_quests(self, search_term):
-        """The active Library quests to list, narrowed by the search term.
+        """The listable Library quests, narrowed by the search term.
 
         Must be called from within the library schema context, and the queryset must be
         evaluated there too: the caller paginates it, which is what runs the queries.
@@ -379,8 +380,10 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
                         - published=True
                         - archived=False (not archived)
                 - num_campaigns (int): Number of campaigns in the displayed list, used for the UI badge.
-                - num_quests (int): Total number of visible (published and not archived) quests,
-                    used for the UI badge in the quest tab.
+                - num_quests (int): Total number of listable quests (published, not archived,
+                    and not behind an unpublished campaign), used for the UI badge in the
+                    quest tab. Read through the same helper the Quests tab lists with, so
+                    the badge agrees whichever tab the user is on.
                 - is_library_view (bool): True, so the campaign table shared with the deck's own
                     campaign list shows the Library's import action instead of the local ones.
         """

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -31,7 +31,7 @@ from .exporter import export_quest_to_library, export_campaign_and_copy_quests
 from .forms import ShareLicenceForm
 from .importer import import_campaign_to, import_quest_to
 from .models import ContentOrigin
-from .utils import get_library_schema_name, library_schema_context, get_library_conflicting_quests
+from .utils import get_library_schema_name, library_schema_context, get_library_conflicting_quests, library_listable_quests
 
 User = get_user_model()
 
@@ -205,7 +205,7 @@ def email_library_staff_of_push(content_type, content_name, exported_obj, sharer
 @method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
 class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
     """
-    View for displaying a list of active quests from the shared library.
+    View for displaying a list of the quests the shared library holds.
 
     Only quests that are both published and not archived
     will be shown. Access is restricted to logged-in staff users.
@@ -264,7 +264,7 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
         Returns:
             QuerySet[Quest]: the matching quests, campaign and tags pre-fetched.
         """
-        quests = Quest.objects.get_active().select_related('campaign').prefetch_related('tags')
+        quests = library_listable_quests().select_related('campaign').prefetch_related('tags')
 
         for word in search_term.split():
             quests = quests.filter(
@@ -281,7 +281,7 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         """
-        Populate context with a page of active quests from the shared library.
+        Populate context with a page of the shared library's listable quests.
 
         The Library is read one page at a time: the whole thing used to be loaded into
         memory and rendered on every request, which does not survive a Library worth
@@ -295,13 +295,13 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             dict: Template context including:
                 - heading (str): Page title.
                 - tab (str): Active tab identifier.
-                - library_quests (list[Quest]): The current page of active quests, with
+                - library_quests (list[Quest]): The current page of listable quests, with
                     related Campaign and tags prefetched.
                 - page_obj (Page): The current page, for the pagination controls.
                 - search_term (str): What the user searched for, to keep the box filled in.
                 - num_matching_quests (int): How many quests the search matched, across
                     every page.
-                - num_quests (int): Number of active quests in the Library, used for the UI
+                - num_quests (int): Number of listable quests in the Library, used for the UI
                     badge. This is the whole Library, not the search results, so the badge
                     doesn't change as the user types.
                 - num_campaigns (int): Number of active Campaigns with importable quests,
@@ -322,7 +322,7 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             # Force evaluation inside the library context: the template renders this after
             # the schema has switched back to the caller's own deck.
             page_quests = list(page.object_list)
-            num_quests = Quest.objects.get_active().count() if search_term else paginator.count
+            num_quests = library_listable_quests().count() if search_term else paginator.count
             num_campaigns = Category.objects.all_published_with_importable_quests().count()
 
             # One query for this page rather than one per row, and only for the quests
@@ -389,7 +389,7 @@ class LibraryCampaignListView(NonPublicOnlyViewMixin, TemplateView):
         with library_schema_context():
             # Explicitly call len() to force evaluation inside the library context
             # this forces all Campaigns to load.
-            quests_count = Quest.objects.get_active().count()
+            quests_count = library_listable_quests().count()
             campaigns = Category.objects.all_published_with_importable_quests()
             num_campaigns = len(campaigns)
 


### PR DESCRIPTION
### What?

The Library's Quests tab filtered with `Quest.objects.get_active()`, which applies `date_available` and `date_expired`. Those dates travel with the quest, so in the Library they describe the timetable of the deck that shared it. The tab now lists by what the Library holds: published, not archived, and not behind an unpublished campaign.

Adds `library_listable_quests()` to `src/library/utils.py` and points the three places that needed the definition at it (the quest list, its badge, and the Quests badge shown on the Campaigns tab).

### Why?

**A quest dropped out of the catalogue on the day its original term ended.** A teacher who sets "closes at the end of term" and shares the quest gets a Library entry that quietly disappears for everyone once that date passes, months later, with nothing to explain it.

**The two tabs disagreed about what the Library contained.** The Campaigns tab counts a quest as importable when it is `published=True, archived=False`, with no time filters (`Category.objects.all_published_with_importable_quests()`). So the same quest was missing from the Quests tab while its campaign still advertised it and still delivered it.

I measured it before changing anything, pushing a campaign holding one ordinary quest and one whose expiry had passed:

```
[LIBRARY]  actually in library : ['Expired Quest', 'Good Quest']
[LIBRARY]  shown in quests tab  : ['Good Quest']
[LIBRARY]  campaign page shows  : ['Expired Quest', 'Good Quest']
[IMPORT]   arrived on the deck  : ['Expired Quest', 'Good Quest']
```

The quest is in the Library, the campaign page offers it, importing delivers it, and the Quests tab denies it exists. A quest with a *future* `date_available` behaves the same way. Neither is stranded (the direct import URL works, since `get_published_library_object()` does not apply the time filters either), so this is a discovery bug rather than a data-loss one: the browse path is the one place a teacher cannot find it.

The campaign list view's own docstring already described `num_quests` as the number of "published and not archived" quests, which is exactly what `get_active()` was not doing. The code and its documentation disagreed, and the documentation was right.

### How?

`library_listable_quests()` lives in the library app rather than as a manager method on `Quest`, so existing apps stay unaware of the Library (the design constraint #2378 was about). It is `Quest.objects.get_queryset().published().active_or_no_campaign()`: `get_queryset()` already excludes archived, and dropping `datetime_available()` / `not_expired()` is the fix. That matches how the Campaigns tab defines importable, so the two tabs now agree.

Three call sites used the old filter, which is why this is one helper rather than three edits: `LibraryQuestListView.get_library_quests`, its `num_quests` badge, and `LibraryCampaignListView`'s copy of that badge.

### Testing?

New `LibraryListingWindowTests` in `src/library/tests/test_views.py`, five tests: a not-yet-available quest and an expired one both appear in the catalogue, the badge agrees with the list beneath it, the badge agrees across both tabs, and search reaches an expired quest. All five fail on `develop`:

```
FAIL: ...lists_a_quest_whose_availability_date_has_not_arrived
  <Quest: Not Yet Available> not found in [...]
FAIL: ...lists_a_quest_whose_expiry_date_has_passed
  <Quest: Already Expired> not found in [...]
FAIL: ...quest_badge_counts_every_quest_the_list_shows
  7 != 9
FAIL: ...search_finds_a_quest_outside_the_sharing_deck_window
  <Quest: Already Expired> not found in []
```

The Library tenant is seeded with quests of its own, so the counts are measured against a baseline taken in `setUpTestData` before the three test quests are added, rather than against a magic number.

```
src/library                                   123 tests   OK
full suite (python src/manage.py test src)   2317 tests   OK
ruff check src                                            clean
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

The change is to which rows a queryset returns; the template, layout and styling are untouched. What a reviewer would see is a quest present or absent from the list, which the tests above assert directly and name individually.

### Anything Else?

**Not a regression from the recent Library work.** `get_active()` was already the filter before #2408 paginated the list (it is on line 179 of the pre-#2408 view), so this predates the current round of changes rather than arriving with it. Worth saying explicitly, since several Library PRs landed in the same week.

**Found while reviewing, filed separately, not fixed here:** #2448, the shared pagination control renders one link per page for the whole range, which works against the point of paginating the Library in the first place. It is a shared component used by two `quest_manager` tabs as well, so it wants its own change.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Published quests remain visible in the Library before their sharing availability date and after their expiry date.
  * Library search now finds quests outside the sharing deck availability window.
  * Quest listings and badge counts now stay consistent across Library tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->