### PR TITLE
fix: guard the export endpoints with the rule that offers them (#2368)

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -4,7 +4,7 @@ from datetime import date
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError, connection
 from django.http import Http404
 from django.test import RequestFactory
@@ -13,7 +13,7 @@ from django_tenants.utils import get_public_schema_name, schema_exists
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.utils import get_library_schema_name, library_schema_context
 from library.models import ContentOrigin
-from library.views import LibraryQuestListView, shared_library_enabled_view, viewer_is_library_staff
+from library.views import ExportQuestView, LibraryQuestListView, shared_library_enabled_view, viewer_is_library_staff
 from library.importer import import_quest_to, import_campaign_to
 from library.transfer import LibraryTransferError
 from library.exporter import (
@@ -2812,3 +2812,130 @@ class LibraryImportCampaignPreviewTests(LibraryTenantTestCaseMixin):
 
         self.assertContains(response, "Previewed Quest")
         self.assertContains(response, "Published quests in this campaign: 1")
+
+
+class LibraryExportPermissionTests(LibraryTenantTestCaseMixin):
+    """The export endpoints and the export buttons answer to one rule (#2368).
+
+    `SiteConfig.can_user_export_to_library` decides whether the Share buttons render, and
+    the export views' permission check decides whether the endpoints behind them run. Any
+    difference between the two is a button that leads to a refusal, or worse, an endpoint
+    that allows what no button offers.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A deck owner and an ordinary teacher, the two sides of `allow_staff_export`."""
+        cls.owner = User.objects.create_user('export_owner', is_staff=True)
+        cls.teacher = User.objects.create_user('export_teacher', is_staff=True)
+
+    def setUp(self):
+        """Own the deck as `owner`, with staff sharing off and the Library enabled."""
+        super().setUp()
+        config = SiteConfig.get()
+        config.deck_owner = self.owner
+        config.allow_staff_export = False
+        config.enable_shared_library = True
+        config.save()
+
+    def endpoint_allows(self, user):
+        """Whether the export views would let this user through, on the current schema.
+
+        Args:
+            user (User): the user making the request.
+
+        Returns:
+            bool: True when the permission check passes, False when it raises.
+        """
+        request = RequestFactory().post('/')
+        request.user = user
+
+        try:
+            ExportQuestView()._require_export_permission(request)
+        except PermissionDenied:
+            return False
+
+        return True
+
+    def button_offers(self, user):
+        """Whether the Share buttons would be offered to this user, on the current schema.
+
+        Args:
+            user (User): the user viewing the page.
+
+        Returns:
+            bool: what the button gate decides.
+        """
+        return SiteConfig.get().can_user_export_to_library(user)
+
+    def assertEndpointAgreesWithButton(self, user):
+        """Assert the endpoint and the button reach the same verdict for a user.
+
+        Args:
+            user (User): the user to check both gates for.
+
+        Raises:
+            AssertionError: if one gate would allow what the other refuses.
+        """
+        offered = self.button_offers(user)
+        self.assertEqual(
+            self.endpoint_allows(user),
+            offered,
+            f"the endpoint and the button disagree for {user}: button offers={offered}",
+        )
+
+    def test_ExportPermissionMixin__refuses_an_export_from_the_library_deck(self):
+        """The Library does not share into itself, whoever asks.
+
+        Content reaching the Library is a copy from somewhere else, so an export run from
+        the Library deck has no meaning: it would be copying a quest over itself.
+
+        The Library deck's own config is opened up first, so being on the Library schema is
+        the only thing left that can refuse. Without that the check would pass on the
+        Library deck simply not recognising this user, which is true of every user and would
+        hide whether the schema rule is applied at all.
+
+        Its `deck_owner` is left alone: users are per-schema, so the Library's config cannot
+        point at a user from this deck. Staff sharing covers the same ground here, since the
+        user is staff.
+        """
+        with library_schema_context():
+            library_config = SiteConfig.get()
+            library_config.allow_staff_export = True
+            library_config.enable_shared_library = True
+            library_config.save()
+
+            self.assertFalse(self.endpoint_allows(self.owner))
+            self.assertEndpointAgreesWithButton(self.owner)
+
+    def test_ExportPermissionMixin__lets_the_deck_owner_export(self):
+        """The deck owner can always share from their own deck."""
+        self.assertTrue(self.endpoint_allows(self.owner))
+        self.assertEndpointAgreesWithButton(self.owner)
+
+    def test_ExportPermissionMixin__refuses_other_staff_while_staff_sharing_is_off(self):
+        """With `allow_staff_export` off, sharing is the deck owner's decision alone."""
+        self.assertFalse(self.endpoint_allows(self.teacher))
+        self.assertEndpointAgreesWithButton(self.teacher)
+
+    def test_ExportPermissionMixin__lets_other_staff_export_once_staff_sharing_is_on(self):
+        """With `allow_staff_export` on, any teacher on the deck can share."""
+        config = SiteConfig.get()
+        config.allow_staff_export = True
+        config.save()
+
+        self.assertTrue(self.endpoint_allows(self.teacher))
+        self.assertEndpointAgreesWithButton(self.teacher)
+
+    def test_ExportPermissionMixin__refuses_everyone_when_the_shared_library_is_off(self):
+        """A deck that opted out of the Library cannot share to it.
+
+        The view decorator 404s such a request first, so this is the second line rather
+        than the one users meet; it matters because it is what keeps the two gates equal.
+        """
+        config = SiteConfig.get()
+        config.enable_shared_library = False
+        config.save()
+
+        self.assertFalse(self.endpoint_allows(self.owner))
+        self.assertEndpointAgreesWithButton(self.owner)

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -799,19 +799,29 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
 
 
 class ExportPermissionMixin:
-    def _require_export_permission(self, request):
-        """
-        Ensure the requesting user has permission to perform an export.
+    """Guards the export endpoints with the same rule that decides whether to offer them.
 
-        A user is allowed to export if either:
-        - They are the configured deck owner, or
-        - `allow_staff_export` is enabled in the site configuration and the user is staff.
+    `SiteConfig.can_user_export_to_library` is that rule, and it is asked here rather than
+    restated, so the endpoint and the Share buttons cannot drift apart. A second copy of the
+    rule is worse than a long one: whichever clause it is missing becomes an endpoint that
+    allows what no button offers, and nothing points at the difference (#2368).
+    """
+
+    def _require_export_permission(self, request):
+        """Refuse the request unless this user may share from this deck.
+
+        Args:
+            request (HttpRequest): the current request, for the user and its deck.
+
+        Returns:
+            None. Returns normally when the export may proceed.
 
         Raises:
-            PermissionDenied: If the requesting user does not have export permission.
+            PermissionDenied: if the user may not export. The message names the usual
+                reason, which is a teacher sharing on a deck where the owner has not
+                turned staff sharing on.
         """
-        config = SiteConfig.get()
-        if not (config.allow_staff_export or request.user == config.deck_owner):
+        if not SiteConfig.get().can_user_export_to_library(request.user):
             raise PermissionDenied("Only the deck owner can export unless allow_staff_export is enabled.")
 
 


### PR DESCRIPTION
### What?

"May this user share to the Library" is now decided in one place. The export endpoints ask `SiteConfig.can_user_export_to_library`, the same rule that decides whether the Share buttons render, instead of restating a subset of it.

Closes #2368.

### Why?

There were two rules. `SiteConfig.can_user_export_to_library` gated the buttons; `ExportPermissionMixin` gated the endpoints behind them with its own three-line version:

```python
config = SiteConfig.get()
if not (config.allow_staff_export or request.user == config.deck_owner):
    raise PermissionDenied(...)
```

Two clauses were missing from that copy. It did not refuse an export run **from the Library deck itself**, which the buttons have refused since #1888, and it did not check the Shared Library flag. It also allowed *anyone* when `allow_staff_export` was on, having dropped the `is_staff` half of that condition; `staff_member_required` on the view covers that in practice, which is why it never showed.

**The Library-deck case is reachable today**, not theoretical. On a dev Library deck with staff sharing on, a Library admin opens the "Export Quest to Library" page for a quest that is already in the Library by definition, and the only thing that stops the push is the unrelated "already exists in the shared library" guard further down, which reports the wrong reason. The issue calls that a latent bug held shut by an accident, and that is exactly what it looked like when I went to reproduce it.

### How?

The mixin asks the rule rather than restating it, and its docstring says why that matters: a second copy is worse than a long one, because whichever clause it lacks becomes an endpoint that allows what no button offers, with nothing pointing at the difference.

The `PermissionDenied` message is unchanged. It names the common case (a teacher on a deck where the owner has not enabled staff sharing) rather than every clause, and the docstring says so.

**The MRO half of the issue is already fixed.** #2368 also asks for `(ExportPermissionMixin, View)` rather than `(View, ExportPermissionMixin)`; both export views already read `(NonPublicOnlyViewMixin, ExportPermissionMixin, View)`, so the mixin precedes the base class and there is nothing to change.

### Testing?

`LibraryExportPermissionTests` asserts the two gates **agree**, which is the property that was broken, rather than only that each behaves. Every case checks the endpoint's verdict against the button's: the deck owner, another teacher with staff sharing off and on, a deck with the Shared Library off, and a request from the Library deck.

Getting the Library-deck test to fail for the right reason took a second pass worth mentioning: the obvious version passed against the unfixed code, because on the Library deck the check simply did not recognise the user, which is true of every user and says nothing about whether the schema rule is applied. The test now opens up the Library deck's own config first, so being on the Library schema is the only thing left that can refuse. (Its `deck_owner` is deliberately left alone: users are per-schema, so the Library's config cannot point at a user from another deck.)

```
src/library                                   181 tests   OK
full suite (python src/manage.py test src)   2502 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

From the running dev stack, signed in as staff **on the Library deck** (`library.localhost`) with `allow_staff_export` on, opening the export page for a quest that is in the Library.

**Before:** the page opens (HTTP 200) and gives the accidental reason.

![Before: the Export Quest page, saying the quest already exists in the shared library](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2368/export-gate-before.png)

**After:** the endpoint refuses (HTTP 403), because the Library does not share into itself.

![After: a 403 Permission Denied page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2368/export-gate-after.png)

### Anything Else?

**Worth being straight about the trade-off in those screenshots.** For a Library admin the message quality goes *down*: a page explaining something (even the wrong something) becomes a bare 403. What improves is that the refusal is now the real reason and comes from the same rule that hides the button, so the two cannot disagree. The bare-403 problem is #2373, which covers turning these `PermissionDenied`s into an explanation on a page the user can act from; this PR deliberately does not widen into it, and #2373 will improve this screen along with the others.

**Nobody reaches that screen by clicking.** The buttons have never been offered on the Library deck, so getting there means typing the URL or following a stale link. That is the case a second, laxer copy of a permission rule exists to catch, which is the argument for not having one.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export access now consistently follows Library sharing and permission settings.
  * Exporting from the Library deck is denied when appropriate.
  * Staff export restrictions and disabled Shared Library settings are correctly enforced.
  * Export authorization now matches the visibility of the Share button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->