### PR TITLE
feat: make Library losses the sharer's business, not the importer's

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -183,8 +183,9 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
         campaign_import_id (UUID): Import ID of the campaign to export.
 
     Returns:
-        TransferResult: The quests as they now exist in the library, and the names of any
-            prerequisites that could not travel with them.
+        TransferResult: The quests as they now exist in the library, the names of any
+            prerequisites that could not travel with them, and the names of any quests in
+            the campaign that were not shared at all.
 
     Raises:
         Category.DoesNotExist: If the campaign is not found in the source schema.
@@ -194,6 +195,17 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
     with schema_context(source_schema):
         local_campaign = Category.objects.get(import_id=campaign_import_id)
         local_quests = list(local_campaign.current_quests())
+
+        # `current_quests()` is published and not archived, so archiving a quest quietly
+        # takes it out of the share. Name them, so the sharer finds out now rather than
+        # from whoever imports the campaign and wonders where the quest went (#2442).
+        shared_ids = {quest.id for quest in local_quests}
+        skipped_quests = sorted(
+            Quest.objects.all_including_archived()
+            .filter(campaign=local_campaign, archived=True)
+            .exclude(id__in=shared_ids)
+            .values_list('name', flat=True)
+        )
 
     # detect which local quests already exist in the library before the export happens
     library_conflicting_ids = get_library_conflicting_quests(local_quests)
@@ -228,4 +240,5 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
     return TransferResult(
         quests=exported.quests + cloned.quests,
         unmet_prereqs=sorted(set(exported.unmet_prereqs) | set(cloned.unmet_prereqs)),
+        skipped_quests=skipped_quests,
     )

--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -199,10 +199,14 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
         # `current_quests()` is published and not archived, so archiving a quest quietly
         # takes it out of the share. Name them, so the sharer finds out now rather than
         # from whoever imports the campaign and wonders where the quest went (#2442).
+        #
+        # Published, because that is what makes "unarchive it and share again" true. An
+        # archived *draft* fails both halves of the filter, so unarchiving alone would not
+        # send it, and a draft staying behind is what a sharer expects anyway.
         shared_ids = {quest.id for quest in local_quests}
         skipped_quests = sorted(
             Quest.objects.all_including_archived()
-            .filter(campaign=local_campaign, archived=True)
+            .filter(campaign=local_campaign, published=True, archived=True)
             .exclude(id__in=shared_ids)
             .values_list('name', flat=True)
         )

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2266,6 +2266,29 @@ class LibrarySharerWarningTests(LibraryTenantTestCaseMixin):
         self.assertIn(active.import_id, shared)
         self.assertNotIn(archived.import_id, shared)
 
+    def test_export_category__does_not_name_an_archived_quest_that_is_also_a_draft(self):
+        """A draft is not reported as left behind, because unarchiving would not send it.
+
+        The share carries `current_quests()`, which is published *and* not archived, so an
+        archived draft fails both tests. Naming it would attach advice that does not work:
+        unarchive it and share again, and it still would not travel. A draft not travelling
+        is what a sharer expects anyway; an archived quest disappearing is not.
+        """
+        campaign = baker.make(Category, published=True)
+        baker.make(Quest, name="Ordinary Shared Quest", campaign=campaign, published=True)
+        baker.make(Quest, name="Archived Draft", campaign=campaign, published=False, archived=True)
+        self._allow_staff_export()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('library:export_category', args=[campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertFalse(
+            any("Archived Draft" in text for text in self._message_texts(response)),
+            f"an archived draft should not be reported, got {self._message_texts(response)}",
+        )
+
     def test_export_category__stays_quiet_when_every_quest_travels(self):
         """A campaign with nothing archived shares without a left-behind warning."""
         campaign = baker.make(Category, published=True)

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2105,12 +2105,13 @@ class LibraryImportCollisionMessageTests(LibraryTenantTestCaseMixin):
         self.assertFalse(Category.objects.filter(import_id=self.library_campaign.import_id).exists())
 
 
-class LibraryUnmetPrereqWarningTests(LibraryTenantTestCaseMixin):
-    """A prerequisite the importing deck does not have is reported, not dropped in silence.
+class LibraryImportPrereqBehaviourTests(LibraryTenantTestCaseMixin):
+    """What happens to a quest's gating when the importing deck does not have it.
 
-    The loss fails open: a quest meant to unlock after another one arrives with no gate at
-    all, so it is immediately available to anyone who can see it. The teacher is told which
-    requirement did not come across, beside the message telling them to publish it (#2399).
+    Imported content is a self-contained package: the importing teacher places it into
+    their own map and sets their own prerequisites, so a gate that did not travel is not
+    something they need telling about. It is the sharer's business, and is warned about on
+    the push instead (see `LibrarySharerWarningTests`).
     """
 
     @classmethod
@@ -2123,21 +2124,8 @@ class LibraryUnmetPrereqWarningTests(LibraryTenantTestCaseMixin):
 
         cls.test_teacher = User.objects.create_user('unmet_prereq_teacher', is_staff=True)
 
-    def test_import_quest__warns_that_a_missing_prerequisite_was_not_carried_over(self):
-        """Importing a gated quest onto a deck without the gate names what is missing."""
-        self.client.force_login(self.test_teacher)
-
-        response = self.client.post(
-            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
-        )
-
-        self.assertTrue(
-            any("Finish The Prologue" in text for text in self._message_texts(response)),
-            f"expected the missing prerequisite to be named, got {self._message_texts(response)}",
-        )
-
     def test_import_quest__arrives_ungated_when_the_prerequisite_is_missing(self):
-        """The warning is warranted: the quest really does arrive with no prerequisite."""
+        """A quest whose gate this deck does not have arrives with no prerequisite."""
         self.client.force_login(self.test_teacher)
 
         self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True)
@@ -2145,16 +2133,13 @@ class LibraryUnmetPrereqWarningTests(LibraryTenantTestCaseMixin):
         imported = Quest.objects.all_including_archived().get(import_id=self.library_quest.import_id)
         self.assertEqual(list(imported.prereqs()), [])
 
-    def test_import_quest__stays_quiet_when_the_deck_already_has_the_prerequisite(self):
-        """A deck holding the gate gets the prerequisite rebuilt and no warning."""
+    def test_import_quest__rebuilds_a_prerequisite_the_deck_already_has(self):
+        """A deck holding the gate gets the prerequisite rebuilt rather than dropped."""
         import_quest_to(destination_schema=connection.schema_name, quest_import_id=self.gate.import_id)
         self.client.force_login(self.test_teacher)
 
-        response = self.client.post(
-            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
-        )
+        self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True)
 
-        self.assertFalse(any("did not" in text or "not carried over" in text for text in self._message_texts(response)))
         imported = Quest.objects.all_including_archived().get(import_id=self.library_quest.import_id)
         self.assertEqual([p.get_prereq().name for p in imported.prereqs()], ["Finish The Prologue"])
 
@@ -2172,40 +2157,56 @@ class LibraryUnmetPrereqWarningTests(LibraryTenantTestCaseMixin):
         imported = Quest.objects.all_including_archived().get(import_id=self.library_quest.import_id)
         self.assertEqual([p.get_prereq().name for p in imported.prereqs()], ["Finish The Prologue"])
 
-    def test_import_quest__warns_about_a_prerequisite_that_could_never_travel(self):
-        """A rank gate is stripped on the way out, and the importer is told it is gone.
+    def test_import_quest__tells_the_importer_only_what_they_have_to_do_next(self):
+        """The import message covers publishing and gating, and nothing about what was lost.
 
-        From the teacher's side a requirement that cannot cross (#2450) and one this deck
-        happens not to have (#2399) are the same loss, so both are named.
+        Everything the Library could not carry is reported to the sharer on the push. The
+        importer is told the two things they have to do, which is all that is theirs to act
+        on (#2452).
         """
-        with library_schema_context():
-            gated = baker.make(Quest, name="Rank Gated Quest", published=True)
-            rank = baker.make(Rank, name="Digital Novice")
-            Prereq.add_simple_prereq(gated, rank)
-
         self.client.force_login(self.test_teacher)
 
-        response = self.client.post(reverse('library:import_quest', args=[gated.import_id]), follow=True)
-
-        self.assertTrue(
-            any("Digital Novice" in text for text in self._message_texts(response)),
-            f"expected the stripped rank to be named, got {self._message_texts(response)}",
+        response = self.client.post(
+            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
         )
+
+        texts = self._message_texts(response)
+        self.assertTrue(any("publish" in text.lower() and "prerequisite" in text.lower() for text in texts))
+        self.assertFalse(
+            any("Finish The Prologue" in text for text in texts),
+            f"the importer should not be told about gating that did not travel, got {texts}",
+        )
+
+
+class LibrarySharerWarningTests(LibraryTenantTestCaseMixin):
+    """What the Library tells the sharer it could not carry.
+
+    Content shared to the Library is meant to be a self-contained package, so the losses
+    belong to the person pushing it: they are the only one who can widen what they share,
+    and the only one who can still see what is missing (#2399, #2442, #2450).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a staff user to share content from this deck."""
+        cls.test_teacher = User.objects.create_user('sharer_warning_teacher', is_staff=True)
+
+    def _allow_staff_export(self):
+        """Let a staff user share, rather than only the deck owner."""
+        config = SiteConfig.get()
+        config.allow_staff_export = True
+        config.save()
 
     def test_export_quest__warns_the_sharer_that_a_gate_could_not_travel(self):
         """Sharing a rank-gated quest tells the sharer the Library copy is ungated.
 
         This is the only place the loss is visible. The Library row simply has no
-        prerequisite, so a teacher importing it later has nothing to be warned about
-        (#2399, #2450).
+        prerequisite, so nobody downstream can tell it ever had one (#2399, #2450).
         """
         rank = baker.make(Rank, name="Digital Novice")
         local = baker.make(Quest, name="Locally Gated Quest", published=True)
         Prereq.add_simple_prereq(local, rank)
-
-        config = SiteConfig.get()
-        config.allow_staff_export = True
-        config.save()
+        self._allow_staff_export()
         self.client.force_login(self.test_teacher)
 
         response = self.client.post(
@@ -2227,10 +2228,7 @@ class LibraryUnmetPrereqWarningTests(LibraryTenantTestCaseMixin):
         local = baker.make(Quest, name="Quest With A Shareable Gate", published=True)
         Prereq.add_simple_prereq(local, gate)
         export_quest_to_library(source_schema=connection.schema_name, quest_import_id=gate.import_id)
-
-        config = SiteConfig.get()
-        config.allow_staff_export = True
-        config.save()
+        self._allow_staff_export()
         self.client.force_login(self.test_teacher)
 
         response = self.client.post(
@@ -2239,6 +2237,49 @@ class LibraryUnmetPrereqWarningTests(LibraryTenantTestCaseMixin):
 
         self.assertFalse(
             any("did not travel" in text for text in self._message_texts(response)),
+            f"expected no warning, got {self._message_texts(response)}",
+        )
+
+    def test_export_category__warns_the_sharer_that_an_archived_quest_was_left_out(self):
+        """Sharing a campaign holding an archived quest names the quest that stayed behind.
+
+        The push succeeds and the campaign looks complete, so the omission is invisible
+        without this: it would surface on somebody else's deck, if at all (#2442).
+        """
+        campaign = baker.make(Category, published=True)
+        active = baker.make(Quest, name="Still Active Quest", campaign=campaign, published=True)
+        archived = baker.make(Quest, name="Retired Quest", campaign=campaign, published=True, archived=True)
+        self._allow_staff_export()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('library:export_category', args=[campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("Retired Quest" in text for text in texts),
+            f"expected the archived quest to be named, got {texts}",
+        )
+        with library_schema_context():
+            shared = set(Quest.objects.all_including_archived().values_list('import_id', flat=True))
+        self.assertIn(active.import_id, shared)
+        self.assertNotIn(archived.import_id, shared)
+
+    def test_export_category__stays_quiet_when_every_quest_travels(self):
+        """A campaign with nothing archived shares without a left-behind warning."""
+        campaign = baker.make(Category, published=True)
+        baker.make(Quest, name="First Quest", campaign=campaign, published=True)
+        baker.make(Quest, name="Second Quest", campaign=campaign, published=True)
+        self._allow_staff_export()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('library:export_category', args=[campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertFalse(
+            any("not included" in text for text in self._message_texts(response)),
             f"expected no warning, got {self._message_texts(response)}",
         )
 

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -39,14 +39,19 @@ from .models import IsLibraryContentMixin
 class TransferResult(NamedTuple):
     """What a copy produced, and what it could not bring with it.
 
-    `unmet_prereqs` is the reason this is a result rather than a bare list of quests. A
-    prerequisite whose target the destination does not have cannot be rebuilt, and the
-    loss fails open: the quest arrives more available than its author intended. Naming it
-    here is what lets the view warn the teacher instead of leaving them to notice.
+    The two loss fields are the reason this is a result rather than a bare list of quests.
+    Content shared to the Library is meant to be a self-contained package, so anything the
+    copy could not carry is the *sharer's* business: they are the one who can widen what
+    they share, or decide the gap is fine. The views turn these into a warning on the push.
+
+    `unmet_prereqs` names gating that did not travel, which fails open: the copy in the
+    Library ends up less gated than its author wrote. `skipped_quests` names quests that
+    were left out of a shared campaign altogether.
     """
 
     quests: list
     unmet_prereqs: list
+    skipped_quests: list = ()
 
 
 class LibraryTransferError(Exception):

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -165,6 +165,12 @@ def warn_sharer_about_skipped_quests(request, skipped_quests):
     Args:
         request (HttpRequest): the current request, for the message framework.
         skipped_quests (list[str]): names of the campaign's quests that were not shared.
+            Only published ones: an archived draft would not travel after unarchiving
+            either, so naming it would attach advice that does not work.
+
+    Returns:
+        None. Queues a warning message when anything was left behind, and does nothing
+        when the whole campaign travelled.
     """
     if not skipped_quests:
         return

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -153,29 +153,31 @@ def redirect_failed_import(request, error, redirect_to):
     return redirect(redirect_to)
 
 
-def warn_about_unmet_prereqs(request, unmet_prereqs):
-    """Tell the importer which gating did not come across with the content.
+def warn_sharer_about_skipped_quests(request, skipped_quests):
+    """Tell the sharer which quests were left out of the campaign they just shared.
 
-    A prerequisite can only be rebuilt if this deck has the thing it points at. When it
-    does not, the quest arrives *without* that gate, which means more available than its
-    author intended rather than less: a quest meant to unlock after another one is
-    immediately open to anyone who can see it. Saying so here is what stops that being a
-    surprise found later, and it lands beside the "publish it and give it a prerequisite"
-    message the teacher is already acting on.
+    A campaign push carries `Category.current_quests()`, which is published and not
+    archived, so archiving a quest quietly removes it from everything shared afterwards.
+    The push still succeeds and the campaign still looks complete, so without this the
+    sharer has no way to notice: the gap only shows up on somebody else's deck, and only
+    if they happen to know what was supposed to be there (#2442).
 
     Args:
         request (HttpRequest): the current request, for the message framework.
-        unmet_prereqs (list[str]): names of the prerequisites this deck does not have.
+        skipped_quests (list[str]): names of the campaign's quests that were not shared.
     """
-    if not unmet_prereqs:
+    if not skipped_quests:
         return
 
-    names = ', '.join(f"'{name}'" for name in unmet_prereqs)
+    names = ', '.join(f"'{name}'" for name in skipped_quests)
     messages.warning(
         request,
-        f"Heads up: this content required {names}, which your deck does not have, so "
-        "that requirement was not carried over. Anything gated on it arrives ungated, so "
-        "check its prerequisites before you publish."
+        f"{names} was not included, because archived quests are not shared. Unarchive it "
+        "and share the campaign again if it should be part of what other decks receive."
+        if len(skipped_quests) == 1 else
+        f"These quests were not included, because archived quests are not shared: {names}. "
+        "Unarchive them and share the campaign again if they should be part of what other "
+        "decks receive."
     )
 
 
@@ -558,7 +560,7 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
                 return redirect_awaiting_review(request, 'quest', 'library:quest_list')
             # Use dest_schema because current schema is library
             try:
-                result = import_quest_to(destination_schema=dest_schema, quest_import_id=quest.import_id)
+                import_quest_to(destination_schema=dest_schema, quest_import_id=quest.import_id)
             except LibraryTransferError as error:
                 return redirect_failed_import(request, error, 'library:quest_list')
 
@@ -577,7 +579,6 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
             f"students can see it: <strong>{publish_link}</strong>, and give it a "
             f"<strong>{prereq_link}</strong> so it is reachable on the quest map."
         )
-        warn_about_unmet_prereqs(request, result.unmet_prereqs)
 
         return redirect('quests:drafts')
 
@@ -678,7 +679,7 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
             quest_ids = list(category.quest_set.values_list('import_id', flat=True))
             # Use dest_schema because current schema is library
             try:
-                result = import_campaign_to(
+                import_campaign_to(
                     destination_schema=dest_schema, quest_import_ids=quest_ids, campaign_import_id=category.import_id,
                 )
             except LibraryTransferError as error:
@@ -702,7 +703,6 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
             f"quests), and give its first quest a <strong>{prereq_link}</strong> so the campaign "
             "is reachable on the quest map."
         )
-        warn_about_unmet_prereqs(request, result.unmet_prereqs)
 
         # The campaign will be deactivated by import_campaign_to()
         return redirect('quests:categories_inactive')
@@ -988,6 +988,7 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
             "it will appear in the Library once they review and publish it."
         )
         warn_sharer_about_unmet_prereqs(request, shared.unmet_prereqs)
+        warn_sharer_about_skipped_quests(request, shared.skipped_quests)
         return redirect('quests:categories')
 
 


### PR DESCRIPTION
### What?

Applies the design you set out across #2399, #2442, #2450 and #2452: Library content is a self-contained package, so anything that could not travel is reported to the **sharer**, and the importer is told only what they have to do next.

Two halves:

* **Removes** the import-time warning about gating that did not travel (added in #2451).
* **Adds** a share-time warning naming quests left out of a shared campaign because they are archived.

Closes #2442.

### Why?

> Importers don't need to be warned about anything except that they should set a prerequisite for the content they import. The import is a self-contained package if it's a campaign, external prerequisites are irrelevant. (#2452)

> It is irrelevant to the importer. They can add a prereq as they desire. However, the exporter should be informed. (#2450)

I had this backwards. I built the importer warning first, on the reasoning that a missing gate fails open. That is true, but it is not the importing teacher's problem to solve: they are placing the content into their own map and setting their own prerequisites anyway, so naming a gate from a deck they cannot see is noise attached to the one message that does matter.

The sharer is the opposite case. They are the only person who can still see what is missing, and the only one who can act on it by widening what they share.

**The archived-quest case is the sharper example.** Sharing a campaign carries `Category.current_quests()`, which is published and not archived. Archiving a quest therefore removes it from every later share of that campaign, silently: the push succeeds, the campaign looks complete, and the gap only surfaces on somebody else's deck, if anyone notices at all. Archiving is how teachers retire a quest without deleting it, so the campaigns most likely to contain one are exactly the long-lived ones people want to share.

### How?

**Import side.** `warn_about_unmet_prereqs` and its two call sites are gone. The existing message is untouched and already covers both steps you named:

> Successfully imported 'X' to your deck. Two things left to do before students can see it: **publish it**, and give it a **prerequisite** so it is reachable on the quest map.

**Share side.** `TransferResult` gains `skipped_quests`. `export_campaign_and_copy_quests` already computes the quests it will share (`current_quests()`), so the ones left behind fall out of the same query, and `ExportCampaignView.post` warns:

> 'Retired Quest' was not included, because archived quests are not shared. Unarchive it and share the campaign again if it should be part of what other decks receive.

The gating warning it sits beside is unchanged from #2451.

**Not changed:** #2399's other half, "don't copy over quests not in the campaign", is already how it works. A campaign push carries only that campaign's quests, and a prerequisite pointing outside it is dropped rather than dragging an extra quest along.

### Testing?

`LibraryUnmetPrereqWarningTests` is split into two classes that now say what they are for:

* `LibraryImportPrereqBehaviourTests` keeps the behavioural assertions (a quest arrives ungated when the gate is absent, the gate is rebuilt when present, re-importing does not duplicate it) and adds `test_import_quest__tells_the_importer_only_what_they_have_to_do_next`, which asserts the message covers publishing and gating **and** does not name the gate that stayed behind. That last assertion is what keeps the importer's message from quietly growing again.
* `LibrarySharerWarningTests` covers both share-time warnings, including a campaign whose archived quest is named while its active sibling really does arrive in the Library.

```
src/library                                   141 tests   OK
full suite (python src/manage.py test src)   2347 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

The change is two Django messages on flows that already show messages: one removed, one added, both quoted verbatim above and asserted in the tests. No template, layout or styling changes.

### Anything Else?

**#2452 should be closed as not planned.** I filed it to persist the dropped gating alongside Library content so the importer could be warned later. Your answer makes that unnecessary rather than deferred, and this PR removes the warning it was meant to feed. I will close it when this merges unless you would rather keep it.

**Worth deciding separately:** a campaign push also silently omits *unpublished* quests, for the same reason (`current_quests()` filters on both). I have left that alone, since a draft not travelling seems like what a sharer would expect, where an archived quest disappearing does not. Easy to widen the same warning to cover drafts if you disagree.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign exports now identify quests omitted because they are archived.
  * Export results include skipped quest details.
  * Sharers receive clear warnings when archived quests are excluded, including singular and plural guidance.

* **Bug Fixes**
  * Improved prerequisite handling when importing shared content.
  * Prevented duplicate prerequisites during re-imports.
  * Added clearer warnings for rank-gated quest requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->