### PR TITLE
fix: make a push to the Library all-or-nothing (#2372)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -1,6 +1,7 @@
 from datetime import date
 from uuid import uuid4
 
+from django.db import transaction
 from django_tenants.utils import schema_context
 from quest_manager.models import Quest, Category
 from django.core.exceptions import ValidationError
@@ -184,6 +185,27 @@ def export_campaign_and_copy_quests(source_schema, campaign_import_id):
         Category.DoesNotExist: If the campaign is not found in the source schema.
     """
 
+    # One transaction for the whole push. `write_quests` is atomic per batch, but this
+    # runs several of them (the campaign's own quests, then the conflict clones) with
+    # a campaign write between, so without this a failure part-way leaves the Library
+    # holding some of a campaign and the sharer being told nothing arrived (#2372).
+    with transaction.atomic():
+        return _push_campaign(source_schema, campaign_import_id)
+
+
+def _push_campaign(source_schema, campaign_import_id):
+    """Do the work of `export_campaign_and_copy_quests`, inside its transaction.
+
+    Split out so the transaction is one line at the top rather than an indent around
+    everything, and so the steps below read in the order they happen.
+
+    Args:
+        source_schema (str): Tenant schema that contains the source campaign.
+        campaign_import_id (UUID): Import ID of the campaign to export.
+
+    Returns:
+        TransferResult: as `export_campaign_and_copy_quests` describes.
+    """
     # Step 1: get local campaign and quests first (in source schema)
     with schema_context(source_schema):
         local_campaign = Category.objects.get(import_id=campaign_import_id)

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -488,7 +488,11 @@ class QuestLibraryTestsCase(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse('library:export_quest', args=[self.local_quest.import_id])
-        response = self.client.post(url, data=AGREED_LICENCE)
+        # captureOnCommitCallbacks: the email waits for the push to commit, so that a
+        # rolled-back push cannot invite anyone to review it (#2372). Under TestCase the
+        # surrounding transaction never commits, so the callbacks are run here instead.
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(url, data=AGREED_LICENCE)
         self.assertRedirects(response, reverse('quests:quests'))
 
         # An email was dispatched asynchronously to the library staff member.
@@ -1082,7 +1086,9 @@ class CampaignLibraryTestCases(LibraryTenantTestCaseMixin):
         self.client.force_login(self.test_teacher)
 
         url = reverse('library:export_category', kwargs={'campaign_import_id': str(self.local_category.import_id)})
-        response = self.client.post(url, data=AGREED_LICENCE)
+        # captureOnCommitCallbacks: see the quest export test above.
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(url, data=AGREED_LICENCE)
         self.assertRedirects(response, reverse('quests:categories'))
 
         # An email was dispatched asynchronously to the library staff member.
@@ -3099,3 +3105,104 @@ class LibraryConflictMessageTests(LibraryTenantTestCaseMixin):
         )
 
         self.assertContains(response, f'<a href="{local.get_absolute_url()}">Our Own Copy</a>')
+
+
+class LibraryPushAtomicityTests(LibraryTenantTestCaseMixin):
+    """A push either lands whole or leaves the Library as it was (#2372).
+
+    A campaign push writes in several steps: its own quests, the campaign row, and the
+    conflict clones. Between them the Library holds part of a campaign, and a failure
+    there would strand it: quests whose prerequisites point at ones that never arrived,
+    under a campaign nobody pushed on purpose, with the sharer told nothing happened.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """A staff user here, and a Library reviewer with an address to email."""
+        cls.test_teacher = User.objects.create_user('atomic_teacher', is_staff=True)
+        with library_schema_context():
+            # The review email goes to Library staff with an address, and returns early
+            # without one, which would make the "no email on failure" test vacuous.
+            User.objects.create_user('library_reviewer', email='reviewer@example.com', is_staff=True)
+
+    def setUp(self):
+        """Let staff share, sign the teacher in, and build the campaign to push."""
+        super().setUp()
+        config = SiteConfig.get()
+        config.allow_staff_export = True
+        config.save()
+        self.client.force_login(self.test_teacher)
+
+        self.campaign = baker.make(Category, title="Atomic Campaign", published=True)
+        for name in ["Atomic Quest One", "Atomic Quest Two"]:
+            quest = baker.make(Quest, name=name, campaign=self.campaign)
+            Quest.objects.filter(pk=quest.pk).update(published=True)
+
+    def library_holds_anything(self):
+        """Whether the Library holds any part of the campaign being pushed.
+
+        Returns:
+            bool: True if its campaign row or either of its quests is there.
+        """
+        with library_schema_context():
+            return (
+                Category.objects.filter(import_id=self.campaign.import_id).exists()
+                or Quest.objects.all_including_archived().filter(name__startswith="Atomic Quest").exists()
+            )
+
+    def test_ExportCampaignView__leaves_the_library_untouched_when_the_push_fails(self):
+        """A failure part-way through a campaign push rolls the whole push back.
+
+        The origin row is written after the content, in the same transaction, so failing
+        there is the narrow case that used to leave the content behind with nothing to
+        undo it.
+        """
+        with patch('library.views.record_push_origin', side_effect=IntegrityError("no origin for you")):
+            with self.assertRaises(IntegrityError):
+                self.client.post(
+                    reverse('library:export_category', args=[self.campaign.import_id]), {'agree_license': 'on'},
+                )
+
+        self.assertFalse(self.library_holds_anything())
+
+    def test_ExportCampaignView__sends_no_review_email_when_the_push_fails(self):
+        """Nobody is invited to review content that was rolled back.
+
+        An email cannot be recalled, so it waits for the transaction to commit rather
+        than going out as soon as the code reaches it.
+        """
+        with patch('library.views.send_email_message') as send_email:
+            with patch('library.views.record_push_origin', side_effect=IntegrityError("no origin for you")):
+                with self.assertRaises(IntegrityError):
+                    self.client.post(
+                        reverse('library:export_category', args=[self.campaign.import_id]), {'agree_license': 'on'},
+                    )
+
+        send_email.apply_async.assert_not_called()
+
+    def test_ExportCampaignView__sends_the_review_email_when_the_push_succeeds(self):
+        """The deferral must not swallow the email on the path that should send one.
+
+        Pairs with the test above: on its own, "no email on failure" would also pass if the
+        email had simply stopped being sent.
+        """
+        # The patch has to outlive the capture block: the callbacks run when the capture
+        # block exits, which is after an inner patch would have been undone.
+        with patch('library.views.send_email_message') as send_email:
+            with self.captureOnCommitCallbacks(execute=True):
+                self.client.post(
+                    reverse('library:export_category', args=[self.campaign.import_id]), {'agree_license': 'on'},
+                )
+
+        send_email.apply_async.assert_called_once()
+
+    def test_ExportCampaignView__pushes_the_whole_campaign_when_nothing_fails(self):
+        """The transaction is not so tight that an ordinary push stops working."""
+        response = self.client.post(
+            reverse('library:export_category', args=[self.campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        with library_schema_context():
+            self.assertTrue(Category.objects.filter(import_id=self.campaign.import_id).exists())
+            self.assertEqual(Quest.objects.all_including_archived().filter(name__startswith="Atomic Quest").count(), 2)

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -3,7 +3,7 @@ import functools
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
@@ -430,7 +430,12 @@ def email_library_staff_of_push(content_type, content_name, exported_obj, sharer
         "review_url": review_url,
         "source_deck_url": source_deck_url,
     })
-    send_email_message.apply_async(args=[subject, message, recipient_list], queue="default")
+    # on_commit, not straight away: the push that this announces is written in one
+    # transaction, and an email is not recallable. Sending it inline would mean a reviewer
+    # could be told to come and look at content that a later failure rolled back (#2372).
+    transaction.on_commit(
+        lambda: send_email_message.apply_async(args=[subject, message, recipient_list], queue="default")
+    )
 
 
 @method_decorator([login_required, staff_member_required, shared_library_enabled_view], name='dispatch')
@@ -978,33 +983,36 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         if already_shared:
             return redirect_already_shared(request, quest, 'quest', 'quests:quests')
 
-        # Perform export
-        shared = export_quest_to_library(source_schema=source_schema, quest_import_id=quest.import_id)
+        # One transaction over the push, the notification it raises and the origin row it
+        # records: a reviewer told to come and look at content, or an attribution pointing
+        # at content, must not outlive a failure that rolled the content back (#2372).
+        with transaction.atomic():
+            shared = export_quest_to_library(source_schema=source_schema, quest_import_id=quest.import_id)
 
-        with library_schema_context():
-            # Get the newly exported quest
-            exported_quest = Quest.objects.get(import_id=quest.import_id)
+            with library_schema_context():
+                # Get the newly exported quest
+                exported_quest = Quest.objects.get(import_id=quest.import_id)
 
-            config = SiteConfig.get()
-            sender = config.deck_ai
+                config = SiteConfig.get()
+                sender = config.deck_ai
 
-            recipients = User.objects.filter(is_active=True, is_staff=True)
+                recipients = User.objects.filter(is_active=True, is_staff=True)
 
-            # Notification sent to all active Library staff about the export
-            notify.send(
-                sender=sender,
-                recipient=None,
-                affected_users=list(recipients),
-                verb=f"{request.user} exported a quest to the library from {source_schema}:",
-                action=quest,
-                target=exported_quest,
-                icon="<i class='fa fa-book'></i>"
-            )
+                # Notification sent to all active Library staff about the export
+                notify.send(
+                    sender=sender,
+                    recipient=None,
+                    affected_users=list(recipients),
+                    verb=f"{request.user} exported a quest to the library from {source_schema}:",
+                    action=quest,
+                    target=exported_quest,
+                    icon="<i class='fa fa-book'></i>"
+                )
 
-            # Email active Library staff so they know there's a quest to review/publish (#1949).
-            email_library_staff_of_push("quest", quest.name, exported_quest, request.user, source_deck_url)
+                # Email active Library staff so they know there's a quest to review/publish (#1949).
+                email_library_staff_of_push("quest", quest.name, exported_quest, request.user, source_deck_url)
 
-            record_push_origin(ContentOrigin.QUEST, [quest.import_id], request, source_deck_url)
+                record_push_origin(ContentOrigin.QUEST, [quest.import_id], request, source_deck_url)
 
         # Success message displayed on local deck
         link = f'<a href="{quest.get_absolute_url()}">{quest.name}</a>'
@@ -1122,38 +1130,40 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         if already_shared:
             return redirect_already_shared(request, campaign, 'campaign', 'quests:categories')
 
-        # Export campaign and quests
-        shared = export_campaign_and_copy_quests(source_schema=source_schema, campaign_import_id=campaign.import_id)
+        # One transaction over the push, the notification it raises and the origin rows it
+        # records, for the same reason as the quest push above (#2372).
+        with transaction.atomic():
+            shared = export_campaign_and_copy_quests(source_schema=source_schema, campaign_import_id=campaign.import_id)
 
-        with library_schema_context():
-            exported_campaign = Category.objects.get(import_id=campaign.import_id)
+            with library_schema_context():
+                exported_campaign = Category.objects.get(import_id=campaign.import_id)
 
-            config = SiteConfig.get()
-            sender = config.deck_ai
-            recipients = User.objects.filter(is_active=True, is_staff=True)
+                config = SiteConfig.get()
+                sender = config.deck_ai
+                recipients = User.objects.filter(is_active=True, is_staff=True)
 
-            notify.send(
-                sender=sender,
-                recipient=None,
-                affected_users=list(recipients),
-                verb=f"{request.user} exported a campaign to the library from {source_schema}:",
-                action=campaign,
-                target=exported_campaign,
-                icon="<i class='fa fa-book'></i>",
-            )
+                notify.send(
+                    sender=sender,
+                    recipient=None,
+                    affected_users=list(recipients),
+                    verb=f"{request.user} exported a campaign to the library from {source_schema}:",
+                    action=campaign,
+                    target=exported_campaign,
+                    icon="<i class='fa fa-book'></i>",
+                )
 
-            # Email active Library staff so they know there's a campaign to review/publish (#1949).
-            email_library_staff_of_push("campaign", campaign.name, exported_campaign, request.user, source_deck_url)
+                # Email active Library staff so they know there's a campaign to review/publish (#1949).
+                email_library_staff_of_push("campaign", campaign.name, exported_campaign, request.user, source_deck_url)
 
-            record_push_origin(ContentOrigin.CAMPAIGN, [campaign.import_id], request, source_deck_url)
-            # ...and each quest that travelled with it, so a quest imported on its own still
-            # says where it came from
-            record_push_origin(
-                ContentOrigin.QUEST,
-                exported_campaign.quest_set.values_list('import_id', flat=True),
-                request,
-                source_deck_url,
-            )
+                record_push_origin(ContentOrigin.CAMPAIGN, [campaign.import_id], request, source_deck_url)
+                # ...and each quest that travelled with it, so a quest imported on its own still
+                # says where it came from
+                record_push_origin(
+                    ContentOrigin.QUEST,
+                    exported_campaign.quest_set.values_list('import_id', flat=True),
+                    request,
+                    source_deck_url,
+                )
 
         link = f'<a href="{campaign.get_absolute_url()}">{campaign.name}</a>'
         messages.success(


### PR DESCRIPTION
### What?

A push to the Library now lands whole or not at all. The content, the notification it raises and the origin rows that attribute it are written in one transaction, and the review email waits for that transaction to commit.

Closes #2372.

### Why?

A campaign push writes in several steps: the campaign's own quests, then the campaign row, then the conflict clones, and afterwards the notification and the origin rows. `write_quests` is atomic per batch, so each *step* held, but nothing held the steps together.

A failure between them left the Library holding part of a campaign: quests under a campaign nobody meant to push, some with prerequisites pointing at quests that never arrived, and no record of where any of it came from. The sharer is told the push failed, so nobody goes looking.

The review email made it worse, because it went out the moment the code reached it. A reviewer could be invited to come and look at content that a later failure rolled back. An email is the one part of this that cannot be undone.

**Half of the issue is already fixed, and this PR says so rather than claiming credit for it.** #2372 also describes a window in which unreviewed content was briefly *live* in the Library, between a committing import and a follow-up `save()` that unpublished it. That was the tablib path, and it is gone: content is written unpublished from the outset (`write_quests(..., published=False)`), so there is no window left to close.

### How?

* `export_campaign_and_copy_quests` wraps its whole sequence in `transaction.atomic()`. The body moved into `_push_campaign` so the transaction is one line at the top rather than an indent around forty.
* Both export views wrap the push, the `notify.send` and `record_push_origin` in one `transaction.atomic()`.
* `email_library_staff_of_push` dispatches through `transaction.on_commit`, so the Celery task is only queued once the content is really there.

Schema switching inside a transaction is fine here, and is what the transfer layer already relies on: `schema_context` changes the search path on the same connection, so one transaction spans both decks.

### Testing?

`LibraryPushAtomicityTests`, four tests around a campaign push made to fail at the origin-row write, which is the last thing in the transaction and so the narrowest case:

* the Library is left with nothing: no campaign row, neither quest
* no review email goes out
* the email **is** sent on the successful path, so the previous test cannot be satisfied by the email quietly never being sent
* an ordinary push still works, so the transaction is not drawn too tight

I checked the two failure-path tests actually fail against the unfixed code rather than assuming they were testing anything. Worth recording that the first version of the "no email" test was **vacuous**: the Library deck in that fixture had no staff member with an email address, so the helper returned early and nothing was ever dispatched, in either version. It now creates a Library reviewer with an address.

Two existing email tests needed updating: under `TestCase` the surrounding transaction never commits, so a deferred callback never runs. They now wrap their POST in `captureOnCommitCallbacks(execute=True)`.

```
src/library                                   193 tests   OK
full suite (python src/manage.py test src)   2528 tests   OK
ruff check src                                            clean
coverage, src/library                                     100%
```

Environment note: Docker images could not be pulled through this session's egress policy, so the stack ran from a local venv against system Postgres 16 rather than `docker compose`. Same Django, same suite, same settings.

### Screenshots (if front end is affected)

None: this changes transaction boundaries and the timing of a background email. Nothing a user sees changes on the successful path, and the failing path already showed a server error. The behaviour that changed is what is *left behind* afterwards, which is what the tests assert.

### Anything Else?

**The import direction was already atomic** (`import_campaign_to` wraps its arrival, added with the transfer rewrite), so this PR is the push side catching up rather than a new pattern.

**`on_commit` has a cost worth naming.** Any future test that asserts on the review email has to run its POST inside `captureOnCommitCallbacks`, or it will look as though no email was sent. The two existing tests carry a comment saying so.

### Review request

@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Campaign and quest exports now complete atomically, preventing partial content from being saved when an export fails.
  - Review emails are sent only after a successful export is committed.
  - Related notifications and attribution records now stay consistent with exported content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->