### PR TITLE
feat: rename an arriving quest instead of refusing the import (#2364, #2397)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -5,37 +5,25 @@ from django_tenants.utils import schema_context
 from quest_manager.models import Quest, Category
 from django.core.exceptions import ValidationError
 
-from .transfer import TransferResult, snapshot_quest, write_quests
+from .transfer import TransferResult, build_available_quest_name, snapshot_quest, write_quests
 from .utils import library_schema_context, get_library_conflicting_quests
 
 
 def build_library_clone_name(local_name, taken_names):
     """Return a name for a clone of `local_name` that is free in the Library.
 
-    Quest names are unique per schema and capped at the model's max_length, so a
-    clone of a quest whose original is already in the Library needs a name of its
-    own. Falls back to numbered suffixes when the dated one is also taken.
+    A clone of a quest whose original is already in the Library needs a name of its own,
+    and dating it says what the copy is. The uniqueness work itself is shared with the
+    import direction, which faces the same constraint from the other side.
 
     Args:
         local_name (str): the source quest's name.
         taken_names (set[str]): every name already spoken for in the Library.
-            Must include archived quests: they still hold their name against the
-            unique constraint even though the default manager hides them.
 
     Returns:
         str: a name not in `taken_names`, within the field's max_length.
     """
-    max_len = Quest._meta.get_field('name').max_length or 50
-    base_suffix = f" (Exported on {date.today()})"
-
-    candidate = local_name[:max_len - len(base_suffix)] + base_suffix
-    counter = 1
-    while candidate in taken_names:
-        full_suffix = f"{base_suffix} #{counter}"
-        candidate = local_name[:max_len - len(full_suffix)] + full_suffix
-        counter += 1
-
-    return candidate
+    return build_available_quest_name(local_name, taken_names, f" (Exported on {date.today()})")
 
 
 def clone_quests_into_library(*, source_schema, quests):

--- a/src/library/importer.py
+++ b/src/library/importer.py
@@ -1,9 +1,57 @@
+from datetime import date
+
 from django.db import transaction
 from django_tenants.utils import schema_context
 from quest_manager.models import Quest, Category
 
-from .transfer import snapshot_quest, write_quests
+from .transfer import build_available_quest_name, snapshot_quest, write_quests
 from .utils import library_schema_context
+
+
+def resolve_name_collisions(snapshots):
+    """Give an arriving quest a name of its own when this deck already uses the one it has.
+
+    `Quest.name` is unique per schema, so a quest whose name is already taken here cannot
+    be written at all: the whole import fails, and for a campaign that means one clashing
+    name costs every other quest in it. The names most likely to clash are exactly the ones
+    a shared library exists to distribute, since two decks that both wrote a quest called
+    "Welcome to ByteDeck" is the expected case rather than an exotic one (#2364, #2397).
+
+    A quest this deck already holds under the same `import_id` is not a collision: that is
+    the same quest arriving again, and it keeps its row (and its name) rather than being
+    renamed alongside itself.
+
+    Must be called from within the destination schema context.
+
+    Args:
+        snapshots (list[dict]): the quest snapshots about to be written.
+
+    Returns:
+        tuple[dict, list]: field overrides keyed by `import_id`, ready to hand to
+        `write_quests`; and the renames as `(wanted_name, given_name)` pairs, in the order
+        the quests were snapshotted, so the importer can be told what changed.
+    """
+    arriving_ids = {snapshot['fields']['import_id'] for snapshot in snapshots}
+    taken_names = set(
+        Quest.objects.all_including_archived()
+        .exclude(import_id__in=arriving_ids)
+        .values_list('name', flat=True)
+    )
+    suffix = f" (Imported on {date.today()})"
+
+    overrides = {}
+    renames = []
+    for snapshot in snapshots:
+        wanted = snapshot['fields']['name']
+        if wanted not in taken_names:
+            continue
+
+        given = build_available_quest_name(wanted, taken_names, suffix)
+        taken_names.add(given)
+        overrides[snapshot['fields']['import_id']] = {'name': given}
+        renames.append((wanted, given))
+
+    return overrides, renames
 
 
 def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_id):
@@ -20,12 +68,12 @@ def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_
         campaign_import_id (UUID): The import ID of the campaign to deactivate after import.
 
     Returns:
-        TransferResult: The quests as they now exist on the destination deck, and the
-            names of any prerequisites this deck does not have.
+        TransferResult: The quests as they now exist on the destination deck, the names of
+            any prerequisites this deck does not have, and any quests renamed on the way in
+            because this deck already used their name.
 
     Raises:
-        LibraryTransferError: If a quest cannot be written to the destination deck, for
-            instance because one of its names is already taken there.
+        LibraryTransferError: If a quest cannot be written to the destination deck.
     """
     with library_schema_context():
         # select_related/prefetch_related: snapshot_quest reads each quest's campaign and
@@ -46,10 +94,15 @@ def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_
         with transaction.atomic():
             existing_quests = Quest.objects.filter(import_id__in=quest_import_ids)
             local_visibility = {quest.import_id: quest.published for quest in existing_quests}
+            overrides, renames = resolve_name_collisions(snapshots)
 
             imported = write_quests(
                 [
-                    (snapshot, local_visibility.get(snapshot['fields']['import_id'], False), None)
+                    (
+                        snapshot,
+                        local_visibility.get(snapshot['fields']['import_id'], False),
+                        overrides.get(snapshot['fields']['import_id']),
+                    )
                     for snapshot in snapshots
                 ],
                 with_campaign=True,
@@ -61,7 +114,7 @@ def import_campaign_to(*, destination_schema, quest_import_ids, campaign_import_
                 category.full_clean()
                 category.save()
 
-    return imported
+    return imported._replace(renamed_quests=renames)
 
 
 def import_quest_to(*, destination_schema, quest_import_id):
@@ -75,20 +128,23 @@ def import_quest_to(*, destination_schema, quest_import_id):
         quest_import_id (UUID): The import ID of the quest to import.
 
     Returns:
-        TransferResult: The quest as it now exists on the destination deck, and the names
-            of any prerequisites this deck does not have.
+        TransferResult: The quest as it now exists on the destination deck, the names of
+            any prerequisites this deck does not have, and the rename if this deck already
+            used the quest's name.
 
     Raises:
         Quest.DoesNotExist: If no *published* quest with the given import_id exists in
             the library. Content awaiting a Library admin's review is unpublished and
             must not travel to other decks (#1949), so it is filtered out here as well
             as in the view.
-        LibraryTransferError: If the quest cannot be written to the destination deck,
-            for instance because its name is already taken there.
+        LibraryTransferError: If the quest cannot be written to the destination deck.
     """
     with library_schema_context():
         quest = Quest.objects.get(import_id=quest_import_id, published=True)
         snapshot = snapshot_quest(quest)
 
     with schema_context(destination_schema):
-        return write_quests([(snapshot, False, None)], with_campaign=False)
+        overrides, renames = resolve_name_collisions([snapshot])
+        imported = write_quests([(snapshot, False, overrides.get(quest_import_id))], with_campaign=False)
+
+        return imported._replace(renamed_quests=renames)

--- a/src/library/templates/library/confirm_import_campaign.html
+++ b/src/library/templates/library/confirm_import_campaign.html
@@ -40,6 +40,16 @@
           You will lose any local changes.
         </div>
       {% endif %}
+      {% if colliding_names %}
+        <div class="alert alert-info panel-top">
+          Your deck already has {{ colliding_names|length|pluralize:"a quest,quests" }} called
+          {% for name in colliding_names %}<strong>{{ name }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %},
+          and two quests cannot share a name. The arriving
+          {{ colliding_names|length|pluralize:"copy,copies" }} will have today's date added to
+          {{ colliding_names|length|pluralize:"its,their" }} name so both can exist; rename
+          {{ colliding_names|length|pluralize:"it,them" }} afterwards to whatever suits your deck.
+        </div>
+      {% endif %}
       <div class="well panel-top">
         <p>Are you sure you want to import this campaign into your deck?</p>
         <p>This will import all quests associated with the campaign from the shared library.</p>

--- a/src/library/templates/library/confirm_import_quest.html
+++ b/src/library/templates/library/confirm_import_quest.html
@@ -15,6 +15,13 @@
       <p>Import ID: {{ local_quest.import_id }}</p>
     </div>
   {% else %}
+    {% if colliding_names %}
+      <div class="alert alert-info">
+        Your deck already has a quest called <strong>{{ colliding_names.0 }}</strong>, and two quests
+        cannot share a name. The copy you import will arrive with today's date added to its name so
+        both can exist; rename it afterwards to whatever suits your deck.
+      </div>
+    {% endif %}
     <p>Are you sure you want to import this quest into your deck?</p>
   {% endif %}
   <form action="" method="post">

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -723,49 +723,119 @@ class LibraryTransferCollisionContractTests(LibraryTenantTestCaseMixin):
         Quest.objects.all_including_archived().filter(import_id__in=import_ids).delete()
         Category.objects.filter(import_id=campaign.import_id).delete()
 
-    def test_import_quest_to__raises_a_readable_error_when_the_name_is_already_taken_locally(self):
-        """Importing a quest whose name a different local quest holds says so (#2364).
+    def test_import_quest_to__renames_a_quest_whose_name_is_already_taken_locally(self):
+        """A quest arrives under a name of its own when this deck already uses the one it has (#2364).
 
-        Quest.name is unique per deck, and the view guards only on import_id, so the clash
-        reaches the database. The failure is raised as a `LibraryTransferError` naming the
-        quest, which is a type the view can catch and put in front of the teacher, rather
-        than a library-internal exception that escapes as a 500 carrying a constraint name.
+        Quest.name is unique per deck, so the clash would otherwise reach the database and
+        fail the import. The arriving copy is renamed instead, which is what makes a
+        collision recoverable in place: the teacher does not have to go and rename their own
+        quest first. Their quest is left exactly as it was.
         """
         campaign, import_ids = self._push_campaign("Collision Campaign", ["Photoshop Basics"])
         self._clear_locally(campaign, import_ids)
-        Quest.objects.create(name="Photoshop Basics", xp=999)
+        local = Quest.objects.create(name="Photoshop Basics", xp=999)
 
-        with self.assertRaises(LibraryTransferError) as caught:
-            import_quest_to(destination_schema=connection.schema_name, quest_import_id=import_ids[0])
+        result = import_quest_to(destination_schema=connection.schema_name, quest_import_id=import_ids[0])
 
-        self.assertIn("Photoshop Basics", str(caught.exception))
-        self.assertFalse(Quest.objects.all_including_archived().filter(import_id=import_ids[0]).exists())
+        imported = Quest.objects.all_including_archived().get(import_id=import_ids[0])
+        self.assertNotEqual(imported.pk, local.pk)
+        self.assertTrue(imported.name.startswith("Photoshop Basics (Imported on "))
+        self.assertEqual(result.renamed_quests, [("Photoshop Basics", imported.name)])
+        local.refresh_from_db()
+        self.assertEqual(local.name, "Photoshop Basics")
+        self.assertEqual(local.xp, 999)
 
-    def test_import_campaign_to__one_colliding_name_discards_the_whole_import(self):
-        """One taken quest name still discards the whole campaign import, but says so (#2397).
+    def test_import_campaign_to__renames_only_the_quest_that_collides(self):
+        """One taken name costs that quest its name, not the campaign its import (#2397).
 
-        The import stays all-or-nothing: a campaign that arrived half-imported would leave
-        the deck holding quests whose prerequisites point at the ones that never came. What
-        changes is that the caller is told. The failure is raised as a `LibraryTransferError`
-        naming the quest that clashed, instead of being recorded in a result object that no
-        caller reads and leaving the view to fall through to a bare 404.
+        A clash used to discard the whole campaign, and the bigger the campaign the likelier
+        one of its quests collided, so the campaigns most worth importing were the hardest
+        to import. Only the colliding quest is renamed; its siblings arrive untouched.
         """
         campaign, import_ids = self._push_campaign(
-            "Partial Campaign", ["Good Quest One", "Bad Quest Two", "Good Quest Three"],
+            "Partial Campaign", ["Good Quest One", "Taken Quest Two", "Good Quest Three"],
         )
         self._clear_locally(campaign, import_ids)
-        Quest.objects.create(name="Bad Quest Two", xp=999)
+        Quest.objects.create(name="Taken Quest Two", xp=999)
 
-        with self.assertRaises(LibraryTransferError) as caught:
-            import_campaign_to(
-                destination_schema=connection.schema_name,
-                quest_import_ids=import_ids,
-                campaign_import_id=campaign.import_id,
-            )
+        result = import_campaign_to(
+            destination_schema=connection.schema_name,
+            quest_import_ids=import_ids,
+            campaign_import_id=campaign.import_id,
+        )
 
-        self.assertIn("Bad Quest Two", str(caught.exception))
+        imported = Quest.objects.all_including_archived().filter(import_id__in=import_ids)
+        self.assertEqual(imported.count(), 3)
+        self.assertTrue(Category.objects.filter(import_id=campaign.import_id).exists())
+        self.assertEqual([wanted for wanted, _ in result.renamed_quests], ["Taken Quest Two"])
+        self.assertQuerySetEqual(
+            imported.filter(name__in=["Good Quest One", "Good Quest Three"]).order_by('name'),
+            ["Good Quest One", "Good Quest Three"],
+            transform=lambda quest: quest.name,
+        )
+
+    def test_import_campaign_to__discards_the_whole_import_when_a_quest_cannot_be_written(self):
+        """A failure that renaming cannot fix still takes the whole campaign with it (#2397).
+
+        The import stays all-or-nothing: a campaign that arrived half-imported would leave
+        the deck holding quests whose prerequisites point at the ones that never came. Only
+        the name clash is recoverable, because renaming is an answer to it; anything else is
+        raised as a `LibraryTransferError` naming the quest, and nothing is written.
+        """
+        campaign, import_ids = self._push_campaign(
+            "Rejected Campaign", ["Fine Quest One", "Rejected Quest Two"],
+        )
+        self._clear_locally(campaign, import_ids)
+
+        def reject_the_second(self, *args, **kwargs):
+            """Fail the write for one quest of the batch, as the database would."""
+            if self.name == "Rejected Quest Two":
+                raise IntegrityError("duplicate key value")
+            return original_save(self, *args, **kwargs)
+
+        original_save = Quest.save
+        with patch.object(Quest, 'save', reject_the_second):
+            with self.assertRaises(LibraryTransferError) as caught:
+                import_campaign_to(
+                    destination_schema=connection.schema_name,
+                    quest_import_ids=import_ids,
+                    campaign_import_id=campaign.import_id,
+                )
+
+        self.assertIn("Rejected Quest Two", str(caught.exception))
         self.assertEqual(list(Quest.objects.all_including_archived().filter(import_id__in=import_ids)), [])
         self.assertFalse(Category.objects.filter(import_id=campaign.import_id).exists())
+
+    def test_import_quest_to__leaves_the_name_alone_when_nothing_local_holds_it(self):
+        """A quest whose name is free arrives with the name its author gave it.
+
+        The rename is the exception, so this pins that it stays the exception: a deck with
+        no clash sees no suffix and `renamed_quests` is empty.
+        """
+        campaign, import_ids = self._push_campaign("Free Name Campaign", ["Unclaimed Quest"])
+        self._clear_locally(campaign, import_ids)
+
+        result = import_quest_to(destination_schema=connection.schema_name, quest_import_id=import_ids[0])
+
+        imported = Quest.objects.all_including_archived().get(import_id=import_ids[0])
+        self.assertEqual(imported.name, "Unclaimed Quest")
+        self.assertEqual(result.renamed_quests, [])
+
+    def test_import_quest_to__re_importing_is_not_treated_as_a_name_collision(self):
+        """A quest this deck already holds is the same quest arriving again, not a clash.
+
+        It is matched by `import_id` and its row is updated in place, so its own name must
+        not count as taken against it: renaming here would leave the deck with the quest
+        under a dated name every time it was re-imported.
+        """
+        campaign, import_ids = self._push_campaign("Repeat Campaign", ["Repeatable Quest"])
+        Quest.objects.all_including_archived().filter(import_id__in=import_ids).update(name="Repeatable Quest")
+
+        result = import_quest_to(destination_schema=connection.schema_name, quest_import_id=import_ids[0])
+
+        imported = Quest.objects.all_including_archived().get(import_id=import_ids[0])
+        self.assertEqual(imported.name, "Repeatable Quest")
+        self.assertEqual(result.renamed_quests, [])
 
 
 class LibraryContentRegistrationTests(ByteDeckTenantTestCase):

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -748,9 +748,10 @@ class LibraryTransferCollisionContractTests(LibraryTenantTestCaseMixin):
     def test_import_campaign_to__renames_only_the_quest_that_collides(self):
         """One taken name costs that quest its name, not the campaign its import (#2397).
 
-        A clash used to discard the whole campaign, and the bigger the campaign the likelier
-        one of its quests collided, so the campaigns most worth importing were the hardest
-        to import. Only the colliding quest is renamed; its siblings arrive untouched.
+        Every quest in the campaign arrives, and the rename is confined to the one whose
+        name this deck already holds: its siblings keep theirs. The bigger the campaign the
+        likelier one of its quests collides, so a clash must stay a local matter rather
+        than something the whole import rides on.
         """
         campaign, import_ids = self._push_campaign(
             "Partial Campaign", ["Good Quest One", "Taken Quest Two", "Good Quest Three"],

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2050,12 +2050,12 @@ class ConflictingQuestCloneTests(LibraryTenantTestCaseMixin):
             clone = self._library_clone_of(quest)
             self.assertTrue(clone.name.endswith("#1"), f"expected a numbered suffix, got {clone.name!r}")
 
-class LibraryImportCollisionMessageTests(LibraryTenantTestCaseMixin):
-    """A name clash on import is reported to the teacher, not raised in their face.
+class LibraryImportNameCollisionTests(LibraryTenantTestCaseMixin):
+    """Importing a quest whose name this deck already uses for something else.
 
-    Quest names are unique per deck, so importing a quest whose name this deck already
-    uses for something else cannot succeed. The teacher is told which name clashed and
-    that nothing was added, rather than meeting a 500 page or a bare 404 (#2364, #2397).
+    Quest names are unique per deck, so the arriving copy is renamed rather than refused:
+    a teacher should not have to go and rename their own quest before they can import
+    (#2364), and one clashing name should not cost a whole campaign its import (#2397).
     """
 
     @classmethod
@@ -2069,8 +2069,33 @@ class LibraryImportCollisionMessageTests(LibraryTenantTestCaseMixin):
 
         cls.test_teacher = User.objects.create_user('collision_teacher', is_staff=True)
 
-    def test_import_quest__tells_the_teacher_which_name_clashed(self):
-        """Importing onto a name this deck already uses redirects with an explanation."""
+    def test_import_quest__gives_the_arriving_copy_a_name_of_its_own(self):
+        """The import succeeds, and both quests exist afterwards under different names."""
+        local = baker.make(Quest, name="Contested Name")
+        self.client.force_login(self.test_teacher)
+
+        self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True)
+
+        imported = Quest.objects.all_including_archived().get(import_id=self.library_quest.import_id)
+        self.assertNotEqual(imported.pk, local.pk)
+        self.assertTrue(imported.name.startswith("Contested Name (Imported on "))
+
+    def test_import_quest__leaves_the_teachers_own_quest_untouched(self):
+        """Renaming happens to the arriving copy, never to what the deck already had."""
+        local = baker.make(Quest, name="Contested Name")
+        self.client.force_login(self.test_teacher)
+
+        self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True)
+
+        local.refresh_from_db()
+        self.assertEqual(local.name, "Contested Name")
+
+    def test_import_quest__tells_the_teacher_the_copy_arrived_under_another_name(self):
+        """A quest that is not called what the Library said it was called is worth saying.
+
+        Otherwise the teacher goes looking for the name they clicked on and finds their own
+        quest instead, with the import apparently having done nothing.
+        """
         baker.make(Quest, name="Contested Name")
         self.client.force_login(self.test_teacher)
 
@@ -2078,31 +2103,112 @@ class LibraryImportCollisionMessageTests(LibraryTenantTestCaseMixin):
             reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(any("Contested Name" in text for text in self._message_texts(response)))
+        imported = Quest.objects.all_including_archived().get(import_id=self.library_quest.import_id)
+        self.assertTrue(
+            any(imported.name in text for text in self._message_texts(response)),
+            f"expected the new name to be given, got {self._message_texts(response)}",
+        )
 
-    def test_import_quest__adds_nothing_to_the_deck_when_the_name_clashes(self):
-        """The failed import leaves the deck exactly as it was."""
+    def test_import_quest__says_nothing_about_renaming_when_the_name_was_free(self):
+        """An import with no clash keeps the message to the two steps that always apply."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
+        )
+
+        self.assertFalse(
+            any("already had a quest" in text for text in self._message_texts(response)),
+            f"expected no rename message, got {self._message_texts(response)}",
+        )
+
+    def test_import_category__imports_the_whole_campaign_despite_one_clashing_name(self):
+        """The campaign and every one of its quests arrive; only the clashing one is renamed."""
+        with library_schema_context():
+            baker.make(Quest, name="Uncontested Name", campaign=self.library_campaign, published=True)
         baker.make(Quest, name="Contested Name")
         self.client.force_login(self.test_teacher)
 
-        self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True)
+        self.client.post(reverse('library:import_category', args=[self.library_campaign.import_id]), follow=True)
 
+        self.assertTrue(Category.objects.filter(import_id=self.library_campaign.import_id).exists())
+        imported = Quest.objects.all_including_archived().get(import_id=self.library_quest.import_id)
+        self.assertTrue(imported.name.startswith("Contested Name (Imported on "))
+        self.assertTrue(Quest.objects.all_including_archived().filter(name="Uncontested Name").exists())
+
+    def test_import_quest__names_the_clash_on_the_confirmation_page(self):
+        """The teacher sees the clash before clicking Import, not after.
+
+        The Library page shows what is on offer, not what is already on their own deck, so
+        this is the one thing they cannot check for themselves.
+        """
+        baker.make(Quest, name="Contested Name")
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
+
+        self.assertContains(response, "cannot share a name")
+        self.assertContains(response, "Contested Name")
+
+    def test_import_quest__confirmation_page_stays_quiet_when_no_name_clashes(self):
+        """A quest whose name is free gets the plain confirmation page."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
+
+        self.assertNotContains(response, "cannot share a name")
+
+    def test_import_category__names_the_clash_on_the_confirmation_page(self):
+        """The campaign confirmation page names the quests that will arrive renamed."""
+        baker.make(Quest, name="Contested Name")
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('library:import_category', args=[self.library_campaign.import_id]))
+
+        self.assertContains(response, "cannot share a name")
+        self.assertContains(response, "Contested Name")
+
+    def test_import_quest__reports_a_failure_that_renaming_cannot_fix(self):
+        """A write the database refuses still redirects with an explanation, not a 500.
+
+        Renaming answers the name clash and nothing else, so the failure path stays: the
+        teacher is told which quest could not be copied and that nothing was added.
+        """
+        self.client.force_login(self.test_teacher)
+
+        with patch.object(Quest, 'save', side_effect=IntegrityError("duplicate key value")):
+            response = self.client.post(
+                reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("nothing was added to your deck" in text for text in self._message_texts(response)),
+            f"expected a failure message, got {self._message_texts(response)}",
+        )
         self.assertFalse(
             Quest.objects.all_including_archived().filter(import_id=self.library_quest.import_id).exists()
         )
 
-    def test_import_category__tells_the_teacher_and_imports_none_of_the_campaign(self):
-        """One clashing quest stops the whole campaign, and says so rather than 404ing."""
-        baker.make(Quest, name="Contested Name")
+    def test_import_category__reports_a_failure_that_renaming_cannot_fix(self):
+        """A campaign whose quest the database refuses is discarded whole, and says so.
+
+        The campaign import stays all-or-nothing for everything except the name clash: a
+        half-imported campaign would leave the deck holding quests whose prerequisites point
+        at the ones that never arrived.
+        """
         self.client.force_login(self.test_teacher)
 
-        response = self.client.post(
-            reverse('library:import_category', args=[self.library_campaign.import_id]), follow=True,
-        )
+        with patch.object(Quest, 'save', side_effect=IntegrityError("duplicate key value")):
+            response = self.client.post(
+                reverse('library:import_category', args=[self.library_campaign.import_id]), follow=True,
+            )
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(any("Contested Name" in text for text in self._message_texts(response)))
+        self.assertTrue(
+            any("nothing was added to your deck" in text for text in self._message_texts(response)),
+            f"expected a failure message, got {self._message_texts(response)}",
+        )
         self.assertFalse(Category.objects.filter(import_id=self.library_campaign.import_id).exists())
 
 

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -38,9 +38,9 @@ from .models import IsLibraryContentMixin
 
 
 class TransferResult(NamedTuple):
-    """What a copy produced, and what it could not bring with it.
+    """What a copy produced, what it could not bring with it, and what it had to change.
 
-    The two loss fields are the reason this is a result rather than a bare list of quests.
+    The loss fields are the reason this is a result rather than a bare list of quests.
     Content shared to the Library is meant to be a self-contained package, so anything the
     copy could not carry is the *sharer's* business: they are the one who can widen what
     they share, or decide the gap is fine. The views turn these into a warning on the push.
@@ -49,12 +49,16 @@ class TransferResult(NamedTuple):
     Library ends up less gated than its author wrote. `skipped_quests` names quests that
     were left out of a shared campaign altogether. `dropped_common_data` names the shared
     General Info blocks the copy arrives without.
+
+    `renamed_quests` is the odd one out: nothing was lost, but a name was changed to get
+    the copy in, so it is reported to whoever is standing in front of it (#2364).
     """
 
     quests: list
     unmet_prereqs: list
     skipped_quests: list = ()
     dropped_common_data: list = ()
+    renamed_quests: list = ()
 
 
 class LibraryTransferError(Exception):
@@ -94,6 +98,38 @@ QUESTION_FIELDS_NOT_COPIED = {
     'datetime_created': 'auto_now_add. The destination stamps its own creation time.',
     'datetime_last_edit': 'auto_now. Always the time of the copy.',
 }
+
+
+def build_available_quest_name(name, taken_names, suffix):
+    """Return a version of `name` that no quest in the destination schema is using.
+
+    `Quest.name` is unique per schema, so a copy whose name is already spoken for cannot be
+    written at all. Both directions of the transfer hit this: pushing a second copy of a
+    quest that is already in the Library, and pulling a quest onto a deck that happens to
+    have written its own quest of the same name. Both answer it the same way, by giving the
+    copy a name of its own and saying so, rather than refusing the transfer.
+
+    Args:
+        name (str): the name the copy would like to keep.
+        taken_names (set[str]): every name already spoken for in the destination schema.
+            Must include archived quests: they still hold their name against the unique
+            constraint even though the default manager hides them.
+        suffix (str): what to append to distinguish the copy, e.g. " (Imported on
+            2026-08-17)". Numbered when even the suffixed name is taken.
+
+    Returns:
+        str: a name not in `taken_names`, truncated to fit the field's max_length.
+    """
+    max_len = Quest._meta.get_field('name').max_length or 50
+
+    candidate = name[:max_len - len(suffix)] + suffix
+    counter = 1
+    while candidate in taken_names:
+        numbered = f"{suffix} #{counter}"
+        candidate = name[:max_len - len(numbered)] + numbered
+        counter += 1
+
+    return candidate
 
 
 def _copied_field_names(model, not_copied):

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -72,6 +72,40 @@ def library_listable_quests():
     return Quest.objects.get_queryset().published().active_or_no_campaign()
 
 
+def get_colliding_quest_names(library_quests):
+    """The names among `library_quests` that a different quest on this deck already uses.
+
+    A name clash is what the importing teacher cannot see for themselves: the Library page
+    shows what is on offer, not what is already on their own deck, so without this the
+    first they hear of it is after clicking Import. The import handles the clash by
+    renaming the arriving copy, and naming the clash up front is what makes that a choice
+    rather than a surprise (#2364, #2397).
+
+    Matching is on name and *not* import_id: a quest this deck already holds under the same
+    import_id is the same quest arriving again, which is an overwrite rather than a clash.
+
+    Must be called from within the destination (local) schema context.
+
+    Args:
+        library_quests (Iterable[Quest]): the quests being offered for import, read from
+            the Library schema.
+
+    Returns:
+        list[str]: the clashing names, sorted, empty when nothing on this deck collides.
+    """
+    from quest_manager.models import Quest
+
+    wanted_names = [quest.name for quest in library_quests]
+    arriving_ids = [quest.import_id for quest in library_quests]
+
+    return sorted(
+        Quest.objects.all_including_archived()
+        .filter(name__in=wanted_names)
+        .exclude(import_id__in=arriving_ids)
+        .values_list('name', flat=True)
+    )
+
+
 def get_library_conflicting_quests(local_quests):
     """
     Given a list of local Quest objects, return the import_ids of any quests in

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -32,7 +32,13 @@ from .forms import ShareLicenceForm
 from .importer import import_campaign_to, import_quest_to
 from .models import ContentOrigin
 from .transfer import LibraryTransferError
-from .utils import get_library_schema_name, library_schema_context, get_library_conflicting_quests, library_listable_quests
+from .utils import (
+    get_colliding_quest_names,
+    get_library_conflicting_quests,
+    get_library_schema_name,
+    library_listable_quests,
+    library_schema_context,
+)
 
 User = get_user_model()
 
@@ -151,6 +157,37 @@ def redirect_failed_import(request, error, redirect_to):
         "Renaming your own copy and importing again should clear it."
     )
     return redirect(redirect_to)
+
+
+def tell_importer_about_renamed_quests(request, renamed_quests):
+    """Tell the importing teacher which arriving quests were given a name of their own.
+
+    `Quest.name` is unique per deck, so a quest whose name this deck already uses is
+    renamed on the way in rather than blocking the import (see `resolve_name_collisions`).
+    The rename is silent otherwise, and a quest that is not called what the Library page
+    said it was called is exactly the sort of thing a teacher goes looking for and cannot
+    find, so it is named here along with what it is now called (#2364, #2397).
+
+    Args:
+        request (HttpRequest): the current request, for the message framework.
+        renamed_quests (list[tuple[str, str]]): `(wanted_name, given_name)` pairs.
+
+    Returns:
+        None. Queues an informational message when anything was renamed, and does nothing
+        when every quest kept the name it arrived with.
+    """
+    if not renamed_quests:
+        return
+
+    renames = ', '.join(f"'{wanted}' is now '{given}'" for wanted, given in renamed_quests)
+    messages.info(
+        request,
+        f"Your deck already had a quest called '{renamed_quests[0][0]}', so the copy that "
+        f"just arrived is called '{renamed_quests[0][1]}'. Rename it to whatever suits your deck."
+        if len(renamed_quests) == 1 else
+        f"Your deck already had quests with some of these names, so the arriving copies were "
+        f"renamed: {renames}. Rename them to whatever suits your deck."
+    )
 
 
 def warn_sharer_about_dropped_common_data(request, dropped_common_data):
@@ -556,6 +593,8 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
             HttpResponse: Rendered confirmation template with:
                 - quest: The quest from the shared library.
                 - local_quest: The local quest with a matching import_id, if one exists.
+                - colliding_names: The quest's name, when a different local quest already
+                  uses it and the copy will therefore arrive renamed.
         """
         # Look for a matching local quest (even if archived) to show a warning if it already exists
         local_quest = Quest.objects.all_including_archived().filter(import_id=quest_import_id).first()
@@ -579,6 +618,7 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
             'quest': quest,
             # A Quest from the local deck matching the import_id, or None if not found.
             'local_quest': local_quest,
+            'colliding_names': get_colliding_quest_names([quest]),
         })
 
     def post(self, request, quest_import_id):
@@ -608,7 +648,7 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
                 return redirect_awaiting_review(request, 'quest', 'library:quest_list')
             # Use dest_schema because current schema is library
             try:
-                import_quest_to(destination_schema=dest_schema, quest_import_id=quest.import_id)
+                imported = import_quest_to(destination_schema=dest_schema, quest_import_id=quest.import_id)
             except LibraryTransferError as error:
                 return redirect_failed_import(request, error, 'library:quest_list')
 
@@ -627,6 +667,7 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
             f"students can see it: <strong>{publish_link}</strong>, and give it a "
             f"<strong>{prereq_link}</strong> so it is reachable on the quest map."
         )
+        tell_importer_about_renamed_quests(request, imported.renamed_quests)
 
         return redirect('quests:drafts')
 
@@ -681,6 +722,7 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
 
         # Need local import_ids so the template can indicate which library quests already exist locally
         local_quest_import_ids = Quest.objects.filter(import_id__in=quest_import_ids).values_list('import_id', flat=True)
+        colliding_names = get_colliding_quest_names(shared_quests)
 
         context = {
             'category': library_category,
@@ -693,6 +735,7 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
             'category_displayed_quests': shared_quests,
             'local_category': local_category,
             'local_quest_import_ids': local_quest_import_ids,
+            'colliding_names': colliding_names,
         }
         return render(request, self.template_name, context)
 
@@ -727,7 +770,7 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
             quest_ids = list(category.quest_set.values_list('import_id', flat=True))
             # Use dest_schema because current schema is library
             try:
-                import_campaign_to(
+                imported = import_campaign_to(
                     destination_schema=dest_schema, quest_import_ids=quest_ids, campaign_import_id=category.import_id,
                 )
             except LibraryTransferError as error:
@@ -751,6 +794,7 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
             f"quests), and give its first quest a <strong>{prereq_link}</strong> so the campaign "
             "is reachable on the quest map."
         )
+        tell_importer_about_renamed_quests(request, imported.renamed_quests)
 
         # The campaign will be deactivated by import_campaign_to()
         return redirect('quests:categories_inactive')


### PR DESCRIPTION
### What?

Importing a quest whose name your deck already uses for something else now succeeds. The arriving copy is given a dated name of its own instead of the import being refused, the clash is named on the confirmation page before you click, and the name the copy actually landed under is given afterwards.

Closes #2364. Closes #2397.

### Why?

`Quest.name` is unique per deck, so the clash could not be written. What happened before was a dead end dressed up as advice:

> That import could not be completed, so nothing was added to your deck. 'Welcome to ByteDeck!' could not be copied: name: Quest with this Name already exists. Renaming your own copy and importing again should clear it.

Renaming your own quest to make room for someone else's is a strange thing to be asked to do, and it is asked exactly when it is least reasonable: the names most likely to clash are the starter content a shared library exists to distribute. Two decks that both wrote a quest called "Welcome to ByteDeck!" is the expected case, not an exotic one. That is the example #2364 was filed with.

**For a campaign it was worse than an inconvenience.** The import is deliberately all-or-nothing, so one clashing name discarded every other quest in the campaign. The more quests a campaign has, the likelier one of them collides, which meant the campaigns most worth importing were the hardest to import (#2397).

The export side already had the answer. Pushing a second copy of a quest that is already in the Library gives that copy a dated name (`build_library_clone_name`) rather than refusing the push. The import direction faces the same constraint from the other side and now answers it the same way.

### How?

**One helper, both directions.** The uniqueness work moved into `transfer.build_available_quest_name(name, taken_names, suffix)`: append the suffix, truncate to the field's `max_length`, and number it if even that is taken. `build_library_clone_name` is now a thin call to it with `" (Exported on 2026-08-17)"`; the import side passes `" (Imported on 2026-08-17)"`.

**Renaming happens before the write, not as a retry.** `importer.resolve_name_collisions` reads the destination's taken names once and returns `field_overrides` keyed by `import_id`, which `write_quests` already accepts. So the batch is still written in one transaction and there is no failed-then-retried write.

Three things it deliberately does not do:

* It does not touch the teacher's own quest. Only the arriving copy is renamed.
* It does not rename a quest the deck already holds under the same `import_id`. That is the same quest arriving again, matched by identity and updated in place, so its own name must not count as taken against it; otherwise every re-import would add another dated suffix.
* It does not make other failures recoverable. Renaming answers the name clash and nothing else. Anything else a write is refused for still raises `LibraryTransferError` and discards the whole import, because a half-imported campaign leaves the deck holding quests whose prerequisites point at ones that never arrived.

**Reported twice, on purpose.** `get_colliding_quest_names` puts the clash on the confirmation page, because the Library page shows what is on offer and not what is already on your own deck, so this is the one thing you cannot check for yourself. `tell_importer_about_renamed_quests` then gives the name the copy landed under, because a quest that is not called what you clicked on is exactly what you go looking for and cannot find.

### Testing?

Nine view tests in `LibraryImportNameCollisionTests` and five contract tests in `LibraryTransferContractTests`, covering: the copy arriving renamed, the teacher's own quest untouched, the message naming the new name, a campaign importing whole with only its colliding quest renamed, the confirmation page naming the clash (and staying quiet without one), re-import not counting as a clash, and a non-name failure still discarding everything.

```
src/library                                   168 tests   OK
full suite (python src/manage.py test src)   2485 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

From the running `hackerspace` dev deck, signed in as the deck owner, importing a Library quest called "Welcome to ByteDeck!" onto a deck whose own starter quest has that name: the #2364 scenario exactly.

**Confirmation page, before:** nothing says the name is taken, so the clash is invisible until after clicking.

![Before: the plain confirmation page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2364/import-before-confirm.png)

**Confirmation page, after:** the clash is named, with what will happen to it.

![After: the confirmation page naming the clash](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2364/import-after-confirm.png)

**Clicking Import, before:** nothing is added, and the teacher is sent to rename their own quest.

![Before: a red error and no import](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2364/import-before.png)

**Clicking Import, after:** the quest arrives, and the message gives the name it arrived under.

![After: the quest imported under a dated name](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2364/import-after.png)

### Anything Else?

**Why auto-rename rather than a rename field.** #2364 offered either. A field would be the more controlled option for a single quest, but it does not scale to the case that actually hurts: a campaign with several clashes would need a form with one row per quest before anything could be imported at all, which is more friction than the problem. Auto-renaming imports the content and leaves the teacher to rename whatever they care about afterwards, on the quest's own form, where they would be doing it anyway. Happy to add a field on top if you would rather have the choice up front.

**The suffix is dated, not numbered,** matching the export side, so a teacher who imports the same content onto several decks sees the same shape of name each time and can tell at a glance which copy came from the Library.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imports now automatically rename quests when their names conflict with existing quests.
  * Campaign imports continue importing non-conflicting quests while reporting renamed items.
  * Import confirmation screens warn about name conflicts and explain the date-based renaming.
  * Successful imports identify which quests were renamed and allow them to be renamed later.
* **Bug Fixes**
  * Re-importing existing quests no longer causes unnecessary renaming.
  * Non-conflicting quest names remain unchanged.
  * Import failures continue to prevent partial campaign data from being added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->