### PR TITLE
fix: initialize tooltips and popovers for the whole site (#2166)

### DIFF
--- a/src/badges/templates/badges/list.html
+++ b/src/badges/templates/badges/list.html
@@ -50,10 +50,3 @@
 {% endfor %}
 
 {% endblock %}
-{% block js %}
-<script>
-$(document).ready(function() {
-  $('[data-toggle="popover"]').popover()
-});
-</script>
-{% endblock %}

--- a/src/courses/templates/courses/mark_calculations.html
+++ b/src/courses/templates/courses/mark_calculations.html
@@ -193,12 +193,6 @@ for {{user}}
 {% endblock %}
 
 {% block js %}
-  <script>
-      $(document).ready(function () {
-          $('[data-toggle="popover"]').popover(
-          )
-      });
-  </script>
   <script src="{% static 'js/Chart-2.9.4.min.js' %}"></script>
   {% include 'courses/chart_xp_progress.html' %}
   {% include 'courses/chart_mark_distribution.html' %}

--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -339,10 +339,3 @@
 
 {% endblock %}
 
-{% block js %}
-<script>
-$(document).ready(function() {
-  $('[data-toggle="popover"]').popover()
-});
-</script>
-{% endblock %}

--- a/src/quest_manager/templates/quest_manager/quest_approval.html
+++ b/src/quest_manager/templates/quest_manager/quest_approval.html
@@ -79,7 +79,6 @@ $( document ).ready(function() {
         textarea.val(textarea.val() + ' ' + raw + ' ');
     });
 
-    $('[data-toggle="tooltip"]').tooltip();
 });
 
 // all forms that has an id starting with "quick_reply"

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -209,7 +209,6 @@
 {% block js %}
     <script>
         $(document).ready(function() {
-            $('[data-toggle="tooltip"]').tooltip();
 
 
             {% if anchor %}

--- a/src/quest_manager/templates/quest_manager/summary.html
+++ b/src/quest_manager/templates/quest_manager/summary.html
@@ -207,9 +207,6 @@ window.onload = function() {
     console.log($("#histoForm"))
 };
 
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
 
 </script>
 

--- a/src/questions/templates/questions/question_list.html
+++ b/src/questions/templates/questions/question_list.html
@@ -30,13 +30,3 @@
   </div>
   {% include 'questions/snippets/question_table.html' %}
 {% endblock %}
-
-{% block js %}
-<script>
-    // initialize the popovers and tooltips used by the question table
-    $(document).ready(function(){
-        $('[data-toggle="popover"]').popover();
-        $('[data-toggle="tooltip"]').tooltip();
-    });
-</script>
-{% endblock %}

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -481,6 +481,23 @@ class QuestDetailEntryPointTest(QuestionSubmissionFlowTestBase):
         response = self.assert200("quests:submission", args=[self.submission.id])
         self.assertNotContains(response, "Manage Questions")
 
+    def test_quest_detail__marker_notes_popover_is_initialized(self):
+        """The marker-notes popover in the question table is activated on this page (#2166).
+
+        Bootstrap popovers do nothing until initialized, so before the site-wide initializer the
+        icon here showed only its native "Marker Notes" title and the notes themselves could not
+        be read anywhere outside the question-management page.
+        """
+        self.short_question.marker_notes = "<p>Accept any working URL.</p>"
+        self.short_question.save()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse("quests:quest_detail", args=[self.quest.id]))
+
+        self.assertContains(response, "Accept any working URL.")
+        self.assertContains(response, 'data-toggle="popover"')
+        self.assertContains(response, """$('[data-toggle="popover"]').popover();""")
+
 
 class DraftRowHealingTest(QuestionSubmissionFlowTestBase):
     """sync_draft_question_submissions heals duplicate draft rows for the same question."""

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -484,9 +484,9 @@ class QuestDetailEntryPointTest(QuestionSubmissionFlowTestBase):
     def test_quest_detail__marker_notes_popover_is_initialized(self):
         """The marker-notes popover in the question table is activated on this page (#2166).
 
-        Bootstrap popovers do nothing until initialized, so before the site-wide initializer the
-        icon here showed only its native "Marker Notes" title and the notes themselves could not
-        be read anywhere outside the question-management page.
+        A bootstrap popover does nothing until something initializes it: without the site-wide
+        initializer this icon offers only its native "Marker Notes" title, leaving the notes
+        themselves unreadable on the page a teacher marks from.
         """
         self.short_question.marker_notes = "<p>Accept any working URL.</p>"
         self.short_question.save()

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -789,6 +789,13 @@ h3.comment-heading {
     margin-top: 25px;
 }
 
+/* A popover's title is an h3, and bootstrap appends the popover beside its trigger, so a popover
+   opened inside a panel picks up the panel's h3 spacing above and opens with a band of empty
+   space over its title. Popovers set their own spacing. */
+.panel-body .popover-title {
+    margin-top: 0;
+}
+
 .comment-content {
     /* prevent long urls from breaking out of container or forcing a scrollbar */
     overflow-wrap: anywhere;

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -24,7 +24,7 @@
 {% else %}
 <link href="{{ STATIC_PREFIX }}css/custom.css?v=1.7" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.6" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.7" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -188,6 +188,14 @@
       // Enable allowfullscreen on responsive iframes
       $("iframe.embed-responsive-item").attr('allowfullscreen', '');
 
+      // Bootstrap tooltips and popovers are opt-in per element, so activate every element that
+      // asks for one, once, for the whole site. The markup lives in shared snippets (the
+      // submission-questions table, a submission's time-to-complete note) that render on pages
+      // all over the app, and a page that did not run this itself showed no popover at all: the
+      // marker notes and the list of allowed file types were unreachable (#2166).
+      $('[data-toggle="tooltip"]').tooltip();
+      $('[data-toggle="popover"]').popover();
+
       // Dismiss bootstrap alerts
       if ($('.dismiss-in-3').length) {
         setTimeout(function(){ $('.dismiss-in-3').slideUp(); }, 3000);


### PR DESCRIPTION
Closes #2166

### What?

Tooltips and popovers are now activated once, site-wide, in the shared javascript block. The six page-level copies that did the same thing are gone, and a stylesheet rule that was deforming every popover inside a panel is fixed.

### Why?

Bootstrap popovers and tooltips do nothing until something calls `.popover()` / `.tooltip()` on them, and every page was arranging that for itself. Shared snippets put that markup on pages that never did:

* **Marker notes** in the submission-questions table. The table is included by the quest detail page, the submission page, and both library preview pages, but only the question-management page initialized anything. Everywhere else the icon showed nothing on hover, so a teacher could not read their own marker notes while actually marking a submission.
* **Allowed file types** on a file question's answer field, rendered on the submission page. Students only ever saw the coarse "Allowed file types: Image" help text, never the exact list.
* The time-to-complete note's tooltip, in the same position wherever its snippet lands on a page without an initializer.

A page-by-page fix would have to be repeated on four templates and remembered by the next one that includes these snippets, so this does it once instead.

The CSS fix came out of review. `custom_common.css` has `.panel-body h3 { margin-top: 25px }`; a popover's title is an `h3` and bootstrap appends the popover next to its trigger, so any popover opened inside a panel body matched that rule and beat bootstrap's own `.popover-title { margin: 0 }` on specificity. Every such popover opened with 25px of dead space above its title (the badge popovers on the profile page and the marks-page popovers included). Making popovers appear in more places would have spread that, so it is fixed here.

### How?

* `src/templates/javascript.html`: `$('[data-toggle="tooltip"]').tooltip();` and `$('[data-toggle="popover"]').popover();` in the ready handler already there, which `base.html` includes on every page.
* Removed the now-duplicate initializers from `badges/list.html`, `profile_manager/profile_detail.html`, `courses/mark_calculations.html`, `questions/question_list.html`, `quest_manager/quest_approval.html`, `quest_manager/summary.html`, and `quest_manager/submission.html`. All of them called it with no options, so nothing is lost. The badge-modal popover in `javascript.html` keeps its own call, because that markup is injected by ajax after the ready handler has run.
* `src/static/css/custom_common.css`: `.panel-body .popover-title { margin-top: 0 }` beside the rule it counteracts, with the `?v=` cache-buster bumped in `head_css.html`.

### Testing?

Full suite run locally (2348 tests), plus `ruff check src` and `manage.py check`, both clean. The one failure in that run was the notifications id collision, unrelated to this PR and since fixed by #2457, which this branch has picked up.

New test in `questions/tests/test_integration.py`: the quest detail page renders the marker-notes popover trigger and the initializer that makes it work. It fails on `develop` (`Couldn't find '$('[data-toggle="popover"]').popover();'`).

The CSS fix was verified on the running deck by reading the computed style of a live popover title: `margin: 25px 0px 0px` before, `margin: 0px` after.

### Screenshots (if front end is affected)

From the running `hackerspace` dev deck. Marker notes hovered as a teacher on the quest detail page:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2166/before_marker.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2166/after_marker.png) |

Allowed file types hovered as a student on the submission page:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2166/before_file_types.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2166/after_file_types.png) |

The "after" shots are re-captured with the CSS fix in place, so they show the title flush with the top of the popover.

### Anything Else?

This only activates markup that already exists, so it does not conflict with the convention that action buttons use the native `title` attribute: those buttons carry no `data-toggle`, and nothing here changes them.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)