### PR TITLE
fix: read a Library page's data before the schema switches back (#2369)

### DIFF
--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -825,6 +825,11 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
     @patch('courses.models.CourseStudent.xp')
     def test_calc_semester_grades__deactivates_and_sets_final_xp(self, registration_xp):
         """Test that method loops through all students, deactivates the student course, and sets a final_xp value"""
+        # Before any registration is created, not just before calc_semester_grades: saving one
+        # fires coursestudent_post_save_callback, which refreshes the student's cached mark
+        # through CourseStudent.xp(). With the mock still returning a MagicMock, that mark is
+        # written to Profile.mark_cached and the save raises FieldError.
+        registration_xp.return_value = 500
 
         # second student in same course as setup
         student2 = baker.make(User)
@@ -835,7 +840,6 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         course2 = baker.make(Course)
         course_student3 = baker.make(CourseStudent, user=student3, course=course2, semester=SiteConfig.get().active_semester)
 
-        registration_xp.return_value = 500
         CourseStudent.objects.calc_semester_grades(Semester.objects.get_current())
 
         self.course_student.refresh_from_db()

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -825,10 +825,10 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
     @patch('courses.models.CourseStudent.xp')
     def test_calc_semester_grades__deactivates_and_sets_final_xp(self, registration_xp):
         """Test that method loops through all students, deactivates the student course, and sets a final_xp value"""
-        # Before any registration is created, not just before calc_semester_grades: saving one
-        # fires coursestudent_post_save_callback, which refreshes the student's cached mark
-        # through CourseStudent.xp(). With the mock still returning a MagicMock, that mark is
-        # written to Profile.mark_cached and the save raises FieldError.
+        # Configured before the registrations below, not just before calc_semester_grades:
+        # saving a registration fires coursestudent_post_save_callback, which refreshes the
+        # student's cached mark through CourseStudent.xp(). A mark that is a MagicMock rather
+        # than a number is written to Profile.mark_cached, and that save raises FieldError.
         registration_xp.return_value = 500
 
         # second student in same course as setup

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2712,22 +2712,26 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
 
         Args:
             response (HttpResponse): the rendered Library page.
+
+        Raises:
+            AssertionError: if the page did not render, or shows this deck's tag in place
+                of the Library's.
         """
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "chemistry")
         self.assertNotContains(response, "local-only")
 
-    def test_quest_list__shows_the_library_quests_own_tags(self):
+    def test_LibraryQuestListView__shows_the_library_quests_own_tags(self):
         """The Library quest list renders tags read from the Library."""
         self.assertShowsLibraryTags(self.client.get(reverse('library:quest_list')))
 
-    def test_campaign_detail__shows_the_library_quests_own_tags(self):
+    def test_CategoryDetailView__shows_the_library_quests_own_tags(self):
         """The Library campaign detail page renders tags read from the Library."""
         self.assertShowsLibraryTags(
             self.client.get(reverse('library:category_detail_view', args=[self.library_campaign.import_id]))
         )
 
-    def test_import_campaign_confirmation__shows_the_library_quests_own_tags(self):
+    def test_ImportCampaignView__shows_the_library_quests_own_tags(self):
         """The campaign import preview renders tags read from the Library.
 
         This is the page a teacher decides on, so showing their own deck's data back to
@@ -2737,7 +2741,7 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
             self.client.get(reverse('library:import_category', args=[self.library_campaign.import_id]))
         )
 
-    def test_import_quest_confirmation__shows_the_library_quests_own_tags(self):
+    def test_ImportQuestView__shows_the_library_quests_own_tags(self):
         """The quest import preview renders tags read from the Library."""
         self.assertShowsLibraryTags(
             self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2670,3 +2670,75 @@ class LibraryImportPreviewQuestionTests(LibraryTenantTestCaseMixin):
         response = self.client.get(reverse('quests:quest_detail', args=[local_quest.id]))
 
         self.assertContains(response, reverse('questions:list', args=[local_quest.id]))
+
+
+class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
+    """Related data on a Library page comes from the Library, not the viewer's own deck.
+
+    Every Library view collects its objects inside `library_schema_context()`. Anything
+    still lazy when the template renders is evaluated after the connection has switched
+    back, so it queries this deck's tables using the Library row's primary key: no error,
+    just another deck's data presented as the shared content's (#2369).
+
+    Tags are the probe used throughout: they are a related manager on every listed quest,
+    they render on all four pages, and taggit keys them by object id, so a local quest
+    holding the same id supplies exactly the wrong answer.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Publish a tagged quest and campaign in the Library, and a staff user to view them."""
+        with library_schema_context():
+            cls.library_campaign = baker.make(Category, title="Chemistry Basics", published=True)
+            cls.library_quest = baker.make(
+                Quest, name="Titration Practice", campaign=cls.library_campaign, published=True,
+            )
+            cls.library_quest.tags.add("chemistry")
+
+        cls.test_teacher = User.objects.create_user('lazy_queryset_teacher', is_staff=True)
+
+    def setUp(self):
+        """Give this deck a quest at the same id, tagged differently, and sign the teacher in."""
+        super().setUp()
+        # taggit keys tags by object id, so a local quest at the Library quest's id is what
+        # a lazily-evaluated `quest.tags.all` would find after the schema switches back.
+        local = baker.make(Quest, name="A Local Quest")
+        Quest.objects.filter(pk=local.pk).update(id=self.library_quest.id)
+        Quest.objects.get(pk=self.library_quest.id).tags.add("local-only")
+        self.client.force_login(self.test_teacher)
+
+    def assertShowsLibraryTags(self, response):
+        """Assert a rendered page shows the Library quest's tag and not this deck's.
+
+        Args:
+            response (HttpResponse): the rendered Library page.
+        """
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "chemistry")
+        self.assertNotContains(response, "local-only")
+
+    def test_quest_list__shows_the_library_quests_own_tags(self):
+        """The Library quest list renders tags read from the Library."""
+        self.assertShowsLibraryTags(self.client.get(reverse('library:quest_list')))
+
+    def test_campaign_detail__shows_the_library_quests_own_tags(self):
+        """The Library campaign detail page renders tags read from the Library."""
+        self.assertShowsLibraryTags(
+            self.client.get(reverse('library:category_detail_view', args=[self.library_campaign.import_id]))
+        )
+
+    def test_import_campaign_confirmation__shows_the_library_quests_own_tags(self):
+        """The campaign import preview renders tags read from the Library.
+
+        This is the page a teacher decides on, so showing their own deck's data back to
+        them is the most misleading place for it to happen.
+        """
+        self.assertShowsLibraryTags(
+            self.client.get(reverse('library:import_category', args=[self.library_campaign.import_id]))
+        )
+
+    def test_import_quest_confirmation__shows_the_library_quests_own_tags(self):
+        """The quest import preview renders tags read from the Library."""
+        self.assertShowsLibraryTags(
+            self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
+        )

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -1,6 +1,7 @@
 import functools
 
 from django.apps import apps
+from django.db.models import prefetch_related_objects
 from django_tenants.utils import schema_context
 
 
@@ -70,6 +71,38 @@ def library_listable_quests():
     from quest_manager.models import Quest
 
     return Quest.objects.get_queryset().published().active_or_no_campaign()
+
+
+def load_library_quests_for_render(quests):
+    """Read everything a Library quest's template will ask for, while the schema is right.
+
+    Library views select their quests inside `library_schema_context()` and render after it
+    has closed. Anything still lazy at that point (a related manager, a queryset, an
+    unfetched foreign key) is evaluated by the template engine, by which time the connection
+    is back on the viewer's own deck: it reads *this* deck's tables using the Library row's
+    primary key, and the page shows the viewer their own data as though it were the shared
+    content's. Nothing raises, so the only sign is that the wrong thing is on the screen
+    (#2369, #2163).
+
+    Loading it here rather than at each call site means the fix is one line per view instead
+    of a prefetch per relation that the next template change can silently outgrow.
+
+    Rendering the page *on* the Library schema is not the alternative it looks like: the
+    page is mostly the viewer's own deck (their profile, their SiteConfig, their navbar),
+    none of which exists in the Library schema.
+
+    Must be called from within the library schema context, on an already-evaluated list.
+
+    Args:
+        quests (list[Quest]): the quests about to be rendered. A list, not a queryset:
+            `prefetch_related_objects` needs the rows to exist.
+
+    Returns:
+        list[Quest]: the same list, with `tags`, `question_set` and `campaign` populated.
+    """
+    prefetch_related_objects(quests, 'tags', 'question_set', 'campaign')
+
+    return quests
 
 
 def get_colliding_quest_names(library_quests):

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db import connection
-from django.db.models import Q, prefetch_related_objects
+from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
@@ -38,6 +38,7 @@ from .utils import (
     get_library_schema_name,
     library_listable_quests,
     library_schema_context,
+    load_library_quests_for_render,
 )
 
 User = get_user_model()
@@ -481,9 +482,9 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             # get_page (rather than page) turns a junk or out-of-range ?page= into the
             # nearest real page instead of raising
             page = paginator.get_page(self.get_page_number())
-            # Force evaluation inside the library context: the template renders this after
-            # the schema has switched back to the caller's own deck.
-            page_quests = list(page.object_list)
+            # Read inside the library context: the template renders this after the schema
+            # has switched back to the caller's own deck.
+            page_quests = load_library_quests_for_render(list(page.object_list))
             num_quests = library_listable_quests().count() if search_term else paginator.count
             num_campaigns = Category.objects.all_published_with_importable_quests().count()
 
@@ -604,12 +605,9 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
             quest = get_published_library_object(Quest, quest_import_id)
 
             if quest is not None:
-                # The page renders outside this context, and a quest's questions are a lazy
-                # queryset: evaluated at render time it would read *this* deck's questions
-                # table with the Library quest's pk, and show whichever local quest happens
-                # to hold that id (#2163). Reading them here, in the schema they live in,
-                # fills the prefetch cache the template then renders from.
-                prefetch_related_objects([quest], 'question_set')
+                # The page renders outside this context, so everything it shows has to be
+                # read in here (#2163, #2369).
+                load_library_quests_for_render([quest])
 
         if quest is None:
             return redirect_awaiting_review(request, 'quest', 'library:quest_list')
@@ -715,8 +713,8 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
             category_total_xp_available = library_category.xp_sum()
             category_published = library_category.published
 
-            # Force evaluation of the queryset in the library to get full Quest objects for rendering.
-            shared_quests = list(library_category.current_quests())
+            # Read in the library, since the page renders after this context has closed.
+            shared_quests = load_library_quests_for_render(list(library_category.current_quests()))
             # Extract import_ids from the list to compare with the local quests.
             quest_import_ids = [q.import_id for q in shared_quests]
 
@@ -1141,7 +1139,7 @@ class CategoryDetailView(NonPublicOnlyViewMixin, TemplateView):
         with library_schema_context():
             category = get_object_or_404(Category, import_id=campaign_import_id)
 
-            displayed_quests = list(category.current_quests())
+            displayed_quests = load_library_quests_for_render(list(category.current_quests()))
 
             if displayed_quests:
                 quest_info = [


### PR DESCRIPTION
### What?

Library pages now show the Library's data. Tags, submission questions and campaigns on a shared quest are read while the connection is still on the Library schema, instead of being fetched at render time from whichever quest on the viewer's own deck happens to hold the same primary key.

Closes #2369.

Also carries a one-line fix to an unrelated `courses` test that is red on `develop` and was therefore blocking this PR's CI. See *Anything Else*.

### Why?

Every Library view selects its objects inside `library_schema_context()` and renders after that block has closed. Anything still lazy at that point (a related manager, a queryset, an unfetched foreign key) is evaluated by the template engine, and by then the connection is back on the viewer's own deck. The lookup runs against *this* deck's tables using the Library row's primary key.

Nothing raises. The page renders, and it shows the viewer their own data presented as the shared content's. It is worst on the two import confirmation pages, since those are the pages a teacher makes the decision on.

The Library quest list was already correct, but only by accident: its own query happens to `prefetch_related('tags')`, which forces evaluation while the schema context is still open. Dropping that prefetch as a performance tweak would have broken it silently.

### How?

`library.utils.load_library_quests_for_render(quests)` reads `tags`, `question_set` and `campaign` for the quests about to be rendered. It is called from the four pages that show Library quests:

* `LibraryQuestListView` (which previously relied on its query's own prefetch)
* `CategoryDetailView`
* `ImportCampaignView.get`
* `ImportQuestView.get` (which already read `question_set` for #2163, now through the shared helper)

One call per view rather than a prefetch per relation, so a template that starts using another relation cannot silently reintroduce the bug. It must be called inside the library schema context, on an evaluated list, and its docstring says so.

### Testing?

`LibraryLazyQuerysetRenderTests`: four regression tests, one per page. Tags are the probe, because they are a related manager on every listed quest, they render on all four pages, and taggit keys them by object id. Each test plants a local quest at the Library quest's id and tags it differently, so a lazily-evaluated `quest.tags.all` returns exactly the wrong answer rather than an empty one.

Three of the four failed before the fix; the quest list passed for the accidental reason above.

```
src/library                                   172 tests   OK
full suite (python src/manage.py test src)   2490 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

From the running `hackerspace` dev deck, signed in as the deck owner. The Library's copies of the Orientation quests are tagged `chemistry, shared-from-library`; this deck's own quests, which sit at the same primary keys, are tagged `this-deck-only`.

**Campaign import confirmation page, before:** every Library quest shows this deck's tag.

![Before: the import preview showing this-deck-only](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2369/lazy-before.png)

**After:** the Library's own tags.

![After: the import preview showing chemistry, shared-from-library](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2369/lazy-after.png)

**Library campaign detail page, before and after:** same mechanism, same page-level symptom.

![Before: the campaign detail page showing this-deck-only](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2369/lazy-detail-before.png)

![After: the campaign detail page showing chemistry, shared-from-library](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2369/lazy-detail-after.png)

### Anything Else?

**The fix proposed in the issue does not work, and I built it first.** #2369 suggested rendering the response *inside* the schema context, which would close off the whole class of bug in one place rather than one relation at a time. That is the better-shaped fix, and it fails immediately: a Library page is mostly the viewer's own deck. The navbar reads their profile, the banner reads their `SiteConfig`, and none of it exists in the Library schema, so every one of the four pages 500s with a `NoReverseMatch` on `profile_detail`, because the viewer has no profile row in the Library schema for the navbar to link to.

Rendering on the Library schema reverses the direction of the bug rather than fixing it. Recording it here so it is not tried again: making that approach work would mean rendering the Library-content includes to a string on the Library schema and interpolating them into a page rendered locally, which is a template refactor rather than a bug fix, and worth its own issue if the per-view call ever becomes a burden.

**An unrelated `courses` test fix rides along, because `develop` is red.** `courses.tests.test_models.CourseStudentManagerTest.test_calc_semester_grades__deactivates_and_sets_final_xp` fails on a clean `origin/develop`, standalone, with none of this branch's changes, raising `FieldError: Aggregate functions are not allowed in this query` with a MagicMock as the `mark_cached` value.

It patches `CourseStudent.xp`, creates registrations, and only then gives the mock a return value. Saving a registration fires `coursestudent_post_save_callback`, which refreshes the student's cached mark through `xp()`, so `Profile.mark_cached` is assigned a MagicMock and the update fails. Since that breaks CI for every open PR and this one cannot merge against a red base, the one-line fix (set the return value first) is included here. It touches only that test, and I am happy to split it into its own PR if you would rather keep this one purely Library.

The shape that produced it remains: `CourseStudent.xp()` is now on the write path of every registration save via a signal, so any test that patches it and then saves a registration fails the same way, with a traceback pointing at `Profile.save()` rather than at the patch. Filed as #2486 with options, since it belongs with #2440's follow-ups.

**This makes the accidental prefetch deliberate.** `get_library_quests` still does `select_related('campaign').prefetch_related('tags')` for its own query efficiency. That is now belt-and-braces rather than the thing correctness rests on: `prefetch_related_objects` skips relations that are already cached, so the helper costs nothing where the query already did the work.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)