### PR TITLE
fix: explain an already-imported or already-shared conflict (#2373)

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -3062,3 +3062,40 @@ class LibraryConflictMessageTests(LibraryTenantTestCaseMixin):
         self.assertEqual(
             Quest.objects.all_including_archived().filter(import_id=self.library_quest.import_id).count(), 1,
         )
+
+    def test_ImportQuestView__escapes_markup_in_a_quest_name(self):
+        """A quest name carrying markup reaches the page as text, not as markup.
+
+        Every message renders through `|safe` (`templates/messages-snippet.html`), so a
+        name interpolated into one goes to the browser as HTML. Quest names are written by
+        staff, which narrows who could do it, not what happens if they do.
+        """
+        self.local_copy_of(Quest, self.library_quest, name="<script>alert(1)</script>")
+
+        response = self.client.post(
+            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
+        )
+
+        self.assertNotContains(response, "<script>alert(1)</script>", html=False)
+        self.assertContains(response, "&lt;script&gt;alert(1)&lt;/script&gt;")
+
+    def test_ExportQuestView__escapes_markup_in_a_quest_name(self):
+        """The share-side message escapes a name carrying markup too."""
+        local = self.local_copy_of(Quest, self.library_quest, name="<script>alert(2)</script>")
+
+        response = self.client.post(
+            reverse('library:export_quest', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertNotContains(response, "<script>alert(2)</script>", html=False)
+        self.assertContains(response, "&lt;script&gt;alert(2)&lt;/script&gt;")
+
+    def test_ImportQuestView__keeps_the_link_to_the_local_copy_live(self):
+        """Escaping the name must not also escape the link the message provides."""
+        local = self.local_copy_of(Quest, self.library_quest, name="Our Own Copy")
+
+        response = self.client.post(
+            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
+        )
+
+        self.assertContains(response, f'<a href="{local.get_absolute_url()}">Our Own Copy</a>')

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -293,8 +293,12 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
 
         self.assertIn(expected_link, message)
 
-    def test_import_quest__post_when_quest_exists_locally_is_denied(self):
-        """POSTing to import a quest whose import_id already exists on the local deck is blocked (403), not duplicated."""
+    def test_import_quest__post_when_quest_exists_locally_is_refused(self):
+        """POSTing to import a quest whose import_id already exists on the local deck imports nothing.
+
+        The refusal is a redirect carrying an explanation rather than a 403, since the deck
+        already having the quest is a conflict and not a permission problem (#2373).
+        """
         self.client.force_login(self.test_teacher)
 
         local_quest = baker.make(Quest)
@@ -304,8 +308,8 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         url = reverse('library:import_quest', args=[library_quest.import_id])
         response = self.client.post(url)
 
-        self.assertEqual(response.status_code, 403)
-        # the local quest was not duplicated by the blocked import
+        self.assertRedirects(response, reverse('library:quest_list'))
+        # the local quest was not duplicated by the refused import
         self.assertEqual(Quest.objects.all_including_archived().filter(import_id=local_quest.import_id).count(), 1)
 
     def test_quest_library_list__shows_correct_badge_count(self):
@@ -507,9 +511,11 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
             f"Expected a pending-review message, got: {sharer_messages}",
         )
 
-    def test_export_post__denied_if_quest_already_exists_in_library(self):
-        """
-        Test that a POST request to export is denied with 403 if the quest already exists in the library.
+    def test_export_post__refused_if_quest_already_exists_in_library(self):
+        """A POST to export a quest already in the Library is refused with an explanation.
+
+        A redirect rather than a 403: the Library having it already is a conflict, not
+        something the sharer lacks permission for (#2373).
         """
         self.config.allow_staff_export = True
         self.config.full_clean()
@@ -520,7 +526,7 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         url = reverse("library:export_quest", kwargs={"quest_import_id": str(self.shared_quest.import_id)})
         response = self.client.post(url, data=AGREED_LICENCE)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, reverse('quests:quests'))
 
 
 class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
@@ -600,8 +606,12 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         response = self.client.get(import_url)
         self.assertContains(response, 'Your deck already contains a campaign with a matching name.')
 
-    def test_import_campaign__post_when_campaign_exists_locally_is_denied(self):
-        """POSTing to import a campaign whose import_id already exists on the local deck is blocked (403), not duplicated."""
+    def test_import_campaign__post_when_campaign_exists_locally_is_refused(self):
+        """POSTing to import a campaign whose import_id already exists on the local deck imports nothing.
+
+        The refusal is a redirect carrying an explanation rather than a 403, since the deck
+        already having the campaign is a conflict and not a permission problem (#2373).
+        """
         self.client.force_login(self.test_teacher)
 
         with library_schema_context():
@@ -612,7 +622,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         import_url = reverse('library:import_category', args=[library_category.import_id])
         response = self.client.post(import_url)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, reverse('library:category_list'))
         self.assertEqual(Category.objects.filter(import_id=library_category.import_id).count(), 1)
 
     def test_category_detail__with_no_displayed_quests_has_empty_quest_info(self):
@@ -986,10 +996,11 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         response = self.client.get(url)
         self.assertContains(response, "A campaign with the same import ID already exists in the shared library")
 
-    def test_export_post__denied_if_campaign_exists(self):
-        """
-        Ensure that attempting to POST (perform export) for a campaign that already
-        exists in the library schema is forbidden and returns HTTP 403.
+    def test_export_post__refused_if_campaign_exists(self):
+        """A POST to export a campaign already in the Library is refused with an explanation.
+
+        A redirect rather than a 403: the Library having it already is a conflict, not
+        something the sharer lacks permission for (#2373).
         """
         self.config.allow_staff_export = True
         self.config.full_clean()
@@ -998,7 +1009,7 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
 
         url = reverse('library:export_category', kwargs={'campaign_import_id': str(self.shared_category.import_id)})
         response = self.client.post(url, data=AGREED_LICENCE)
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, reverse('quests:categories'))
 
     def test_export_get__disables_button_if_no_quests(self):
         """
@@ -2939,3 +2950,115 @@ class LibraryExportPermissionTests(LibraryTenantTestCaseMixin):
 
         self.assertFalse(self.endpoint_allows(self.owner))
         self.assertEndpointAgreesWithButton(self.owner)
+
+
+class LibraryConflictMessageTests(LibraryTenantTestCaseMixin):
+    """Content that is already on the other side is a conflict, not a permission problem.
+
+    The confirmation pages disable the button in these cases, so the guards behind them
+    only fire when the button was not what was clicked: a stale tab, the back button, a
+    resubmitted form, or two teachers working at once. Meeting a bare 403 there says the
+    user did something forbidden, when what happened is that somebody got there first
+    (#2373).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Publish a quest and a campaign in the Library, and a staff user to move them."""
+        with library_schema_context():
+            cls.library_campaign = baker.make(Category, title="Contested Campaign", published=True)
+            cls.library_quest = baker.make(
+                Quest, name="Contested Quest", campaign=cls.library_campaign, published=True,
+            )
+
+        cls.test_teacher = User.objects.create_user('conflict_teacher', is_staff=True)
+
+    def setUp(self):
+        """Sign the teacher in and let them share, so only the conflict guards can refuse."""
+        super().setUp()
+        config = SiteConfig.get()
+        config.allow_staff_export = True
+        config.save()
+        self.client.force_login(self.test_teacher)
+
+    def local_copy_of(self, model, obj, **kwargs):
+        """Give this deck its own copy of a Library object, under the same import_id.
+
+        Args:
+            model (type[Model]): Quest or Category.
+            obj (Model): the Library object to mirror.
+            **kwargs: extra field values for the local copy.
+
+        Returns:
+            Model: the local copy.
+        """
+        return baker.make(model, import_id=obj.import_id, **kwargs)
+
+    def test_ImportQuestView__explains_that_the_deck_already_has_the_quest(self):
+        """Re-importing a quest this deck already holds explains itself instead of 403ing."""
+        local = self.local_copy_of(Quest, self.library_quest, name="Our Own Copy")
+
+        response = self.client.post(
+            reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("Our Own Copy" in text for text in self._message_texts(response)),
+            f"expected the local quest to be named, got {self._message_texts(response)}",
+        )
+        self.assertContains(response, local.get_absolute_url())
+
+    def test_ImportCampaignView__explains_that_the_deck_already_has_the_campaign(self):
+        """Re-importing a campaign this deck already holds explains itself instead of 403ing."""
+        local = self.local_copy_of(Category, self.library_campaign, title="Our Own Campaign")
+
+        response = self.client.post(
+            reverse('library:import_category', args=[self.library_campaign.import_id]), follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("Our Own Campaign" in text for text in self._message_texts(response)),
+            f"expected the local campaign to be named, got {self._message_texts(response)}",
+        )
+        self.assertContains(response, local.get_absolute_url())
+
+    def test_ExportQuestView__explains_that_the_quest_is_already_in_the_library(self):
+        """Re-sharing a quest already in the Library explains itself instead of 403ing."""
+        local = self.local_copy_of(Quest, self.library_quest, name="Already Shared Quest")
+
+        response = self.client.post(
+            reverse('library:export_quest', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("Already Shared Quest" in text for text in self._message_texts(response)),
+            f"expected the quest to be named, got {self._message_texts(response)}",
+        )
+
+    def test_ExportCampaignView__explains_that_the_campaign_is_already_in_the_library(self):
+        """Re-sharing a campaign already in the Library explains itself instead of 403ing."""
+        local = self.local_copy_of(Category, self.library_campaign, title="Already Shared Campaign")
+        baker.make(Quest, campaign=local, published=True)
+
+        response = self.client.post(
+            reverse('library:export_category', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("Already Shared Campaign" in text for text in self._message_texts(response)),
+            f"expected the campaign to be named, got {self._message_texts(response)}",
+        )
+
+    def test_ImportQuestView__adds_nothing_when_the_deck_already_has_the_quest(self):
+        """The guard still holds: explaining the conflict must not also perform the import."""
+        self.local_copy_of(Quest, self.library_quest, name="Our Own Copy")
+
+        self.client.post(reverse('library:import_quest', args=[self.library_quest.import_id]), follow=True)
+
+        self.assertEqual(
+            Quest.objects.all_including_archived().filter(import_id=self.library_quest.import_id).count(), 1,
+        )

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.html import format_html
 from django.views import View
 from django.views.generic import TemplateView
 from django.contrib.auth import get_user_model
@@ -182,12 +183,17 @@ def redirect_already_imported(request, local_object, content_type, redirect_to):
     Returns:
         HttpResponseRedirect: a redirect carrying the warning message.
     """
-    link = f'<a href="{local_object.get_absolute_url()}">{local_object.name}</a>'
+    # format_html, not an f-string: every message is rendered through `|safe`
+    # (`templates/messages-snippet.html`), so a name carrying markup would reach the page
+    # as markup. The link below is ours and stays live; the name and URL are escaped.
     messages.warning(
         request,
-        f"Your deck already has this {content_type}: {link}. Nothing was imported, because "
-        f"replacing a {content_type} you already have is not supported yet. Delete your copy "
-        "first if you want the Library's version instead."
+        format_html(
+            'Your deck already has this {}: <a href="{}">{}</a>. Nothing was imported, '
+            'because replacing a {} you already have is not supported yet. Delete your '
+            "copy first if you want the Library's version instead.",
+            content_type, local_object.get_absolute_url(), local_object.name, content_type,
+        )
     )
     return redirect(redirect_to)
 
@@ -211,11 +217,14 @@ def redirect_already_shared(request, local_object, content_type, redirect_to):
     Returns:
         HttpResponseRedirect: a redirect carrying the warning message.
     """
+    # format_html for the same reason as `redirect_already_imported`: messages render safe.
     messages.warning(
         request,
-        f"'{local_object.name}' is already in the Library, so it was not shared again. "
-        f"Sharing an updated version of a {content_type} that is already there is not "
-        "supported yet."
+        format_html(
+            "'{}' is already in the Library, so it was not shared again. Sharing an "
+            "updated version of a {} that is already there is not supported yet.",
+            local_object.name, content_type,
+        )
     )
     return redirect(redirect_to)
 

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -160,6 +160,66 @@ def redirect_failed_import(request, error, redirect_to):
     return redirect(redirect_to)
 
 
+def redirect_already_imported(request, local_object, content_type, redirect_to):
+    """Send the user back, explaining that this deck already has the content.
+
+    Content is matched across decks by `import_id`, so a deck that already holds this
+    content holds *this* content, not something like it. Re-importing is refused because
+    overwriting a deck's own copy is not supported yet (#2376), and the confirmation page
+    says so and disables its button.
+
+    That makes this the case where the button was not what was clicked: a stale tab, the
+    back button, a resubmitted form, or two teachers importing at once. Meeting a bare 403
+    there reads as "you are not allowed to do that", when what happened is that the deck
+    already has it, so the answer names the local copy and links to it (#2373).
+
+    Args:
+        request (HttpRequest): the current request, for the message framework.
+        local_object (Quest | Category): this deck's copy, which the message links to.
+        content_type (str): "quest" or "campaign", used in the message.
+        redirect_to (str): the URL name to redirect to.
+
+    Returns:
+        HttpResponseRedirect: a redirect carrying the warning message.
+    """
+    link = f'<a href="{local_object.get_absolute_url()}">{local_object.name}</a>'
+    messages.warning(
+        request,
+        f"Your deck already has this {content_type}: {link}. Nothing was imported, because "
+        f"replacing a {content_type} you already have is not supported yet. Delete your copy "
+        "first if you want the Library's version instead."
+    )
+    return redirect(redirect_to)
+
+
+def redirect_already_shared(request, local_object, content_type, redirect_to):
+    """Send the user back, explaining that the Library already has this content.
+
+    The counterpart to `redirect_already_imported`, for a push that would land on a copy
+    already in the Library. Pushing again is refused for the same reason in reverse:
+    updating what is already there is not supported yet (#2376).
+
+    The message names the content but does not link to the Library's copy, because a
+    teacher cannot open another deck: the link would be a dead end.
+
+    Args:
+        request (HttpRequest): the current request, for the message framework.
+        local_object (Quest | Category): the content that was being shared.
+        content_type (str): "quest" or "campaign", used in the message.
+        redirect_to (str): the URL name to redirect to.
+
+    Returns:
+        HttpResponseRedirect: a redirect carrying the warning message.
+    """
+    messages.warning(
+        request,
+        f"'{local_object.name}' is already in the Library, so it was not shared again. "
+        f"Sharing an updated version of a {content_type} that is already there is not "
+        "supported yet."
+    )
+    return redirect(redirect_to)
+
+
 def tell_importer_about_renamed_quests(request, renamed_quests):
     """Tell the importing teacher which arriving quests were given a name of their own.
 
@@ -630,15 +690,17 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
         Returns:
             HttpResponseRedirect: Redirects to the draft quests view on success.
 
-        Raises:
-            PermissionDenied: If a quest with the same import ID already exists locally.
+            HttpResponseRedirect: back to the Library with an explanation when this deck
+                already has the quest.
         """
         # Set the local schema as dest_schema for later use
         dest_schema = connection.schema_name
 
-        # Block import if the quest already exists locally (shouldn't happen because import button would be disabled)
-        if Quest.objects.all_including_archived().filter(import_id=quest_import_id).exists():
-            raise PermissionDenied(f'Quest with import_id {quest_import_id} already exists in the current deck.')
+        # The real check behind the confirmation page's disabled button, which a stale tab
+        # or a resubmitted form gets past (#2373).
+        local_quest = Quest.objects.all_including_archived().filter(import_id=quest_import_id).first()
+        if local_quest:
+            return redirect_already_imported(request, local_quest, 'quest', 'library:quest_list')
 
         with library_schema_context():
             quest = get_published_library_object(Quest, quest_import_id)
@@ -748,16 +810,17 @@ class ImportCampaignView(NonPublicOnlyViewMixin, View):
         Returns:
             HttpResponseRedirect: Redirects to the inactive campaigns view after import.
 
-        Raises:
-            PermissionDenied: If a campaign with the same import ID already exists locally.
+            HttpResponseRedirect: back to the Library with an explanation when this deck
+                already has the campaign.
         """
         # Set the local schema as dest_schema for later use
         dest_schema = connection.schema_name
 
-        # Block import if campaign already exists locally (shouldn't happen because import button would be disabled)
-        local_category_qs = Category.objects.filter(import_id=campaign_import_id)
-        if local_category_qs.exists():
-            raise PermissionDenied(f'Campaign with import ID {campaign_import_id} already exists in the current deck.')
+        # The real check behind the confirmation page's disabled button, which a stale tab
+        # or a resubmitted form gets past (#2373).
+        local_category = Category.objects.filter(import_id=campaign_import_id).first()
+        if local_category:
+            return redirect_already_imported(request, local_category, 'campaign', 'library:category_list')
 
         with library_schema_context():
             category = get_published_library_object(Category, campaign_import_id)
@@ -876,8 +939,8 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         Returns:
             HttpResponseRedirect: Redirect to the main quests list after successful export.
 
-        Raises:
-            PermissionDenied: If a quest with the same import ID already exists in the library.
+            HttpResponseRedirect: back to the deck's quests with an explanation when the
+                Library already has the quest.
         """
         self._require_export_permission(request)
 
@@ -901,8 +964,10 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         source_deck_url = request.tenant.get_root_url()
 
         with library_schema_context():
-            if Quest.objects.all_including_archived().filter(import_id=quest.import_id).exists():
-                raise PermissionDenied(f"A quest with import_id {quest.import_id} already exists in the shared library.")
+            already_shared = Quest.objects.all_including_archived().filter(import_id=quest.import_id).exists()
+
+        if already_shared:
+            return redirect_already_shared(request, quest, 'quest', 'quests:quests')
 
         # Perform export
         shared = export_quest_to_library(source_schema=source_schema, quest_import_id=quest.import_id)
@@ -1024,8 +1089,8 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         Returns:
             HttpResponseRedirect: Redirect to the quests categories list on success.
 
-        Raises:
-            PermissionDenied: If a campaign with the same import ID already exists in the shared library.
+            HttpResponseRedirect: back to the deck's campaigns with an explanation when the
+                Library already has the campaign.
         """
         self._require_export_permission(request)
 
@@ -1043,11 +1108,10 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         source_deck_url = request.tenant.get_root_url()
 
         with library_schema_context():
-            # Block if campaign already exists in library
-            if Category.objects.filter(import_id=campaign.import_id).exists():
-                raise PermissionDenied(
-                    f"A campaign with import_id {campaign.import_id} already exists in the shared library."
-                )
+            already_shared = Category.objects.filter(import_id=campaign.import_id).exists()
+
+        if already_shared:
+            return redirect_already_shared(request, campaign, 'campaign', 'quests:categories')
 
         # Export campaign and quests
         shared = export_campaign_and_copy_quests(source_schema=source_schema, campaign_import_id=campaign.import_id)


### PR DESCRIPTION
### What?

Trying to import content this deck already has, or share content the Library already has, now redirects with an explanation instead of showing a bare 403 page.

Closes #2373.

### Why?

Four guards raised `PermissionDenied` for what is a **conflict**, not an authorization failure:

* importing a quest, or a campaign, this deck already holds
* sharing a quest, or a campaign, the Library already has

None of those means the user lacks permission, and the 403 page they got says nothing about what happened or what to do next: *"You may have been logged out, or you are trying to access a page that you do not have sufficient permissions to view."*

The code called these cases "shouldn't happen", because the confirmation pages disable the button. That is exactly backwards: it means the guard only ever fires when the button was *not* what was clicked. A stale tab, the back button, the browser's resubmit prompt, or two teachers working on the same campaign all land here, and the person who gets told they lack permission has done nothing but be second.

### How?

Two helpers beside the existing `redirect_failed_import`, so the four sites read the same way:

* `redirect_already_imported` names **this deck's copy and links to it**, so the teacher can go and look at what they already have.
* `redirect_already_shared` names the content but deliberately **does not link** to the Library's copy: a teacher cannot open another deck, so the link would be a dead end. (Same reasoning as `viewer_is_library_staff` for attribution links.)

> Your deck already has this quest: **Welcome to ByteDeck!**. Nothing was imported, because replacing a quest you already have is not supported yet. Delete your copy first if you want the Library's version instead.

> 'Build a Simple Circuit' is already in the Library, so it was not shared again. Sharing an updated version of a quest that is already there is not supported yet.

Both messages describe the *current* limitation rather than promising anything; #2376 is the issue for letting a sharer push a corrected version, and #1845 for import options when the deck already has the content.

Both are built with `format_html`, not f-strings, so the content's name is escaped while the message's own link stays live. That matters because `templates/messages-snippet.html` renders **every** message through `|safe`: a quest named `<script>…</script>` would otherwise reach the browser as a script tag. See *Anything Else*.

**The guards themselves are unchanged.** They are still the real server-side check behind the disabled buttons, and the tests assert that nothing is written on the refused path.

### Testing?

`LibraryConflictMessageTests` covers all four sites: each redirects rather than 403s, and each message names the content (the import ones also assert the link to the local copy is on the page). One more test asserts the refused import still adds nothing, so the explanation cannot quietly become an import.

Three further tests cover the escaping: a name carrying a script tag arrives escaped on the import side and on the share side, and the message's own link is still a link, so the escaping cannot later be "fixed" by escaping everything. I checked all three fail against the f-string version rather than assuming they were testing anything.

Four existing tests pinned the old 403 and are updated to the new contract, renamed from `..._is_denied` / `..._denied_if_...` to `..._is_refused` / `..._refused_if_...`, since "denied" was describing the 403 specifically.

```
src/library                                   189 tests   OK
full suite (python src/manage.py test src)   2524 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

From the running `hackerspace` dev deck, signed in as the deck owner, submitting the share form for a quest that is already in the Library. (The confirmation page hides the form in this case, so the POST is made the way a stale tab or the back button would.)

**Before:** a bare 403 with no mention of the quest, the Library, or what to do.

![Before: 403 Error Permission Denied](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2373/conflict-before.png)

**After:** back on the quests page, with the reason.

![After: a warning naming the quest and saying it is already in the Library](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2373/conflict-after.png)

### Anything Else?

**A wider escaping problem turned up, and is filed rather than swept in.** `templates/messages-snippet.html` renders every message `|safe`, and its guard does nothing, because both branches are identical:

```django
{% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message|safe }}{% endif %}
```

So any message built by interpolating stored text is injected as HTML. The two helpers added here are fixed; the pre-existing call sites are not. There are four more in `src/library/views.py` alone, and the files that both call `messages.` and contain `<a href` include `quest_manager/views.py`, `badges/views.py`, `tenant/views.py`, `profile_manager/views.py` and `profile_manager/models.py`. That is #2498, with both halves: `format_html` at the remaining sites, then making the template's `safe` tag mean something (which cannot be done first, or every message that legitimately carries a link starts showing raw tags). Same class as #2113.

**This is the follow-up #2495 pointed at, but it does not fix that PR's 403.** Exporting from the Library deck really is a permission failure, so it still raises `PermissionDenied` and still renders the 403 page. What changes here is only the four cases that were never permission failures in the first place. Improving the 403 page itself, for the cases that legitimately reach it, would be a separate change.

**Both messages point at a limitation rather than a rule.** "Not supported yet" is accurate today, and if #2376 lands (pushing a corrected version) or #1845 (import options for content you already have), these are the two messages that should change with them.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)