### PR TITLE
feat: show image, video and audio answers on the page (#2172)

### DIFF
--- a/src/questions/templates/questions/snippets/comment_answers.html
+++ b/src/questions/templates/questions/snippets/comment_answers.html
@@ -27,8 +27,9 @@
               <p class="text-muted"><small><b>Solution:</b> {{ answer.question.solution_text|linebreaksbr }}</small></p>
             {% endif %}
             {% if answer.question.solution_file %}
-              <p class="text-muted"><small><b>Solution file:</b>
-                <a href="{{ answer.question.solution_file.url }}" target="_blank">{{ answer.question.solution_file|filename }}</a></small></p>
+              {# a div, not a paragraph: the snippet can render a video or audio player, which is invalid inside one #}
+              <div class="text-muted"><small><b>Solution file:</b>
+                {% include 'questions/snippets/question_file.html' with file=answer.question.solution_file %}</small></div>
             {% endif %}
             {% if answer.question.marker_notes %}
               {# unwrap_p strips Summernote's wrapping paragraph element so a one-line note sits beside its label, like Solution above. #}
@@ -42,7 +43,7 @@
       </td>
       <td class="col-sm-7">
         {% if answer.response_file %}
-          <a href="{{ answer.response_file.url }}" target="_blank">{{ answer.response_file|filename }}</a>
+          {% include 'questions/snippets/question_file.html' with file=answer.response_file %}
         {% elif answer.response_text %}
           {{ answer.response_text|safe }}
         {% else %}

--- a/src/questions/templates/questions/snippets/question_file.html
+++ b/src/questions/templates/questions/snippets/question_file.html
@@ -1,0 +1,36 @@
+{% load comment_tags question_tags %}
+{% comment %}
+  One of a question's stored files (a student's file answer, or the teacher's solution file),
+  shown as the browser can show it: an image, a video player or an audio player, and a link
+  to open it either way (#2172). A file of any other kind is the link alone.
+
+  Expects `file` (a file field's value). Pass `thumb=True` in a narrow space, such as a table
+  cell: there only images embed, as a small thumbnail standing in for the link, since a video
+  or audio player has no useful size there.
+{% endcomment %}
+{% with kind=file|media_kind %}
+  {% if kind == 'image' %}
+    <a href="{{ file.url }}" target="_blank">
+      {# alt is the file's own name: it is the only description of the picture anyone has entered #}
+      <img class="{% if thumb %}question-media-thumb{% else %}question-media{% endif %}"
+           src="{{ file.url }}" alt="{{ file|filename|striptags }}">
+    </a>
+    {% if not thumb %}<br><a href="{{ file.url }}" target="_blank">{{ file|filename }}</a>{% endif %}
+  {% elif kind == 'video' and not thumb %}
+    <video class="question-media" controls preload="metadata">
+      <source src="{{ file.url }}">
+      Your browser cannot play this video.
+    </video>
+    <br><a href="{{ file.url }}" target="_blank">{{ file|filename }}</a>
+  {% elif kind == 'audio' and not thumb %}
+    <audio class="question-media" controls preload="metadata">
+      <source src="{{ file.url }}">
+      Your browser cannot play this audio.
+    </audio>
+    <br><a href="{{ file.url }}" target="_blank">{{ file|filename }}</a>
+  {% else %}
+    {# in a table cell the name is cut short, so one long file name cannot stretch the column #}
+    <a href="{{ file.url }}" target="_blank">
+      {% if thumb %}{{ file|filename|default:"Unnamed File"|truncatechars:20 }}{% else %}{{ file|filename }}{% endif %}</a>
+  {% endif %}
+{% endwith %}

--- a/src/questions/templates/questions/snippets/question_table.html
+++ b/src/questions/templates/questions/snippets/question_table.html
@@ -37,7 +37,8 @@
       {% if question.type == 'file_upload' %}
           <td>
           {% if question.solution_file %}
-              <a href='{{ question.solution_file.url }}'>{{ question.solution_file|filename|default:"Unnamed File"|truncatechars:20 }}</a>
+              {# thumb: the column is narrow, so an image stands in for its own link (#2172) #}
+              {% include 'questions/snippets/question_file.html' with file=question.solution_file thumb=True %}
           {% else %}
               -
           {% endif %}

--- a/src/questions/templatetags/question_tags.py
+++ b/src/questions/templatetags/question_tags.py
@@ -6,6 +6,7 @@ from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 
 from questions.models import QuestionType
+from utilities.fields import media_kind_of
 
 register = template.Library()
 
@@ -23,6 +24,27 @@ _TYPE_ICONS = {
 def question_type_icon(question_type):
     """Return the Font Awesome icon class for a question's ``type`` (empty string if unknown)."""
     return _TYPE_ICONS.get(question_type, "")
+
+
+@register.filter
+def media_kind(value):
+    """Return how a question's stored file can be shown: 'image', 'video', 'audio' or ''.
+
+    A marker reading a set of answers should see the picture, not a filename to download and
+    open (#2172), so the answer display asks each file what it is and embeds it accordingly.
+    Anything else, and anything with no file, answers with the empty string and is offered
+    as a link.
+
+    Args:
+        value: a file field's value (a `FieldFile`), or None/empty when nothing was uploaded.
+
+    Returns:
+        str: the kind of media, or '' when it is not one this page can embed.
+    """
+    if not value:
+        return ''
+
+    return media_kind_of(value.name)
 
 
 @register.filter

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -476,6 +476,84 @@ class AnswerDisplayTest(QuestionSubmissionFlowTestBase):
         # multi-paragraph notes keep their tags (rather than being flattened or escaped)
         self.assertContains(response, "<p>First note.</p><p>Second note.</p>")
 
+    def publish_file_answer(self, file_name, content=b"pretend media"):
+        """Give the submission a published file answer, as if the student had uploaded one.
+
+        Args:
+            file_name (str): the name to store the file under, whose extension decides how
+                the page shows it.
+            content (bytes): the file's contents, which nothing here reads.
+
+        Returns:
+            QuestionSubmission: the published answer, with the file attached.
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload", required=False,
+            instructions="<p>Upload your work.</p>",
+        )
+        self.complete_with_answers()
+        answer = QuestionSubmission.objects.get(quest_submission=self.submission, question=file_question)
+        answer.response_file = SimpleUploadedFile(file_name, content)
+        answer.save()
+
+        return answer
+
+    def test_display__an_image_answer_is_shown_on_the_page(self):
+        """A picture a student uploaded is displayed where it is read (#2172).
+
+        A marker working through a set of answers reads the image itself; the link stays for
+        opening or saving the original.
+        """
+        answer = self.publish_file_answer("my_drawing.png")
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
+
+        self.assertContains(response, '<img class="question-media"')
+        self.assertContains(response, answer.response_file.url)
+
+    def test_display__a_video_answer_gets_a_player(self):
+        """A video answer is playable on the page rather than only downloadable."""
+        self.publish_file_answer("my_clip.mp4")
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
+
+        self.assertContains(response, '<video class="question-media" controls preload="metadata">')
+
+    def test_display__an_audio_answer_gets_a_player(self):
+        """An audio answer is playable on the page, the same as a video one."""
+        self.publish_file_answer("my_reading.mp3")
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
+
+        self.assertContains(response, '<audio class="question-media" controls preload="metadata">')
+
+    def test_display__any_other_answer_file_is_offered_as_a_link(self):
+        """A file no browser can show is a download link, which is all it ever was."""
+        answer = self.publish_file_answer("my_notes.pdf")
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
+
+        self.assertNotContains(response, '<img class="question-media"')
+        self.assertContains(response, f'<a href="{answer.response_file.url}" target="_blank">')
+
+    def test_display__a_solution_image_is_shown_to_staff(self):
+        """The teacher's example answer is shown too, beside the answers it is compared with."""
+        self.short_question.solution_file = SimpleUploadedFile("the_solution.png", b"pretend image")
+        self.short_question.save()
+        self.complete_with_answers()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse("quests:submission", args=[self.submission.id]))
+
+        self.short_question.refresh_from_db()
+        self.assertContains(response, "<b>Solution file:</b>")
+        self.assertContains(response, self.short_question.solution_file.url)
+        self.assertContains(response, '<img class="question-media"')
+
     def test_display__student_does_not_see_marker_notes(self):
         """Solutions and marker notes stay staff-only in the answers display."""
         self.short_question.solution_text = "SECRET SOLUTION"

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -513,7 +513,7 @@ class AnswerDisplayTest(QuestionSubmissionFlowTestBase):
         self.assertContains(response, answer.response_file.url)
 
     def test_display__a_video_answer_gets_a_player(self):
-        """A video answer is playable on the page rather than only downloadable."""
+        """A video answer is playable on the page, where the marker is reading it."""
         self.publish_file_answer("my_clip.mp4")
         self.client.force_login(self.test_teacher)
 
@@ -531,7 +531,7 @@ class AnswerDisplayTest(QuestionSubmissionFlowTestBase):
         self.assertContains(response, '<audio class="question-media" controls preload="metadata">')
 
     def test_display__any_other_answer_file_is_offered_as_a_link(self):
-        """A file no browser can show is a download link, which is all it ever was."""
+        """A file the page cannot embed is offered as a link to open or save."""
         answer = self.publish_file_answer("my_notes.pdf")
         self.client.force_login(self.test_teacher)
 

--- a/src/questions/tests/test_templatetags.py
+++ b/src/questions/tests/test_templatetags.py
@@ -1,8 +1,10 @@
+from types import SimpleNamespace
+
 from django.test import SimpleTestCase
 from django.utils.safestring import SafeString
 
 from questions.models import QuestionType
-from questions.templatetags.question_tags import plain_text, question_type_icon, unwrap_p
+from questions.templatetags.question_tags import media_kind, plain_text, question_type_icon, unwrap_p
 
 
 class UnwrapPTest(SimpleTestCase):
@@ -88,3 +90,20 @@ class PlainTextTest(SimpleTestCase):
     def test_plain_text__result_is_not_marked_safe(self):
         """The result stays escapable, so a stray quote cannot break out of a title attribute."""
         self.assertNotIsInstance(plain_text('<p>a " quote</p>'), SafeString)
+
+
+class MediaKindFilterTest(SimpleTestCase):
+    """Tests for the ``media_kind`` filter, which the answer display uses to embed a file."""
+
+    def test_media_kind__reads_a_file_fields_name(self):
+        """The filter is handed a file field's value, and answers from the name it stores."""
+        self.assertEqual(media_kind(SimpleNamespace(name="answers/2026/my_drawing.png")), "image")
+
+    def test_media_kind__is_empty_for_no_file(self):
+        """A question with nothing uploaded answers with the empty string, not an error.
+
+        Every file field on a question is optional, so the template asks about plenty of
+        empty ones; `None` and an unset `FieldFile` are both falsy, hence one check.
+        """
+        self.assertEqual(media_kind(None), "")
+        self.assertEqual(media_kind(""), "")

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -108,6 +108,33 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
         self.assertNotContains(response, "—")
         self.assertNotContains(response, "&mdash;")
 
+    def test_list__an_image_solution_shows_as_a_thumbnail(self):
+        """A picture used as a solution is shown in the table, not just named (#2172).
+
+        The Solution column is narrow, so the thumbnail stands in for the download link
+        rather than sitting beside it.
+        """
+        image_question = baker.make(
+            Question, quest=self.quest, ordinal=7, type="file_upload",
+            instructions="Upload a photo", solution_file=SimpleUploadedFile("example.png", b"pretend image"),
+        )
+        self.client.force_login(self.test_teacher)
+
+        response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
+
+        self.assertContains(response, '<img class="question-media-thumb"')
+        self.assertContains(response, image_question.solution_file.url)
+
+    def test_list__a_video_solution_stays_a_link(self):
+        """A video solution is named rather than embedded: a player has no room in the column."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
+
+        # the setUp file question's solution is an .mp4
+        self.assertNotContains(response, "<video")
+        self.assertContains(response, self.file_question1.solution_file.url)
+
     def test_list__invalid_quest_404(self):
         """The question list for a nonexistent quest is a 404."""
         self.client.force_login(self.test_teacher)

--- a/src/static/css/custom_common.css
+++ b/src/static/css/custom_common.css
@@ -1361,3 +1361,19 @@ table[data-toggle="table"].bt-reveal {
 .fa-modifier-picker-input {
     display: none;
 }
+
+
+/* A question's file shown where it is read (questions/snippets/question_file.html): a
+   student's image, video or audio answer, and the teacher's solution file. Sized to sit in
+   the answer table without pushing the page wide, and to stay whole on a phone. */
+.question-media {
+    max-width: 100%;
+    max-height: 300px;
+    margin-bottom: 4px;
+}
+/* The same file in a narrow table cell (the Solution column of the question list), where it
+   stands in for its own download link rather than being read at full size. */
+.question-media-thumb {
+    max-width: 100%;
+    max-height: 40px;
+}

--- a/src/templates/head_css.html
+++ b/src/templates/head_css.html
@@ -24,7 +24,7 @@
 {% else %}
 <link href="{{ STATIC_PREFIX }}css/custom.css?v=1.7" rel="stylesheet">
 {% endif %}
-<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.11" rel="stylesheet">
+<link href="{{ STATIC_PREFIX }}css/custom_common.css?v=2.12" rel="stylesheet">
 <link href="{% static 'css/jquery-packed-img-strip.css' %}" rel="stylesheet">
 
 <!-- Bootstrap DateTimePicker Widget -->

--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.db.utils import OperationalError, ProgrammingError
@@ -58,6 +60,40 @@ FILE_MIME_TYPES = {
     'media': IMAGE_MIME_TYPES + VIDEO_MIME_TYPES,
     'all': 'All',
 }
+
+# Which browser element can play a stored file, by the MIME types above. The value is the
+# kind of media, so a template can pick between an image, a video player and an audio
+# player without repeating the type lists.
+_MEDIA_KINDS = (
+    ('image', IMAGE_MIME_TYPES),
+    ('video', VIDEO_MIME_TYPES),
+    ('audio', AUDIO_MIME_TYPES),
+)
+
+
+def media_kind_of(file_name):
+    """Say whether a stored file is an image, a video, an audio file, or none of those.
+
+    The answer is guessed from the name, because that is all a page rendering a saved file
+    has: the content type the browser sent is checked when the file is uploaded (see
+    `RestrictedFileFormField.validate_file`) and not kept. The guess is measured against
+    the same MIME lists that validation uses, so a file a question accepted as an image is
+    the kind of file this reports as an image.
+
+    Args:
+        file_name (str): the stored file's name or path.
+
+    Returns:
+        str: 'image', 'video', 'audio', or '' for anything else (a PDF, a zip, a name with
+        no extension to guess from).
+    """
+    mime_type = mimetypes.guess_type(file_name)[0] or ''
+
+    for kind, mime_types in _MEDIA_KINDS:
+        if mime_type in mime_types:
+            return kind
+
+    return ''
 
 
 class GFKChoiceIterator(ModelChoiceIterator):

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -6,11 +6,12 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.utils import OperationalError, ProgrammingError
+from django.test import SimpleTestCase
 
 from queryset_sequence import QuerySetSequence
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
-from utilities.fields import GFKChoiceField, RestrictedFileFormField
+from utilities.fields import FILE_MIME_TYPES, GFKChoiceField, RestrictedFileFormField, media_kind_of
 from utilities.models import RestrictedFileField
 
 
@@ -222,3 +223,42 @@ class AllowedGFKChoiceFieldRebuildTest(ByteDeckTenantTestCase):
         # And a real form built from the declared fields resolves choices too.
         form = PrereqFormInline()
         self.assertTrue([qs.model for qs in form.fields['prereq_object'].queryset.get_querysets()])
+
+
+class MediaKindOfTest(SimpleTestCase):
+    """What `media_kind_of` says a stored file is, which decides how a page shows it (#2172)."""
+
+    def test_media_kind_of__names_an_image(self):
+        """An image the upload rules accept is reported as an image."""
+        self.assertEqual(media_kind_of("uploads/my_drawing.png"), "image")
+        self.assertEqual(media_kind_of("photo.JPEG"), "image")
+
+    def test_media_kind_of__names_a_video(self):
+        """A video is reported as a video, so a player is used rather than a picture."""
+        self.assertEqual(media_kind_of("clips/demo.mp4"), "video")
+
+    def test_media_kind_of__names_audio(self):
+        """Audio is reported as audio: also playable, but with no picture to show."""
+        self.assertEqual(media_kind_of("readings/chapter.mp3"), "audio")
+
+    def test_media_kind_of__says_nothing_about_other_files(self):
+        """A file a browser cannot play is reported as nothing, and is offered as a link.
+
+        The empty string covers both a type outside the lists (a PDF, an archive) and a name
+        with no extension to go on, so a caller has one case to handle rather than two.
+        """
+        self.assertEqual(media_kind_of("notes.pdf"), "")
+        self.assertEqual(media_kind_of("archive.zip"), "")
+        self.assertEqual(media_kind_of("README"), "")
+
+    def test_media_kind_of__only_accepts_types_the_upload_rules_do(self):
+        """The answer is drawn from the same MIME lists a file-upload question validates with.
+
+        A question restricted to images accepts exactly `IMAGE_MIME_TYPES`, so a file this
+        reports as an image is one such a question would have taken: the two cannot drift,
+        because they read the same list.
+        """
+        for mime_type, extension in (("image/png", ".png"), ("video/mp4", ".mp4"), ("audio/mpeg", ".mp3")):
+            with self.subTest(mime_type=mime_type):
+                self.assertIn(mime_type, FILE_MIME_TYPES["image"] + FILE_MIME_TYPES["video"] + FILE_MIME_TYPES["audio"])
+                self.assertNotEqual(media_kind_of(f"file{extension}"), "")


### PR DESCRIPTION
Closes #2172

### What?

A file answer to a submission question is now shown where it is read: a picture appears on the page, a video and an audio file get players, and the teacher's solution file does the same.

### Why?

Both were a download link and nothing else. Marking a quest whose question asks for a photo meant opening each answer in a new tab, looking at it, and coming back, once per student, and the teacher's own example answer sat beside it as a second link to open. The thing being marked is the picture, so the picture is what the page should show.

### How?

* `utilities.fields.media_kind_of(file_name)` says whether a stored file is an `'image'`, a `'video'`, `'audio'`, or `''` for anything else. It guesses from the name (all a page rendering a saved file has: the browser's content type is checked at upload and not kept) and measures the guess against the **same** `IMAGE_MIME_TYPES` / `VIDEO_MIME_TYPES` / `AUDIO_MIME_TYPES` lists a file-upload question validates with, so what a question accepted as an image is what this reports as an image.
* A `media_kind` template filter exposes it, and a new snippet, `questions/snippets/question_file.html`, renders one file: embedded when the browser can show it, plus a link to open or save the original either way.
* The answers table (`comment_answers.html`) uses it for the student's answer and, for staff, the question's solution file. The question list's Solution column uses it with `thumb=True`: there only images embed, as a small thumbnail standing in for the link, because a video or audio player has no useful size in a table cell and a long file name would stretch the column.
* Two theme-agnostic rules in `custom_common.css` (`.question-media`, `.question-media-thumb`) size the media so it cannot push the page wide, with the `head_css.html` cache-buster bumped to `v=2.12`. A browser applies `max-width: 100%` and `max-height: 300px` whichever binds first, keeping the aspect ratio, so a panorama is held by the width of the cell and a tall photo by the height cap; neither is distorted and neither stretches the table.

Audio is included alongside image and video: the same helper covers it in a line, and a question can already restrict its uploads to audio, so leaving it out would have been the odd choice rather than the cautious one.

### Testing?

`python src/manage.py test src` green (2506 tests), `ruff check src` and `manage.py check` clean.

14 new tests; 5 of them fail on `develop`:

* `questions/tests/test_integration.py`: an image answer is shown, a video answer gets a player, an audio answer gets a player, any other file stays a link, and a solution image is shown to staff;
* `questions/tests/test_views.py`: the question list shows an image solution as a thumbnail, and leaves a video solution as a link;
* `utilities/tests/test_fields.py`: `media_kind_of` names images, video and audio, says nothing about other files (a PDF, an archive, a name with no extension), and only accepts what the upload rules accept;
* `questions/tests/test_templatetags.py`: the filter reads a file field's name, and answers with `''` when no file was uploaded.

### Screenshots (if front end is affected)

The `hackerspace` deck's "Design Portfolio Submission" quest, submitted by `student1`, viewed by the deck owner. The quest asks for a photo, a video and an audio recording, so all three kinds appear in one table, with the image question also carrying a solution file:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/before_all_three_kinds.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/after_all_three_kinds.png) |

Before, five answers are five file names. After: the photo is shown (with the teacher's solution image beside it in the question column), the video has a player, the audio has a player, and every one of them is still linked by name underneath for opening or saving the original. The video and audio files are real media, played by the browser in that screenshot.

A teacher's own example gets the same treatment, so a video or audio solution is playable beside the answer it is compared with:

| Video question | Audio question |
| --- | --- |
| ![video](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/video_solution_and_answer.png) | ![audio](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/audio_solution_and_answer.png) |

Extreme shapes stay inside the cell. A 2400x300 panorama displays at 466x58, held by the width; a 400x2000 photo displays at 60x300, held by the height cap:

| Very wide | Very tall |
| --- | --- |
| ![wide](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/wide_image_answer.png) | ![tall](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/tall_image_answer.png) |

The Solution column of the same quest's Manage Questions list, where the column is too narrow for a player and only an image embeds:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/before_solution_column.png) | ![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/after_solution_column.png) |

With a video and an audio solution added, that column keeps them as named links:

![solution column](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2172/solution_column_all_kinds.png)

### Anything Else?

Two things came out of the review and are filed rather than folded in:

* #2492: Python's `mimetypes` calls a `.wav` file `audio/x-wav`, and `AUDIO_MIME_TYPES` lists only `audio/wav`, so a WAV recording is treated as a plain file both by this display and by the upload restriction on an audio question. It is the allow-list that needs the alias, not the rendering.
* #2493: whether a question should be able to ask for a specific kind of media as its own question type, rather than a File Upload question with an "allowed file type" selector. The issue lays out both shapes and the middle option; nothing in this PR depends on the answer, since the display asks the file what it is, not the question.

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Uploaded images now appear as linked images or thumbnails.
  - Video and audio uploads can be played directly in supported views.
  - Unsupported file types continue to appear as download links.
  - Staff can preview solution images.
- **Improvements**
  - Media previews are consistently displayed across answer and question-list views.
  - Preview sizing and spacing improve readability, with compact thumbnails in tables.
  - File names and fallback labels are displayed more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->