### PR TITLE
style: drop the em dashes from the Manage Questions help text (#2357)

### DIFF
--- a/src/questions/templates/questions/question_list.html
+++ b/src/questions/templates/questions/question_list.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="help-block">
-    <p>Students answer these questions as part of submitting the quest — each question adds its own
+    <p>Students answer these questions as part of submitting the quest: each question adds its own
     answer field to the quest's submission form, shown in order above the usual comment box.
     Use the buttons above to add a question of each type:</p>
     <ul>
@@ -24,7 +24,7 @@
     <p>Questions marked <strong>Required</strong> must be answered before the quest can be submitted;
     optional questions can be left blank. Text answers autosave with the student's draft as they
     work; file answers upload when the quest is submitted. Once submitted, answers appear with the
-    submission for marking — right beside each question's <strong>Solution</strong> and
+    submission for marking, right beside each question's <strong>Solution</strong> and
     <strong>Marker Notes</strong>, which only staff ever see.
     Deleting a question keeps any answers students have already submitted.</p>
   </div>

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -95,6 +95,19 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, self.question1.instructions)
         self.assertContains(response, self.question2.instructions)
 
+    def test_list__help_text_uses_no_em_dashes(self):
+        """The page's copy keeps to the project's punctuation (#2357).
+
+        Em dashes are ruled out in anything users read, so the help text explaining what
+        questions do uses a colon and a comma where it needs a break in a sentence.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
+
+        self.assertNotContains(response, "—")
+        self.assertNotContains(response, "&mdash;")
+
     def test_list__invalid_quest_404(self):
         """The question list for a nonexistent quest is a 404."""
         self.client.force_login(self.test_teacher)


### PR DESCRIPTION
Closes #2357

### What?

The two em dashes in the Manage Questions page's help text become a colon and a comma.

### Why?

Em dashes are ruled out in anything users read, and this page had two of them in the paragraphs explaining what submission questions do.

### How?

* "…as part of submitting the quest **—** each question adds…" becomes "…as part of submitting the quest**:** each question adds…", where the second half explains the first.
* "…with the submission for marking **—** right beside each question's Solution…" becomes "…with the submission for marking**,** right beside…", which is an ordinary aside.

Nothing else on the page changes.

### Testing?

`python src/manage.py test src` green, `ruff check src` and `manage.py check` clean.

One new test, `test_list__help_text_uses_no_em_dashes`, which fails on `develop`: it renders the page as a teacher and asserts neither an em dash nor `&mdash;` reaches it, so the punctuation cannot creep back in unnoticed.

### Screenshots (if front end is affected)

The help block on the `hackerspace` deck's Manage Questions page, as the deck owner:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2357/before_help_text.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2357/after_help_text.png) |

### Anything Else?

The same punctuation appears in one other piece of user-facing copy, the "No semester is open yet, so you can't join a course — ask your teacher to open one." line, which three templates repeat. That is outside this issue, so it is filed as #2481 rather than folded in here. The em dashes in code comments and docstrings across `src/` are noted there too, as a separate sweep.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)