### PR TITLE
fix: show the campaign's name and blurb on the import preview (#2370)

### DIFF
--- a/src/library/templates/library/confirm_import_campaign.html
+++ b/src/library/templates/library/confirm_import_campaign.html
@@ -5,7 +5,7 @@
 {% block heading %}
   <i class="fa fa-compass pull-right"></i>
   {% block heading_inner %}
-    {% firstof object.title category_campaign_name %} Campaign
+    {{ category.title }} Campaign
   {% endblock %}
 {% endblock %}
 
@@ -20,46 +20,37 @@
         Import ID: {{ local_category.import_id }}
       </p>
     </div>
-  {% elif object.published or request.user.is_staff %}
-    {% with object as category %}
-      <form action="" method="post">
-        {% csrf_token %}
-        <a href="{% url 'library:category_list' %}"
-           role="button"
-           class="btn btn-info">Cancel</a>
-        <input type="submit"
-               value="Import"
-               class="btn btn-success"
-               {% if local_category %}disabled{% endif %} />
-      </form>
-      {% if local_quest_import_ids %}
-        <div class="alert alert-danger panel-top">
-          <strong>Warning:</strong> One or more quests in this campaign already exist in your deck;
-          they are indicated with this icon <i class="icon-spacing fa fa-fw fa-exclamation-triangle"></i> in the quest list below.
-          Importing this campaign will <strong>overwrite</strong> those existing quests with the versions from the library.
-          You will lose any local changes.
-        </div>
-      {% endif %}
-      {% if colliding_names %}
-        <div class="alert alert-info panel-top">
-          Your deck already has {{ colliding_names|length|pluralize:"a quest,quests" }} called
-          {% for name in colliding_names %}<strong>{{ name }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %},
-          and two quests cannot share a name. The arriving
-          {{ colliding_names|length|pluralize:"copy,copies" }} will have today's date added to
-          {{ colliding_names|length|pluralize:"its,their" }} name so both can exist; rename
-          {{ colliding_names|length|pluralize:"it,them" }} afterwards to whatever suits your deck.
-        </div>
-      {% endif %}
-      <div class="well panel-top">
-        <p>Are you sure you want to import this campaign into your deck?</p>
-        <p>This will import all quests associated with the campaign from the shared library.</p>
-      </div>
-      {% include "quest_manager/category_detail_content.html" %}
-    {% endwith %}
   {% else %}
-    <p>
-      The campaign you're trying to reach is currently unavailable. Please contact your teacher if this comes as a surprise.
-    </p>
+    <form action="" method="post">
+      {% csrf_token %}
+      <a href="{% url 'library:category_list' %}"
+         role="button"
+         class="btn btn-info">Cancel</a>
+      <input type="submit" value="Import" class="btn btn-success" />
+    </form>
+    {% if local_quest_import_ids %}
+      <div class="alert alert-danger panel-top">
+        <strong>Warning:</strong> One or more quests in this campaign already exist in your deck;
+        they are indicated with this icon <i class="icon-spacing fa fa-fw fa-exclamation-triangle"></i> in the quest list below.
+        Importing this campaign will <strong>overwrite</strong> those existing quests with the versions from the library.
+        You will lose any local changes.
+      </div>
+    {% endif %}
+    {% if colliding_names %}
+      <div class="alert alert-info panel-top">
+        Your deck already has {{ colliding_names|length|pluralize:"a quest,quests" }} called
+        {% for name in colliding_names %}<strong>{{ name }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %},
+        and two quests cannot share a name. The arriving
+        {{ colliding_names|length|pluralize:"copy,copies" }} will have today's date added to
+        {{ colliding_names|length|pluralize:"its,their" }} name so both can exist; rename
+        {{ colliding_names|length|pluralize:"it,them" }} afterwards to whatever suits your deck.
+      </div>
+    {% endif %}
+    <div class="well panel-top">
+      <p>Are you sure you want to import this campaign into your deck?</p>
+      <p>This will import all quests associated with the campaign from the shared library.</p>
+    </div>
+    {% include "quest_manager/category_detail_content.html" %}
   {% endif %}
 {% endblock %}
 {% block js %}

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2751,10 +2751,11 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
 class LibraryImportCampaignPreviewTests(LibraryTenantTestCaseMixin):
     """What the campaign import confirmation page tells a teacher about the campaign.
 
-    It is the page the import decision is made on, so the campaign's own name and blurb
-    have to be on it. They were not: the template read an `object` variable this view never
-    supplies, and rebound `category` to it for the whole block, so every `category.*` lookup
-    inside resolved to nothing (#2370).
+    It is the page the import decision is made on, so the campaign's name, its blurb and
+    the quests that would arrive all belong on it, and a campaign that genuinely has no
+    blurb has to say so rather than leave a gap. The page reads some of that from the
+    campaign object and some from values the view pre-computes, so these assert on what
+    is rendered rather than on which source it came from (#2370).
     """
 
     @classmethod

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2746,3 +2746,68 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         self.assertShowsLibraryTags(
             self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
         )
+
+
+class LibraryImportCampaignPreviewTests(LibraryTenantTestCaseMixin):
+    """What the campaign import confirmation page tells a teacher about the campaign.
+
+    It is the page the import decision is made on, so the campaign's own name and blurb
+    have to be on it. They were not: the template read an `object` variable this view never
+    supplies, and rebound `category` to it for the whole block, so every `category.*` lookup
+    inside resolved to nothing (#2370).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Publish a described campaign with one quest in the Library, and a staff user."""
+        with library_schema_context():
+            cls.library_campaign = baker.make(
+                Category,
+                title="Rendered Campaign Title",
+                short_description="A blurb the importing teacher needs to read.",
+                published=True,
+            )
+            cls.library_quest = baker.make(
+                Quest, name="Previewed Quest", campaign=cls.library_campaign, published=True,
+            )
+
+        cls.test_teacher = User.objects.create_user('preview_teacher', is_staff=True)
+
+    def preview(self):
+        """Fetch the campaign import confirmation page as a signed-in teacher.
+
+        Returns:
+            HttpResponse: the rendered confirmation page.
+        """
+        self.client.force_login(self.test_teacher)
+
+        return self.client.get(reverse('library:import_category', args=[self.library_campaign.import_id]))
+
+    def test_ImportCampaignView__names_the_campaign_in_the_heading(self):
+        """The heading says which campaign is being imported."""
+        response = self.preview()
+
+        self.assertContains(response, "Rendered Campaign Title")
+
+    def test_ImportCampaignView__shows_the_campaigns_own_description(self):
+        """The campaign's blurb is shown, rather than being reported as absent."""
+        response = self.preview()
+
+        self.assertContains(response, "A blurb the importing teacher needs to read.")
+        self.assertNotContains(response, "[No description provided]")
+
+    def test_ImportCampaignView__says_a_campaign_with_no_description_has_none(self):
+        """A campaign that really has no blurb still says so, rather than showing nothing."""
+        with library_schema_context():
+            Category.objects.filter(pk=self.library_campaign.pk).update(short_description="")
+
+        response = self.preview()
+
+        self.assertContains(response, "[No description provided]")
+
+    def test_ImportCampaignView__lists_the_campaigns_quests(self):
+        """The quests that would arrive are listed, with their count and XP."""
+        response = self.preview()
+
+        self.assertContains(response, "Previewed Quest")
+        self.assertContains(response, "Published quests in this campaign: 1")


### PR DESCRIPTION
### What?

The campaign import confirmation page now says which campaign it is about. Its heading names the campaign, and its own short description is shown instead of "[No description provided]".

Closes #2370.

### Why?

`confirm_import_campaign.html` read an `object` variable that `ImportCampaignView` never supplies, and then did this:

```django
{% with object as category %}
```

`{% with A as B %}` assigns B = A, so that rebound `category` to the missing `object` for the entire block, shadowing the campaign the view had passed in. Every `category.*` lookup inside resolved to nothing. The heading (`{% firstof object.title category_campaign_name %}`) named two variables the view does not pass either, so it rendered as bare " Campaign".

The result is that the page a teacher makes the import decision on showed no campaign name and asserted the campaign had no description, whatever it actually said. It failed silently, which is why it lasted.

### How?

Three things, all in the template:

* Read the title from `category`, which the view already passes.
* Drop the `{% with %}` block, so the rest of the template sees the real campaign.
* Drop the `{% elif object.published or request.user.is_staff %}` branch and the "currently unavailable" message it guarded. That condition never tested what it appears to: `object` is absent, so it passed on `is_staff` alone, and the view is staff-only. Publication is enforced before the template is reached (`get_published_library_object` redirects an unpublished campaign back to the Library with an explanation), so the template only ever renders a published campaign and the dead branch was unreachable. The disabled-button check inside it went the same way: it tested `local_category` from inside a branch that only runs when `local_category` is falsy.

**The hand-copied scalars in the context dict stay.** #2370 suggests they exist only to dodge the shadowing, and for `category_name` that is true, but not for the rest: `quest_count()`, `xp_sum()` and `get_icon_url()` each hit the database, and this page renders after the Library schema context has closed, so reading them off the campaign object at render time would query the importing deck instead. That is #2369, which merged an hour ago. Only the already-loaded fields (`title`, `short_description`) are read from the object.

### Testing?

`LibraryImportCampaignPreviewTests`: the heading names the campaign, the description is shown, a campaign that genuinely has no description still says so, and the quest list and counts render. The first two failed before this change.

```
src/library                                   176 tests   OK
full suite (python src/manage.py test src)   2496 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

From the running `hackerspace` dev deck, signed in as the deck owner, previewing the Library's "Orientation" campaign, which has a real short description.

**Before:** the heading is just "Campaign", and the campaign is reported as having no description.

![Before: bare Campaign heading and No description provided](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2370/preview-before.png)

**After:** the campaign is named, and its description is shown.

![After: Orientation Campaign heading and the real description](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2370/preview-after.png)

### Anything Else?

**Worth knowing what else `{% with object as category %}` was hiding.** With the shadowing gone, `category_detail_content.html` reads the real campaign on this page for the first time. Its `{% firstof category_X category.X %}` pairs are what keep that safe: the view's pre-computed value still wins for every lookup that would otherwise query, which is why this PR does not simplify them away. If those scalars are ever removed, the schema-context hazard from #2369 comes back through this template rather than through the views.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the campaign import flow with clearer category titles.
  * Import previews now display campaign titles, descriptions, included quest details, and published quest counts.

* **Bug Fixes**
  * Removed unnecessary restrictions that prevented importing unpublished campaigns or campaigns without staff users.
  * Import is no longer disabled when a local category already exists.
  * Removed the unavailable-campaign message from the import flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->