### PR TITLE
feat: show a multicourse student their rank in each course (#2453)

### DIFF
--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -716,6 +716,53 @@ class CourseStudentManager(models.Manager):
         """
         return self.current_courses(user).aggregate(total=Sum('xp_adjustment'))['total'] or 0
 
+    def xp_for_registrations(self, user, profile=None):
+        """Every current registration this student holds, with the XP counting toward it.
+
+        The assigned-versus-shared split (issue #2440) is the same question for every course a
+        student holds, so it is answered once here for all of them rather than once per
+        registration. Whatever wants more than one registration's XP goes through this: the
+        per-course ranks in the navbar ask on every page.
+
+        Args:
+            user: the student whose XP is being divided.
+            profile (Profile): their profile, for a caller holding one whose xp_cached is
+                newer than the database. Defaults to reading it.
+
+        Returns:
+            list[tuple]: (CourseStudent, xp) in registration order, empty when the student is
+            in no course. A student in one course has their whole total against it.
+        """
+        profile = profile if profile is not None else user.profile
+        registrations = list(self.current_courses(user))
+        if len(registrations) <= 1:
+            return [(registration, profile.xp_cached) for registration in registrations]
+
+        # xp_cached is the student's deck-wide total: quest XP, badge XP, and every one of
+        # their registrations' adjustments. Take out the parts that belong to a particular
+        # course, share what is left, and hand each registration back its own pieces.
+        xp_by_course = QuestSubmission.objects.xp_by_course(user)
+        for course_id, xp in BadgeAssertion.objects.xp_by_course(user).items():
+            xp_by_course[course_id] = xp_by_course.get(course_id, 0) + xp
+
+        # only courses the student still holds can claim XP: work assigned to a course whose
+        # registration has since been deleted has nowhere to count, so it stays in the shared
+        # pool rather than being subtracted from it and lost
+        course_ids = {registration.course_id for registration in registrations}
+        assigned = sum(xp for course_id, xp in xp_by_course.items() if course_id in course_ids)
+        adjustments = sum(registration.xp_adjustment for registration in registrations)
+        shared = (profile.xp_cached - assigned - adjustments) / len(registrations)
+
+        return [
+            (
+                registration,
+                (xp_by_course.get(registration.course_id, 0) if registration.course_id else 0)
+                + registration.xp_adjustment
+                + shared,
+            )
+            for registration in registrations
+        ]
+
     def calc_semester_grades(self, semester, clamp_negative_xp=False):
         """Record every registration's final XP and deactivate it.
 
@@ -959,27 +1006,12 @@ class CourseStudent(models.Model):
             xp_adjustment. Their whole total when this is their only course.
         """
         profile = profile if profile is not None else self.user.profile
-        registrations = CourseStudent.objects.current_courses(self.user)
-        current_course_ids = set(registrations.values_list('course_id', flat=True))
-        if len(current_course_ids) <= 1:
-            return profile.xp_cached
-
-        # xp_cached is the student's deck-wide total: quest XP, badge XP, and every one of
-        # their registrations' adjustments. Take out the parts that belong to a particular
-        # course, share what is left, and hand this registration back its own pieces.
-        xp_by_course = QuestSubmission.objects.xp_by_course(self.user)
-        for course_id, xp in BadgeAssertion.objects.xp_by_course(self.user).items():
-            xp_by_course[course_id] = xp_by_course.get(course_id, 0) + xp
-
-        # only courses the student still holds can claim XP: work assigned to a course whose
-        # registration has since been deleted has nowhere to count, so it goes back into the
-        # shared pool rather than being subtracted from it and lost
-        assigned_here = xp_by_course.get(self.course_id, 0) if self.course_id else 0
-        assigned_anywhere = sum(xp for course_id, xp in xp_by_course.items() if course_id in current_course_ids)
-        adjustments = CourseStudent.objects.calculate_xp(self.user)
-        shared = profile.xp_cached - assigned_anywhere - adjustments
-
-        return assigned_here + self.xp_adjustment + shared / len(current_course_ids)
+        # the split is worked out for the whole student at once; a registration that is not a
+        # current one is not part of that division, so it answers with the student's total
+        for registration, xp in CourseStudent.objects.xp_for_registrations(self.user, profile):
+            if registration.pk == self.pk:
+                return xp
+        return profile.xp_cached
 
     def mark(self, profile=None):
         """This registration's mark, worked out from its own XP.

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -745,10 +745,15 @@ class CourseStudentManager(models.Manager):
         for course_id, xp in BadgeAssertion.objects.xp_by_course(user).items():
             xp_by_course[course_id] = xp_by_course.get(course_id, 0) + xp
 
-        # only courses the student still holds can claim XP: work assigned to a course whose
+        # Only courses the student still holds can claim XP: work assigned to a course whose
         # registration has since been deleted has nowhere to count, so it stays in the shared
-        # pool rather than being subtracted from it and lost
-        course_ids = {registration.course_id for registration in registrations}
+        # pool rather than being subtracted from it and lost. A registration with no course at
+        # all is not one of those claims: unassigned XP is filed under no course too, and
+        # counting it as claimed would take the student's shared work out of the pool as well.
+        course_ids = {
+            registration.course_id for registration in registrations
+            if registration.course_id is not None
+        }
         assigned = sum(xp for course_id, xp in xp_by_course.items() if course_id in course_ids)
         adjustments = sum(registration.xp_adjustment for registration in registrations)
         shared = (profile.xp_cached - assigned - adjustments) / len(registrations)

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1142,6 +1142,21 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         self.assertEqual(first.xp(), 10)
         self.assertEqual(second.xp(), 10)
 
+    def test_xp__still_shares_unassigned_work_when_a_registration_has_no_course(self):
+        """A registration with no course holds no course id, and unassigned XP is filed under no
+        course either. The two must not be confused: work the student never assigned is still
+        theirs to share out, not something already counted toward a course of theirs."""
+        student = baker.make(User)
+        maths = baker.make(Course, title='Maths')
+        maths_registration = self._register(student, maths)
+        courseless = self._register(student, None)
+        self._approved(student, xp=40)  # unassigned, so shared between the two
+        student.profile.xp_invalidate_cache()
+
+        self.assertIsNone(courseless.course)
+        self.assertEqual(maths_registration.xp(), 20)
+        self.assertEqual(courseless.xp(), 20)
+
     def test_xp__answers_with_the_whole_total_for_a_registration_that_is_not_current(self):
         """The split divides a student's XP between the courses they are in now, so a
         registration from a semester that is over is not part of it and answers with their

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1142,6 +1142,22 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         self.assertEqual(first.xp(), 10)
         self.assertEqual(second.xp(), 10)
 
+    def test_xp__answers_with_the_whole_total_for_a_registration_that_is_not_current(self):
+        """The split divides a student's XP between the courses they are in now, so a
+        registration from a semester that is over is not part of it and answers with their
+        total, the same as a student with one course."""
+        student = baker.make(User)
+        old = baker.make(
+            CourseStudent, user=student, course=baker.make(Course), block=baker.make(Block),
+            semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
+        )
+        self._register(student, baker.make(Course))
+        self._register(student, baker.make(Course))
+        self._approved(student, xp=40)
+        student.profile.xp_invalidate_cache()
+
+        self.assertEqual(old.xp(), student.profile.xp_cached)
+
     def test_xp__shares_out_work_assigned_to_a_course_the_student_has_left(self):
         """Deleting a registration must not make its XP vanish. Work assigned to a course the
         student no longer holds has nowhere to count, so it goes back into the shared pool and

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -28,6 +28,60 @@ import json
 User = get_user_model()
 
 
+class NavbarRankTests(ByteDeckTenantTestCase):
+    """The navbar's rank control, which is a dropdown for a student in more than one course.
+
+    Their XP is attributed per course (issue #2440), so they hold a rank in each and the navbar
+    shows all of them rather than a single number that belongs to none of their courses (#2453).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A teacher (needed before students exist) and a student to log in as."""
+        cls.teacher = User.objects.create_user('test_teacher', is_staff=True)
+        cls.student = User.objects.create_user('test_student')
+
+    def _register(self, course):
+        """Put the student in a course in the deck's semester."""
+        return baker.make(
+            CourseStudent, user=self.student, course=course, block=baker.make(Block),
+            semester=SiteConfig.get().active_semester,
+        )
+
+    def test_navbar__lists_a_rank_per_course_for_a_multicourse_student(self):
+        """Every course the student holds appears in the dropdown, named, and the icon shown
+        while it is closed is their highest rank."""
+        maths = self._register(baker.make(Course, title='Maths')).course
+        art = self._register(baker.make(Course, title='Art')).course
+        quest = baker.make(Quest, xp=60, max_xp=-1)
+        baker.make(
+            QuestSubmission, user=self.student, quest=quest, course=maths,
+            semester=SiteConfig.get().active_semester, is_completed=True, is_approved=True,
+        )
+        self.student.profile.xp_invalidate_cache()
+        self.client.force_login(self.student)
+
+        response = self.client.get(reverse('quests:quests'))
+
+        self.assertContains(response, 'id="ranks-menu"')
+        self.assertContains(response, str(maths))
+        self.assertContains(response, str(art))
+        # 60 XP against Maths reaches the deck's second rank there, and that is the one the
+        # closed navbar shows, not the starting rank they are still at in Art
+        self.assertContains(response, 'title="Rank: Digital Novice in Maths"')
+
+    def test_navbar__keeps_a_single_rank_for_a_student_in_one_course(self):
+        """With one course there is nothing to choose between, so the navbar stays the plain
+        link it has always been rather than growing a dropdown with one row in it."""
+        self._register(baker.make(Course, title='Maths'))
+        self.client.force_login(self.student)
+
+        response = self.client.get(reverse('quests:quests'))
+
+        self.assertNotContains(response, 'id="ranks-menu"')
+        self.assertContains(response, 'title="Rank: Digital Noob"')
+
+
 class RankViewTests(ByteDeckTenantTestCase):
 
     @classmethod

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -409,6 +409,27 @@ class Profile(models.Model):
     def rank(self):
         return Rank.objects.get_rank(self.xp_cached)
 
+    def course_ranks(self):
+        """This student's rank in each of their current courses, highest rank first.
+
+        A student in several courses has a different amount of XP in each (issue #2440), so
+        they hold a different rank in each, and the navbar shows all of them. Their XP is
+        divided once for the whole student rather than per course, since this is asked on
+        every page.
+
+        Returns:
+            list[tuple]: (Course, Rank) pairs ordered by rank XP descending, so the first is
+            the rank to show when only one fits. Empty when they are in no course.
+        """
+        registrations = CourseStudent.objects.xp_for_registrations(self.user, profile=self)
+        if len(registrations) < 2:
+            # one course is the whole of their XP, which is the rank they already have: no
+            # per-course list to show, and the navbar keeps its single icon
+            return []
+
+        ranks = [(registration.course, Rank.objects.get_rank(xp)) for registration, xp in registrations]
+        return sorted(ranks, key=lambda course_rank: course_rank[1].xp, reverse=True)
+
     def next_rank(self):
         return Rank.objects.get_next_rank(self.xp_cached)
 

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -308,6 +308,36 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         default_starting_rank = "Digital Noob"
         self.assertEqual(self.profile.rank().name, default_starting_rank)
 
+    def test_course_ranks__is_empty_without_a_second_course(self):
+        """One course holds all of a student's XP, so its rank is the rank they already have.
+        There is nothing to list, and the navbar keeps its single icon (issue #2453)."""
+        self.assertEqual(self.profile.course_ranks(), [])
+
+        self.create_active_course_registration()
+
+        self.assertEqual(self.profile.course_ranks(), [])
+
+    def test_course_ranks__gives_each_course_its_own_rank_highest_first(self):
+        """A student in two courses has different XP in each, so they are at a different rank
+        in each. The list leads with the highest, which is the one the navbar shows closed."""
+        maths = baker.make('courses.Course', title='Maths')
+        art = baker.make('courses.Course', title='Art')
+        for course in (maths, art):
+            baker.make('courses.CourseStudent', user=self.user, course=course,
+                       block=baker.make('courses.Block'), semester=self.active_sem)
+        baker.make(
+            'quest_manager.QuestSubmission', user=self.user, quest=baker.make('quest_manager.Quest', xp=60),
+            course=maths, semester=self.active_sem, is_completed=True, is_approved=True,
+        )
+        self.profile.xp_invalidate_cache()
+
+        course_ranks = self.profile.course_ranks()
+
+        # 60 XP all against Maths reaches the deck's second rank there, while Art, holding
+        # none of it, is still at the starting rank
+        self.assertEqual([course for course, rank in course_ranks], [maths, art])
+        self.assertEqual([rank.name for course, rank in course_ranks], ['Digital Novice', 'Digital Noob'])
+
     def test_mark__no_courses(self):
         """A student not in any current courses should return None"""
         # the test profile shouldn't be in any courses yet, but sanity check here

--- a/src/templates/navbar-fixed.html
+++ b/src/templates/navbar-fixed.html
@@ -223,12 +223,38 @@
                  --></li>
 
                 {% if not request.user.is_staff %}
+                {% comment %} A student in more than one course has a different amount of XP in
+                   each, so they hold a rank in each (#2453). The icon shown is their highest,
+                   and the dropdown lists every course with the rank they are at in it. With one
+                   course there is nothing to choose between, so it stays a plain link. {% endcomment %}
+                {% with course_ranks=request.user.profile.course_ranks %}
+                {% if course_ranks %}
+                <li id="ranks-menu" class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
+                       aria-haspopup="true" aria-expanded="false"
+                       title="Rank: {{ course_ranks.0.1 }} in {{ course_ranks.0.0 }}">
+                        <i class="{{ course_ranks.0.1.fa_icon }}"></i><!--
+                     --><span class="visible-xs-inline-block">&nbsp;&nbsp;Ranks</span>
+                    </a>
+                    <ul class="dropdown-menu">
+                        {% for course, rank in course_ranks %}
+                        <li>
+                            <a href="{% url 'courses:ranks' %}" title="Rank: {{ rank }}">
+                                <i class="{{ rank.fa_icon }} fa-fw"></i>&nbsp;&nbsp;{{ course }}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </li>
+                {% else %}
                 <li>
                     <a title="Rank: {{request.user.profile.rank}}" href="{% url 'courses:ranks' %}">
                         <i class="{{request.user.profile.rank.fa_icon}}"></i>
                         <span class="visible-xs-inline-block">&nbsp;&nbsp;{{request.user.profile.rank}}</span>
                     </a>
                 </li>
+                {% endif %}
+                {% endwith %}
                 {% endif %}
 
                 <li id="extras-menu" class="dropdown">


### PR DESCRIPTION
### What?

The navbar's rank becomes a dropdown for a student in more than one course: the icon of their
highest rank while it is closed, and one row per course when open, each showing that course's
rank icon with the course beside it and the rank name on hover. Every row links to the ranks
page, the same as the single icon did.

A student in one course sees exactly what they see today, with no dropdown to open. Staff are
unaffected either way.

It also fixes an XP-attribution bug found in review, described under How.

This is the first half of #2453. The per-course XP chart is the other half and follows in its
own PR, since it needs the per-course split worked out as of a date, which is a bigger change
than the presentation here.

### Why?

Since #2440 a student's XP is attributed to the course they earned it in, so a student in two
courses has a different amount in each. Rank comes from XP, so they are at a different rank in
each too. The navbar was still showing one rank worked out from their deck-wide `xp_cached`,
a number that belongs to none of their courses: a student with 140 XP in Maths and 12 in Art
was shown the rank for 152 XP, which is neither.

### How?

`CourseStudentManager.xp_for_registrations()` returns every current registration a student holds
with the XP counting toward it. The assigned-versus-shared split is the same question for all of
their courses, so it is answered once for the whole student rather than once per registration.
`CourseStudent.xp()` now delegates to it, so there is a single implementation of the split.

`Profile.course_ranks()` turns that into (course, rank) pairs, ordered highest rank first so the
navbar can show the top one closed and the whole list open. It returns an empty list for a
student with fewer than two courses, which is what keeps the navbar a plain link for them.

**A bug fixed along the way.** `CourseStudent.course` is nullable, and the by-course totals file
unassigned XP under no course as well. Treating a null registration as one of the courses that
can claim XP therefore counted the student's shared work as already assigned: it came out of the
shared pool and was credited to nobody, so every one of their courses lost it. Only real course
ids can claim XP now. This came in with #2440 rather than with this branch, but the code it lives
in moved here, so it is fixed here (`test_xp__still_shares_unassigned_work_when_a_registration_has_no_course`,
which reads `0.0` instead of `20` without the fix).

**What it costs.** The navbar renders on every page, so I measured it on a seeded dev deck,
loading the same page and counting real queries (django-tenants `SET search_path` excluded):

| | queries per page |
| --- | --- |
| before | 67 |
| after, student in 1 course | 68 |
| after, student in 2 courses | 72 |

One extra query for a single-course student (the registration lookup that finds nothing to list)
and five for a multicourse one. Asking each registration separately instead would have made the
two-course case ten, which is why the split is worked out in one pass.

### Testing?

`python src/manage.py test src` (2393 tests) and `ruff check src` both pass, and coverage of the
two changed modules is 100% of statements and branches.

New tests cover `Profile.course_ranks()` (empty with zero or one course, a rank per course
ordered highest first), the navbar itself rendering the dropdown with both courses named and the
highest rank in its title, the navbar keeping its plain link for a single-course student,
`CourseStudent.xp()` answering with the student's whole total for a registration that is not a
current one, and the null-course sharing fix above. Reverting the template makes the navbar tests
fail.

### Screenshots (if front end is affected)

Captured on a seeded `hackerspace` deck, logged in as a student with 140 XP in Mathematics 10
(Digital Novice II) and 12 XP in Digital Art 11 (Digital Noob).

| Before | After, opened |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/ranks-before-navbar.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/ranks-after-open.png) |

**A student in one course** keeps the plain rank icon, with nothing to open:

![single course](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/ranks-after-single.png)

**On a phone**, where the navbar collapses, the ranks list inside the menu:

![mobile](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/ranks-after-mobile.png)

### Anything Else?

**`Profile.rank()` still means the deck-wide rank**, which is what the places that want one
number use, including `Rank.condition_met_as_prerequisite`, which reads `xp_cached`. This PR adds
the per-course view beside it rather than changing what the existing one means.

**The collapsed phone view lists every rank** rather than just the highest, which is the open
question #2453 raised: there is room for it there, and a student on a phone has the same reason
to want the breakdown.

**Archiving a semester still asks each registration separately.** `xp_for_registrations()` is
exactly the helper #2459 asks for, but rewiring `calc_semester_grades()` to it changes the seam
five existing tests mock, so it is left for that issue rather than folded in here.

### Review request
@tylerecouture

- Claude Code (bytedeck - semester workflow redesign)