### PR TITLE
feat: tell students the short-answer character limit (#2401)

### DIFF
--- a/src/questions/forms.py
+++ b/src/questions/forms.py
@@ -201,9 +201,8 @@ class QuestionSubmissionForm(forms.ModelForm):
             # no visible label (the question's instructions directly above serve as the label,
             # matching the long answer field); a distinct aria-label per question keeps each
             # input tellable apart for screen-reader users when a page has several short answers.
-            # The limit is in the help text because the input enforces it silently: at 200
-            # characters the browser simply stops accepting keystrokes, which reads as a
-            # broken page to a student who has more to say (#2401).
+            # The help text is where the student learns the limit: the input enforces it
+            # silently, by refusing keystrokes once the answer is full (#2401).
             self.fields["response_text"] = forms.CharField(
                 label="",
                 required=self.question.required,

--- a/src/questions/forms.py
+++ b/src/questions/forms.py
@@ -15,6 +15,11 @@ from .models import Question, QuestionSubmission, QuestionType
 # 16 MiB, the maximum size of a student's file response.
 MAX_RESPONSE_FILE_SIZE = 16 * 1024 * 1024
 
+# How many characters a student may type into a short answer. One number for the field's
+# validation, the input's maxlength and the help text that tells the student, so what they
+# are told and what they are held to cannot drift apart (#2401).
+SHORT_ANSWER_MAX_LENGTH = 200
+
 
 class AnswerSummernoteWidget(ByteDeckSummernoteSafeInplaceWidget):
     """A long-answer editor sized for one answer among several on the submission page.
@@ -196,11 +201,18 @@ class QuestionSubmissionForm(forms.ModelForm):
             # no visible label (the question's instructions directly above serve as the label,
             # matching the long answer field); a distinct aria-label per question keeps each
             # input tellable apart for screen-reader users when a page has several short answers.
+            # The limit is in the help text because the input enforces it silently: at 200
+            # characters the browser simply stops accepting keystrokes, which reads as a
+            # broken page to a student who has more to say (#2401).
             self.fields["response_text"] = forms.CharField(
                 label="",
                 required=self.question.required,
-                max_length=200,
-                widget=forms.TextInput(attrs={'maxlength': '200', 'aria-label': self._response_aria_label()}),
+                max_length=SHORT_ANSWER_MAX_LENGTH,
+                help_text=f"Up to {SHORT_ANSWER_MAX_LENGTH} characters.",
+                widget=forms.TextInput(attrs={
+                    'maxlength': str(SHORT_ANSWER_MAX_LENGTH),
+                    'aria-label': self._response_aria_label(),
+                }),
             )
         elif self.question.type == QuestionType.LONG_ANSWER:
             del self.fields["response_file"]

--- a/src/questions/tests/test_forms.py
+++ b/src/questions/tests/test_forms.py
@@ -6,7 +6,12 @@ from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
-from questions.forms import QuestionForm, QuestionSubmissionForm, QuestionSubmissionFormsetFactory
+from questions.forms import (
+    SHORT_ANSWER_MAX_LENGTH,
+    QuestionForm,
+    QuestionSubmissionForm,
+    QuestionSubmissionFormsetFactory,
+)
 from questions.models import Question, QuestionSubmission
 
 
@@ -94,6 +99,19 @@ class QuestionSubmissionFormTest(ByteDeckTenantTestCase):
         self.assertNotIn("response_file", form.fields)
         self.assertEqual(form.fields["response_text"].max_length, 200)
         self.assertTrue(form.fields["response_text"].required)
+
+    def test_init__short_answer_help_text_states_the_limit_it_enforces(self):
+        """The student is told the length the field holds them to (#2401).
+
+        One constant feeds the field's validation, the input's maxlength and this sentence,
+        so the number a student reads is the number they are actually capped at.
+        """
+        form = QuestionSubmissionForm(instance=self.short_answer)
+        field = form.fields["response_text"]
+
+        self.assertEqual(field.help_text, f"Up to {SHORT_ANSWER_MAX_LENGTH} characters.")
+        self.assertEqual(field.max_length, SHORT_ANSWER_MAX_LENGTH)
+        self.assertEqual(field.widget.attrs["maxlength"], str(SHORT_ANSWER_MAX_LENGTH))
 
     def test_init__long_answer_field(self):
         """Long answer forms get an unbounded rich-text field and no file field."""

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -8,6 +8,7 @@ from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
+from questions.forms import SHORT_ANSWER_MAX_LENGTH
 from questions.models import Question, QuestionSubmission
 from questions.utils import sync_draft_question_submissions
 
@@ -78,6 +79,16 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
         self.assertEqual(len(formset.forms), 2)
         self.assertContains(response, "What is your website URL?")
         self.assertContains(response, "Describe your process.")
+
+    def test_submission_page__short_answer_tells_the_student_its_limit(self):
+        """A short answer says how long it may be, where the student is typing it (#2401).
+
+        The input stops accepting keystrokes at the limit and says nothing about why, so a
+        student writing a longer answer meets a page that looks broken.
+        """
+        response = self.assert200("quests:submission", args=[self.submission.id])
+
+        self.assertContains(response, f"Up to {SHORT_ANSWER_MAX_LENGTH} characters.")
 
     def test_submission_page__summernote_assets_load_once(self):
         """The answer editors ride on the assets the comment box already loads (#2169).

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -83,8 +83,8 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
     def test_submission_page__short_answer_tells_the_student_its_limit(self):
         """A short answer says how long it may be, where the student is typing it (#2401).
 
-        The input stops accepting keystrokes at the limit and says nothing about why, so a
-        student writing a longer answer meets a page that looks broken.
+        The input itself enforces the limit silently, by refusing further keystrokes, so the
+        sentence under it is the only thing that tells a student the rule before they hit it.
         """
         response = self.assert200("quests:submission", args=[self.submission.id])
 


### PR DESCRIPTION
Closes #2401

### What?

A short-answer question now tells the student how long their answer may be, under the input they type it into.

### Why?

The 200-character cap was enforced twice (the input's `maxlength` and the form field's `max_length`) and written down once, in the **teacher-facing** help text on the Manage Questions page. Students never see that page. On the submission form they got a bare input, and at 200 characters the browser simply stopped accepting keystrokes with no explanation: a student with more to say meets what looks like a broken page rather than a rule.

### How?

The field carries `help_text` reading "Up to 200 characters.", in the same place and style the file-upload question already says "Allowed file types: Image".

The number comes from a new module constant, `SHORT_ANSWER_MAX_LENGTH` in `src/questions/forms.py`, which now feeds all three uses: the field's validation, the input's `maxlength` attribute and this sentence. The limit was previously written as a literal in two of those places, so the sentence would have been a third copy free to drift from what the student is actually held to.

### Testing?

`python src/manage.py test src` green, `ruff check src` and `manage.py check` clean.

Two new tests, both failing on `develop`:

* `test_init__short_answer_help_text_states_the_limit_it_enforces` (`questions/tests/test_forms.py`): the help text names the limit, and the field's `max_length` and the widget's `maxlength` are the same number;
* `test_submission_page__short_answer_tells_the_student_its_limit` (`questions/tests/test_integration.py`): the student's submission page actually shows it.

### Screenshots (if front end is affected)

The first question of the `hackerspace` deck's "Design Portfolio Submission" quest, on the submission page as `student1`:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2401/before_short_answer.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2401/after_short_answer.png) |

### Anything Else?

The issue offered a second option: a live counter ("148 / 200") that updates as the student types. That is friendlier for a longer answer but needs JavaScript and a styling decision (where it sits, whether it changes colour, how it reads to a screen reader), so it is filed as #2482 rather than folded in here. The help text is not wasted if you want the counter later: it can replace this line when JavaScript runs, and read the same constant.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Short-answer fields now clearly display a 200-character limit.
  - The character limit is enforced consistently during entry and submission.

- **Accessibility**
  - Existing required-field behavior and accessibility support are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->