### PR TITLE
docs: say which population each open-semester roster caller means (#2434)

### DIFF
--- a/src/announcements/tasks.py
+++ b/src/announcements/tasks.py
@@ -21,11 +21,21 @@ User = get_user_model()
 
 @app.task(name='announcements.tasks.send_notifications')
 def send_notifications(user_id, announcement_id):
+    """Notify everyone taking a course that an announcement has been published.
+
+    This is the in-app half of publishing; send_announcement_emails() is the other. They
+    reach different people on purpose: a notification goes to everyone enrolled, while the
+    email adds the teachers and drops anyone who did not ask for it, has no address, or has
+    not verified the one they gave.
+
+    Args:
+        user_id (int): the staff member publishing, who the notification is sent as.
+        announcement_id (int): the Announcement being published.
+    """
     announcement = get_object_or_404(Announcement, pk=announcement_id)
     sending_user = User.objects.get(id=user_id)
     # everyone enrolled, test accounts included, so a test account sees what a student sees
-    # (issue #2434). The announcement email reaches the same people plus the teachers, and
-    # leaves out only those who never asked for it; see ProfileManager.get_mailing_list().
+    # (issue #2434)
     affected_users = CourseStudent.objects.all_users_in_open_semesters()
     notify.send(
         sending_user,

--- a/src/announcements/tasks.py
+++ b/src/announcements/tasks.py
@@ -23,6 +23,9 @@ User = get_user_model()
 def send_notifications(user_id, announcement_id):
     announcement = get_object_or_404(Announcement, pk=announcement_id)
     sending_user = User.objects.get(id=user_id)
+    # everyone enrolled, test accounts included, so a test account sees what a student sees
+    # (issue #2434). The announcement email reaches the same people plus the teachers, and
+    # leaves out only those who never asked for it; see ProfileManager.get_mailing_list().
     affected_users = CourseStudent.objects.all_users_in_open_semesters()
     notify.send(
         sending_user,

--- a/src/prerequisites/tasks.py
+++ b/src/prerequisites/tasks.py
@@ -64,6 +64,11 @@ def update_conditions_for_quest(self, quest_id, start_from_user_id):
     if quest.available_outside_course:
         users = User.objects.all()
     else:
+        # everyone enrolled, test accounts included: this cache is what the Available tab is
+        # built from, and a test account is exactly the account a teacher previews that tab
+        # through. Leaving it out would leave the teacher looking at stale availability. The
+        # badge-grant task below asks for students_only because granting is not a preview: a
+        # badge handed to a test account is a real award (issue #2434).
         users = CourseStudent.objects.all_users_in_open_semesters()
 
     users = users.order_by('id').filter(id__gte=start_from_user_id)[:settings.CELERY_TASKS_BUNCH_SIZE]
@@ -209,7 +214,8 @@ def update_quest_conditions_all_users(self, start_from_user_id):
 
     cache.set('update_conditions_all_task_waiting', True, settings.CONDITIONS_UPDATE_COUNTDOWN)
 
-    # only cycle through users currently in a course
+    # only cycle through users currently in a course, test accounts included, for the same
+    # reason update_conditions_for_quest() does (issue #2434)
     users = CourseStudent.objects.all_users_in_open_semesters()
     users = users.order_by('id').filter(id__gte=start_from_user_id)
 

--- a/src/prerequisites/tasks.py
+++ b/src/prerequisites/tasks.py
@@ -46,6 +46,11 @@ def update_conditions_for_quest(self, quest_id, start_from_user_id):
     Args:
         quest_id (int): The quest with updated prerequisites (i.e this quest is the parent_object of an updated Prereq),
         start_from_user_id (int): user_id to start with for the next bunch of calculations
+
+    Returns:
+        str: what the celery log shows at the end of the task: the quest's name once this
+        bunch is done, or why nothing was done (the quest was deleted while the task was
+        queued, or another run of it had already started).
     """
     quest = Quest.objects.filter(id=quest_id).first()
     if not quest:
@@ -205,7 +210,13 @@ def update_quest_conditions_all_users(self, start_from_user_id):
     This is done in bunches of users (CELERY_TASKS_BUNCH_SIZE), recursively.
 
     Args:
-        user_id to start with for the next bunch of calculations
+        start_from_user_id (int): the user id to start this bunch at. The recursive call
+            passes the id after the last one it handled; a fresh sweep starts at 1.
+
+    Returns:
+        str or None: the "Skipping task, already running." the celery log shows when a sweep
+        is already under way, and nothing otherwise: the work is handed to per-user tasks, so
+        there is no result to report once a bunch has been dispatched.
     """
 
     if start_from_user_id == 1 and cache.get('update_conditions_all_task_waiting'):

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -84,9 +84,14 @@ class ProfileManager(models.Manager):
         mail, usually so a teacher can see what a student receives, and a flag meaning "leave
         this out of student lists" is not a reason to ignore that.
 
+        Whichever roster they come from, everyone here has an address of their own that they
+        verified, so nothing is sent to an address nobody confirmed.
+
         :param as_emails_list: If True, return a list of emails instead of a queryset of users
         :param for_announcement_email: If True, only return users who want announcements by email
         :param for_notification_email: If True, only return users who want notifications by email
+        :returns: the matching Users, deduplicated, or their email addresses as a list of
+            strings when as_emails_list is True (which is what a send passes to bcc).
         """
 
         email_filter = models.Q()

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -61,6 +61,8 @@ class ProfileManager(models.Manager):
             QuerySet[Profile]: the profiles of active students registered in any semester
             that is open right now, across all of them when several are.
         """
+        # the roster is unfiltered because all_students() already drops staff and test
+        # accounts; asking the roster for them as well would only add a join (issue #2434)
         courses_user_list = CourseStudent.objects.all_users_in_open_semesters()
         qs = self.all_students().filter(user__in=courses_user_list, user__is_active=True)
         return qs
@@ -72,7 +74,16 @@ class ProfileManager(models.Manager):
         for_announcement_email=False,
         for_notification_email=False,
     ):
-        """
+        """The users a deck's email should go to: everyone enrolled, plus its teachers.
+
+        Whether a given account receives mail is the account's own choice, not something the
+        roster decides: `get_announcements_by_email` and `get_notifications_by_email` both
+        default to False, and only take effect once the address is verified. So the roster
+        here is deliberately unfiltered, test accounts included (issue #2434): a test account
+        whose address was verified and whose owner turned the option on has asked for this
+        mail, usually so a teacher can see what a student receives, and a flag meaning "leave
+        this out of student lists" is not a reason to ignore that.
+
         :param as_emails_list: If True, return a list of emails instead of a queryset of users
         :param for_announcement_email: If True, only return users who want announcements by email
         :param for_notification_email: If True, only return users who want notifications by email

--- a/src/profile_manager/tests/test_managers.py
+++ b/src/profile_manager/tests/test_managers.py
@@ -1,3 +1,4 @@
+from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 
 from model_bakery import baker
@@ -70,6 +71,25 @@ class ProfileManagerTest(ByteDeckTenantTestCase):
         usernames = Profile.objects.all_in_open_semesters().values_list('user__username', flat=True)
 
         self.assertIn('second_cohort', usernames)
+
+    def test_get_mailing_list__mails_an_enrolled_test_account_that_asked_for_it(self):
+        """A maintainer decision, pinned so it isn't quietly reversed (issue #2434): whether
+        an account receives deck email is the account's own choice, so a test account whose
+        address is verified and whose owner turned announcements-by-email on stays on the
+        mailing list. is_test_account keeps a row out of student lists; it is not a second,
+        silent way to switch off a preference somebody set."""
+        test_account = baker.make(User, username='test_account', email='test_account@bytedeck.com')
+        test_account.profile.is_test_account = True
+        test_account.profile.get_announcements_by_email = True
+        test_account.profile.save()
+        EmailAddress.objects.create(
+            user=test_account, email=test_account.email, verified=True, primary=True,
+        )
+        baker.make(CourseStudent, user=test_account, course=self.course, semester=self.active_semester)
+
+        emails = Profile.objects.get_mailing_list(as_emails_list=True, for_announcement_email=True)
+
+        self.assertIn(test_account.email, emails)
 
     def test_all_active__returns_active_users(self):
         """all_active() returns every active user, including staff, regardless of semester."""


### PR DESCRIPTION
### What?

**No behaviour change.** Each of the five callers of `CourseStudent.objects.all_users_in_open_semesters()` now says which population it means and why, plus one test pinning the mailing-list decision so a later change cannot quietly reverse it.

| Caller | Population | Why |
| --- | --- | --- |
| `ProfileManager.get_mailing_list()` | everyone enrolled | the per-account opt-in decides who gets mail, not the roster |
| `update_conditions_for_quest()` | everyone enrolled | the cache builds the Available tab, which a teacher previews through a test account |
| `update_quest_conditions_all_users()` | everyone enrolled | same reason |
| `grant_badge_assertions_for_badge()` | `students_only=True` (unchanged) | granting is not a preview: a badge on a test account is a real award |
| `send_notifications()` (announcements) | everyone enrolled | so a test account sees what a student sees |
| `Profile.all_in_open_semesters()` | unfiltered | `all_students()` already applies the same filter one join later |

Closes #2434

### Why?

This started as a CodeRabbit question on #2433: why does the badge-grant task filter the deck roster to students while the quest-condition cache tasks right beside it do not? Nothing in the code answered, so the asymmetry read as an oversight and became #2434, which proposed passing `students_only=True` in `get_mailing_list()` and `prerequisites/tasks.py` to make them agree.

I built that as #2479. The maintainer asked why a test account should not receive email, and the honest answer turned out to be that it should be allowed to:

* `get_announcements_by_email` and `get_notifications_by_email` both default to `False`, and only take effect once the address is verified through the allauth confirmation flow. That **is** the per-account switch for this question.
* Excluding test accounts from the mailing list would override an explicit opt-in using an unrelated flag, with nothing in the UI to explain why the mail stopped.
* None of the deck's other test-account exclusions do that. Leaving a row out of a student list, a badge-grant batch, or the billed seat count is not the same as ignoring a preference somebody set.

So #2479 is closed unmerged and the roster keeps the behaviour it had. What was worth salvaging is the documentation: the question had already been asked twice (once by a reviewer, once by an issue) and answered wrongly once, so the answer belongs next to the code rather than in a closed PR.

### How?

Comments only, plus one test.

**`src/profile_manager/models.py`** — `get_mailing_list()` gains a docstring saying the roster is deliberately unfiltered and the opt-in is what decides, so a test account whose owner turned the option on keeps receiving mail. `all_in_open_semesters()` gains a one-line note that its unfiltered roster is intentional because `all_students()` filters anyway.

**`src/prerequisites/tasks.py`** — both cache tasks say why they cover everyone enrolled, and the comment on the first one names the badge-grant task alongside and the distinction between them (preview vs award), so the asymmetry reads as deliberate from either side.

**`src/announcements/tasks.py`** — `send_notifications()` says why the in-app notification covers everyone enrolled, and points at `get_mailing_list()` for how the email's recipients are decided.

**`src/profile_manager/tests/test_managers.py`** — `test_get_mailing_list__mails_an_enrolled_test_account_that_asked_for_it()` builds an enrolled test account with a verified primary address and announcements-by-email on, and asserts it is on the list. The docstring says it is pinning a maintainer decision.

### Testing?

Full suite green: `python src/manage.py test src` (2493 tests), `ruff check src`.

The new test is only worth having if it actually catches a reversal, so I checked: reintroducing `students_only=True` on the mailing list's roster call makes it fail, and removing it again makes it pass.

```
FAIL: test_get_mailing_list__mails_an_enrolled_test_account_that_asked_for_it
Ran 5 tests in 7.986s
FAILED (failures=1)
```

### Screenshots (if front end is affected)

N/A. No front-end change, and no change to any email: the recipients and the message are exactly what they were.

### Anything Else?

The branch was rebuilt from `develop` rather than carrying #2479's history, so this PR's diff is only the surviving documentation and the one test.

If you would rather a test account never receive deck mail regardless of its opt-in, the change #2479 made is a one-liner and I can put it back; the comment at `get_mailing_list()` is where the current reasoning lives, so it would need rewriting rather than deleting.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCf7tPxvnsM34aMhk6fMHz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified notification and mailing-list eligibility, including verified email addresses, preferences, teachers, and test accounts.
  * Documented quest cache and badge eligibility behavior for users enrolled in open semesters.

* **Tests**
  * Added regression coverage confirming eligible enrolled accounts are included in announcement mailing lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->