### PR TITLE
fix: carry a quest's submission questions through the Shared Library (#2162)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -141,8 +141,13 @@ def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import
     """
     with schema_context(source_schema):
         category = Category.objects.get(import_id=campaign_import_id)
-        # select_related: snapshot_quest reads quest.campaign for every row.
-        quests = Quest.objects.select_related('campaign').filter(published=True, campaign=category)
+        # select_related: snapshot_quest reads quest.campaign for every row, and its
+        # questions, which are a query each without the prefetch.
+        quests = (
+            Quest.objects.select_related('campaign')
+            .prefetch_related('question_set')
+            .filter(published=True, campaign=category)
+        )
 
         # filter out conflicts (they'll be cloned and exported later)
         if skip_import_ids:

--- a/src/library/importer.py
+++ b/src/library/importer.py
@@ -28,7 +28,13 @@ def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_
             instance because one of its names is already taken there.
     """
     with library_schema_context():
-        quests = Quest.objects.select_related('campaign').filter(published=True, import_id__in=quest_import_ids)
+        # select_related/prefetch_related: snapshot_quest reads each quest's campaign and
+        # its questions, which are a query each otherwise.
+        quests = (
+            Quest.objects.select_related('campaign')
+            .prefetch_related('question_set')
+            .filter(published=True, import_id__in=quest_import_ids)
+        )
         snapshots = [snapshot_quest(quest) for quest in quests]
 
     with schema_context(destination_schema):

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -13,12 +13,13 @@ or a regression, and the failure is where the decision gets recorded.
 """
 
 import datetime
+from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from model_bakery import baker
 
-from django.db import connection
+from django.db import IntegrityError, connection
 from django_tenants.utils import schema_context
 from taggit.models import Tag
 
@@ -586,6 +587,26 @@ class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):
         self.assertIn("question 2", str(caught.exception))
         with library_schema_context():
             self.assertFalse(Quest.objects.all_including_archived().filter(import_id=quest.import_id).exists())
+
+    def test_export_quest_to_library__reports_a_question_the_database_rejects(self):
+        """A question the database refuses reaches the sharer as a readable failure too.
+
+        `full_clean` catches what it can see, so this is the narrow case it cannot: the row
+        is valid when validated and rejected when written. The quest's own write path
+        already reports that as a transfer error rather than letting a database exception
+        escape into a 500, and a question's write path answers the same way.
+        """
+        quest = Quest.objects.create(name="Quest The Database Refuses", xp=10)
+        Quest.objects.filter(pk=quest.pk).update(published=True)
+        Question.objects.create(quest=quest, ordinal=1, instructions="<p>Fine on the way out.</p>")
+
+        with patch.object(Question, 'save', side_effect=IntegrityError("duplicate key value")):
+            with self.assertRaises(LibraryTransferError) as caught:
+                export_quest_to_library(source_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        self.assertIn("Quest The Database Refuses", str(caught.exception))
+        self.assertIn("question 1", str(caught.exception))
+        self.assertIn("duplicate key value", str(caught.exception))
 
 
 class LibraryTransferErrorMessageTests(SimpleTestCase):

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -33,6 +33,7 @@ from prerequisites.models import IsAPrereqMixin, Prereq
 from badges.models import Badge
 from courses.models import Block, Course, Grade, Rank
 from quest_manager.models import Category, CommonData, Quest
+from questions.models import Question, QuestionType
 
 # The fields a Quest carries into the Library and back, as of today. This is not a wish
 # list: it is what the transfer currently moves, verified by `test_quest_field_inventory__every_field_is_classified`.
@@ -64,6 +65,18 @@ CATEGORY_FIELDS_NOT_TRANSFERRED = {
     'id': 'Primary key. The destination assigns its own.',
     'published': 'Deliberately forced to draft, same as quests.',
     'map_order': 'Dropped. Quest-map placement is relative to the deck it was arranged on (#2396).',
+}
+
+QUESTION_FIELDS_TRANSFERRED = frozenset({
+    'type', 'ordinal', 'required', 'instructions', 'solution_text', 'solution_file',
+    'allowed_file_type', 'marker_notes',
+})
+
+QUESTION_FIELDS_NOT_TRANSFERRED = {
+    'id': 'Primary key. The destination assigns its own.',
+    'quest': 'Not copied as an FK: it is set to the quest being written, whose pk differs per schema.',
+    'datetime_created': 'auto_now_add. The destination row stamps its own creation time.',
+    'datetime_last_edit': 'auto_now. Always the time of the import.',
 }
 
 
@@ -368,6 +381,211 @@ class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
         with library_schema_context():
             library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
             self.assertEqual(list(library_quest.prereqs()), [])
+
+
+class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):
+    """Pin what happens to a quest's submission questions when the quest changes decks."""
+
+    def _quest_with_questions(self):
+        """Create a published quest asking one question of each type.
+
+        Every transferred field is set to a non-default value, so a field that stops
+        travelling fails the round trip instead of matching by coincidence.
+
+        Returns:
+            Quest: the published quest, with three questions attached.
+        """
+        quest = Quest.objects.create(name="Quest With Questions", xp=10)
+        Quest.objects.filter(pk=quest.pk).update(published=True)
+
+        Question.objects.create(
+            quest=quest, ordinal=1, type=QuestionType.SHORT_ANSWER, required=False,
+            instructions="<p>What is the title of your project?</p>",
+            solution_text="Any title", marker_notes="<p>Accept anything</p>",
+        )
+        Question.objects.create(
+            quest=quest, ordinal=2, type=QuestionType.LONG_ANSWER,
+            instructions="<p>Describe your process.</p>",
+            solution_text="A paragraph", marker_notes="<p>Look for reflection</p>",
+        )
+        Question.objects.create(
+            quest=quest, ordinal=3, type=QuestionType.FILE_UPLOAD, allowed_file_type="image",
+            instructions="<p>Upload a photo.</p>",
+            solution_file="quest/question/solution/2026/08/16/example.png",
+            marker_notes="<p>Any photo of the build</p>",
+        )
+
+        return Quest.objects.get(pk=quest.pk)
+
+    def _push_and_pull(self, quest):
+        """Push a quest to the Library, publish it there, then pull it back into this deck.
+
+        The local copy is deleted in between, so the pull takes the path a deck seeing the
+        quest for the first time would.
+
+        Args:
+            quest (Quest): the local quest to push.
+
+        Returns:
+            Quest: the quest as it exists on this deck after being imported back.
+        """
+        local_schema = connection.schema_name
+        export_quest_to_library(source_schema=local_schema, quest_import_id=quest.import_id)
+
+        with library_schema_context():
+            Quest.objects.filter(import_id=quest.import_id).update(published=True)
+
+        Quest.objects.all_including_archived().filter(import_id=quest.import_id).delete()
+        import_quest_to(destination_schema=local_schema, quest_import_id=quest.import_id)
+
+        return Quest.objects.all_including_archived().get(import_id=quest.import_id)
+
+    def test_question_field_inventory__every_field_is_classified(self):
+        """Every concrete Question field is classified as transferred or not.
+
+        Same contract as the quest and campaign inventories: a field added to Question
+        fails this test until someone decides whether it belongs to the content (and so
+        should reach other decks) or to the deck it was written on.
+        """
+        concrete = {f.name for f in Question._meta.concrete_fields}
+        classified = QUESTION_FIELDS_TRANSFERRED | set(QUESTION_FIELDS_NOT_TRANSFERRED)
+
+        self.assertEqual(
+            concrete - classified,
+            set(),
+            "A field was added to Question without deciding whether it should travel to other decks. "
+            "Add it to QUESTION_FIELDS_TRANSFERRED or to QUESTION_FIELDS_NOT_TRANSFERRED with a reason.",
+        )
+        self.assertEqual(
+            classified - concrete,
+            set(),
+            "A field was removed from Question but is still classified in this module.",
+        )
+
+    def test_round_trip__carries_every_question_with_every_transferred_field(self):
+        """A quest's questions arrive on the far side as their author wrote them (#2162).
+
+        Before this, a quest whose instructions said "answer the questions below" arrived
+        as an empty-form quest: the questions were never serialised, so the content loss
+        was silent on both the push and the pull.
+        """
+        quest = self._quest_with_questions()
+        expected = [
+            {name: getattr(question, name) for name in QUESTION_FIELDS_TRANSFERRED}
+            for question in quest.question_set.all()
+        ]
+
+        imported = self._push_and_pull(quest)
+
+        arrived = list(imported.question_set.all())
+        self.assertEqual(len(arrived), 3)
+        for question, values in zip(arrived, expected):
+            for name in sorted(QUESTION_FIELDS_TRANSFERRED):
+                with self.subTest(ordinal=values['ordinal'], field=name):
+                    self.assertEqual(
+                        str(getattr(question, name)),
+                        str(values[name]),
+                        f"question {values['ordinal']}'s '{name}' did not survive the round trip.",
+                    )
+
+    def test_round_trip__carries_the_solution_file_by_path(self):
+        """The marker's example answer arrives pointing at the same stored file.
+
+        Decks share one media namespace, so a file field travels as its path and the bytes
+        never move, exactly as a quest's icon does.
+        """
+        quest = self._quest_with_questions()
+
+        imported = self._push_and_pull(quest)
+
+        file_question = imported.question_set.get(ordinal=3)
+        self.assertEqual(file_question.solution_file.name, "quest/question/solution/2026/08/16/example.png")
+
+    def test_re_import__updates_a_changed_question_in_place(self):
+        """Re-importing a quest refreshes its questions rather than duplicating them.
+
+        The question keeps its row, which is what keeps answers students already gave
+        attached to the question they answered.
+        """
+        quest = self._quest_with_questions()
+        self._push_and_pull(quest)
+        first = Quest.objects.all_including_archived().get(import_id=quest.import_id).question_set.get(ordinal=1)
+
+        with library_schema_context():
+            library_question = Question.objects.get(quest__import_id=quest.import_id, ordinal=1)
+            library_question.instructions = "<p>What did you name it?</p>"
+            library_question.save()
+
+        import_quest_to(destination_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        imported = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+        self.assertEqual(imported.question_set.count(), 3)
+        refreshed = imported.question_set.get(ordinal=1)
+        self.assertEqual(refreshed.pk, first.pk)
+        self.assertEqual(refreshed.instructions, "<p>What did you name it?</p>")
+
+    def test_re_import__removes_a_question_the_author_deleted(self):
+        """A question dropped upstream is dropped here too, so the copies stay the same quest.
+
+        The quest's own fields are overwritten by a re-import, and its questions are part
+        of the same content: leaving a deleted question behind would have this deck asking
+        a question the shared quest no longer asks.
+        """
+        quest = self._quest_with_questions()
+        self._push_and_pull(quest)
+
+        with library_schema_context():
+            Question.objects.get(quest__import_id=quest.import_id, ordinal=2).delete()
+
+        import_quest_to(destination_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        imported = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+        self.assertEqual([question.ordinal for question in imported.question_set.all()], [1, 3])
+
+    def test_export_campaign_and_copy_quests__carries_questions_on_the_conflict_copy(self):
+        """A quest copied in beside the Library's existing version brings its questions.
+
+        The conflict path writes a second copy under a fresh import_id, and that copy is
+        the whole quest: a copy that arrived without its questions would be an empty-form
+        quest with a name saying otherwise.
+        """
+        campaign = Category(title="Conflicted Campaign", published=True)
+        campaign.save()
+        quest = self._quest_with_questions()
+        Quest.objects.filter(pk=quest.pk).update(campaign=campaign)
+        # Put the quest in the Library first, so sharing the campaign hits the conflict path.
+        export_quest_to_library(source_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        with library_schema_context():
+            copy = (
+                Quest.objects.all_including_archived()
+                .filter(name__startswith=quest.name)
+                .exclude(import_id=quest.import_id)
+                .get()
+            )
+            self.assertEqual([question.ordinal for question in copy.question_set.all()], [1, 2, 3])
+
+    def test_export_quest_to_library__reports_a_question_that_cannot_be_written(self):
+        """A question the destination refuses names the quest and the question it came from.
+
+        `instructions` is required, so a row saved without it (as `Question.objects.create`
+        allows, since it does not validate) cannot be written on the far side. The failure
+        is raised as a `LibraryTransferError` a view can put in front of the sharer, rather
+        than escaping as a validation error naming a model they never see.
+        """
+        quest = Quest.objects.create(name="Quest With A Bad Question", xp=10)
+        Quest.objects.filter(pk=quest.pk).update(published=True)
+        Question.objects.create(quest=quest, ordinal=2, instructions="")
+
+        with self.assertRaises(LibraryTransferError) as caught:
+            export_quest_to_library(source_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        self.assertIn("Quest With A Bad Question", str(caught.exception))
+        self.assertIn("question 2", str(caught.exception))
+        with library_schema_context():
+            self.assertFalse(Quest.objects.all_including_archived().filter(import_id=quest.import_id).exists())
 
 
 class LibraryTransferErrorMessageTests(SimpleTestCase):

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -352,11 +352,16 @@ def _write_questions(quest, questions):
             setattr(question, name, value)
 
         try:
-            question.full_clean()
-            question.save()
+            with transaction.atomic():
+                question.full_clean()
+                question.save()
         except ValidationError as error:
             raise LibraryTransferError(
                 f"'{quest.name}' could not be copied: question {fields['ordinal']}: {_describe(error)}"
+            ) from error
+        except IntegrityError as error:
+            raise LibraryTransferError(
+                f"'{quest.name}' could not be copied: question {fields['ordinal']}: {error}"
             ) from error
 
     Question.objects.filter(pk__in=[question.pk for question in superseded.values()]).delete()

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -32,6 +32,7 @@ from django.db import IntegrityError, transaction
 
 from prerequisites.models import Prereq
 from quest_manager.models import Category, Quest
+from questions.models import Question
 
 from .models import IsLibraryContentMixin
 
@@ -82,6 +83,14 @@ CAMPAIGN_FIELDS_NOT_COPIED = {
     'id': 'Primary key. The destination assigns its own.',
     'published': 'Set by the caller: content arrives as a draft for review.',
     'map_order': 'Quest-map placement, which is relative to the deck it was arranged on (#2396).',
+}
+
+# Submission-question fields that do not cross, same idea.
+QUESTION_FIELDS_NOT_COPIED = {
+    'id': 'Primary key. The destination assigns its own.',
+    'quest': 'Set to the quest being written, whose pk differs per schema.',
+    'datetime_created': 'auto_now_add. The destination stamps its own creation time.',
+    'datetime_last_edit': 'auto_now. Always the time of the copy.',
 }
 
 
@@ -148,8 +157,8 @@ def snapshot_quest(quest):
 
     Returns:
         dict: with keys `fields` (the quest's own values), `tags` (tag names), `campaign`
-        (a campaign snapshot or None) and `prereqs` (the shareable things it requires,
-        each as an import_id and a name).
+        (a campaign snapshot or None), `prereqs` (the shareable things it requires, each as
+        an import_id and a name) and `questions` (its submission questions).
     """
     return {
         'fields': {name: _read_field(quest, name) for name in _copied_field_names(Quest, QUEST_FIELDS_NOT_COPIED)},
@@ -158,7 +167,29 @@ def snapshot_quest(quest):
         'tags': sorted(quest.tags.names()),
         'campaign': snapshot_campaign(quest.campaign),
         'prereqs': _snapshot_prereqs(quest),
+        'questions': _snapshot_questions(quest),
     }
+
+
+def _snapshot_questions(quest):
+    """The submission questions a quest asks, in the order the student answers them.
+
+    A question is part of the quest's content, not of the deck it was written on: a quest
+    whose instructions say "answer the questions below" is a different quest without them,
+    so they travel with it (#2162). They have no identity of their own to travel under, so
+    they ride inside the quest's snapshot and are matched on the far side by ordinal.
+
+    Must be called from within the source schema context.
+
+    Args:
+        quest (Quest): the quest whose questions to read.
+
+    Returns:
+        list[dict]: one dict of copied field values per question, ordered by ordinal.
+    """
+    copied = _copied_field_names(Question, QUESTION_FIELDS_NOT_COPIED)
+
+    return [{name: _read_field(question, name) for name in copied} for question in quest.question_set.all()]
 
 
 def _snapshot_prereqs(quest):
@@ -286,6 +317,51 @@ def _write_prereqs(quest, prereqs):
     return unmet
 
 
+def _write_questions(quest, questions):
+    """Make this deck's copy of a quest ask exactly the questions it travelled with.
+
+    Matched by ordinal, which is the only identity a question has across schemas: it
+    carries no import_id, and the model already holds one question per ordinal per quest.
+    A question at an ordinal the quest already uses is updated in place rather than
+    replaced, so answers students gave stay attached to the question they answered.
+
+    Ordinals the arriving quest does not use are deleted, which is what makes re-sharing a
+    quest whose author removed a question actually remove it here. Answers to a deleted
+    question survive it (`QuestionSubmission.question` is SET_NULL) and show in the marking
+    view as answers to a question that is gone.
+
+    Replacing rather than merging is the same bargain the rest of the quest is written
+    under: a re-import overwrites the quest's own instructions and title with the shared
+    version, so a question the destination added to an imported quest goes the same way as
+    an edit it made to that quest's text.
+
+    Must be called from within the destination schema context.
+
+    Args:
+        quest (Quest): the freshly written quest.
+        questions (list[dict]): copied field values, from `_snapshot_questions`.
+
+    Raises:
+        LibraryTransferError: if a question cannot be written.
+    """
+    superseded = {question.ordinal: question for question in Question.objects.filter(quest=quest)}
+
+    for fields in questions:
+        question = superseded.pop(fields['ordinal'], None) or Question(quest=quest)
+        for name, value in fields.items():
+            setattr(question, name, value)
+
+        try:
+            question.full_clean()
+            question.save()
+        except ValidationError as error:
+            raise LibraryTransferError(
+                f"'{quest.name}' could not be copied: question {fields['ordinal']}: {_describe(error)}"
+            ) from error
+
+    Question.objects.filter(pk__in=[question.pk for question in superseded.values()]).delete()
+
+
 def write_quests(writes, *, with_campaign):
     """Write several snapshotted quests into the current schema, then link them up.
 
@@ -329,7 +405,7 @@ def write_quests(writes, *, with_campaign):
 
 
 def _write_quest_row(snapshot, *, published, with_campaign, field_overrides=None):
-    """Write a quest's own fields, campaign and tags, leaving prerequisites to the caller.
+    """Write a quest's own fields, campaign, tags and questions, leaving prerequisites to the caller.
 
     An existing row with the same `import_id` is updated rather than duplicated, which is
     what makes re-sharing a quest refresh the Library's copy instead of adding a second.
@@ -369,6 +445,7 @@ def _write_quest_row(snapshot, *, published, with_campaign, field_overrides=None
         raise LibraryTransferError(f"'{fields['name']}' could not be copied: {error}") from error
 
     quest.tags.set(snapshot['tags'])
+    _write_questions(quest, snapshot['questions'])
 
     return quest
 


### PR DESCRIPTION
Closes #2162

### What?

A quest's submission questions now travel with it to the Shared Library and back.

### Why?

The transfer copied a quest's own fields, its tags, its campaign and its prerequisites, and nothing else. Questions are a separate table hanging off the quest, so they were simply not read: a quest whose instructions say "answer the questions below" arrived on the importing deck as an empty-form quest, and nothing reported the loss on either side. The sharer saw a successful push and the importer saw a successful pull.

That affects every path through the Library: the single-quest push and pull, the campaign push and pull, and the conflict-copy path that puts a second copy beside the Library's existing one.

### How?

`snapshot_quest` now includes the quest's questions, and `_write_quest_row` writes them on the far side, both built on the same helpers the rest of the module uses (`_copied_field_names` for what travels, `_read_field` so `solution_file` crosses as its stored path like every other file field).

Questions are matched by **ordinal**, which is the only identity they have across schemas: they carry no `import_id`, and the model already holds one question per ordinal per quest.

* A question at an ordinal the destination already uses is **updated in place**, so answers students already gave stay attached to the question they answered.
* An ordinal the arriving quest no longer uses is **removed**, so re-sharing a quest whose author deleted a question actually deletes it here. Answers to a deleted question survive it (`QuestionSubmission.question` is `SET_NULL`) and show in the marking view as answers to a question that is gone.

Replacing rather than merging is the bargain the rest of the quest is already written under: a re-import overwrites the quest's own name and instructions with the shared version, so a question the destination added to an imported quest goes the same way as an edit it made to that quest's text.

A question that cannot be written raises `LibraryTransferError` naming the quest and the ordinal, whether it fails validation or the database rejects it, so a view can put it in front of the sharer instead of a model-level error escaping as a 500. The write is wrapped in its own `transaction.atomic()`, matching how the quest's own row is written.

The campaign export and import querysets prefetch `question_set`, since snapshotting reads it once per quest.

### Testing?

`python src/manage.py test src` green, `ruff check src` and `manage.py check` clean.

New `LibraryTransferQuestionContractTests` in `library/tests/test_transfer_contract.py`, sitting beside the existing quest and campaign contracts. Seven of the eight fail on `develop` without this change:

* a round trip carries all three question types with every transferred field;
* the marker's `solution_file` arrives pointing at the same stored file;
* re-importing updates a changed question in place, keeping its row;
* re-importing removes a question the author deleted upstream;
* the conflict-copy path carries questions onto the fresh copy;
* a question that fails validation names the quest and the question;
* a question the database rejects does too (`Question.save` patched to raise, since that is by definition the case `full_clean` cannot see).

The eighth is a field inventory (`test_question_field_inventory__every_field_is_classified`), matching the ones Quest and Category already have: adding a field to `Question` now fails the suite until someone decides whether it belongs to the content or to the deck it was written on.

### Screenshots (if front end is affected)

Real decks on the dev environment: `hackerspace` shares a quest with three questions (short answer, long answer, file upload) to the Library, and `importdeck` imports it. Both shots are `importdeck`'s Manage Questions page for the imported quest, as `teacher2`:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2162/before_imported_questions.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2162/after_imported_questions.png) |

Before, the imported quest says "No questions to display" even though the shared quest asks three. After, all three arrive with their type, instructions, required flag and marker notes.

### Anything Else?

The Library's own import **preview** still renders its Submission Questions panel against the importing deck's schema rather than the Library's ([#2163](https://github.com/bytedeck/bytedeck/issues/2163)), so it can show an unrelated local quest's questions. That is a separate bug in the view, and it is the next one I am picking up.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)