### PR TITLE
test: stop assuming a notification id is free (#2455)

### DIFF
--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
+from django.db.models import Max
 from django.shortcuts import reverse
 from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
@@ -27,6 +28,19 @@ class NotificationViewTests(ByteDeckTenantTestCase):
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
         cls.test_student2 = baker.make(User)
+
+    def unused_notification_id(self):
+        """An id that belongs to no notification, for the "deleted or never existed" path.
+
+        A literal id is not safe here: ids come from a sequence shared by every test in the run,
+        so a long run reaches any number eventually, and the view then finds someone else's
+        notification and 404s instead of redirecting.
+
+        Returns:
+            int: one past the highest notification id in the database.
+        """
+        highest = Notification.objects.all().aggregate(Max('id'))['id__max'] or 0
+        return highest + 1
 
     def test_notification_page_status_codes__anonymous(self):
         ''' If not logged in then all views should redirect to home page '''
@@ -75,7 +89,7 @@ class NotificationViewTests(ByteDeckTenantTestCase):
 
         # Bad id notification read request should redirect to list view
         self.assertRedirects(
-            response=self.client.get(reverse('notifications:read', args=[999])),
+            response=self.client.get(reverse('notifications:read', args=[self.unused_notification_id()])),
             expected_url=reverse('notifications:list'),
         )
 
@@ -144,7 +158,7 @@ class NotificationViewTests(ByteDeckTenantTestCase):
 
         response = self.client.post(
             reverse('notifications:ajax_mark_read'),
-            data={'id': 999999},
+            data={'id': self.unused_notification_id()},
             HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
Closes #2455

### What?

Two notification tests asked for a hard-coded id to stand for "no such notification". They now ask the database for an id one past the highest that exists.

### Why?

`python src/manage.py test src` fails on a clean `develop` (confirmed at 514e521, no local changes), and so does CI on every PR:

```
FAIL: test_notification_page_status_codes__teachers (notifications.tests.test_views.NotificationViewTests)
AssertionError: 404 != 302 : Response didn't redirect as expected: Response code was 404 (expected 302)
```

The test fetches `notifications:read` with id 999 expecting the view's "deleted or never existed" path, which redirects to the list. Ids come from a sequence shared by every test in the run, and notifications are created by signals all over the suite, so a full run is long past 999 by the time the notifications app is reached. Id 999 then resolves to a real notification belonging to another user, which the view correctly answers with a 404. Nothing is wrong with the view; the test's assumption expired as the suite grew.

The same latent trap sat in `test_ajax_mark_read__unknown_id_returns_404` with 999999. It has not fired yet, and it fails differently when it does (the endpoint returns 200 if the id happens to belong to the logged-in student), so it is fixed the same way rather than left to surface later.

It also passes app-standalone (`manage.py test notifications`), which is why it went unnoticed.

### How?

`unused_notification_id()` on the test class returns `Max("id") + 1`, so the lookup cannot hit a real row no matter how far the sequence has run. Both call sites use it.

### Testing?

Full suite green with the fix: 2347 tests, `OK`. The same run without it fails the one test above. `ruff check src` clean.

### Screenshots (if front end is affected)

N/A: test-only change.

### Anything Else?

This is blocking: until it lands, CI is red on `develop` and on every open PR, including my #2454. That one is otherwise green and will go green once it picks this up.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_