### PR TITLE
feat: reorder submission questions without reloading the page (#2216)

### DIFF
--- a/src/questions/templates/questions/question_list.html
+++ b/src/questions/templates/questions/question_list.html
@@ -28,5 +28,46 @@
     <strong>Marker Notes</strong>, which only staff ever see.
     Deleting a question keeps any answers students have already submitted.</p>
   </div>
-  {% include 'questions/snippets/question_table.html' %}
+  <div id="question-table">
+    {% include 'questions/snippets/question_table.html' %}
+  </div>
+{% endblock %}
+
+{% block js %}
+<script>
+  $(document).ready(function () {
+    // Reordering is a several-click job, and letting each move reload the page sends the
+    // teacher back to the top of it every time. The move is posted in the background instead
+    // and the table redrawn from the server's own render, so the ordering and the disabled
+    // arrows at the ends of the list stay the server's business (#2216). Without JavaScript
+    // the same forms post normally and the view redirects, exactly as before.
+    var $table = $('#question-table');
+
+    $table.on('submit', 'form.question-move-form', function (event) {
+      event.preventDefault();
+      var $form = $(this);
+
+      $.ajax({
+        type: 'POST',
+        url: $form.attr('action'),
+        data: $form.serialize(),
+        success: function (data) {
+          $table.html(data.question_table_html);
+          // The site-wide initializer ran on the rows this just replaced, so the new ones
+          // need theirs: an uninitialized bootstrap tooltip or popover does nothing.
+          $table.find('[data-toggle="tooltip"]').tooltip();
+          $table.find('[data-toggle="popover"]').popover();
+          // Put focus back on the same button of the same question, so a teacher moving a
+          // question several places keeps clicking (or pressing enter on) one button.
+          $table.find('form[action="' + $form.attr('action') + '"] button').focus();
+        },
+        error: function () {
+          // Nothing was redrawn, so the page still shows the old order: reload to find out
+          // what the server actually did.
+          window.location.reload();
+        }
+      });
+    });
+  });
+</script>
 {% endblock %}

--- a/src/questions/templates/questions/question_list.html
+++ b/src/questions/templates/questions/question_list.html
@@ -36,11 +36,11 @@
 {% block js %}
 <script>
   $(document).ready(function () {
-    // Reordering is a several-click job, and letting each move reload the page sends the
-    // teacher back to the top of it every time. The move is posted in the background instead
-    // and the table redrawn from the server's own render, so the ordering and the disabled
-    // arrows at the ends of the list stay the server's business (#2216). Without JavaScript
-    // the same forms post normally and the view redirects, exactly as before.
+    // Reordering is a several-click job, so each move is posted in the background and the
+    // table redrawn from the server's answer: the teacher keeps their place in the list
+    // between clicks, and the ordering and the disabled arrows at its ends stay the server's
+    // business (#2216). These are ordinary forms, so with JavaScript off they post normally
+    // and the view redirects to the reloaded list.
     var $table = $('#question-table');
 
     $table.on('submit', 'form.question-move-form', function (event) {

--- a/src/questions/templates/questions/snippets/question_table.html
+++ b/src/questions/templates/questions/snippets/question_table.html
@@ -65,13 +65,13 @@
       </td>
       {% if not dont_edit_questions %}
       <td class="text-nowrap">
-        <form method="post" action="{% url 'questions:move' quest.id question.id 'up' %}" class="preview-action-form">
+        <form method="post" action="{% url 'questions:move' quest.id question.id 'up' %}" class="preview-action-form question-move-form">
           {% csrf_token %}
           <button type="submit" class="btn btn-default" title="Move up"{% if forloop.first %} disabled{% endif %}>
             <i class="fa fa-fw fa-arrow-up"></i>
           </button>
         </form>
-        <form method="post" action="{% url 'questions:move' quest.id question.id 'down' %}" class="preview-action-form">
+        <form method="post" action="{% url 'questions:move' quest.id question.id 'down' %}" class="preview-action-form question-move-form">
           {% csrf_token %}
           <button type="submit" class="btn btn-default" title="Move down"{% if forloop.last %} disabled{% endif %}>
             <i class="fa fa-fw fa-arrow-down"></i>

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -353,10 +353,10 @@ class QuestionMoveViewTest(ByteDeckTenantTestCase):
         )
 
     def test_move__ajax_returns_the_table_in_the_new_order(self):
-        """A background move answers with the re-rendered table instead of a redirect (#2216).
+        """A background move answers with the re-rendered table, in the order it just set (#2216).
 
-        The page swaps that HTML in, so the teacher keeps their place in a long list rather
-        than being returned to the top of the page on every click.
+        The page swaps that HTML into the list, which is what keeps the teacher's place on a
+        long list of questions.
         """
         self.client.force_login(self.test_teacher)
 
@@ -384,10 +384,10 @@ class QuestionMoveViewTest(ByteDeckTenantTestCase):
         self.assertIn("disabled", table[form_start:table.index("</form>", form_start)])
 
     def test_move__ajax_at_the_end_of_the_list_still_returns_the_table(self):
-        """A move with nowhere to go redraws the list unchanged rather than failing quietly.
+        """A move with nowhere to go answers with the list as it stands.
 
-        The buttons at the ends are disabled, so this only happens if a stale page is clicked
-        after someone else reordered the quest, and the answer is the current order.
+        The arrows at the ends are disabled, so this happens when a stale page is clicked
+        after someone else reordered the quest: the reply shows that person's order.
         """
         self.client.force_login(self.test_teacher)
 
@@ -397,11 +397,11 @@ class QuestionMoveViewTest(ByteDeckTenantTestCase):
         self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
         self.assertIn("Q1", response.json()["question_table_html"])
 
-    def test_move__a_plain_post_still_redirects(self):
-        """Without JavaScript the form posts normally and the view redirects to the list.
+    def test_move__a_plain_post_redirects_to_the_list(self):
+        """A form post that is not an XHR redirects to the question list.
 
-        The background move is an enhancement layered on top of that, so a browser that never
-        runs the script reorders questions exactly as it did before.
+        That is the path a browser running no JavaScript takes, so reordering works there
+        too: each click reloads the list in its new order.
         """
         self.client.force_login(self.test_teacher)
 

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -336,3 +336,75 @@ class QuestionMoveViewTest(ByteDeckTenantTestCase):
         response = self.client.get(reverse(
             "questions:move", kwargs={"quest_id": self.quest.id, "pk": self.q1.id, "direction": "up"}))
         self.assertEqual(response.status_code, 405)
+
+    def _move_by_ajax(self, question, direction):
+        """POST a move the way the question list's JavaScript does.
+
+        Args:
+            question (Question): the question to move.
+            direction (str): 'up' or 'down'.
+
+        Returns:
+            HttpResponse: the view's response to an XHR.
+        """
+        return self.client.post(
+            reverse("questions:move", kwargs={"quest_id": self.quest.id, "pk": question.id, "direction": direction}),
+            headers={"x-requested-with": "XMLHttpRequest"},
+        )
+
+    def test_move__ajax_returns_the_table_in_the_new_order(self):
+        """A background move answers with the re-rendered table instead of a redirect (#2216).
+
+        The page swaps that HTML in, so the teacher keeps their place in a long list rather
+        than being returned to the top of the page on every click.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self._move_by_ajax(self.q1, "down")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._ordinals(), {"Q1": 2, "Q2": 1, "Q3": 3})
+        table = response.json()["question_table_html"]
+        self.assertLess(table.index("Q2"), table.index("Q1"), "the table came back in the old order")
+
+    def test_move__ajax_table_disables_the_arrows_at_the_ends_of_the_list(self):
+        """The re-rendered table decides which arrows are dead, so the page never has to.
+
+        A question moved to the top can go no further, and the returned HTML says so: it is
+        the same template the page was built from, rendered by the same server.
+        """
+        self.client.force_login(self.test_teacher)
+
+        table = self._move_by_ajax(self.q2, "up").json()["question_table_html"]
+
+        up_at_top = reverse(
+            "questions:move", kwargs={"quest_id": self.quest.id, "pk": self.q2.id, "direction": "up"})
+        # the form of the question now at the top, up to its button's disabled attribute
+        form_start = table.index(up_at_top)
+        self.assertIn("disabled", table[form_start:table.index("</form>", form_start)])
+
+    def test_move__ajax_at_the_end_of_the_list_still_returns_the_table(self):
+        """A move with nowhere to go redraws the list unchanged rather than failing quietly.
+
+        The buttons at the ends are disabled, so this only happens if a stale page is clicked
+        after someone else reordered the quest, and the answer is the current order.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self._move_by_ajax(self.q1, "up")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._ordinals(), {"Q1": 1, "Q2": 2, "Q3": 3})
+        self.assertIn("Q1", response.json()["question_table_html"])
+
+    def test_move__a_plain_post_still_redirects(self):
+        """Without JavaScript the form posts normally and the view redirects to the list.
+
+        The background move is an enhancement layered on top of that, so a browser that never
+        runs the script reorders questions exactly as it did before.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self._move(self.q1, "down")
+
+        self.assertRedirects(response, reverse("questions:list", kwargs={"quest_id": self.quest.id}))

--- a/src/questions/views.py
+++ b/src/questions/views.py
@@ -1,7 +1,8 @@
 from django.db import transaction
 from django.db.models import Max
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView, View
 
@@ -138,14 +139,35 @@ class QuestionMoveView(
     swapping ordinals. The question swaps with the nearest question in the requested direction;
     ordinals aren't necessarily contiguous (deleting a question leaves a gap), so the neighbour is
     found by ordering rather than by ``ordinal ± 1``. Moving the first question up or the last
-    question down is a no-op. Always redirects back to the quest's question list.
+    question down is a no-op.
+
+    Reordering takes several clicks, and a redirect drops the teacher back at the top of the
+    page between them, so the question list posts these moves in the background and swaps the
+    table in place (#2216). An AJAX request therefore gets the re-rendered table back as JSON;
+    a plain form post still redirects to the list, which is what the page does without
+    JavaScript.
     """
 
     http_method_names = ['post']
 
     def post(self, request, *args, **kwargs):
-        """Swap the question's ordinal with its up/down neighbour (if any), then redirect to
-        the list. `direction` comes from the URL and must be 'up' or 'down' (else 404)."""
+        """Swap the question's ordinal with its up/down neighbour (if any), then show the list.
+
+        Args:
+            request (HttpRequest): the move request. An ``X-Requested-With`` header of
+                ``XMLHttpRequest`` asks for the table back instead of a redirect.
+            *args: unused, passed through from the URL resolver.
+            **kwargs: URL keywords; ``pk`` names the question and ``direction`` (which must be
+                'up' or 'down') the way to move it.
+
+        Returns:
+            JsonResponse | HttpResponseRedirect: the re-rendered question table under
+            ``question_table_html`` for an AJAX caller, otherwise a redirect to the list.
+
+        Raises:
+            Http404: if ``direction`` is neither 'up' nor 'down', or the question is not one of
+                this quest's.
+        """
         direction = self.kwargs['direction']
         if direction not in ('up', 'down'):
             raise Http404(f"Cannot move a question '{direction}'.")
@@ -162,7 +184,32 @@ class QuestionMoveView(
         if neighbour is not None:
             self._swap_ordinals(question, neighbour)
 
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
+            return JsonResponse({'question_table_html': self._render_table(request, question.quest)})
+
         return redirect('questions:list', quest_id=question.quest_id)
+
+    @staticmethod
+    def _render_table(request, quest):
+        """Render the quest's questions as the list page shows them.
+
+        The server re-renders the snippet the page was built from, so the order and which
+        arrows are disabled at the ends of the list stay decided in one place. Working that
+        out in JavaScript instead would be a second copy of the same rule, free to drift.
+
+        Args:
+            request (HttpRequest): the current request, so the template renders with the same
+                context processors the page uses.
+            quest (Quest): the quest whose questions to render.
+
+        Returns:
+            str: the rendered table.
+        """
+        return render_to_string(
+            'questions/snippets/question_table.html',
+            {'quest': quest, 'questions': Question.objects.filter(quest_id=quest.id)},
+            request=request,
+        )
 
     @staticmethod
     def _swap_ordinals(question, neighbour):

--- a/src/questions/views.py
+++ b/src/questions/views.py
@@ -141,11 +141,11 @@ class QuestionMoveView(
     found by ordering rather than by ``ordinal ± 1``. Moving the first question up or the last
     question down is a no-op.
 
-    Reordering takes several clicks, and a redirect drops the teacher back at the top of the
-    page between them, so the question list posts these moves in the background and swaps the
-    table in place (#2216). An AJAX request therefore gets the re-rendered table back as JSON;
-    a plain form post still redirects to the list, which is what the page does without
-    JavaScript.
+    There are two ways to ask for a move. The question list posts one in the background and
+    swaps the answer into the page, which keeps the teacher's place in a long list across the
+    several clicks a reorder takes (#2216): that request gets the re-rendered table as JSON. A
+    plain form post gets a redirect to the list, which is the path a browser running no
+    JavaScript takes.
     """
 
     http_method_names = ['post']


### PR DESCRIPTION
Closes #2216

### What?

The up/down arrows on the Manage Questions page now reorder the list in place, instead of reloading the page on every click.

### Why?

Each arrow posted a small form and the view redirected back to the list, so the browser landed at the **top** of the page after every move. Reordering is a several-click job, so on a quest with a handful of questions the teacher was scrolling back down between clicks: move, scroll, move, scroll. It is invisible on a two-question quest and tiresome on a ten-question one.

### How?

Progressive enhancement, using the pattern already in the codebase (`render_to_string` into a `JsonResponse`, consumed with jQuery, as `ajax_quest_info` does) rather than a new dependency:

* `QuestionMoveView` answers an AJAX post with the **re-rendered question table** instead of a redirect. A plain form post still redirects, so the page reorders exactly as before with JavaScript off.
* The list page intercepts the arrow submits, posts in the background and swaps the table in.

The server re-renders the same snippet the page was built from, so the ordering and which arrows are disabled at the ends of the list stay decided in one place; recomputing "which arrow is dead now" in JavaScript would be a second copy of that rule, free to drift.

Two details the swap has to handle: the new rows need their tooltips and popovers initialized (the site-wide initializer already ran on the rows they replaced), and focus is put back on the same button of the same question, so a teacher moving a question several places keeps clicking or pressing enter on one button. If the request fails, the page reloads rather than leaving a stale order on screen.

### Testing?

`python src/manage.py test src` green, `ruff check src` and `manage.py check` clean.

Four new tests in `QuestionMoveViewTest`, three of which fail on `develop`:

* a background move returns the table in the new order;
* that table has the arrow disabled for the question now at the top, so the page never has to work it out;
* a move with nowhere to go still returns the current table (a stale page clicked after someone else reordered the quest);
* a plain post still redirects to the list, which is the no-JavaScript path.

The JavaScript itself has no test harness, so it was exercised on the running `hackerspace` deck: the screenshots below are that session, and the scroll position was read from the page.

### Screenshots (if front end is affected)

The `hackerspace` deck's "Design Portfolio Submission" quest with ten questions, as the deck owner. In both shots the page is scrolled to the bottom of the list (`scrollY` 440) and the **last question's up arrow** is clicked:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2216/before_after_move.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2216/after_after_move.png) |

Before, the reload leaves the teacher at the top of the page (`scrollY` 0) with the question they moved off screen. After, `scrollY` is still 440, the moved question is right there one row higher, and its up arrow still has focus, ready for the next click.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorder questions without leaving the page when JavaScript is enabled.
  * The question table updates automatically after moving an item.
  * Focus is preserved on the moved question’s control, with tooltips and popovers refreshed.
  * Standard form submission remains available when JavaScript is disabled.

* **Bug Fixes**
  * Boundary controls now correctly reflect when a question cannot move further.
  * Failed asynchronous updates safely reload the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->