### PR TITLE
perf: work out a student's per-course XP once when archiving (#2459)

### DIFF
--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -765,9 +765,29 @@ class CourseStudentManager(models.Manager):
             list[tuple]: (CourseStudent, xp) in registration order, empty when the student is
             in no course. A student in one course has their whole total against it.
         """
+        return self.xp_across(user, list(self.current_courses(user)), profile=profile, up_to_date=up_to_date)
+
+    def xp_across(self, user, registrations, profile=None, up_to_date=None):
+        """The same division as xp_for_registrations(), across registrations given explicitly.
+
+        Whoever already holds a student's registrations can hand them straight over rather
+        than having them read back (issue #2459): archiving a semester has all of them in
+        memory, and asking each one separately would repeat this whole calculation, which is
+        one question about the student rather than one per course.
+
+        Args:
+            user: the student whose XP is being divided.
+            registrations (list[CourseStudent]): the registrations to divide it between. They
+                should all be the student's own, and from one semester: the shared pool is
+                split by how many there are.
+            profile (Profile): as xp_for_registrations().
+            up_to_date (date): as xp_for_registrations().
+
+        Returns:
+            list[tuple]: (CourseStudent, xp) in the order given.
+        """
         profile = profile if profile is not None else user.profile
         total = profile.xp_cached if up_to_date is None else profile.xp_to_date(up_to_date)
-        registrations = list(self.current_courses(user))
         if len(registrations) <= 1:
             return [(registration, total) for registration in registrations]
 
@@ -804,27 +824,51 @@ class CourseStudentManager(models.Manager):
     def calc_semester_grades(self, semester, clamp_negative_xp=False):
         """Record every registration's final XP and deactivate it.
 
-        clamp_negative_xp: record a negative XP as zero instead of raising (used
-        by the suspension auto-close, where there is no teacher around to fix
-        the balance first).
+        The work is done a student at a time rather than a registration at a time (issue
+        #2459). Both of the things this repeats are per-student, not per-course: the
+        assigned-versus-shared split, and the XP cache the save invalidates. Asking once per
+        registration ran each of them again for every course a student holds.
+
+        Args:
+            semester: the Semester being archived.
+            clamp_negative_xp (bool): record a negative XP as zero instead of raising (used
+                by the suspension auto-close, where there is no teacher around to fix the
+                balance first).
+
+        Raises:
+            ValueError: when a student's XP is negative and clamp_negative_xp is False.
         """
-        coursestudents = self.get_queryset().get_semester(semester)
-        # atomic: a negative-XP refusal mid-loop must roll back the registrations
-        # already deactivated in this call, or they'd sit deactivated while the
-        # semester stays open (CodeRabbit find on the #1734 B2 review)
+        by_student = {}
+        for coursestudent in self.get_queryset().get_semester(semester).select_related('user__profile'):
+            by_student.setdefault(coursestudent.user, []).append(coursestudent)
+
+        # atomic: a negative-XP refusal must roll back the registrations already written in
+        # this call, or they'd sit deactivated while the semester stays open (CodeRabbit find
+        # on the #1734 B2 review)
         with transaction.atomic():
-            for coursestudent in coursestudents:
+            graded = []
+            for student, registrations in by_student.items():
                 # each registration's own XP, not a single figure reused for all of them: a
                 # student who assigned their work to one course must not have that course's
-                # total recorded against the other one too (issue #2440)
-                coursestudent.final_xp = coursestudent.xp()
-                if coursestudent.final_xp < 0:
-                    if not clamp_negative_xp:
-                        raise ValueError(f"{coursestudent.user.get_full_name()} has a negative XP. "
-                                         f"Fix it before closing the semester")
-                    coursestudent.final_xp = 0
-                coursestudent.active = False
-                coursestudent.save()
+                # total recorded against the other one too (issue #2440). Divided across the
+                # registrations being archived, which is what this semester holds, rather than
+                # across whatever the student is registered in now.
+                for coursestudent, final_xp in self.xp_across(student, registrations):
+                    if final_xp < 0:
+                        if not clamp_negative_xp:
+                            raise ValueError(f"{coursestudent.user.get_full_name()} has a negative XP. "
+                                             f"Fix it before closing the semester")
+                        final_xp = 0
+                    coursestudent.final_xp = final_xp
+                    coursestudent.active = False
+                    graded.append(coursestudent)
+
+            # written in one statement, which fires no post_save, so the XP cache each save
+            # would have invalidated is invalidated here instead: once per student, after all
+            # of their registrations are final, rather than once per registration
+            self.bulk_update(graded, ['final_xp', 'active'])
+            for student in by_student:
+                student.profile.xp_invalidate_cache()
 
     def all_for_semester(self, semester, students_only=False):
         """The registrations in one particular semester.

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -863,12 +863,18 @@ class CourseStudentManager(models.Manager):
                     coursestudent.active = False
                     graded.append(coursestudent)
 
-            # written in one statement, which fires no post_save, so the XP cache each save
-            # would have invalidated is invalidated here instead: once per student, after all
-            # of their registrations are final, rather than once per registration
+            # written in one statement, which fires no post_save. Everything those saves set
+            # off is therefore done here instead, once per student after all of their
+            # registrations are final, rather than once per registration:
+            #  - the XP cache, which coursestudent_post_save_callback invalidates;
+            #  - the available-quest cache, which prerequisites.signals queues a rebuild of,
+            #    because deactivating a registration changes what the student can see.
+            from prerequisites.tasks import update_quest_conditions_for_user  # locally: prerequisites imports this module
+
             self.bulk_update(graded, ['final_xp', 'active'])
             for student in by_student:
                 student.profile.xp_invalidate_cache()
+                update_quest_conditions_for_user.apply_async(args=[student.id], queue='default')
 
     def all_for_semester(self, semester, students_only=False):
         """The registrations in one particular semester.

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import date, datetime, timedelta
 
 from django.contrib.auth import get_user_model
@@ -13,6 +14,7 @@ from model_bakery import baker
 
 from badges.models import Badge, BadgeAssertion
 from courses.models import Block, Course, CourseStudent, ExcludedDate, Grade, MarkRange, Rank, Semester
+from courses.tests.utils import patch_registration_xp
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
 from siteconfig.models import SiteConfig
@@ -247,7 +249,7 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
         student = baker.make(User)
         registration = baker.make(CourseStudent, user=student, semester=SiteConfig.get().active_semester)
 
-        with patch('courses.models.CourseStudent.xp', return_value=-50):
+        with patch_registration_xp(-50):
             self.assertEqual(Semester.objects.complete_semester(), Semester.STUDENTS_WITH_NEGATIVE_XP)
             result = Semester.objects.complete_semester(clamp_negative_xp=True)
 
@@ -272,8 +274,7 @@ class SemesterModelManagerTest(ByteDeckTenantTestCase):
         # is called is an implementation detail this test should not depend on
         negative = students[1].coursestudent_set.get().pk
 
-        with patch('courses.models.CourseStudent.xp', autospec=True,
-                   side_effect=lambda registration, profile=None: -50 if registration.pk == negative else 10):
+        with patch_registration_xp(lambda registration: -50 if registration.pk == negative else 10):
             with self.assertRaises(ValueError):
                 CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
 
@@ -822,14 +823,9 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(course_students.count(), 2)
         self.assertQuerySetEqual(course_students, [sc1, sc2], ordered=False)
 
-    @patch('courses.models.CourseStudent.xp')
-    def test_calc_semester_grades__deactivates_and_sets_final_xp(self, registration_xp):
+    @patch_registration_xp(500)
+    def test_calc_semester_grades__deactivates_and_sets_final_xp(self, registration_split):
         """Test that method loops through all students, deactivates the student course, and sets a final_xp value"""
-        # Configured before the registrations below, not just before calc_semester_grades:
-        # saving a registration fires coursestudent_post_save_callback, which refreshes the
-        # student's cached mark through CourseStudent.xp(). A mark that is a MagicMock rather
-        # than a number is written to Profile.mark_cached, and that save raises FieldError.
-        registration_xp.return_value = 500
 
         # second student in same course as setup
         student2 = baker.make(User)
@@ -854,10 +850,45 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(course_student2.final_xp, 500)
         self.assertEqual(course_student3.final_xp, 500)
 
-    @patch('courses.models.CourseStudent.xp')
-    def test_calc_semester_grades__student_with_negative_xp(self, registration_xp):
+    def test_calc_semester_grades__divides_a_students_xp_once_however_many_courses(self):
+        """The split is one calculation about the whole student, so archiving asks for it a
+        fixed number of times per student rather than once per course they hold (issue #2459).
+        Pinned as a comparison rather than an absolute count, so the guard survives any
+        unrelated change to how many times a student's XP is worked out."""
+        three_courses = baker.make(User, username='three_courses')
+        for _ in range(3):
+            baker.make(
+                CourseStudent, user=three_courses, course=baker.make(Course),
+                semester=SiteConfig.get().active_semester,
+            )
+
+        splits = Counter()
+        divide = CourseStudent.objects.xp_across  # bound, so the patch below can delegate to it
+
+        def counting_divide(manager, user, registrations, profile=None, up_to_date=None):
+            splits[user.pk] += 1
+            return divide(user, registrations, profile=profile, up_to_date=up_to_date)
+
+        with patch('courses.models.CourseStudentManager.xp_across', autospec=True, side_effect=counting_divide):
+            CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
+
+        self.assertEqual(splits[three_courses.pk], splits[self.student.pk])
+
+    def test_xp_across__divides_between_the_registrations_it_is_given(self):
+        """The split is over the registrations handed in, not the ones the student holds in an
+        open semester, which is what lets archiving divide a closing semester's XP (#2459)."""
+        another_semester = baker.make(Semester, status=Semester.Status.ARCHIVED)
+        elsewhere = baker.make(
+            CourseStudent, user=self.student, course=baker.make(Course), semester=another_semester,
+        )
+
+        pairs = CourseStudent.objects.xp_across(self.student, [self.course_student, elsewhere])
+
+        self.assertEqual([registration for registration, _ in pairs], [self.course_student, elsewhere])
+
+    @patch_registration_xp(-10)
+    def test_calc_semester_grades__student_with_negative_xp(self, registration_split):
         """Test that an assertion error is raised when there is a student with negative xp"""
-        registration_xp.return_value = -10
         self.assertRaises(ValueError, CourseStudent.objects.calc_semester_grades,
                           Semester.objects.get_current())
 

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -874,6 +874,25 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
 
         self.assertEqual(splits[three_courses.pk], splits[self.student.pk])
 
+    def test_calc_semester_grades__queues_an_available_quest_rebuild_per_student(self):
+        """Deactivating a registration changes what a student can see, so their available-quest
+        cache has to be rebuilt. prerequisites.signals queues that off CourseStudent's post_save,
+        which the bulk write here does not fire, so archiving asks for it itself: once per
+        student, and for every student, not only the multicourse ones."""
+        three_courses = baker.make(User, username='three_courses')
+        for _ in range(3):
+            baker.make(
+                CourseStudent, user=three_courses, course=baker.make(Course),
+                semester=SiteConfig.get().active_semester,
+            )
+
+        with patch('prerequisites.tasks.update_quest_conditions_for_user.apply_async') as rebuild:
+            CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
+
+        rebuilt_for = Counter(call.kwargs['args'][0] for call in rebuild.call_args_list)
+        self.assertEqual(rebuilt_for[three_courses.pk], 1)
+        self.assertEqual(rebuilt_for[self.student.pk], 1)
+
     def test_xp_across__divides_between_the_registrations_it_is_given(self):
         """The split is over the registrations handed in, not the ones the student holds in an
         open semester, which is what lets archiving divide a closing semester's XP (#2459)."""

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -16,6 +16,7 @@ from courses.views import SemesterActivate, SemesterUpdate, SerializedRegistrati
 from quest_manager.models import Quest, QuestSubmission
 from badges.models import Badge, BadgeAssertion
 from notifications.models import Notification, notify_rank_up
+from courses.tests.utils import patch_registration_xp
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase, generate_form_data, model_to_form_data, generate_formset_data
 from siteconfig.models import SiteConfig
 from djcytoscape.models import CytoScape
@@ -1503,13 +1504,12 @@ class SemesterViewTests(ByteDeckTenantTestCase):
 
         self.assertFalse(ExcludedDate.objects.exists())
 
-    @patch('courses.models.CourseStudent.xp')
-    def test_SemesterArchive__student_with_negative_xp__view(self, registration_xp):
+    @patch_registration_xp(-10)
+    def test_SemesterArchive__student_with_negative_xp__view(self, registration_split):
         """
             Test if SemesterArchive returns a warning when there is a course student with
             a negative xp.
         """
-        registration_xp.return_value = -10
         self.client.force_login(self.test_teacher)
 
         post_data = {

--- a/src/courses/tests/utils.py
+++ b/src/courses/tests/utils.py
@@ -1,0 +1,27 @@
+"""Helpers shared by the courses tests."""
+from unittest.mock import patch
+
+
+def patch_registration_xp(xp):
+    """Patch the per-course XP split so a test can say what each registration is worth.
+
+    Archiving a semester works a student at a time and asks
+    `CourseStudentManager.xp_across()` for all of one student's registrations at once (issue
+    #2459), so that is the seam a test controls. Patching `CourseStudent.xp()` instead would
+    miss it: nothing on the archive path goes through the per-registration method.
+
+    The patch has to be in place before the registrations are saved, not just before
+    archiving: saving one refreshes the student's cached mark, which asks for its XP, and a
+    mark that is a MagicMock rather than a number raises FieldError on the profile save.
+
+    Args:
+        xp: the XP every registration is worth, or a callable taking a CourseStudent and
+            returning its XP, for a test that needs them to differ.
+
+    Returns:
+        The patcher, for use as a decorator or a context manager.
+    """
+    def split(manager, user, registrations, profile=None, up_to_date=None):
+        return [(registration, xp(registration) if callable(xp) else xp) for registration in registrations]
+
+    return patch('courses.models.CourseStudentManager.xp_across', autospec=True, side_effect=split)


### PR DESCRIPTION
### What?

Archiving a semester now does its work a student at a time instead of a registration at a time. Same recorded figures, **less than half the queries**.

| | queries | query time (3 runs) |
| --- | --- | --- |
| before | 451 | 0.10s / 0.06s / 0.11s |
| after | **208** | **0.06s / 0.05s / 0.05s** |

Part of #2459. The chart half of that issue is deliberately **not** here, so the issue stays open. See *Anything Else?* for why it needs a different fix.

### Why?

`calc_semester_grades()` asked each registration for its own XP, and `CourseStudent.xp()` answers that by dividing the student's whole total across all of their courses (#2440). Two things therefore repeated for every course a student holds, and **both are questions about the student, not about one of their courses**:

* the assigned-versus-shared split, which runs `QuestSubmission.objects.xp_by_course()`, `BadgeAssertion.objects.xp_by_course()` and `calculate_xp()`;
* the caches each `save()` invalidated, through `coursestudent_post_save_callback` (which recomputes the student's total *and* their mark, and the mark asks for the division again) and through `prerequisites.signals` (which queues an available-quest rebuild).

A student in three courses paid for all of that three times. It scales with registrations, so it grows with the roster, on an operation a teacher waits on at the end of every term.

### How?

**`CourseStudentManager.xp_across(user, registrations, profile=None, up_to_date=None)`** is new: the same division as `xp_for_registrations()`, but over registrations handed in rather than read back. `xp_for_registrations()` becomes a thin wrapper over it with the student's current registrations, so nothing else changes.

**`calc_semester_grades()`** groups the semester's registrations by student, calls `xp_across()` once per student, then writes them all with a single `bulk_update()`. `bulk_update()` fires no `post_save`, so **everything those saves set off is done explicitly instead**, once per student after all of their registrations are final:

* `Profile.xp_invalidate_cache()`;
* `update_quest_conditions_for_user`, because deactivating a registration takes the student out of a course, and out of a course only the quests marked available outside one are visible. (Missed on the first pass and caught in review; see the thread on `src/courses/models.py`.)

Two things fall out of the restructure, both improvements:

* The division is now over **the registrations being archived**, not whatever `current_courses()` returns. Those are the same set today, but the recorded figures no longer depend on when the semester's status is flipped relative to the grading.
* The negative-XP refusal happens **before anything is written**, rather than relying on the surrounding transaction to roll back registrations already saved.

### Testing?

Full suite green against current `develop`: `python src/manage.py test src` (2500 tests), `ruff check src`, `makemigrations --check`.

Two guards, both checked to actually fail without their fix rather than assumed:

* `test_calc_semester_grades__divides_a_students_xp_once_however_many_courses` asserts a three-course student costs the *same* number of splits as a one-course student. Written as a comparison rather than an absolute query count on purpose, so it survives unrelated changes to how many times XP gets worked out. Fails `4 != 2` if the work goes back per-registration.
* `test_calc_semester_grades__queues_an_available_quest_rebuild_per_student` asserts every student gets exactly one rebuild queued. Fails `0 != 1` without the explicit dispatch.

Plus `test_xp_across__divides_between_the_registrations_it_is_given`, covering the new method's own contract.

**Five existing tests had to move seam.** They patched `courses.models.CourseStudent.xp` to say what a registration was worth, and the archive path no longer goes through it. They now patch `CourseStudentManager.xp_across` via a small `src/courses/tests/utils.py` helper, `patch_registration_xp()`, whose docstring records why that is the seam and why the patch has to be in place before the registrations are saved.

**Measurements** are from a seeded `hackerspace` deck (21 registrations, 13 students, 6 of them multicourse), archiving inside a rolled-back transaction, counting real queries with django-tenants' `SET search_path` statements excluded. Each figure is three runs on an otherwise idle machine: an earlier draft of this description quoted a single cold run as the baseline and badly overstated the time saved. **The query count is the meaningful number**, since that is what grows with the roster; on a deck this size the wall time is noise either way.

Where the win comes from, by step:

| | queries |
| --- | --- |
| before | 451 |
| grouping by student alone | 356 |
| grouping + one bulk_update | 208 |

### Screenshots (if front end is affected)

N/A. No front-end change, and no change to any recorded figure: this is the same arithmetic asked for fewer times.

### Anything Else?

**Why the chart half of #2459 is not here.** The issue proposed one fix for both call sites, "compute the maps once and hand them round". That works for archiving but not for `courses:ajax_progress_chart`, which plots a point per class day:

* `xp_by_course(user, up_to_date=D)` genuinely differs for every `D`, so there is no single map to reuse across the series.
* It is not a prefix sum either, because a quest's `max_xp` cap applies to its total *as of that date*, so every point has to re-apply the cap.

Doing it properly means pulling the capping-and-splitting rule out of `QuestSubmission.objects.xp_by_course()` into a helper over `(quest, max_xp, course) -> xp_sum` rows, so the existing aggregate and a new series builder share one implementation of the rule rather than it being written twice, then walking the dates in order off one submissions query plus one assertions query. That is its own reviewable change, so #2459 stays open with the analysis and the current cost (143 queries for an 11-day semester) recorded on it.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)