### PR TITLE
feat: chart each of a multicourse student's courses separately (#2453)

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -525,7 +525,7 @@ class BadgeAssertionManager(models.Manager):
         ]
         return by_type
 
-    def xp_by_course(self, user):
+    def xp_by_course(self, user, up_to_date=None):
         """How much of this student's badge XP counts toward each of their courses.
 
         A badge granted alongside a quest carries that quest's course; one granted on its own
@@ -534,13 +534,16 @@ class BadgeAssertionManager(models.Manager):
 
         Args:
             user: the student whose badge XP is being divided.
+            up_to_date (date): count only badges granted by then, for charting their progress
+                through the semester (issue #2453). Defaults to all of them.
 
         Returns:
             dict: course id to XP, with None collecting everything left unassigned.
         """
-        rows = self.get_queryset(True, user=user).grant_xp().get_user(user).values('course').annotate(
-            xp_sum=Sum('badge__xp'),
-        )
+        qs = self.get_queryset(True, user=user).grant_xp().get_user(user)
+        if up_to_date is not None:
+            qs = qs.get_issued_before(up_to_date)
+        rows = qs.values('course').annotate(xp_sum=Sum('badge__xp'))
         return {row['course']: row['xp_sum'] or 0 for row in rows}
 
     def calculate_xp(self, user):

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -716,7 +716,7 @@ class CourseStudentManager(models.Manager):
         """
         return self.current_courses(user).aggregate(total=Sum('xp_adjustment'))['total'] or 0
 
-    def xp_for_registrations(self, user, profile=None):
+    def xp_for_registrations(self, user, profile=None, up_to_date=None):
         """Every current registration this student holds, with the XP counting toward it.
 
         The assigned-versus-shared split (issue #2440) is the same question for every course a
@@ -728,21 +728,24 @@ class CourseStudentManager(models.Manager):
             user: the student whose XP is being divided.
             profile (Profile): their profile, for a caller holding one whose xp_cached is
                 newer than the database. Defaults to reading it.
+            up_to_date (date): divide what they had earned by then rather than their total,
+                which is how each course's progress chart is plotted (issue #2453).
 
         Returns:
             list[tuple]: (CourseStudent, xp) in registration order, empty when the student is
             in no course. A student in one course has their whole total against it.
         """
         profile = profile if profile is not None else user.profile
+        total = profile.xp_cached if up_to_date is None else profile.xp_to_date(up_to_date)
         registrations = list(self.current_courses(user))
         if len(registrations) <= 1:
-            return [(registration, profile.xp_cached) for registration in registrations]
+            return [(registration, total) for registration in registrations]
 
-        # xp_cached is the student's deck-wide total: quest XP, badge XP, and every one of
+        # the total is the student's deck-wide figure: quest XP, badge XP, and every one of
         # their registrations' adjustments. Take out the parts that belong to a particular
         # course, share what is left, and hand each registration back its own pieces.
-        xp_by_course = QuestSubmission.objects.xp_by_course(user)
-        for course_id, xp in BadgeAssertion.objects.xp_by_course(user).items():
+        xp_by_course = QuestSubmission.objects.xp_by_course(user, up_to_date=up_to_date)
+        for course_id, xp in BadgeAssertion.objects.xp_by_course(user, up_to_date=up_to_date).items():
             xp_by_course[course_id] = xp_by_course.get(course_id, 0) + xp
 
         # Only courses the student still holds can claim XP: work assigned to a course whose
@@ -756,7 +759,7 @@ class CourseStudentManager(models.Manager):
         }
         assigned = sum(xp for course_id, xp in xp_by_course.items() if course_id in course_ids)
         adjustments = sum(registration.xp_adjustment for registration in registrations)
-        shared = (profile.xp_cached - assigned - adjustments) / len(registrations)
+        shared = (total - assigned - adjustments) / len(registrations)
 
         return [
             (
@@ -1017,6 +1020,23 @@ class CourseStudent(models.Model):
             if registration.pk == self.pk:
                 return xp
         return profile.xp_cached
+
+    def xp_to_date(self, date):
+        """The XP that counted toward this registration as of a date.
+
+        The same division as xp(), taken at a point in the past, which is what plots a course's
+        progress through the semester rather than the student's whole-deck line (issue #2453).
+
+        Args:
+            date: the day to count up to, inclusive.
+
+        Returns:
+            float: this registration's share of what the student had earned by then.
+        """
+        for registration, xp in CourseStudent.objects.xp_for_registrations(self.user, up_to_date=date):
+            if registration.pk == self.pk:
+                return xp
+        return self.user.profile.xp_to_date(date)
 
     def mark(self, profile=None):
         """This registration's mark, worked out from its own XP.

--- a/src/courses/templates/courses/chart_xp_progress.html
+++ b/src/courses/templates/courses/chart_xp_progress.html
@@ -268,7 +268,7 @@
       options: options,
   });
 
-  function ajax_update_plot() {
+  function ajax_update_plot(course_id) {
 
     // user in this view is the request.user, if a student,
     // or the user matching the id in the url
@@ -278,16 +278,24 @@
       url: "{% url 'courses:ajax_progress_chart' user.id %}",
       data: {
         csrfmiddlewaretoken: "{{ csrf_token }}",
+        // which course to plot: a student in several has a different amount of XP in each,
+        // so each course is its own line out of its own total (#2453)
+        course: course_id,
       },
       success: function(data){
-        // console.log(data.xp_data);
         XPData.data = data.xp_data;
-        console.log(data.xp_data);
+
+        // courses can be out of different amounts, so the axis and the mark lines are
+        // rescaled to whichever course is being shown
+        if (data.xp_for_100_percent) {
+          max_xp = data.xp_for_100_percent;
+          myChart.options.scales.yAxes[0].ticks.max = max_xp;
+          myChart.options.scales.yAxes[0].ticks.stepSize = max_xp / 20;
+        }
+
         generate_trend(data.days_in_semester);
         generate_mark_lines(data.days_in_semester);
         myChart.options.scales.xAxes[0].ticks.max = data.days_in_semester;
-
-        //console.log(myChart);
 
         $('div.loading').remove();
         $('#myChart').show("slow");
@@ -317,7 +325,17 @@
   });
 
   $(document).ready(function() {
-    ajax_update_plot();
+    var $courseButtons = $('.xp-chart-courses button');
+
+    // no buttons means a single course (or a deck that shares XP evenly), and the one chart
+    // is the student's whole progress
+    ajax_update_plot($courseButtons.filter('.active').data('course'));
+
+    $courseButtons.on('click', function() {
+      $courseButtons.removeClass('active');
+      $(this).addClass('active');
+      ajax_update_plot($(this).data('course'));
+    });
   });
 
 

--- a/src/courses/templates/courses/mark_calculations.html
+++ b/src/courses/templates/courses/mark_calculations.html
@@ -135,6 +135,17 @@ for {{user}}
 
           {# == XP Progress == #}
           <div role="tabpanel" class="tab-pane active" id="progress">
+            {% comment %} One chart per course, since each holds its own XP and is out of its
+               own amount (#2453). Buttons rather than a second tab strip, so it reads as
+               "which course am I looking at" and not as another kind of chart. {% endcomment %}
+            {% if chart_per_course %}
+              <div class="btn-group xp-chart-courses" role="group" aria-label="Which course to chart">
+                {% for course in courses %}
+                  <button type="button" class="btn btn-default {% if forloop.first %}active{% endif %}"
+                          data-course="{{ course.course.id }}">{{ course.course }}</button>
+                {% endfor %}
+              </div>
+            {% endif %}
             <div class="well chart-container">
               <div class="loading">
                 <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1173,6 +1173,38 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
 
         self.assertEqual(old.xp(), student.profile.xp_cached)
 
+    def test_xp_to_date__answers_with_the_whole_total_for_a_registration_that_is_not_current(self):
+        """Charting a registration from a semester that is over plots the student's own total,
+        for the same reason xp() does: it is not part of the division between their courses."""
+        student = baker.make(User)
+        old = baker.make(
+            CourseStudent, user=student, course=baker.make(Course), block=baker.make(Block),
+            semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
+        )
+        self._register(student, baker.make(Course))
+        self._register(student, baker.make(Course))
+        self._approved(student, xp=40)
+        today = timezone.localtime()
+
+        self.assertEqual(old.xp_to_date(today), student.profile.xp_to_date(today))
+
+    def test_xp_to_date__divides_what_the_student_had_earned_by_then(self):
+        """A course's progress line is its own share as of each day, not an even share of the
+        student's whole total (issue #2453)."""
+        student = baker.make(User)
+        maths = baker.make(Course, title='Maths')
+        maths_registration = self._register(student, maths)
+        art_registration = self._register(student, baker.make(Course, title='Art'))
+        today = timezone.localtime()
+        # approved yesterday: the date filter is on time_approved, which baker would otherwise
+        # fill with a random datetime that may not be behind us
+        submission = self._approved(student, xp=40, course=maths)
+        submission.time_approved = today - timedelta(days=1)
+        submission.save()
+
+        self.assertEqual(maths_registration.xp_to_date(today), 40)
+        self.assertEqual(art_registration.xp_to_date(today), 0)
+
     def test_xp__shares_out_work_assigned_to_a_course_the_student_has_left(self):
         """Deleting a registration must not make its XP vanish. Work assigned to a course the
         student no longer holds has nowhere to count, so it goes back into the shared pool and

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -2121,6 +2121,55 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
         # their term started Jan 15, so only its class days are plotted, not the deck semester's
         self.assertEqual(len(data['xp_data']), their_semester.days_so_far())
 
+    @freeze_time('2024-02-01')
+    def test_ajax_progress_chart__charts_the_named_courses_own_xp(self):
+        """A student in two courses has a different amount of XP in each (#2440), so each course
+        gets its own line: the course named in the request, not an even share of everything."""
+        art = baker.make(Course, title='Art', xp_for_100_percent=500)
+        baker.make(CourseStudent, user=self.student, semester=self.semester, course=art, block=baker.make(Block))
+        quest = baker.make(Quest, xp=40, max_xp=-1)
+        baker.make(
+            QuestSubmission, user=self.student, quest=quest, course=self.course, semester=self.semester,
+            is_completed=True, is_approved=True, time_approved=datetime.datetime(2024, 1, 3, tzinfo=self.tz),
+        )
+        self.student.profile.xp_invalidate_cache()
+        self.client.force_login(self.student)
+        url = reverse('courses:ajax_progress_chart', args=[self.student.pk])
+
+        assigned = self.client.post(url, {'course': self.course.id}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        other = self.client.post(url, {'course': art.id}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        # all 40 XP went to the first course, so its line ends at 40 and the other's at 0
+        self.assertEqual(json.loads(assigned.content)['xp_data'][-1]['y'], 40)
+        self.assertEqual(json.loads(other.content)['xp_data'][-1]['y'], 0)
+
+    @freeze_time('2024-02-01')
+    def test_ajax_progress_chart__scales_to_the_charted_courses_own_total(self):
+        """Courses can be out of different amounts of XP, so the chart is told which total to
+        draw its axis and mark lines against."""
+        art = baker.make(Course, title='Art', xp_for_100_percent=500)
+        baker.make(CourseStudent, user=self.student, semester=self.semester, course=art, block=baker.make(Block))
+        self.client.force_login(self.student)
+        url = reverse('courses:ajax_progress_chart', args=[self.student.pk])
+
+        response = self.client.post(url, {'course': art.id}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        self.assertEqual(json.loads(response.content)['xp_for_100_percent'], 500)
+
+    @freeze_time('2024-02-01')
+    def test_ajax_progress_chart__falls_back_to_a_course_the_student_is_in(self):
+        """A request naming no course, or one the student is not registered in, charts one of
+        their own courses rather than failing or charting somebody else's."""
+        self.client.force_login(self.student)
+        url = reverse('courses:ajax_progress_chart', args=[self.student.pk])
+        someone_elses = baker.make(Course, xp_for_100_percent=999)
+
+        unnamed = self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        not_theirs = self.client.post(url, {'course': someone_elses.id}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        for response in (unnamed, not_theirs):
+            self.assertEqual(json.loads(response.content)['xp_for_100_percent'], self.course.xp_for_100_percent)
+
     def test_ajax_xp_data__correct_xp_current_day(self):
         """ tests if xp_data from ajax request holds the correct xp on different days of the week.
         uses freeze_time to test the current day as Fri, Sat, Sun, and Mon
@@ -2355,6 +2404,59 @@ class MarkCalculationsViewTests(ByteDeckTenantTestCase):
         # 50 XP halfway through the semester projects to 100, out of the course's 1000
         self.assertContains(response, '<strong>10%</strong>', html=True)
         self.assertContains(response, '<strong>0%</strong>', html=True)
+
+    def test_mark_calculations__offers_a_chart_per_course_to_a_multicourse_student(self):
+        """Each course holds its own XP, so each gets its own progress chart, chosen with a
+        button per course (issue #2453)."""
+        art = baker.make(Course, title='Art', xp_for_100_percent=1000)
+        baker.make(
+            CourseStudent, user=self.student, semester=SiteConfig.get().active_semester,
+            block=baker.make(Block), course=art,
+        )
+        self.client.force_login(self.student)
+
+        response = self.client.get(reverse('courses:my_marks'))
+
+        self.assertTrue(response.context['chart_per_course'])
+        self.assertContains(response, f'data-course="{self.course.id}"')
+        self.assertContains(response, f'data-course="{art.id}"')
+
+    def test_mark_calculations__offers_one_chart_when_xp_is_shared_evenly(self):
+        """With the per-course setting off every course holds an even share, so a chart each
+        would be the same line at different scales: less use than the single chart."""
+        siteconfig = SiteConfig.get()
+        siteconfig.students_choose_xp_course = False
+        siteconfig.save()
+        self.addCleanup(self._restore_course_choice)
+        baker.make(
+            CourseStudent, user=self.student, semester=SiteConfig.get().active_semester,
+            block=baker.make(Block), course=baker.make(Course, title='Art'),
+        )
+        self.client.force_login(self.student)
+
+        response = self.client.get(reverse('courses:my_marks'))
+
+        self.assertFalse(response.context['chart_per_course'])
+        # the chart's JS names the selector on every page, so the buttons' own attribute is
+        # what says whether any were rendered
+        self.assertNotContains(response, 'data-course=')
+
+    def test_mark_calculations__offers_one_chart_to_a_student_in_one_course(self):
+        """One course means one chart, with no button bar to choose between."""
+        self.client.force_login(self.student)
+
+        response = self.client.get(reverse('courses:my_marks'))
+
+        self.assertFalse(response.context['chart_per_course'])
+        # the chart's JS names the selector on every page, so the buttons' own attribute is
+        # what says whether any were rendered
+        self.assertNotContains(response, 'data-course=')
+
+    def _restore_course_choice(self):
+        """Put the shared deck's per-course XP setting back on, for the test that turns it off."""
+        siteconfig = SiteConfig.get()
+        siteconfig.students_choose_xp_course = True
+        siteconfig.save()
 
     def test_mark_calculations__deactivated_shows_staff_the_deactivated_notice(self):
         """When mark-calculation display is turned off, staff get the 'deactivated' notice page

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -2166,8 +2166,13 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
 
         unnamed = self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         not_theirs = self.client.post(url, {'course': someone_elses.id}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        # the page asks for no course when the student has one, which posts an empty value,
+        # and nothing stops a request naming something that is not an id at all
+        empty = self.client.post(url, {'course': ''}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        nonsense = self.client.post(url, {'course': 'undefined'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
-        for response in (unnamed, not_theirs):
+        for response in (unnamed, not_theirs, empty, nonsense):
+            self.assertEqual(response.status_code, 200)
             self.assertEqual(json.loads(response.content)['xp_for_100_percent'], self.course.xp_for_100_percent)
 
     def test_ajax_xp_data__correct_xp_current_day(self):
@@ -2421,25 +2426,36 @@ class MarkCalculationsViewTests(ByteDeckTenantTestCase):
         self.assertContains(response, f'data-course="{self.course.id}"')
         self.assertContains(response, f'data-course="{art.id}"')
 
-    def test_mark_calculations__offers_one_chart_when_xp_is_shared_evenly(self):
-        """With the per-course setting off every course holds an even share, so a chart each
-        would be the same line at different scales: less use than the single chart."""
+    def test_mark_calculations__still_charts_per_course_with_the_setting_off(self):
+        """Turning the per-course setting off stops students being asked where new XP goes; it
+        does not un-assign the XP already put against a course. Those courses still hold
+        different amounts, which the marks table on this page shows, so the charts stay per
+        course rather than collapsing into one line that could only be one of them."""
         siteconfig = SiteConfig.get()
         siteconfig.students_choose_xp_course = False
         siteconfig.save()
         self.addCleanup(self._restore_course_choice)
-        baker.make(
+        art = baker.make(Course, title='Art', xp_for_100_percent=1000)
+        art_registration = baker.make(
             CourseStudent, user=self.student, semester=SiteConfig.get().active_semester,
-            block=baker.make(Block), course=baker.make(Course, title='Art'),
+            block=baker.make(Block), course=art,
         )
+        quest = baker.make('quest_manager.Quest', xp=50, max_xp=-1)
+        baker.make(
+            'quest_manager.QuestSubmission', user=self.student, quest=quest, course=self.course,
+            semester=SiteConfig.get().active_semester, is_completed=True, is_approved=True,
+        )
+        self.student.profile.xp_invalidate_cache()
         self.client.force_login(self.student)
 
         response = self.client.get(reverse('courses:my_marks'))
 
-        self.assertFalse(response.context['chart_per_course'])
-        # the chart's JS names the selector on every page, so the buttons' own attribute is
-        # what says whether any were rendered
-        self.assertNotContains(response, 'data-course=')
+        self.assertTrue(response.context['chart_per_course'])
+        self.assertContains(response, f'data-course="{self.course.id}"')
+        self.assertContains(response, f'data-course="{art.id}"')
+        # the courses really do still differ, which is why one chart would not do
+        self.assertEqual(self.stu_course.xp(), 50)
+        self.assertEqual(art_registration.xp(), 0)
 
     def test_mark_calculations__offers_one_chart_to_a_student_in_one_course(self):
         """One course means one chart, with no button bar to choose between."""

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -114,10 +114,12 @@ def mark_calculations(request, user_id=None):
         'xp_per_course': xp_per_course,
         'num_courses': num_courses,
         'markranges': markranges,
-        # One progress chart per course, for a student whose courses actually hold different
-        # amounts (issue #2453). With the setting off every course holds an even share, so the
-        # charts would be one line at different scales, which says less than a single chart.
-        'chart_per_course': num_courses > 1 and SiteConfig.get().students_choose_xp_course,
+        # One progress chart per course, for anyone holding more than one (issue #2453). Not
+        # gated on students_choose_xp_course: that setting decides whether students are asked
+        # where new XP goes, while XP already assigned keeps counting where it was put. A deck
+        # that turns it off still has courses holding different amounts, which is what the marks
+        # table above shows too, and a single unlabelled chart could only be one of them.
+        'chart_per_course': num_courses > 1,
     }
     return render(request, template_name, context)
 
@@ -1031,11 +1033,13 @@ def _registration_to_chart(user, course_id):
         in no course at all, which the caller charts as a flat zero.
     """
     registrations = CourseStudent.objects.current_courses(user)
-    if course_id:
-        chosen = registrations.filter(course_id=course_id).first()
-        if chosen is not None:
-            return chosen
-    return registrations.first()
+    try:
+        # whatever the page posted: the chart asks for no course at all when the student has
+        # only one, and nothing stops a request naming something that is not an id
+        chosen = registrations.filter(course_id=int(course_id)).first()
+    except (TypeError, ValueError):
+        chosen = None
+    return chosen if chosen is not None else registrations.first()
 
 
 @xml_http_request_required

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -114,6 +114,10 @@ def mark_calculations(request, user_id=None):
         'xp_per_course': xp_per_course,
         'num_courses': num_courses,
         'markranges': markranges,
+        # One progress chart per course, for a student whose courses actually hold different
+        # amounts (issue #2453). With the setting off every course holds an even share, so the
+        # charts would be one line at different scales, which says less than a single chart.
+        'chart_per_course': num_courses > 1 and SiteConfig.get().students_choose_xp_course,
     }
     return render(request, template_name, context)
 
@@ -1013,6 +1017,27 @@ class SemesterArchive(RefuseSemesterMixin, NonPublicOnlyViewMixin, LoginRequired
         return redirect('courses:semester_list')
 
 
+def _registration_to_chart(user, course_id):
+    """Which of a student's registrations the progress chart is being asked for.
+
+    Args:
+        user: the student being charted.
+        course_id: the course the request named, as a string from the POST, or None for
+            whichever course comes first.
+
+    Returns:
+        CourseStudent or None: their registration in that course, falling back to their first
+        one when the request named no course or named one they are not in. None when they are
+        in no course at all, which the caller charts as a flat zero.
+    """
+    registrations = CourseStudent.objects.current_courses(user)
+    if course_id:
+        chosen = registrations.filter(course_id=course_id).first()
+        if chosen is not None:
+            return chosen
+    return registrations.first()
+
+
 @xml_http_request_required
 @non_public_only_view
 @login_required
@@ -1063,11 +1088,14 @@ def ajax_progress_chart(request, user_id=0):
         #   x: day into course
         #   y: XP earned so far
 
-        xp = 0
-        num_courses = user.profile.num_courses()
+        # A course's own line, not an even share of the student's whole total: since #2440 the
+        # two are different numbers for a student who assigned their work (issue #2453). The
+        # course to chart comes from the request, defaulting to the first of their courses.
+        registration = _registration_to_chart(user, request.POST.get('course'))
+
         # days_so_far == len(datelist)
         for day in range(0, sem.days_so_far()):
-            xp = user.profile.xp_to_date(datelist[day]) / num_courses
+            xp = registration.xp_to_date(datelist[day]) if registration else 0
             xp_data.append(
                 # day 0-indexed
                 {'x': day + 1, 'y': xp}
@@ -1085,7 +1113,8 @@ def ajax_progress_chart(request, user_id=0):
             # ie. if today is sunday: friday's total xp <= sunday's total xp
             # (if a submission is removed then will subtract from both friday and sunday xp)
             total_xp = xp_data[-1]['y']
-            difference = user.profile.xp_to_date(today) - total_xp
+            today_xp = registration.xp_to_date(today) if registration else 0
+            difference = today_xp - total_xp
 
             # if true: user has earned xp during the weekend.
             # add that xp to the last valid date
@@ -1095,6 +1124,9 @@ def ajax_progress_chart(request, user_id=0):
         progress_chart = {
             "days_in_semester": sem.num_days(),
             "xp_data": xp_data,
+            # the charted course's own scale: courses can be out of different amounts, so the
+            # axis and the mark lines have to be redrawn when a student switches (issue #2453)
+            "xp_for_100_percent": registration.course.xp_for_100_percent if registration and registration.course else 0,
         }
         json_data = json.dumps(progress_chart)
 

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -313,9 +313,6 @@ class Profile(models.Model):
     #
     #################################
 
-    def num_courses(self):
-        return self.current_courses().count()
-
     def current_courses(self):
         return CourseStudent.objects.current_courses(self.user)
 

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -1216,7 +1216,7 @@ class QuestSubmissionManager(models.Manager):
 
         return total_xp
 
-    def xp_by_course(self, user):
+    def xp_by_course(self, user, up_to_date=None):
         """How much of this student's quest XP they assigned to each of their courses.
 
         A quest's `max_xp` caps what it can ever be worth, however many times it was repeated,
@@ -1227,12 +1227,14 @@ class QuestSubmissionManager(models.Manager):
 
         Args:
             user: the student whose XP is being divided.
+            up_to_date (date): count only what they had earned by then, for charting their
+                progress through the semester (issue #2453). Defaults to everything.
 
         Returns:
             dict: course id to XP, with None collecting everything left unassigned. Only the
             student's own semester counts, and only quests that grant XP.
         """
-        submissions = self.all_approved(user).grant_xp().annotate(
+        submissions = self.all_approved(user, up_to_date=up_to_date).grant_xp().annotate(
             xp_earned=Greatest('quest__xp', 'xp_requested'),
         )
         per_quest_course = submissions.order_by().values(

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -957,6 +957,16 @@ div.btn-group.action-btn-group {
 
 /*Make the container act like container-fluid at small and medium sizes*/
 
+/************ XP PROGRESS CHART **********************/
+
+/* The course picker above a multicourse student's progress chart (#2453): one button per
+   course, sitting between the chart's tab strip and the chart's own panel, so it needs a
+   little air on both sides to read as belonging to neither. */
+.xp-chart-courses {
+    margin: 8px 0;
+}
+
+
 /*LESS to mimic Bootstrap without importing the less files.*/
 /*@screen-xs-max: 767px;
 @screen-sm-min: 768px;

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -24,7 +24,7 @@
 {% else %}
 <link href="{{ STATIC_PREFIX }}css/custom.css?v=1.7" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.7" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.8" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->


### PR DESCRIPTION
### What?

The XP Progress chart on the mark calculations page becomes one chart per course for a student
in more than one, chosen with a button per course above it. Each course's line is its own XP over
the semester, drawn against that course's own XP-for-100%.

A student in one course sees no buttons and no change.

Closes #2453, whose other half (the per-course rank dropdown) merged as #2461.

### Why?

The chart plotted `profile.xp_to_date(day) / num_courses`: the student's deck-wide total, split
evenly. Since #2440 that is not what any of their courses holds. A student with 140 XP in Maths
and 12 in Art was shown one line at 76, a number neither course has, and the same line whichever
course they were thinking about.

### How?

`xp_by_course()` on both the quest and badge managers takes an `up_to_date`, and
`CourseStudent.xp_to_date()` runs the same assigned-versus-shared split as of a day rather than
as of now. The chart endpoint takes the course to plot in its POST and asks that registration for
each day's figure, so the series is the course's own.

The response also carries the charted course's `xp_for_100_percent`, since courses can be out of
different amounts and the axis and mark lines have to be redrawn when a student switches.

**The charts follow the courses, not the `students_choose_xp_course` setting.** That setting
decides whether students are *asked* where new XP goes; it does not un-assign what is already
assigned, and nothing that reads a student's XP consults it, including the marks table at the top
of this page. A deck that turns it off still has courses holding different amounts (that table
still shows 140% and 12%), so gating the charts on it would have left a multicourse student one
unlabelled chart that was silently their first course, contradicting the table above it.

**Bugs fixed along the way.**

- The old chart divided each day's point by the course count but not the weekend top-up added
  afterwards (the correction for XP earned on a non-class day), so a student who earned XP over a
  weekend saw the last point of their line jump to their undivided total. That is the spike in
  the "before" screenshot. Both figures come from the registration now.
- The charted course id arrives from the page's POST and reached the query unchecked, so a
  request naming something that is not a number (`course=abc`) raised
  `ValueError: Field 'id' expected a number but got 'abc'` and returned a 500. It falls back to
  one of the student's own courses now.

**What it costs.** The chart asks per class day, so I measured the endpoint on a seeded dev deck,
counting real queries (django-tenants `SET search_path` excluded):

| | queries | query time |
| --- | --- | --- |
| before (deck-wide line) | 76 | 0.04s |
| after (a course's own line) | 132 | 0.08s |

That is a 16-class-day semester and it scales with the days behind you, so a full term is nearer
800 queries for one chart load. It is on demand rather than per page, and only multicourse
students reach the split at all (a single course short-circuits), so rewriting the chart's day
loop, with its weekend and holiday handling, was not worth it here. Noted with the numbers on
#2459, which already tracks computing this once instead of per call.

### Testing?

`python src/manage.py test src` (2403 tests) and `ruff check src` both pass, and no file in the
codebase is below 100% statement and branch coverage.

New tests cover the endpoint charting the named course's own XP (one course's line ends at 40
where the other's ends at 0), scaling to the charted course's total, falling back to a course the
student is in when the request names none, names someone else's, sends the empty value the page
posts for a single-course student, or sends junk; the page offering a button per course for a
multicourse student with the setting on and with it off; and `CourseStudent.xp_to_date()` both
dividing as of a date and answering with the whole total for a registration that is not current.

### Screenshots (if front end is affected)

Captured on a seeded `hackerspace` deck, as a student with 140 XP in Mathematics 10 and 12 XP in
Digital Art 11, both courses out of 1000.

**Before**: one line at the even share, with the weekend top-up spiking the final point up to the
undivided total.

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/chart-before.png)

**After**, with a button per course. Digital Art 11 holds 12 XP, so its line barely leaves the
axis:

![after, art](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/chart-after-art.png)

Clicking Mathematics 10 redraws it against that course's 140 XP and its own trend:

![after, maths](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2453/chart-after-maths.png)

### Anything Else?

**The Mark Distribution and Tags Distribution tabs are unchanged.** Mark distribution is a
deck-wide comparison rather than a personal progress line, and tags are not attributed per course
at all, so neither has a per-course meaning to show yet.

**`Profile.num_courses()` is gone.** Its last caller was the chart, dividing a student's total by
how many courses they are in; the chart asks a registration for its own XP now, so nothing called
it.

### Review request
@tylerecouture

- Claude Code (bytedeck - semester workflow redesign)