### PR TITLE
fix: stop between-terms work landing in another cohort's semester (#2441, #2413)

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -349,16 +349,17 @@ class BadgeAssertionQuerySet(models.query.QuerySet):
     def get_semester(self, semester):
         """Assertions granted in `semester`.
 
+        None is a semester's worth of badges in its own right rather than a missing filter
+        (issue #2413), matching how submissions read: a student between terms is in no
+        semester, so a badge granted to them is stamped with none, and it is still theirs.
+
         Args:
-            semester: a Semester, or None when no semester is open.
+            semester: a Semester, or None for the badges that belong to no semester.
 
         Returns:
-            BadgeAssertionQuerySet: the assertions from that semester, or an empty queryset
-            when there is no semester (no semester is open). Assertions granted while no
-            semester was open belong to no semester, so they are left out either way.
+            BadgeAssertionQuerySet: the assertions from that semester, or the unstamped ones
+            when there is no semester.
         """
-        if semester is None:
-            return self.none()
         return self.filter(semester=semester)
 
     def get_issued_before(self, date):

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -418,14 +418,19 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
 
         self.assertIsNone(new_assertion.semester_id)
 
-    def test_get_queryset__active_semester_only_is_empty_with_no_open_semester(self):
-        """With no semester open, nothing was earned this semester: the semester-scoped
-        queryset is empty rather than matching the unstamped assertions."""
+    def test_get_queryset__active_semester_only_holds_the_unstamped_assertions_with_no_open_semester(self):
+        """With no semester open, "this semester" is the work that belongs to none: a badge
+        granted between terms is stamped with no semester (issue #2413) and is still the
+        student's, so the semester-scoped queryset is where it shows up. The assertion from
+        the archived semester is past, so it drops out of that queryset but not the
+        unscoped one."""
         Semester.objects.complete_semester()
-        BadgeAssertion.objects.create_assertion(self.student, baker.make(Badge), issued_by=self.teacher)
+        unstamped = BadgeAssertion.objects.create_assertion(self.student, baker.make(Badge), issued_by=self.teacher)
 
-        self.assertFalse(BadgeAssertion.objects.get_queryset(active_semester_only=True).exists())
-        self.assertTrue(BadgeAssertion.objects.get_queryset(active_semester_only=False).exists())
+        semester_scoped = BadgeAssertion.objects.get_queryset(active_semester_only=True)
+        self.assertIn(unstamped, semester_scoped)
+        self.assertNotIn(self.assertion, semester_scoped)
+        self.assertIn(self.assertion, BadgeAssertion.objects.get_queryset(active_semester_only=False))
 
     def test_post_save_receiver__uses_badge_type_fa_icon_when_set(self):
         """The granted notification uses the badge type's own fa_icon when it has one, rather
@@ -454,6 +459,8 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
     def test_get_by_type_for_user__one_entry_per_badge_type(self):
         """ get_by_type_for_user should return one entry per BadgeType, where the entry for the
         granted badge's type contains the user's assertion and all other entries are empty. """
+        # registered in the semester the recipe stamps, or the assertion isn't theirs to list
+        baker.make('courses.CourseStudent', user=self.student, course=baker.make('courses.Course'), semester=self.sem)
         assertion = self.badge_assertion_recipe.make()
         badge_list_by_type = BadgeAssertion.objects.get_by_type_for_user(self.student)
         self.assertEqual(len(badge_list_by_type), BadgeType.objects.count())

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -841,18 +841,22 @@ class CourseStudentManager(models.Manager):
         pointer can no longer say which of them a given student is in, but their
         registration always can.
 
+        Someone holding no open-semester registration is in no semester at all (issue
+        #2441). Handing them the deck's default instead puts their work in a term they were
+        never registered in: it lands in a deck-wide approval queue no teacher owns, counts
+        toward that cohort's totals, and is dropped when that cohort's semester is archived,
+        because archiving records final XP from the registrations and they hold none.
+
         Args:
             user: the User whose semester is wanted.
 
         Returns:
-            Semester or None: the open semester this user is registered in. Someone with no
-            such registration (a teacher trying out a quest, a student who hasn't joined a
-            course yet) gets the deck's open semester, which is None between semesters.
+            Semester or None: the open semester this user is registered in, or None when
+            they hold none (a teacher trying out a quest, a student between terms, a student
+            who hasn't joined a course yet).
         """
         registration = self.current_courses(user).select_related('semester').first()
-        if registration is not None:
-            return registration.semester
-        return SiteConfig.get().open_semester
+        return registration.semester if registration is not None else None
 
     def has_multicourse_students(self):
         """Whether anyone on the deck is currently registered in more than one course.
@@ -922,7 +926,8 @@ def semester_for(user=None):
 
     Returns:
         Semester or None: that student's own semester, or the deck's open semester when no
-        particular student is in view. None when neither exists, between semesters.
+        particular student is in view. None when neither exists: between semesters, and for
+        anyone not registered in one, whose work belongs to no semester (issue #2441).
     """
     if user is None:
         return SiteConfig.get().open_semester
@@ -1082,6 +1087,21 @@ def coursestudent_post_save_callback(instance, **kwargs):
     If they make a manual XP adjustment we need to invalidate the user's xp_cache to recalculate xp
     """
     instance.user.profile.xp_invalidate_cache()
+
+
+@receiver(post_save, sender=CourseStudent)
+def coursestudent_adopt_unstamped_work_callback(instance, created, **kwargs):
+    """Bring the quests a student had on the go into the semester they have just joined.
+
+    Work handed in while they were registered in no semester belongs to none (issue #2441),
+    and joining a course is the moment it gains one. Without this it would be stranded: out
+    of their in-progress list, which is their new semester's, and out of their available
+    list, which drops a quest they already have a submission of.
+    """
+    from quest_manager.models import QuestSubmission  # locally, since quest_manager imports this module
+
+    if created and instance.semester_id is not None and instance.semester.is_open:
+        QuestSubmission.objects.adopt_unstamped_in_progress(instance.user_id, instance.semester_id)
 
 
 @receiver(post_save, sender=Rank)

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -675,26 +675,25 @@ class StudentOwnSemesterTest(ByteDeckTenantTestCase):
         self.assertEqual(SiteConfig.get().open_semester, self.deck_semester)
         self.assertEqual(CourseStudent.objects.current_semester(self.other_student), self.other_semester)
 
-    def test_current_semester__unregistered_user_falls_back_to_the_deck(self):
+    def test_current_semester__unregistered_user_is_in_no_semester(self):
         """Someone with no registration (a teacher trying a quest, a student who hasn't
-        joined a course) keeps earning XP in the deck's open semester, as before."""
-        self.assertEqual(CourseStudent.objects.current_semester(self.teacher), self.deck_semester)
-
-    def test_current_semester__unregistered_user_between_semesters_is_none(self):
-        """With nothing open and no registration to fall back on, there is no semester."""
-        Semester.objects.filter(pk=self.other_semester.pk).update(status=Semester.Status.ARCHIVED)
-        Semester.objects.complete_semester()
+        joined a course) is in no semester, even while the deck has one open: the deck's
+        default names a term they were never in (issue #2441)."""
+        self.assertEqual(SiteConfig.get().open_semester, self.deck_semester)
         self.assertIsNone(CourseStudent.objects.current_semester(self.teacher))
 
     def test_current_semester__archived_registration_is_not_current(self):
-        """Archiving the semester a student was in leaves them with no current registration, so
-        they stop being attached to the archived semester and fall back to the deck's default
-        like anyone who hasn't joined a course, until they register again."""
+        """Archiving the semester a student was in leaves them with no current registration,
+        and so with no semester: they are not moved into the cohort still running, whose
+        roster they are absent from and whose teachers are not theirs (issue #2441). This is
+        the case the deck-wide fallback used to get wrong, and the one that costs a student
+        their work: XP earned into that cohort's semester is dropped when it is archived,
+        because archiving records final XP from the registrations and they hold none."""
         Semester.objects.complete_semester(self.deck_semester)
         self.other_semester.refresh_from_db()
         self.assertTrue(self.other_semester.is_open)
 
-        self.assertEqual(CourseStudent.objects.current_semester(self.student), self.other_semester)
+        self.assertIsNone(CourseStudent.objects.current_semester(self.student))
 
     def test_current_semester__archived_registration_with_nothing_left_open_is_none(self):
         """When the archived semester was the last one running, a student whose registration it

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -686,9 +686,9 @@ class StudentOwnSemesterTest(ByteDeckTenantTestCase):
         """Archiving the semester a student was in leaves them with no current registration,
         and so with no semester: they are not moved into the cohort still running, whose
         roster they are absent from and whose teachers are not theirs (issue #2441). This is
-        the case the deck-wide fallback used to get wrong, and the one that costs a student
-        their work: XP earned into that cohort's semester is dropped when it is archived,
-        because archiving records final XP from the registrations and they hold none."""
+        the case that costs a student their work if it goes wrong: XP earned into a cohort's
+        semester is dropped when that semester is archived, because archiving records final
+        XP from the registrations, and a student outside that cohort holds none."""
         Semester.objects.complete_semester(self.deck_semester)
         self.other_semester.refresh_from_db()
         self.assertTrue(self.other_semester.is_open)

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1880,9 +1880,11 @@ class TestAjax_TagChart(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create the target user whose tag chart is requested, and cache the active semester."""
+        """Create the target user whose tag chart is requested, registered in the deck's
+        semester so their work counts toward it, and cache that semester."""
         cls.user = baker.make(User)
         cls.semester = SiteConfig.get().active_semester
+        baker.make(CourseStudent, user=cls.user, course=baker.make(Course), semester=cls.semester)
 
     def _tagged_quest_with_submissions(self, tag, xp, max_xp, quantity):
         """Make a tagged quest and `quantity` approved, active-semester submissions for self.user.

--- a/src/profile_manager/tests/test_views.py
+++ b/src/profile_manager/tests/test_views.py
@@ -331,7 +331,12 @@ class ProfileViewTests(ByteDeckTenantTestCase):
             # add unique tag for each quest
             [quest.tags.add(f'TAG-{count}') for count, quest in enumerate(quest_set)]
 
-            # have a submission for one of the quests
+            # have a submission for one of the quests. The student is registered in the
+            # semester it names, or it is not work they earned XP in this term (issue #2441)
+            baker.make(
+                'courses.CourseStudent', user=self.test_student1, course=baker.make('courses.Course'),
+                semester=SiteConfig.get().active_semester,
+            )
             baker.make(
                 'quest_manager.questsubmission',
                 quest=quest_set[0],

--- a/src/quest_manager/migrations/0054_inprogress_submission_no_semester_constraint.py
+++ b/src/quest_manager/migrations/0054_inprogress_submission_no_semester_constraint.py
@@ -1,0 +1,88 @@
+from django.db import migrations, models
+
+# Delete duplicates in bounded batches so a deck with a pathological number of
+# duplicate rows can't produce an unbounded pk__in list in a single query.
+DEDUP_BATCH_SIZE = 500
+
+
+def remove_duplicate_unstamped_in_progress_submissions(apps, schema_editor):
+    """Delete duplicate never-yet-completed in-progress submissions that belong to
+    no semester, before adding the unique constraint covering them (issue #2413).
+
+    Migration 0049 added the same rule for submissions that name a semester, and
+    deliberately left the NULL-semester rows alone: Postgres treats NULLs as
+    distinct, so its partial index could never see two of them as duplicates. Those
+    rows are reachable on any deck (``QuestSubmission.semester`` is
+    ``on_delete=SET_NULL``, and work handed in while the student is in no semester
+    is stamped with none), so dedup them the same way here: keep the earliest
+    (lowest pk) of each ``(user, quest)`` group and delete the rest.
+
+    Untouched, exactly as in 0049 (they can't violate the partial index):
+    - completed submissions;
+    - *returned* submissions (``is_completed=False`` but ``first_time_completed``
+      set), which are a legitimate state alongside a new in-progress attempt;
+    - rows that name a semester, which 0049's constraint already covers.
+    """
+    QuestSubmission = apps.get_model("quest_manager", "QuestSubmission")
+    db_alias = schema_editor.connection.alias
+
+    # ``seen`` is bounded by the number of distinct never-completed in-progress
+    # (user, quest) groups with no semester, which is small in practice; deletes are
+    # flushed in DEDUP_BATCH_SIZE chunks so no single query gets an unbounded
+    # pk__in list.
+    seen = set()
+    duplicate_pks = []
+    unstamped_in_progress = (
+        QuestSubmission.objects.using(db_alias)
+        .filter(is_completed=False, first_time_completed__isnull=True, semester__isnull=True)
+        .order_by("pk")
+        .values_list("pk", "user_id", "quest_id")
+        # Clear any prefetch the active manager may have added (QuestSubmission's
+        # default manager prefetches quest__tags): this scan only reads scalar
+        # tuples, and since Django 5.1 iterator() raises if the queryset carries
+        # a prefetch_related() without an explicit chunk_size. A real migration
+        # uses the historical (plain) manager and has nothing to clear; this keeps
+        # the scan correct if the concrete manager is ever used instead.
+        .prefetch_related(None)
+    )
+    for pk, user_id, quest_id in unstamped_in_progress.iterator():
+        key = (user_id, quest_id)
+        if key in seen:
+            duplicate_pks.append(pk)
+            if len(duplicate_pks) >= DEDUP_BATCH_SIZE:
+                QuestSubmission.objects.using(db_alias).filter(pk__in=duplicate_pks).delete()
+                duplicate_pks = []
+        else:
+            seen.add(key)
+
+    if duplicate_pks:
+        QuestSubmission.objects.using(db_alias).filter(pk__in=duplicate_pks).delete()
+
+
+class Migration(migrations.Migration):
+    """Add the partial unique constraint that blocks concurrent double-starts of a quest
+    handed in outside any semester (issue #2413), first deduplicating the existing
+    unstamped in-progress rows so the constraint can be installed on existing decks."""
+
+    dependencies = [
+        ("quest_manager", "0053_questsubmission_course"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_duplicate_unstamped_in_progress_submissions,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="questsubmission",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    ("is_completed", False),
+                    ("first_time_completed__isnull", True),
+                    ("semester__isnull", True),
+                ),
+                fields=("user", "quest"),
+                name="unique_inprogress_submission_per_quest_no_semester",
+            ),
+        ),
+    ]

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -841,45 +841,49 @@ class QuestSubmissionQuerySet(models.query.QuerySet):
     def get_semester(self, semester):
         """Submissions made in `semester`.
 
+        None is a semester's worth of work in its own right rather than a missing filter
+        (issue #2413): a student between terms, and staff who never register, are in no
+        semester, so what they hand in is stamped with none. Reading those rows back is the
+        only way the student who made them can see them.
+
         Args:
-            semester: a Semester or its id, or None when no semester is open.
+            semester: a Semester or its id, or None for the work that belongs to no semester.
 
         Returns:
-            QuestSubmissionQuerySet: the submissions in that semester, or an empty queryset
-            when there is no semester (no semester is open). Submissions whose semester was
-            deleted are left out either way: they belong to no semester rather than to this one.
+            QuestSubmissionQuerySet: the submissions in that semester, or the unstamped ones
+            when there is no semester.
         """
-        if semester is None:
-            return self.none()
         return self.filter(semester=semester)
 
-    def in_open_semesters(self):
-        """Submissions made in any semester that is open right now.
+    def in_open_or_no_semester(self):
+        """Submissions no finished term owns: what a deck-wide staff view of current work holds.
 
-        What a deck-wide staff view of "current" work should filter on: a deck can run
-        several semesters at once (issue #2157 Phase 3, #1781), and scoping to the deck's
-        default would hide everything the other cohort hands in.
+        Every open semester's work, since a deck can run several at once (issue #2157 Phase
+        3, #1781) and scoping to the deck's default would hide everything the other cohort
+        hands in. Plus the work stamped with no semester at all (issue #2413), which is what
+        someone registered in none hands in: a student between terms doing a quest marked
+        available outside a course, or staff trying one out. That work reaches no teacher's
+        own queue, since the queue is built from a registration and they hold none, so the
+        deck-wide view is the only place it can be approved from.
 
         Returns:
-            QuestSubmissionQuerySet: the submissions whose semester is open, empty between
-            semesters.
+            QuestSubmissionQuerySet: the submissions in an open semester or in none.
         """
         from courses.models import Semester  # locally, since courses imports this module
 
-        return self.filter(semester__status=Semester.Status.OPEN)
+        return self.filter(Q(semester__status=Semester.Status.OPEN) | Q(semester__isnull=True))
 
     def get_not_semester(self, semester):
         """Submissions made outside `semester`.
 
         Args:
-            semester: a Semester or its id, or None when no semester is open.
+            semester: a Semester or its id, or None for the work that belongs to no semester.
 
         Returns:
-            QuestSubmissionQuerySet: the submissions from any other semester, or all of them
-            when there is no semester (with none open, every submission is from a past one).
+            QuestSubmissionQuerySet: the submissions from any other semester. For None that
+            is every stamped submission: someone in no semester has all their past terms
+            behind them, and the unstamped work is what they are doing now.
         """
-        if semester is None:
-            return self
         return self.exclude(semester=semester)
 
     def get_completed_before(self, date):
@@ -944,9 +948,11 @@ class QuestSubmissionManager(models.Manager):
             exclude_quests_not_published (bool): drop submissions of draft quests.
             include_related (bool): join the related objects the templates almost always need.
             user (User): whose semester to limit to. Their registration names it (issue #2157
-                Phase 3). Without a user this is a deck-wide staff view, which covers every
-                open semester: a deck can run two cohorts on different calendars, and a
-                teacher's queues have to hold both cohorts' work, not one semester's.
+                Phase 3), and someone holding none is in no semester, so their work is the
+                work stamped with none. Without a user this is a deck-wide staff view, which
+                covers every open semester and the unstamped work besides: a deck can run two
+                cohorts on different calendars, and a teacher's queues have to hold both
+                cohorts' work rather than one semester's.
 
         Returns:
             QuestSubmissionQuerySet: the matching submissions.
@@ -955,7 +961,7 @@ class QuestSubmissionManager(models.Manager):
 
         qs = QuestSubmissionQuerySet(self.model, using=self._db)
         if active_semester_only:
-            qs = qs.get_semester(semester_for(user)) if user is not None else qs.in_open_semesters()
+            qs = qs.get_semester(semester_for(user)) if user is not None else qs.in_open_or_no_semester()
         if exclude_archived_quests:
             qs = qs.exclude_archived_quests()
         if exclude_quests_not_published:
@@ -1022,8 +1028,9 @@ class QuestSubmissionManager(models.Manager):
 
         Returns:
             QuestSubmissionQuerySet: their completed submissions outside their current
-            semester, awaiting-approval ones first. Between semesters they are in none, so
-            every completed submission counts as past.
+            semester, awaiting-approval ones first. For someone registered in no semester
+            that is every submission naming one, since the terms they were in are all behind
+            them and the unstamped work is what they are doing now.
         """
         from courses.models import semester_for  # locally, since courses imports this module
 
@@ -1119,16 +1126,20 @@ class QuestSubmissionManager(models.Manager):
     def create_submission(self, user, quest):
         """Create and return a new in-progress QuestSubmission of ``quest`` for ``user``.
 
-        The submission is placed in the active semester, with an ordinal
-        continuing from the user's last submission of this quest (1 for a first
-        attempt).
+        The submission is placed in the semester the student is registered in, with
+        an ordinal continuing from the user's last submission of this quest (1 for
+        a first attempt). Someone registered in none (staff trying out a quest, a
+        student between terms) is in no semester, so theirs is stamped with none
+        (issue #2441) rather than with a term they were never in.
 
-        Concurrency (issue #1345): the partial unique constraint on
-        QuestSubmission forbids a second *never-yet-completed* in-progress
+        Concurrency (issue #1345): the partial unique constraints on
+        QuestSubmission forbid a second *never-yet-completed* in-progress
         submission of the same quest per user/semester -- exactly what a
-        concurrent "double start" (e.g. two browser tabs) would create. If this
-        call loses that race, the existing in-progress submission is returned
-        instead of a duplicate.
+        concurrent "double start" (e.g. two browser tabs) would create. A separate
+        constraint covers the submissions that name no semester (issue #2413),
+        which Postgres would otherwise treat as all distinct. If this call loses
+        that race, the existing in-progress submission is returned instead of a
+        duplicate.
 
         :param user: the student starting the quest.
         :param quest: the Quest being started.
@@ -1147,7 +1158,8 @@ class QuestSubmissionManager(models.Manager):
         from courses.models import semester_for  # locally, since courses imports this module
 
         # the student's own semester, not the deck's: with more than one semester open the
-        # deck can't say which one this student earns XP in, but their registration can
+        # deck can't say which one this student earns XP in, but their registration can, and
+        # someone holding no registration is in none
         semester = semester_for(user)
         new_submission = QuestSubmission(
             quest=quest,
@@ -1259,6 +1271,42 @@ class QuestSubmissionManager(models.Manager):
 
         return xp_by_course
 
+    def adopt_unstamped_in_progress(self, user, semester):
+        """Move the work `user` has on the go that belongs to no semester into `semester`.
+
+        Someone registered in no semester hands work in stamped with none (issue #2441): the
+        welcome quest a new student does before joining a course, or a quest marked available
+        outside a course, done between terms. Once they join a course, that work is in
+        neither their in-progress list (which is now their new semester's) nor their
+        available list (which drops a quest they already have a submission of), so it would
+        sit where nobody can reach it. Re-attaching it is what mark_returned() already does
+        for a submission returned in a later semester (issue #1231).
+
+        Only work still in progress moves. What they finished outside a semester was
+        finished there, and its XP belongs to no term rather than to the one they are
+        starting.
+
+        Args:
+            user: the student who just registered, or their id.
+            semester: the Semester they registered in, or its id.
+
+        Returns:
+            int: how many submissions were moved.
+        """
+        # the base manager throughout: a submission of a quest since archived or unpublished
+        # is still theirs to finish, and the default manager would leave it behind
+        already_in_semester = self.model._base_manager.filter(
+            user=user, semester=semester, is_completed=False, first_time_completed__isnull=True,
+        ).values('quest_id')
+        return self.model._base_manager.filter(
+            user=user, semester__isnull=True, is_completed=False,
+        ).exclude(
+            # a never-completed submission can't join one already in that semester: the
+            # partial unique constraint holds one per (user, quest, semester), and it is the
+            # rule this would be breaking rather than an accident to work around
+            Q(first_time_completed__isnull=True) & Q(quest_id__in=already_in_semester),
+        ).update(semester=semester)
+
     def remove_in_progress(self, semester=None):
         """Delete the submissions students had on the go but never completed.
 
@@ -1335,6 +1383,16 @@ class QuestSubmission(models.Model):
                 fields=["user", "quest", "semester"],
                 condition=Q(is_completed=False) & Q(first_time_completed__isnull=True),
                 name="unique_inprogress_submission_per_quest_semester",
+            ),
+            # The same rule for the work that belongs to no semester (issue #2413). Postgres
+            # treats NULLs as distinct, so the constraint above never sees two unstamped
+            # rows as a duplicate and the double-start race goes unguarded. Semester is left
+            # out of the fields and pinned in the condition instead, which is the same rule
+            # written so the index can compare the rows.
+            models.UniqueConstraint(
+                fields=["user", "quest"],
+                condition=Q(is_completed=False) & Q(first_time_completed__isnull=True) & Q(semester__isnull=True),
+                name="unique_inprogress_submission_per_quest_no_semester",
             ),
         ]
 

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -122,8 +122,25 @@ class QuestQuerysetTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create a student user shared across the queryset tests."""
+        """Create a student user shared across the queryset tests, registered in the deck's
+        semester: their registration is what names the semester their work counts in."""
         cls.student = baker.make(User, username='student', is_staff=False)
+        baker.make(
+            CourseStudent, user=cls.student, course=baker.make(Course),
+            semester=SiteConfig.get().active_semester,
+        )
+
+    def start_new_semester(self):
+        """Start a fresh semester and move the student into it, the way a term rolls over.
+
+        Pointing the deck at a new semester is only half of it: a student's semester comes
+        from their own registration, so per-semester repeat limits only reset for them once
+        they are registered in the new one.
+        """
+        new_semester = baker.make(Semester)
+        SiteConfig.get().set_active_semester(new_semester.id)
+        CourseStudent.objects.filter(user=self.student).update(semester=new_semester)
+        return new_semester
 
     def test_not_in_progress_completed_or_cooldown__all_five_conditions(self):
         """ Test that all 5 conditions are met for this queryset method:
@@ -236,9 +253,8 @@ class QuestQuerysetTest(ByteDeckTenantTestCase):
                 self.assertIn(quest_repeatable_twice_all_time, qs)
                 self.assertIn(quest_infinite_repeatables, qs)  # only the infinite repeats should be avail.
 
-                # Create a new semester and set it to the current one, which should make the per semester quest available again
-                new_semester = baker.make(Semester)
-                SiteConfig.get().set_active_semester(new_semester.id)
+                # Start a new semester and register the student in it, which should make the per semester quest available again
+                new_semester = self.start_new_semester()
                 qs = Quest.objects.all().not_in_progress_completed_or_cooldown(self.student)
                 self.assertNotIn(quest_not_repeatable, qs)
                 self.assertIn(quest_repeatable_once_per_sem, qs)
@@ -265,8 +281,7 @@ class QuestQuerysetTest(ByteDeckTenantTestCase):
 
                     # Finally, make sure quest_repeatable_twice_all_time doesn't refresh in a new semester
                     # Condition 5
-                    new_semester = baker.make(Semester)
-                    SiteConfig.get().set_active_semester(new_semester.id)
+                    self.start_new_semester()
                     qs = Quest.objects.all().not_in_progress_completed_or_cooldown(self.student)
 
                     self.assertNotIn(quest_not_repeatable, qs)
@@ -581,6 +596,9 @@ class QuestManagerTest(ByteDeckTenantTestCase):
 
         """
         active_semester = baker.make(Semester)
+        # the student's registration is what makes this their semester, so the submissions
+        # stamped with it below are the ones that read as their current work
+        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=active_semester)
 
         quest_inprog_sem2 = baker.make(Quest, name='Quest-inprogress-sem2')
         sub_inprog_sem2 = baker.make(QuestSubmission, user=self.student, quest=quest_inprog_sem2)
@@ -788,16 +806,32 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create a teacher, a student, and a stack of submissions spanning two semesters."""
+        """Create a teacher, a student registered in the semester they earn XP in, and a
+        stack of submissions spanning two semesters."""
         cls.teacher = baker.make(User, username='teacher', is_staff=True)
         cls.student = baker.make(User, username='student', is_staff=False)
 
         cls.sub1, cls.sub2 = cls.make_test_submissions_stack()
         cls.active_semester = cls.sub1.semester
+        # the registration is what names the student's semester (issue #2441): without one
+        # they are in no semester, and none of their stamped submissions read as current
+        baker.make(CourseStudent, user=cls.student, course=baker.make(Course), semester=cls.active_semester)
 
     def setUp(self):
         """Set the active semester to the one holding sub1 before each test."""
         SiteConfig.get().set_active_semester(self.active_semester.id)
+
+    def close_every_semester(self):
+        """Put the deck between terms: nothing open and nothing pointed at.
+
+        Archiving the semesters is the half that matters to a student, since their semester
+        comes from a registration and an archived one is not current; clearing the pointer is
+        what leaves the deck itself with no default.
+        """
+        Semester.objects.update(status=Semester.Status.ARCHIVED)
+        config = SiteConfig.get()
+        config.active_semester = None
+        config.save()
 
     def test_get_queryset__default_returns_published_unarchived(self):
         """QuestSubmissionManager.get_queryset by default should return all published, not archived quest submissions"""
@@ -809,10 +843,13 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         qs = QuestSubmission.objects.get_queryset(active_semester_only=True)
         self.assertQuerySetEqual(qs, [self.sub1])
 
-    def test_get_queryset__active_semester_only_is_empty_with_no_open_semester(self):
-        """Between semesters nothing was earned "this semester", so the semester-scoped
-        queryset is empty instead of matching submissions whose semester was deleted."""
-        orphaned = baker.make(QuestSubmission, user=self.student, quest__published=True, quest__archived=False, semester=None)
+    def test_get_queryset__active_semester_only_holds_the_unstamped_work_with_no_open_semester(self):
+        """Between semesters the deck-wide staff view holds exactly what belongs to no
+        semester: what was handed in while nobody was registered anywhere. Leaving it out
+        would put it beyond every approval queue on the deck (issue #2413), since a teacher's
+        own queue is built from a registration and between terms nobody holds one. The
+        archived semesters' work is past, so it drops out."""
+        unstamped = baker.make(QuestSubmission, user=self.student, quest__published=True, quest__archived=False, semester=None)
         Semester.objects.update(status=Semester.Status.ARCHIVED)
         config = SiteConfig.get()
         config.active_semester = None
@@ -820,8 +857,7 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
 
         qs = QuestSubmission.objects.get_queryset(active_semester_only=True)
 
-        self.assertFalse(qs.exists())
-        self.assertNotIn(orphaned, qs)
+        self.assertQuerySetEqual(qs, [unstamped])
 
     def test_get_queryset__active_semester_only_spans_every_open_semester(self):
         """A deck-wide staff view covers both cohorts when a deck runs two semesters at once
@@ -838,34 +874,73 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         self.assertIn(their_submission, qs)
 
     def test_create_submission__is_not_stamped_when_no_semester_is_open(self):
-        """A quest started between semesters belongs to no semester, so its XP counts toward
-        none. See #2413: starting a quest at all in that state is the open question."""
-        config = SiteConfig.get()
-        config.active_semester = None
-        config.save()
+        """A quest started between semesters belongs to no semester, and the student can
+        still see it: their in-progress list is the work in the semester they are in, which
+        is none, so it holds the unstamped rows (issue #2413)."""
+        self.close_every_semester()
 
         submission = QuestSubmission.objects.create_submission(self.student, baker.make(Quest, published=True))
 
         self.assertIsNone(submission.semester_id)
+        self.assertIn(submission, QuestSubmission.objects.all_not_completed(user=self.student))
 
     def test_create_submission__is_stamped_with_the_students_own_semester(self):
         """A quest is stamped with the semester the student is registered in, not the one the
         deck points at (issue #2157 Phase 3). The two are the same until several semesters can
         be open at once, so the second one here is built directly to tell them apart."""
         other_semester = baker.make(Semester, status=Semester.Status.OPEN)
-        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=other_semester)
+        their_student = baker.make(User, username='other_cohort_student')
+        baker.make(CourseStudent, user=their_student, course=baker.make(Course), semester=other_semester)
 
-        submission = QuestSubmission.objects.create_submission(self.student, baker.make(Quest, published=True))
+        submission = QuestSubmission.objects.create_submission(their_student, baker.make(Quest, published=True))
 
         self.assertEqual(submission.semester_id, other_semester.id)
         self.assertNotEqual(submission.semester_id, SiteConfig.get().open_semester_id)
 
-    def test_create_submission__unregistered_user_still_uses_the_deck_semester(self):
+    def test_create_submission__unregistered_user_is_stamped_with_no_semester(self):
         """A teacher trying out a quest has no registration to read a semester from, so their
-        submission keeps landing in the deck's open semester as it always did."""
+        submission belongs to no semester rather than to the deck's open one, which is a term
+        they are not in (issue #2441)."""
+        self.assertIsNotNone(SiteConfig.get().open_semester_id)
+
         submission = QuestSubmission.objects.create_submission(self.teacher, baker.make(Quest, published=True))
 
-        self.assertEqual(submission.semester_id, SiteConfig.get().open_semester_id)
+        self.assertIsNone(submission.semester_id)
+
+    def test_create_submission__student_between_terms_is_stamped_with_no_semester(self):
+        """The regression #2441 is about. A student whose semester was archived while a second
+        cohort keeps running holds no current registration, so their work belongs to no
+        semester: stamping it with the cohort still running would attribute it to a term they
+        are absent from, and archiving that term would then drop it, since final XP is
+        recorded from the registrations and they hold none there."""
+        alum = baker.make(User, username='archived_cohort_student')
+        baker.make(
+            CourseStudent, user=alum, course=baker.make(Course),
+            semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
+        )
+        still_running = SiteConfig.get().open_semester
+
+        submission = QuestSubmission.objects.create_submission(alum, baker.make(Quest, published=True))
+
+        self.assertIsNotNone(still_running)
+        self.assertIsNone(submission.semester_id)
+        self.assertFalse(CourseStudent.objects.filter(user=alum, semester=still_running).exists())
+
+    def test_create_submission__unstamped_double_start_returns_the_existing_submission(self):
+        """The double-start guard covers the work that belongs to no semester too (issue
+        #2413). Postgres treats NULLs as distinct, so the constraint keyed on the semester
+        never sees two unstamped rows as duplicates; the second constraint does, and the
+        request that loses the race is handed the submission that won rather than a copy."""
+        self.close_every_semester()
+        quest = baker.make(Quest, published=True)
+
+        first = QuestSubmission.objects.create_submission(self.student, quest)
+        # bypass the in-progress check start() would make, which is what a concurrent second
+        # request effectively does: it passed that check before the first request saved
+        second = QuestSubmission.objects.create_submission(self.student, quest)
+
+        self.assertEqual(first, second)
+        self.assertEqual(QuestSubmission.objects.all_not_completed(user=self.student).filter(quest=quest).count(), 1)
 
     def test_all_completed_past__returns_every_semester_when_none_is_open(self):
         """With no open semester every completed submission is in a past semester, so the

--- a/src/quest_manager/tests/test_models.py
+++ b/src/quest_manager/tests/test_models.py
@@ -10,7 +10,7 @@ from model_bakery import baker
 from model_bakery.recipe import Recipe
 from comments.models import Comment
 
-from courses.models import Semester
+from courses.models import Course, CourseStudent, Semester
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Category, CommonData, Quest, QuestSubmission
 from siteconfig.models import SiteConfig
@@ -326,6 +326,12 @@ class QuestTestModel(ByteDeckTenantTestCase):
 
         baker.make(User, is_staff=True)  # need a teacher or student creation will fail.
         student = baker.make(User)
+        # registered, so their submissions land in this semester and the per-semester
+        # repeat limits below count them
+        baker.make(
+            CourseStudent, user=student, course=baker.make(Course),
+            semester=SiteConfig.get().active_semester,
+        )
         quest_not_repeatable = baker.make(Quest, name="quest-not-repeatable")
         quest_infinite_repeat = baker.make(Quest, name="quest-infinite-repeatable", max_repeats=-1)
         quest_repeat_1hr = baker.make(Quest, name="quest-repeatable-1hr", max_repeats=1, hours_between_repeats=1)
@@ -389,9 +395,11 @@ class QuestTestModel(ByteDeckTenantTestCase):
         # No repeat left this semester
         self.assertFalse(quest_semester.is_repeat_available(student))
 
-        # change semesters and the quest should appear
+        # change semesters and the quest should appear. Moving the student's registration
+        # is what puts them in the new semester: the deck's pointer is only the default
         new_active_sem = baker.make(Semester)
         SiteConfig.get().set_active_semester(new_active_sem.id)
+        CourseStudent.objects.filter(user=student).update(semester=new_active_sem)
         self.assertTrue(quest_semester_repeat.is_repeat_available(student))
 
         # Repeat this semester, another two should be available
@@ -455,13 +463,18 @@ class SubmissionManagerTest(ByteDeckTenantTestCase):
 
         quest = baker.make(Quest, name="test quest")
         user = baker.make(User, username="test_user")
+        # registered, so the user= filter below reads this semester as theirs
+        baker.make(CourseStudent, user=user, course=baker.make(Course), semester=self.active_semester)
 
         # various submissions
         baker.make(QuestSubmission, semester=self.active_semester)  # in progress shoulnd't appear
         baker.make(QuestSubmission, is_completed=True, semester=self.active_semester)  # completed/submitted shouldn't appear
         sub_approved = baker.make(QuestSubmission, quest=quest, is_completed=True, is_approved=True, semester=self.active_semester)
         sub_approved_different_quest = baker.make(QuestSubmission, is_completed=True, is_approved=True, semester=self.active_semester)
-        sub_approved_other_semester = baker.make(QuestSubmission, quest=quest, is_completed=True, is_approved=True)
+        sub_approved_other_semester = baker.make(
+            QuestSubmission, quest=quest, is_completed=True, is_approved=True,
+            semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
+        )
         sub_approved_no_xp = baker.make(QuestSubmission, quest=quest, is_completed=True, is_approved=True,
                                         do_not_grant_xp=True, semester=self.active_semester)
         sub_approved_user = baker.make(QuestSubmission, user=user, quest=quest, is_completed=True, is_approved=True,
@@ -538,6 +551,8 @@ class SubmissionManagerTest(ByteDeckTenantTestCase):
     def test_all_returned__with_user_returns_that_users_returned_submissions(self):
         """all_returned(user) returns the given user's returned submissions."""
         user = baker.make(User)
+        # registered, so the user= filter reads this semester as theirs
+        baker.make(CourseStudent, user=user, course=baker.make(Course), semester=self.active_semester)
         returned = baker.make(
             QuestSubmission, user=user, is_completed=False, time_completed=timezone.now(), semester=self.active_semester,
         )
@@ -563,11 +578,20 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create a semester, teacher, student, and a base submission shared across the tests."""
+        """Create a semester, teacher, student, and a base submission shared across the tests.
+
+        The student is left unregistered so each test can put them in the semester it needs:
+        their registration is what names the semester a returned submission moves to, and
+        some of these tests are about a student who holds none.
+        """
         cls.semester = baker.make(Semester)
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
         cls.submission = baker.make(QuestSubmission, quest__name="Test")
+
+    def register_student(self, semester):
+        """Register the shared student in `semester`, which is what makes it theirs."""
+        return baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=semester)
 
     def test_submission__creation_and_quest_name(self):
         """Creating a QuestSubmission yields a QuestSubmission linked to its quest."""
@@ -701,6 +725,7 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         )
         active_semester = SiteConfig.get().active_semester
         self.assertNotEqual(past_semester, active_semester)
+        self.register_student(active_semester)
 
         # A quest completed and approved back in the past (closed) semester.
         sub = baker.make(
@@ -717,10 +742,8 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
     def test_mark_returned__moves_submission_to_the_students_own_semester(self):
         """The redo lands in the semester the student is in, not the one the deck points at
         (issue #2157 Phase 3): a returned quest is re-attached from their registration."""
-        from courses.models import Course, CourseStudent
-
         other_semester = baker.make(Semester, status=Semester.Status.OPEN)
-        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=other_semester)
+        self.register_student(other_semester)
         sub = baker.make(
             QuestSubmission, user=self.student,
             semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
@@ -757,6 +780,7 @@ class SubmissionTestModel(ByteDeckTenantTestCase):
         made -- must not be disturbed by the re-attachment above.
         """
         active_semester = SiteConfig.get().active_semester
+        self.register_student(active_semester)
         sub = baker.make(
             QuestSubmission, user=self.student, semester=active_semester,
             is_completed=True, is_approved=True,

--- a/src/quest_manager/tests/test_regression_1345.py
+++ b/src/quest_manager/tests/test_regression_1345.py
@@ -185,15 +185,15 @@ class RepeatableQuestFlowRegressionTest(ByteDeckTenantTestCase):
 
 
 class MigrationDedupTest(ByteDeckTenantTestCase):
-    # Drops and re-adds the QuestSubmission unique constraint via the schema
-    # editor, so give it a private fresh schema rather than mutating the shared
-    # reused one (and to avoid colliding with the persistent test tenant).
-    reuse_schema = False
-
     """Cover migration 0049's ``remove_duplicate_in_progress_submissions``:
     it must delete duplicate never-completed in-progress rows (keeping the
     earliest, flushing deletes in bounded batches) and spare completed,
     returned, and NULL-semester rows."""
+
+    # Drops and re-adds the QuestSubmission unique constraint via the schema
+    # editor, so give it a private fresh schema rather than mutating the shared
+    # reused one (and to avoid colliding with the persistent test tenant).
+    reuse_schema = False
 
     def _constraints(self):
         """Return QuestSubmission's partial unique constraints, so tests can drop and

--- a/src/quest_manager/tests/test_regression_1345.py
+++ b/src/quest_manager/tests/test_regression_1345.py
@@ -24,6 +24,7 @@ from django.utils import timezone
 
 from model_bakery import baker
 
+from courses.models import Course, CourseStudent
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
@@ -41,8 +42,8 @@ class DoubleStartRaceTest(ByteDeckTenantTestCase):
     """The concurrent-double-start vector from issue #1345."""
 
     def setUp(self):
-        """Create a student and a non-repeatable published quest, and grab the
-        active semester the submissions will land in."""
+        """Create a student registered in the active semester and a non-repeatable
+        published quest, and grab the semester the submissions will land in."""
         self.student = baker.make(User, is_staff=False)
         self.quest = baker.make(
             Quest, name="One-time quest", xp=10,
@@ -50,6 +51,10 @@ class DoubleStartRaceTest(ByteDeckTenantTestCase):
             published=True, archived=False,
         )
         self.active_semester = SiteConfig.get().active_semester
+        # the registration is what puts their submissions in this semester (issue #2441):
+        # without one they are in none, and the constraint under test here is the one keyed
+        # on a semester
+        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=self.active_semester)
 
     def _in_progress_count(self):
         """Return how many in-progress (not completed) submissions of the test
@@ -190,13 +195,18 @@ class MigrationDedupTest(ByteDeckTenantTestCase):
     earliest, flushing deletes in bounded batches) and spare completed,
     returned, and NULL-semester rows."""
 
-    def _constraint(self):
-        """Return the partial unique constraint object from QuestSubmission's
-        Meta, so tests can drop and re-add it via the schema editor."""
-        return next(
+    def _constraints(self):
+        """Return QuestSubmission's partial unique constraints, so tests can drop and
+        re-add them via the schema editor. Both are needed: one covers the submissions
+        that name a semester, the other the ones that name none (issue #2413), and the
+        historical state this test rebuilds predates each of them."""
+        return [
             c for c in QuestSubmission._meta.constraints
-            if c.name == "unique_inprogress_submission_per_quest_semester"
-        )
+            if c.name in (
+                "unique_inprogress_submission_per_quest_semester",
+                "unique_inprogress_submission_per_quest_no_semester",
+            )
+        ]
 
     def _run_dedup(self):
         """Invoke the migration's dedup function against the current (test)
@@ -214,9 +224,10 @@ class MigrationDedupTest(ByteDeckTenantTestCase):
         quest = baker.make(Quest, published=True, archived=False)
         active = SiteConfig.get().active_semester
 
-        # Recreate the historical duplicate state by dropping the constraint first.
+        # Recreate the historical duplicate state by dropping the constraints first.
         with connection.schema_editor() as schema_editor:
-            schema_editor.remove_constraint(QuestSubmission, self._constraint())
+            for constraint in self._constraints():
+                schema_editor.remove_constraint(QuestSubmission, constraint)
         try:
             keeper = baker.make(
                 QuestSubmission, user=student, quest=quest, semester=active, is_completed=False,
@@ -237,8 +248,9 @@ class MigrationDedupTest(ByteDeckTenantTestCase):
                 QuestSubmission, user=student, quest=quest, semester=active,
                 is_completed=False, first_time_completed=timezone.now(),
             )
-            # NULL-semester rows are skipped by the dedup (NULLs never violate
-            # the partial unique index).
+            # NULL-semester rows are skipped by this dedup (NULLs never violate the
+            # partial unique index it installs). Migration 0054 is what covers them,
+            # with a dedup of its own.
             null_sem_1 = baker.make(QuestSubmission, user=student, quest=quest, semester=None, is_completed=False)
             null_sem_2 = baker.make(QuestSubmission, user=student, quest=quest, semester=None, is_completed=False)
 
@@ -255,11 +267,16 @@ class MigrationDedupTest(ByteDeckTenantTestCase):
         finally:
             # The dedup's deletes leave deferred trigger events pending in the
             # test transaction, and Postgres refuses CREATE INDEX while they
-            # exist -- force them to fire before re-adding the constraint.
+            # exist -- force them to fire before re-adding the constraints.
             with connection.cursor() as cursor:
                 cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+            # The surviving NULL-semester duplicates would violate the no-semester
+            # constraint, so clear them before putting it back. The base manager, since
+            # the default one filters by the quest's published/archived flags.
+            QuestSubmission._base_manager.filter(semester__isnull=True).delete()
             with connection.schema_editor() as schema_editor:
-                schema_editor.add_constraint(QuestSubmission, self._constraint())
+                for constraint in self._constraints():
+                    schema_editor.add_constraint(QuestSubmission, constraint)
 
     def test_remove_duplicate_in_progress_submissions__noop_when_no_duplicates(self):
         """With no duplicate rows the dedup deletes nothing (the empty branch)."""

--- a/src/quest_manager/tests/test_regression_2413.py
+++ b/src/quest_manager/tests/test_regression_2413.py
@@ -1,0 +1,360 @@
+"""Regression tests for issue #2413 -- "Starting a quest while no semester is open
+makes a submission nobody can see".
+
+Work handed in by someone registered in no semester is stamped with no semester
+(issue #2441 is why: the deck's default names a term they are not in). Two things
+follow, and both are covered here:
+
+* the student has to be able to see it, so the semester-scoped reads treat "no
+  semester" as a semester's worth of work rather than as nothing;
+* the double-start guard from #1345 has to cover it, which its constraint cannot:
+  the constraint is keyed on ``(user, quest, semester)`` and Postgres treats NULLs
+  as distinct, so two unstamped rows never look like duplicates to it. Migration
+  0054 adds a second constraint keyed on ``(user, quest)`` for the unstamped rows,
+  after deduplicating whatever a deck already has.
+"""
+import importlib
+from unittest import mock
+
+from django.apps import apps as django_apps
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError, connection, transaction
+from django.utils import timezone
+
+from model_bakery import baker
+
+from courses.models import Course, CourseStudent, Semester
+from hackerspace_online.tests.utils import ByteDeckTenantTestCase
+from quest_manager.models import Quest, QuestSubmission
+from siteconfig.models import SiteConfig
+
+User = get_user_model()
+
+# The migration module starts with a digit, so it can't be imported with a
+# plain ``import`` statement.
+migration_0054 = importlib.import_module(
+    "quest_manager.migrations.0054_inprogress_submission_no_semester_constraint"
+)
+
+
+class UnstampedSubmissionVisibilityTest(ByteDeckTenantTestCase):
+    """A student between terms can see and finish the work they hand in."""
+
+    def setUp(self):
+        """Create a student whose only registration is in an archived semester, while a
+        second cohort's semester keeps running: the two-cohort state from issue #2441."""
+        self.student = baker.make(User, is_staff=False)
+        baker.make(
+            CourseStudent, user=self.student, course=baker.make(Course),
+            semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
+        )
+        self.still_running = SiteConfig.get().active_semester
+        self.quest = baker.make(Quest, xp=5, published=True, archived=False, available_outside_course=True)
+
+    def test_start__submission_is_in_the_students_own_in_progress_list(self):
+        """The symptom the issue opens with: the quest looked un-started, because the
+        student's in-progress list was scoped to a semester they are not in and so held
+        nothing. Their list is now the work in the semester they are in, which is none."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+
+        self.assertIsNone(submission.semester_id)
+        self.assertIn(submission, QuestSubmission.objects.all_not_completed(user=self.student))
+
+    def test_start__submission_reaches_the_deck_wide_approval_queue(self):
+        """Somebody has to be able to approve it. No teacher's own queue holds it, since
+        that queue is built from a registration and this student holds none, so the
+        deck-wide queue is where it has to appear."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        submission.mark_completed()
+
+        self.assertIn(submission, QuestSubmission.objects.all_awaiting_approval())
+
+    def test_approve__xp_counts_toward_the_students_total(self):
+        """Approved work that belongs to no semester still counts for the student who did
+        it: their XP is what they earned in the semester they are in, and unstamped work is
+        what that comes to."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        submission.mark_completed()
+        submission.mark_approved()
+
+        self.assertEqual(QuestSubmission.objects.calculate_xp(self.student), self.quest.xp)
+
+    def test_completed__unstamped_work_is_current_rather_than_past(self):
+        """Their past tab holds the terms behind them, not what they are doing now: the
+        archived semester's work is past, and the unstamped work is current."""
+        old_submission = baker.make(
+            QuestSubmission, user=self.student, quest=self.quest, is_completed=True,
+            semester=CourseStudent.objects.all_for_user(self.student).first().semester,
+        )
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        submission.mark_completed()
+
+        self.assertIn(submission, QuestSubmission.objects.all_completed(user=self.student))
+        self.assertNotIn(submission, QuestSubmission.objects.all_completed_past(self.student))
+        self.assertIn(old_submission, QuestSubmission.objects.all_completed_past(self.student))
+
+    def test_start__work_is_not_attributed_to_the_cohort_still_running(self):
+        """The #2441 half: the semester still running belongs to the other cohort, whose
+        roster this student is absent from. Their work must not land in it, or archiving
+        that cohort would drop it while recording final XP from registrations they don't
+        hold."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+
+        self.assertIsNotNone(self.still_running)
+        self.assertNotEqual(submission.semester_id, self.still_running.id)
+        self.assertNotIn(submission, QuestSubmission.objects.get_queryset().get_semester(self.still_running))
+
+
+class AdoptUnstampedWorkOnRegistrationTest(ByteDeckTenantTestCase):
+    """Joining a course brings the work a student had on the go into that semester."""
+
+    def setUp(self):
+        """Create an unregistered student, so what they hand in belongs to no semester, and
+        the semester they are about to join."""
+        self.student = baker.make(User, is_staff=False)
+        self.quest = baker.make(Quest, xp=5, published=True, archived=False, available_outside_course=True)
+        self.semester = SiteConfig.get().active_semester
+
+    def register(self, user=None):
+        """Register `user` (the student by default) in the semester under test."""
+        return baker.make(
+            CourseStudent, user=user or self.student, course=baker.make(Course), semester=self.semester,
+        )
+
+    def test_register__in_progress_work_moves_into_the_semester_joined(self):
+        """The welcome-quest case: a new student starts a quest before joining a course, so
+        it belongs to no semester. Joining is the moment it gains one, and without that it
+        would be stranded: out of their in-progress list, which is the new semester's, and
+        out of their available list, which drops a quest they already have a submission of."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        self.assertIsNone(submission.semester_id)
+
+        self.register()
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.semester_id, self.semester.id)
+        self.assertIn(submission, QuestSubmission.objects.all_not_completed(user=self.student))
+
+    def test_register__completed_work_stays_where_it_was_finished(self):
+        """Only work still in progress moves. A quest finished outside a semester was
+        finished there, so its XP belongs to no term rather than to the one being started:
+        otherwise a student could bank XP between terms and cash it in on the next one."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        submission.mark_completed()
+
+        self.register()
+
+        submission.refresh_from_db()
+        self.assertIsNone(submission.semester_id)
+
+    def test_register__work_of_an_archived_quest_moves_too(self):
+        """A quest archived while the student had it on the go is still theirs to finish, so
+        it moves with the rest rather than being left behind by a manager that hides it."""
+        archived_quest = baker.make(Quest, published=True, archived=False)
+        submission = QuestSubmission.objects.create_submission(self.student, archived_quest)
+        archived_quest.archived = True
+        archived_quest.save()
+
+        self.register()
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.semester_id, self.semester.id)
+
+    def test_register__leaves_work_that_would_collide_with_the_semesters_own(self):
+        """A student who was in this semester before, left it, and is registering again can
+        hold both a submission of a quest stamped with it and an unstamped one. Only one
+        never-completed in-progress submission per quest and semester is allowed, so the
+        unstamped one stays where it is rather than breaking that rule."""
+        stamped = baker.make(
+            QuestSubmission, user=self.student, quest=self.quest, semester=self.semester,
+            is_completed=False,
+        )
+        unstamped = baker.make(
+            QuestSubmission, user=self.student, quest=self.quest, semester=None, is_completed=False,
+        )
+
+        self.register()
+
+        unstamped.refresh_from_db()
+        stamped.refresh_from_db()
+        self.assertIsNone(unstamped.semester_id)
+        self.assertEqual(stamped.semester_id, self.semester.id)
+
+    def test_register__another_students_work_is_left_alone(self):
+        """One student joining a course says nothing about anyone else's work."""
+        classmate = baker.make(User, is_staff=False)
+        theirs = QuestSubmission.objects.create_submission(classmate, self.quest)
+
+        self.register()
+
+        theirs.refresh_from_db()
+        self.assertIsNone(theirs.semester_id)
+
+    def test_register__into_a_semester_that_is_not_open_moves_nothing(self):
+        """A registration in a semester that has not started (or is over) is not a semester
+        the student is earning in yet, so there is nothing for their work to join."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+
+        baker.make(
+            CourseStudent, user=self.student, course=baker.make(Course),
+            semester=baker.make(Semester, status=Semester.Status.UPCOMING),
+        )
+
+        submission.refresh_from_db()
+        self.assertIsNone(submission.semester_id)
+
+    def test_register__editing_a_registration_later_moves_nothing(self):
+        """Only joining brings work along. Saving an existing registration again (a teacher
+        making an XP adjustment, say) must not sweep up whatever the student has done outside
+        a semester since."""
+        registration = self.register()
+        later = QuestSubmission.objects.create_submission(self.student, baker.make(Quest, published=True))
+        # they left the semester after starting it, which is how the work came to be unstamped
+        QuestSubmission._base_manager.filter(pk=later.pk).update(semester=None)
+
+        registration.xp_adjustment = 10
+        registration.save()
+
+        later.refresh_from_db()
+        self.assertIsNone(later.semester_id)
+
+
+class UnstampedDoubleStartRaceTest(ByteDeckTenantTestCase):
+    """The #1345 double-start race, for the submissions that name no semester."""
+
+    def setUp(self):
+        """Create an unregistered student (so their work is unstamped) and a
+        non-repeatable published quest."""
+        self.student = baker.make(User, is_staff=False)
+        self.quest = baker.make(
+            Quest, name="One-time quest", xp=10,
+            max_repeats=0, repeat_per_semester=False,
+            published=True, archived=False,
+        )
+
+    def test_save__second_fresh_unstamped_submission_raises_integrity_error(self):
+        """The DB-level guard: a second never-completed in-progress submission of the same
+        quest with no semester is refused, which the constraint keyed on the semester could
+        not do, since Postgres compares NULLs as distinct."""
+        first = QuestSubmission.objects.create_submission(self.student, self.quest)
+        self.assertIsNone(first.semester_id)
+
+        duplicate = QuestSubmission(quest=self.quest, user=self.student, ordinal=2, semester=None)
+        with self.assertRaises(IntegrityError):
+            # Wrapped so the failed statement doesn't poison the test transaction.
+            with transaction.atomic():
+                # Constraint validation skipped so the DB constraint itself
+                # (the behaviour under test) raises, not full_clean.
+                duplicate.full_clean(validate_constraints=False)
+                duplicate.save()
+
+    def test_mark_returned__allowed_while_new_unstamped_submission_in_progress(self):
+        """The exemption carries over: a teacher returning an old submission while a new
+        one is in progress leaves two in-progress rows with no semester, and only one of
+        them was never completed, so the constraint stays out of the way."""
+        repeatable = baker.make(Quest, max_repeats=-1, published=True, archived=False)
+        first = QuestSubmission.objects.create_submission(self.student, repeatable)
+        first.mark_completed()
+        first.mark_approved()
+        second = QuestSubmission.objects.create_submission(self.student, repeatable)
+
+        first.mark_returned()
+
+        first.refresh_from_db()
+        self.assertIsNotNone(first.first_time_completed)  # what exempts it
+        self.assertIsNone(second.semester_id)
+        self.assertEqual(
+            QuestSubmission.objects.filter(user=self.student, quest=repeatable, is_completed=False).count(), 2,
+        )
+
+
+class MigrationDedupTest(ByteDeckTenantTestCase):
+    # Drops and re-adds the QuestSubmission unique constraint via the schema
+    # editor, so give it a private fresh schema rather than mutating the shared
+    # reused one (and to avoid colliding with the persistent test tenant).
+    reuse_schema = False
+
+    """Cover migration 0054's ``remove_duplicate_unstamped_in_progress_submissions``:
+    it must delete duplicate never-completed in-progress rows that name no semester
+    (keeping the earliest, flushing deletes in bounded batches) and spare completed,
+    returned, and stamped rows."""
+
+    def _constraint(self):
+        """Return the no-semester partial unique constraint object from QuestSubmission's
+        Meta, so tests can drop and re-add it via the schema editor."""
+        return next(
+            c for c in QuestSubmission._meta.constraints
+            if c.name == "unique_inprogress_submission_per_quest_no_semester"
+        )
+
+    def _run_dedup(self):
+        """Invoke the migration's dedup function against the current (test)
+        schema, exactly as RunPython would."""
+        with connection.schema_editor() as schema_editor:
+            migration_0054.remove_duplicate_unstamped_in_progress_submissions(
+                django_apps, schema_editor,
+            )
+
+    def test_remove_duplicate_unstamped_in_progress_submissions__removes_duplicates_spares_rest(self):
+        """Duplicate fresh in-progress rows with no semester (what a deck can already hold,
+        since 0049's dedup left them alone) are deleted keeping the earliest -- in bounded
+        batches -- while completed, returned, and stamped rows survive."""
+        student = baker.make(User, is_staff=False)
+        quest = baker.make(Quest, published=True, archived=False)
+
+        # Recreate the pre-constraint state by dropping the constraint first.
+        with connection.schema_editor() as schema_editor:
+            schema_editor.remove_constraint(QuestSubmission, self._constraint())
+        try:
+            keeper = baker.make(
+                QuestSubmission, user=student, quest=quest, semester=None, is_completed=False,
+            )
+            # Three duplicates + a batch size of 2 (patched below) exercises both
+            # the mid-loop batch flush and the final leftover flush.
+            duplicates = baker.make(
+                QuestSubmission, user=student, quest=quest, semester=None,
+                is_completed=False, _quantity=3,
+            )
+            completed = baker.make(
+                QuestSubmission, user=student, quest=quest, semester=None, is_completed=True,
+            )
+            # A *returned* submission (in progress again, but first_time_completed
+            # set) must be skipped by the dedup even alongside a fresh in-progress
+            # row -- it's exempt from the constraint.
+            returned = baker.make(
+                QuestSubmission, user=student, quest=quest, semester=None,
+                is_completed=False, first_time_completed=timezone.now(),
+            )
+            # A row that names a semester is 0049's business, not this dedup's.
+            stamped = baker.make(
+                QuestSubmission, user=student, quest=quest,
+                semester=SiteConfig.get().active_semester, is_completed=False,
+            )
+
+            with mock.patch.object(migration_0054, "DEDUP_BATCH_SIZE", 2):
+                self._run_dedup()
+
+            self.assertTrue(QuestSubmission.objects.filter(pk=keeper.pk).exists())
+            for duplicate in duplicates:
+                self.assertFalse(QuestSubmission.objects.filter(pk=duplicate.pk).exists())
+            self.assertTrue(QuestSubmission.objects.filter(pk=completed.pk).exists())
+            self.assertTrue(QuestSubmission.objects.filter(pk=returned.pk).exists())
+            self.assertTrue(QuestSubmission.objects.filter(pk=stamped.pk).exists())
+        finally:
+            # The dedup's deletes leave deferred trigger events pending in the
+            # test transaction, and Postgres refuses CREATE INDEX while they
+            # exist -- force them to fire before re-adding the constraint.
+            with connection.cursor() as cursor:
+                cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+            with connection.schema_editor() as schema_editor:
+                schema_editor.add_constraint(QuestSubmission, self._constraint())
+
+    def test_remove_duplicate_unstamped_in_progress_submissions__noop_when_no_duplicates(self):
+        """With no duplicate rows the dedup deletes nothing (the empty branch)."""
+        student = baker.make(User, is_staff=False)
+        quest = baker.make(Quest, published=True, archived=False)
+        sub = QuestSubmission.objects.create_submission(student, quest)
+
+        self._run_dedup()
+
+        self.assertTrue(QuestSubmission.objects.filter(pk=sub.pk).exists())

--- a/src/quest_manager/tests/test_regression_2413.py
+++ b/src/quest_manager/tests/test_regression_2413.py
@@ -269,15 +269,15 @@ class UnstampedDoubleStartRaceTest(ByteDeckTenantTestCase):
 
 
 class MigrationDedupTest(ByteDeckTenantTestCase):
-    # Drops and re-adds the QuestSubmission unique constraint via the schema
-    # editor, so give it a private fresh schema rather than mutating the shared
-    # reused one (and to avoid colliding with the persistent test tenant).
-    reuse_schema = False
-
     """Cover migration 0054's ``remove_duplicate_unstamped_in_progress_submissions``:
     it must delete duplicate never-completed in-progress rows that name no semester
     (keeping the earliest, flushing deletes in bounded batches) and spare completed,
     returned, and stamped rows."""
+
+    # Drops and re-adds the QuestSubmission unique constraint via the schema
+    # editor, so give it a private fresh schema rather than mutating the shared
+    # reused one (and to avoid colliding with the persistent test tenant).
+    reuse_schema = False
 
     def _constraint(self):
         """Return the no-semester partial unique constraint object from QuestSubmission's

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -368,6 +368,12 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student1 = User.objects.create_user('test_student')
         cls.test_student2 = baker.make(User)
+        # the registration is what makes the deck's semester theirs, so sub4 below reads as
+        # their current work rather than as another term's
+        baker.make(
+            'courses.CourseStudent', user=cls.test_student1, course=baker.make('courses.Course'),
+            semester=SiteConfig.get().active_semester,
+        )
 
         cls.quest1 = baker.make(Quest)
         cls.quest2 = baker.make(Quest)
@@ -931,6 +937,12 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
         cls.test_student = User.objects.create_user('test_student')
 
         cls.semester = SiteConfig.get().active_semester
+        # the registration is what puts the student in this semester, so the submissions
+        # stamped with it count toward the XP that completing them earns
+        baker.make(
+            'courses.CourseStudent', user=cls.test_student, course=baker.make('courses.Course'),
+            semester=cls.semester,
+        )
         cls.quest = baker.make(Quest, xp=5)
         cls.draft_comment = baker.make(Comment, text="test draft comment")
         cls.sub = baker.make(QuestSubmission, user=cls.test_student, quest=cls.quest,
@@ -3313,7 +3325,12 @@ class QuestListViewTest(ByteDeckTenantTestCase):
         self.client.force_login(self.test_student)
 
         # a returned submission (completed once, then sent back by a teacher):
-        # is_completed is False but time_completed is set, so is_returned() is True
+        # is_completed is False but time_completed is set, so is_returned() is True.
+        # Registered in the semester it names, or their in-progress tab is not scoped to it
+        baker.make(
+            'courses.CourseStudent', user=self.test_student, course=baker.make('courses.Course'),
+            semester=SiteConfig.get().active_semester,
+        )
         returned_sub = baker.make(
             QuestSubmission,
             user=self.test_student,
@@ -4224,8 +4241,15 @@ class AjaxSubmissionInfoTest(ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create a student, a quest, and one of the student's submissions shared across the tests."""
+        """Create a student registered in the deck's semester, a quest, and one of the
+        student's submissions shared across the tests."""
         cls.test_student = User.objects.create_user('test_student')
+        # the registration is what makes the deck's semester theirs, so a submission stamped
+        # with it reads as current work and one from another semester reads as past
+        baker.make(
+            'courses.CourseStudent', user=cls.test_student, course=baker.make('courses.Course'),
+            semester=SiteConfig.get().active_semester,
+        )
         cls.quest = baker.make(Quest)
         cls.submission = baker.make(QuestSubmission, user=cls.test_student)
         # cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
@@ -4315,12 +4339,15 @@ class AjaxSubmissionInfoTest(ByteDeckTenantTestCase):
         url(r'^ajax_submission_info/(?P<submission_id>[0-9]+)/past/$', views.ajax_submission_info, name='ajax_info_past')
         """
         self.submission.mark_completed()
+        # a term the student has behind them, which is what "past" means: their current
+        # semester comes from their registration, and this is not it
+        self.submission.semester = baker.make(Semester, status=Semester.Status.ARCHIVED)
+        self.submission.save()
         response = self.client.post(
             reverse('quests:ajax_info_past', args=[self.submission.id]),
             content_type='application/json',
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
-        # Submission is NOT in current semester (cus setUp doesn't put it there)
         self.assertEqual(response.status_code, 200)
 
         # Check context variables
@@ -4964,6 +4991,12 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
         # baker.make('courses.CourseStudent', block=other_teacher_block, user=cls.test_student, semester=SiteConfig.get().active_semester)
 
         cls.semester = SiteConfig.get().active_semester
+        # the registration is what puts the student in this semester, so the submissions
+        # stamped with it below count toward the XP the approvals here grant
+        baker.make(
+            'courses.CourseStudent', user=cls.test_student, course=baker.make('courses.Course'),
+            semester=cls.semester,
+        )
         cls.quest = baker.make(Quest, name="Test Quest")
         cls.sub = baker.make(QuestSubmission, quest=cls.quest)
 

--- a/src/tags/tests/test_models.py
+++ b/src/tags/tests/test_models.py
@@ -18,6 +18,19 @@ User = get_user_model()
 
 class TagHelper:
 
+    @staticmethod
+    def register_in_active_semester(user):
+        """Register `user` in the deck's semester and return the registration.
+
+        A user's semester is the one their own registration names (issue #2441), so without
+        one they are in none and the semester-scoped XP totals these tests read come back
+        empty however much work is stamped with the deck's semester.
+        """
+        return baker.make(
+            'courses.CourseStudent', user=user, course=baker.make('courses.Course'),
+            semester=SiteConfig.get().active_semester,
+        )
+
     def create_quest_and_submissions(self, xp, quest_submission_quantity=1):
         """
         Creates and returns quest with linked quest submission objects for self.user
@@ -73,8 +86,10 @@ class Tag_get_quest_submission_badge_assertion_by_tag_Tests(TagHelper, ByteDeckT
     """
     @classmethod
     def setUpTestData(cls):
-        """Create a shared user for the tag/xp helper tests."""
+        """Create a shared user for the tag/xp helper tests, registered in the deck's
+        semester so the work stamped with it counts as theirs."""
         cls.user = baker.make(User)
+        cls.register_in_active_semester(cls.user)
 
     def test_get_quest_submission_by_tag__multiple_tags(self):
         """  check if multiple tags can be caught by get_quest_submission_by_tag """
@@ -177,8 +192,10 @@ class Tag_get_user_tags_and_xp_Tests(TagHelper, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create a shared user for the tag/xp helper tests."""
+        """Create a shared user for the tag/xp helper tests, registered in the deck's
+        semester so the work stamped with it counts as theirs."""
         cls.user = baker.make(User)
+        cls.register_in_active_semester(cls.user)
 
     def test_get_user_tags_and_xp__unique_tag_quest_badges(self):
         """
@@ -299,8 +316,10 @@ class Tag_get_tags_from_user_Tests(TagHelper, ByteDeckTenantTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        """Create a shared user for the tag/xp helper tests."""
+        """Create a shared user for the tag/xp helper tests, registered in the deck's
+        semester so the work stamped with it counts as theirs."""
         cls.user = baker.make(User)
+        cls.register_in_active_semester(cls.user)
 
     def test_get_tags_from_user__unique_tag_per_quest_badges(self):
         """
@@ -374,8 +393,10 @@ class Tag_total_xp_by_tags_and_quest_badges_total_xp_Tests(TagHelper, ByteDeckTe
 
     @classmethod
     def setUpTestData(cls):
-        """Create a shared user for the tag/xp helper tests."""
+        """Create a shared user for the tag/xp helper tests, registered in the deck's
+        semester so the work stamped with it counts as theirs."""
         cls.user = baker.make(User)
+        cls.register_in_active_semester(cls.user)
 
     # MISC. TEST
 

--- a/src/tags/tests/test_views.py
+++ b/src/tags/tests/test_views.py
@@ -80,6 +80,12 @@ class TagCRUDViewTests(ByteDeckTenantTestCase):
         """Create teacher/student users and a tag for the CRUD view tests."""
         cls.test_teacher = User.objects.create_user('test_teacher', is_staff=True)
         cls.test_student = User.objects.create_user('test_student')
+        # the registration is what makes the deck's semester theirs (issue #2441), so the
+        # work stamped with it below counts toward the XP these views total by tag
+        baker.make(
+            'courses.CourseStudent', user=cls.test_student, course=baker.make('courses.Course'),
+            semester=SiteConfig.get().active_semester,
+        )
 
         cls.tag = Tag.objects.create(name="test-tag")
 


### PR DESCRIPTION
### What?

A student registered in no semester (their term was archived, or none is open, or they haven't joined a course yet) now belongs to **no semester**, rather than to whichever semester the deck happens to point at. The reads are made to match, so that work is still visible, still approvable, and still guarded against a double start:

* `CourseStudent.objects.current_semester()` returns `None` for someone holding no open-semester registration, instead of falling back to `SiteConfig.open_semester`.
* `get_semester(None)` (quests and badges alike) means *the work that belongs to no semester*, rather than nothing. `get_not_semester(None)` is its complement, so the past tab holds the terms behind them.
* The deck-wide staff view (`in_open_or_no_semester()`, replacing `in_open_semesters()`) covers every open semester **and** the unstamped work, so somebody can approve it.
* A second partial unique constraint covers the double-start race for submissions that name no semester, with migration `0054` deduplicating existing unstamped rows first.
* Joining a course brings the work the student had **in progress** into that semester, so it isn't stranded.

Which quests a student can do outside a course is unchanged: `Quest.is_available()` already limits someone with no current course to the quests marked *available outside a course*, and `start()` enforces it. That is the rule this PR builds on, not one it changes.

Closes #2441
Closes #2413

### Why?

Archiving one cohort's semester while the other keeps running (the point of #1781) leaves the archived cohort's students with no active registration. `semester_for()` fell back to the deck's default, so their work was stamped with **the other cohort's** semester:

```
registrations: [('Summer 2026', False)]
semester_for(alum): Fall 2026
started a quest -> stamped with Fall 2026
is alum registered in that semester? False
```

Nothing owned that work. It reached no teacher's queue (`for_teacher_only()` requires a registration matching the submission's semester), it counted toward Fall's totals while the student was absent from Fall's roster, and archiving Fall would drop it entirely: `calc_semester_grades()` records final XP from that semester's registrations, and they hold none.

Returning `None` instead is the honest answer, but on its own it lands the student in #2413's state: their in-progress list was scoped to a semester, `None` matched nothing, so the quest looked un-started while the submission sat where only the admin could see it, and the `(user, quest, semester)` constraint could not catch a double start because Postgres compares NULLs as distinct. So the two issues are settled together: no semester is a real bucket that the student, and the deck-wide approval queue, can both read.

### How?

**`src/courses/models.py`** — `current_semester()` drops the deck-default fallback. A new `post_save` receiver on `CourseStudent` calls the adoption below when a registration is created into an open semester.

**`src/quest_manager/models.py`** — `get_semester()` / `get_not_semester()` treat `None` as the unstamped rows; `in_open_semesters()` becomes `in_open_or_no_semester()` (it had one caller); `QuestSubmission.Meta.constraints` gains `unique_inprogress_submission_per_quest_no_semester`, keyed on `(user, quest)` with `semester IS NULL` pinned in the condition so the index can compare the rows; `adopt_unstamped_in_progress()` moves a student's in-progress unstamped submissions into the semester they just joined, skipping any that would collide with a never-completed submission already in it, and reading through `_base_manager` so a since-archived quest's submission travels too.

**`src/badges/models.py`** — the same `get_semester(None)` change, so a badge granted between terms is still the student's.

**`src/quest_manager/migrations/0054_...`** — deduplicates the unstamped never-completed in-progress rows (keeping the earliest of each `(user, quest)`, flushed in bounded batches) before adding the constraint, mirroring `0049`. Decks can already hold such rows: `QuestSubmission.semester` is `on_delete=SET_NULL`, and `0049` deliberately left NULL-semester rows alone.

Only work **still in progress** is adopted on registration. What a student finished outside a semester was finished there, and its XP belongs to no term rather than to the one they are starting, otherwise XP could be banked between terms and cashed in on the next one.

### Testing?

Full suite green: `python src/manage.py test src` (2435 tests), `ruff check src`, `makemigrations --check`.

New `src/quest_manager/tests/test_regression_2413.py` covers the between-terms student seeing their work, it reaching the deck-wide queue, its XP counting for them, it reading as current rather than past, it not being attributed to the cohort still running, the unstamped double-start guard (and the returned-submission exemption carrying over), the seven adoption cases, and migration `0054`'s dedup (duplicates removed in batches; completed, returned and stamped rows spared; the no-duplicates branch).

Many existing test fixtures gave a student submissions stamped with the active semester without ever registering them, which is not a state a real deck reaches. Those now register the student, which is what names their semester. Where a test switches the deck's active semester mid-test, the student's registration moves with it (`start_new_semester()` helpers), since the deck's pointer is only the default.

Verified end to end on a seeded `hackerspace` deck running Summer 2026 (archived) and Fall 2026:

```
registrations: [('Summer 2026', False)]
semester_for(alum): None
outside-course quest available? True
stamped with: None
visible in their in-progress list? True
in the deck-wide approval queue? True
in the named teacher queue? True
```

and the adoption:

```
started between terms, stamped with: None
after joining a Fall course, stamped with: Fall 2026
in their in-progress list? True
```

### Screenshots (if front end is affected)

Captured from the running dev deck with no semester open, as `summer.student3`, after starting *Send your teacher a Message* (the seeded quest marked available outside a course).

**The student's In Progress tab.** Before, the quest they just started is nowhere: not here, and not in Available either, since a quest with a submission is dropped from that list. After, it is where they expect it.

| Before | After |
| --- | --- |
| ![In Progress before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2441/before-inprogress.png) | ![In Progress after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2441/after-inprogress.png) |

**The teacher's approval queue (All).** Same submission, handed in. Before, no teacher could reach it from anywhere on the deck. After, it is in the deck-wide queue.

| Before | After |
| --- | --- |
| ![Queue before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2441/before-queue.png) | ![Queue after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2441/after-queue.png) |

### Anything Else?

Three things this deliberately leaves alone, each filed so it isn't lost:

* **Not adopted: completed work.** A quest a student finished before joining a course keeps `semester = NULL`, so its XP does not count toward the course they then join. That is deliberate (see How?), but it is a judgement call rather than an obvious answer, and worth a maintainer's eye. Tracked with the badge question below, in #2474.
* **Badges are not adopted either.** A badge granted between terms is an award already made, not work in progress, so there is nothing to strand. Filed as #2474 in case that should follow the quests.
* **A semester opened *after* a student is registered in it** does not adopt their unstamped work: the adoption hangs off registration creation, and opening the semester saves no registration. Only reachable by pre-registering a student against an upcoming semester through the admin, since `CourseStudentForm` narrows the choices to `Semester.objects.open()`. Filed as #2476.

One more, found while writing this rather than reviewed in: **`BadgeAssertion`'s deck-wide semester-scoped view** still reads through the deck's default semester rather than every open one, unlike quests, which now use `in_open_or_no_semester()`. No production caller passes `user=None`, so this is latent rather than a live bug; filed as #2475.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unstamped quest work remains visible between semesters and is treated as current for learners without an active registration.
  * New registrations automatically adopt eligible in-progress work.
  * Learners without an active registration are no longer assigned to an unrelated semester.
  * Duplicate unstamped in-progress submissions for the same quest are prevented.
  * Semester filtering is more accurate across badges, quests, XP, and related views.
  * Archived or completed work remains correctly separated from current work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->