### PR TITLE
perf: draw a progress chart from one pass over a student's work (#2459)

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -526,7 +526,7 @@ class BadgeAssertionManager(models.Manager):
         ]
         return by_type
 
-    def xp_by_course(self, user, up_to_date=None):
+    def xp_by_course(self, user):
         """How much of this student's badge XP counts toward each of their courses.
 
         A badge granted alongside a quest carries that quest's course; one granted on its own
@@ -535,17 +535,51 @@ class BadgeAssertionManager(models.Manager):
 
         Args:
             user: the student whose badge XP is being divided.
-            up_to_date (date): count only badges granted by then, for charting their progress
-                through the semester (issue #2453). Defaults to all of them.
 
         Returns:
             dict: course id to XP, with None collecting everything left unassigned.
         """
         qs = self.get_queryset(True, user=user).grant_xp().get_user(user)
-        if up_to_date is not None:
-            qs = qs.get_issued_before(up_to_date)
         rows = qs.values('course').annotate(xp_sum=Sum('badge__xp'))
         return {row['course']: row['xp_sum'] or 0 for row in rows}
+
+    def xp_by_course_series(self, user, dates):
+        """How much of this student's badge XP counted toward each course, at each of `dates`.
+
+        What xp_by_course() answers for one date, answered for a whole series off a single
+        query (issue #2459). Charting a course's progress asks it once per class day, and
+        asking the database that many times over is the cost this removes.
+
+        Badges have no per-badge cap the way quests do, so each date's figure is simply the
+        running total of everything granted by then, and a date's whole badge XP is the sum
+        of its map.
+
+        Args:
+            user: the student whose badge XP is being divided.
+            dates: the dates to answer for, in ascending order.
+
+        Returns:
+            list[dict]: one course-id-to-XP map per date, in the order the dates were given,
+            with None collecting everything left unassigned.
+        """
+        assertions = self.get_queryset(True, user=user).grant_xp().get_user(user).order_by(
+            'timestamp',
+        ).values('course', 'badge__xp', 'timestamp')
+
+        # one pass over the assertions and one over the dates, walking both forward together
+        pending = list(assertions)
+        position = 0
+        running = {}  # course -> the XP granted toward it so far
+        series = []
+        for date in dates:
+            while position < len(pending) and pending[position]['timestamp'] <= date:
+                row = pending[position]
+                course_id = row['course']
+                running[course_id] = running.get(course_id, 0) + (row['badge__xp'] or 0)
+                position += 1
+            series.append(dict(running))
+
+        return series
 
     def calculate_xp(self, user):
         # self.check_for_new_assertions(user)

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -1,5 +1,9 @@
+import datetime
+
 from unittest import mock
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from model_bakery import baker
@@ -203,6 +207,9 @@ class BadgeAssertionManagerTest(ByteDeckTenantTestCase):
 
         cls.teacher = Recipe(User, is_staff=True).make()  # need a teacher or student creation will fail.
         cls.student = baker.make(User)
+        # a student's semester comes from their registration (issue #2157 Phase 3), so without
+        # one none of their stamped assertions read as this semester's
+        baker.make('courses.CourseStudent', user=cls.student, course=baker.make('courses.Course'), semester=cls.sem)
 
     def test_user_badge_assertion_count__annotates_count_per_user(self):
         """Test that BadgeAssertion.objects.user_assertion_count_of_badge() returns a User queryset with
@@ -221,6 +228,49 @@ class BadgeAssertionManagerTest(ByteDeckTenantTestCase):
         self.assertEqual(qs.get(id=self.student.id).assertion_count, 3)
         self.assertEqual(qs.get(id=user2.id).assertion_count, 1)
         self.assertNotIn(user3, qs)
+
+    def _granted_on(self, date, xp, course=None):
+        """Grant the student a badge worth `xp`, stamped as granted on `date`.
+
+        The timestamp is auto_now_add, so it has to be written after the fact rather than
+        handed to the assertion when it is made.
+        """
+        assertion = baker.make(
+            BadgeAssertion, user=self.student, badge=baker.make(Badge, xp=xp),
+            semester=self.sem, course=course,
+        )
+        BadgeAssertion.objects.filter(pk=assertion.pk).update(timestamp=date)
+        return assertion
+
+    def test_xp_by_course_series__answers_each_date_with_what_had_been_granted_by_then(self):
+        """Each date gets the split as it stood then, which is what plots a course's line
+        through the semester (issue #2459). Badges have no cap, so a date's figure is the
+        running total of everything granted by then."""
+        maths = baker.make('courses.Course')
+        monday = datetime.datetime(2024, 1, 8, tzinfo=datetime.timezone.utc)
+        self._granted_on(monday, xp=10, course=maths)
+        self._granted_on(monday + datetime.timedelta(days=2), xp=25)
+
+        series = BadgeAssertion.objects.xp_by_course_series(
+            self.student, [monday - datetime.timedelta(days=1), monday, monday + datetime.timedelta(days=2)])
+
+        self.assertEqual(series, [{}, {maths.id: 10}, {maths.id: 10, None: 25}])
+
+    def test_xp_by_course_series__costs_the_same_however_many_dates(self):
+        """Reading the assertions once is the point of the series: charting a course asks for
+        a whole semester of class days at a time, and what it costs must not grow with them
+        (issue #2459). Pinned as a comparison rather than an absolute count, so the guard
+        survives any unrelated change to how the assertions are looked up."""
+        monday = datetime.datetime(2024, 1, 8, tzinfo=datetime.timezone.utc)
+        self._granted_on(monday, xp=10)
+        dates = [monday + datetime.timedelta(days=day) for day in range(20)]
+
+        with CaptureQueriesContext(connection) as one_date:
+            BadgeAssertion.objects.xp_by_course_series(self.student, dates[:1])
+        with CaptureQueriesContext(connection) as every_date:
+            BadgeAssertion.objects.xp_by_course_series(self.student, dates)
+
+        self.assertEqual(len(every_date), len(one_date))
 
     def test_all_for_user_distinct__distinct_by_badge_and_sorted(self):
         """

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -329,7 +329,18 @@ class SemesterManager(models.Manager.from_queryset(SemesterQuerySet)):
     e.g. Semester.objects.open()."""
 
     def get_queryset(self):
-        return SemesterQuerySet(self.model, using=self._db).order_by('-first_day')
+        """Semesters newest term first, with a tiebreaker so the order is stable.
+
+        Two semesters can start on the same day (a new one takes today as its default first
+        day, so a deck setting up a second cohort has two), and ordering by the date alone
+        leaves the database free to return those two in either order: a registration form's
+        semester list would then reshuffle between page loads.
+
+        Returns:
+            SemesterQuerySet: every semester, latest first day first, oldest record first
+            among semesters sharing one.
+        """
+        return SemesterQuerySet(self.model, using=self._db).order_by('-first_day', 'id')
 
     def get_current(self, as_queryset=False):
         """The semester students are currently earning XP in, or nothing when none is open.

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -21,6 +21,52 @@ from quest_manager.models import QuestSubmission
 from siteconfig.models import SiteConfig
 
 
+def split_xp_between_registrations(registrations, total, xp_by_course):
+    """Hand each of a student's registrations the XP that counts toward it.
+
+    Work they assigned to one of their current courses counts wholly toward it; everything
+    else is shared evenly (issue #2440), which is what every submission did before they could
+    assign one, and is still what happens to badge XP, to work handed in while the deck had
+    the setting off, and to anything from before the choice existed.
+
+    Args:
+        registrations (list[CourseStudent]): the registrations to divide the XP between. They
+            should all be one student's, and from one semester: the shared pool is split by
+            how many there are.
+        total (float): the student's whole deck-wide XP, including their adjustments.
+        xp_by_course (dict): course id to the XP assigned to it, with None collecting
+            everything left unassigned.
+
+    Returns:
+        list[tuple]: (CourseStudent, xp) in the order given.
+    """
+    if len(registrations) <= 1:
+        return [(registration, total) for registration in registrations]
+
+    # Only courses the student still holds can claim XP: work assigned to a course whose
+    # registration has since been deleted has nowhere to count, so it stays in the shared
+    # pool rather than being subtracted from it and lost. A registration with no course at
+    # all is not one of those claims: unassigned XP is filed under no course too, and
+    # counting it as claimed would take the student's shared work out of the pool as well.
+    course_ids = {
+        registration.course_id for registration in registrations
+        if registration.course_id is not None
+    }
+    assigned = sum(xp for course_id, xp in xp_by_course.items() if course_id in course_ids)
+    adjustments = sum(registration.xp_adjustment for registration in registrations)
+    shared = (total - assigned - adjustments) / len(registrations)
+
+    return [
+        (
+            registration,
+            (xp_by_course.get(registration.course_id, 0) if registration.course_id else 0)
+            + registration.xp_adjustment
+            + shared,
+        )
+        for registration in registrations
+    ]
+
+
 class MarkRangeManager(models.Manager):
     def get_range(self, mark, courses=None):
         """ return the MarkRange encompassed by this mark adn the list of courses """
@@ -532,11 +578,6 @@ class Semester(models.Model):
         Returns:
             {datetime} -- [description]
         """
-        excluded_days = self.excluded_days()
-
-        # The next day of class excluding holidays/weekends, -1 because first day counts as 1, not zero.
-        d = numpy.busday_offset(self.first_day, class_days - 1, roll='forward', holidays=excluded_days).astype(date)
-
         # Might want to include the holidays (if class day is Friday, then work done on weekend/holidays won't show up
         # till Monday.  For chart, want to include those days
         # if (add_holidays):
@@ -544,11 +585,35 @@ class Semester(models.Model):
         #     # next_date = workday(self.first_day, class_days + 1, excluded_days)
         #     num_holidays_to_add = next_date - d - timedelta(days=1)  # If more than one day difference
         #     d += num_holidays_to_add
+        return self.get_datetimes_by_days_since_start([class_days])[0]
 
-        # convert from date to datetime
-        dt = datetime.combine(d, datetime.max.time())
-        # make timezone aware
-        return timezone.make_aware(dt, timezone.get_default_timezone())
+    def get_datetimes_by_days_since_start(self, class_days):
+        """The dates a run of class days fall on, off a single read of the excluded days.
+
+        A progress chart plots a point per class day so far and needs the date of every one of
+        them, so asking a day at a time is a query per day (issue #2459).
+
+        Args:
+            class_days: how many class days into the semester each wanted date is, counting
+                the semester's first day as 1.
+
+        Returns:
+            list[datetime]: the end of each of those days, in the order asked for and timezone
+            aware. Weekends and excluded days are not class days, so an offset landing on one
+            rolls forward to the next day that is.
+        """
+        excluded_days = list(self.excluded_days())
+
+        # The next day of class excluding holidays/weekends, -1 because first day counts as 1, not zero.
+        days = numpy.busday_offset(
+            self.first_day, [class_day - 1 for class_day in class_days], roll='forward', holidays=excluded_days,
+        ).astype(date)
+
+        # convert from date to datetime, and make timezone aware
+        return [
+            timezone.make_aware(datetime.combine(day, datetime.max.time()), timezone.get_default_timezone())
+            for day in days
+        ]
 
     def reset_students_xp_cached(self):
         """Zero the cached XP of every student registered in this semester.
@@ -746,7 +811,7 @@ class CourseStudentManager(models.Manager):
         """
         return self.current_courses(user).aggregate(total=Sum('xp_adjustment'))['total'] or 0
 
-    def xp_for_registrations(self, user, profile=None, up_to_date=None):
+    def xp_for_registrations(self, user, profile=None):
         """Every current registration this student holds, with the XP counting toward it.
 
         The assigned-versus-shared split (issue #2440) is the same question for every course a
@@ -758,16 +823,14 @@ class CourseStudentManager(models.Manager):
             user: the student whose XP is being divided.
             profile (Profile): their profile, for a caller holding one whose xp_cached is
                 newer than the database. Defaults to reading it.
-            up_to_date (date): divide what they had earned by then rather than their total,
-                which is how each course's progress chart is plotted (issue #2453).
 
         Returns:
             list[tuple]: (CourseStudent, xp) in registration order, empty when the student is
             in no course. A student in one course has their whole total against it.
         """
-        return self.xp_across(user, list(self.current_courses(user)), profile=profile, up_to_date=up_to_date)
+        return self.xp_across(user, list(self.current_courses(user)), profile=profile)
 
-    def xp_across(self, user, registrations, profile=None, up_to_date=None):
+    def xp_across(self, user, registrations, profile=None):
         """The same division as xp_for_registrations(), across registrations given explicitly.
 
         Whoever already holds a student's registrations can hand them straight over rather
@@ -781,45 +844,61 @@ class CourseStudentManager(models.Manager):
                 should all be the student's own, and from one semester: the shared pool is
                 split by how many there are.
             profile (Profile): as xp_for_registrations().
-            up_to_date (date): as xp_for_registrations().
 
         Returns:
             list[tuple]: (CourseStudent, xp) in the order given.
         """
         profile = profile if profile is not None else user.profile
-        total = profile.xp_cached if up_to_date is None else profile.xp_to_date(up_to_date)
+        total = profile.xp_cached
         if len(registrations) <= 1:
+            # nothing to divide, so the two queries below are not worth making
             return [(registration, total) for registration in registrations]
 
         # the total is the student's deck-wide figure: quest XP, badge XP, and every one of
         # their registrations' adjustments. Take out the parts that belong to a particular
         # course, share what is left, and hand each registration back its own pieces.
-        xp_by_course = QuestSubmission.objects.xp_by_course(user, up_to_date=up_to_date)
-        for course_id, xp in BadgeAssertion.objects.xp_by_course(user, up_to_date=up_to_date).items():
+        xp_by_course = QuestSubmission.objects.xp_by_course(user)
+        for course_id, xp in BadgeAssertion.objects.xp_by_course(user).items():
             xp_by_course[course_id] = xp_by_course.get(course_id, 0) + xp
 
-        # Only courses the student still holds can claim XP: work assigned to a course whose
-        # registration has since been deleted has nowhere to count, so it stays in the shared
-        # pool rather than being subtracted from it and lost. A registration with no course at
-        # all is not one of those claims: unassigned XP is filed under no course too, and
-        # counting it as claimed would take the student's shared work out of the pool as well.
-        course_ids = {
-            registration.course_id for registration in registrations
-            if registration.course_id is not None
-        }
-        assigned = sum(xp for course_id, xp in xp_by_course.items() if course_id in course_ids)
-        adjustments = sum(registration.xp_adjustment for registration in registrations)
-        shared = (total - assigned - adjustments) / len(registrations)
+        return split_xp_between_registrations(registrations, total, xp_by_course)
 
-        return [
-            (
-                registration,
-                (xp_by_course.get(registration.course_id, 0) if registration.course_id else 0)
-                + registration.xp_adjustment
-                + shared,
-            )
-            for registration in registrations
-        ]
+    def xp_across_series(self, user, registrations, dates):
+        """The same division as xp_across(), answered for a whole series of dates at once.
+
+        A course's progress chart plots a point per class day, so it asks what each date's XP
+        was over and over. Asking one date at a time re-queries the student's submissions and
+        their assertions for every one of them (issue #2459); this reads each once and walks
+        the dates.
+
+        Args:
+            user: the student whose XP is being divided.
+            registrations (list[CourseStudent]): as xp_across(). These should be all of the
+                student's current ones, since the total being divided counts every one of
+                their adjustments.
+            dates: the dates to answer for, in ascending order.
+
+        Returns:
+            list[list[tuple]]: one (CourseStudent, xp) list per date, in the order the dates
+            were given, each in the order the registrations were given.
+        """
+        quest_series = QuestSubmission.objects.xp_by_course_series(user, dates)
+        badge_series = BadgeAssertion.objects.xp_by_course_series(user, dates)
+        # every one of the student's adjustments counts toward the total being divided, the
+        # same as calculate_xp() adds them into their deck-wide XP: the registrations given
+        # are all of their current ones, so they are already in memory
+        adjustments = sum(registration.xp_adjustment for registration in registrations)
+
+        series = []
+        for quest_xp, badge_by_course in zip(quest_series, badge_series):
+            xp_by_course = dict(quest_xp.by_course)
+            for course_id, xp in badge_by_course.items():
+                xp_by_course[course_id] = xp_by_course.get(course_id, 0) + xp
+
+            total = quest_xp.total + sum(badge_by_course.values()) + adjustments
+            series.append(split_xp_between_registrations(registrations, total, xp_by_course))
+
+        return series
 
     def calc_semester_grades(self, semester, clamp_negative_xp=False):
         """Record every registration's final XP and deactivate it.
@@ -1105,23 +1184,6 @@ class CourseStudent(models.Model):
             if registration.pk == self.pk:
                 return xp
         return profile.xp_cached
-
-    def xp_to_date(self, date):
-        """The XP that counted toward this registration as of a date.
-
-        The same division as xp(), taken at a point in the past, which is what plots a course's
-        progress through the semester rather than the student's whole-deck line (issue #2453).
-
-        Args:
-            date: the day to count up to, inclusive.
-
-        Returns:
-            float: this registration's share of what the student had earned by then.
-        """
-        for registration, xp in CourseStudent.objects.xp_for_registrations(self.user, up_to_date=date):
-            if registration.pk == self.pk:
-                return xp
-        return self.user.profile.xp_to_date(date)
 
     def mark(self, profile=None):
         """This registration's mark, worked out from its own XP.

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -525,6 +525,19 @@ class SemesterModelTest(ByteDeckTenantTestCase):
         expected = timezone.make_aware(datetime(2019, 9, 9, 23, 59, 59, 999999), timezone.get_default_timezone())
         self.assertEqual(dt, expected)
 
+    def test_get_queryset__orders_semesters_sharing_a_first_day_by_record(self):
+        """A new semester takes today as its default first day, so a deck setting up a second
+        cohort has two starting on the same date. Ordering on the date alone would let the
+        database return those two in either order, reshuffling a registration form's semester
+        list between page loads, so the oldest record comes first among them."""
+        first_day = self.semester.first_day
+        first = baker.make(Semester, first_day=first_day, last_day=self.semester.last_day)
+        second = baker.make(Semester, first_day=first_day, last_day=self.semester.last_day)
+
+        sharing_a_first_day = Semester.objects.filter(first_day=first_day)
+
+        self.assertEqual(list(sharing_a_first_day), [self.semester, first, second])
+
     def test_get_datetimes_by_days_since_start__answers_a_run_of_days_off_one_read(self):
         """A whole run of class days at once, each the same date asking for it singly gives,
         and read from the semester's excluded days once however many days are wanted: the

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -2,6 +2,8 @@ from collections import Counter
 from datetime import date, datetime, timedelta
 
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from django.core.exceptions import ValidationError
@@ -523,6 +525,18 @@ class SemesterModelTest(ByteDeckTenantTestCase):
         expected = timezone.make_aware(datetime(2019, 9, 9, 23, 59, 59, 999999), timezone.get_default_timezone())
         self.assertEqual(dt, expected)
 
+    def test_get_datetimes_by_days_since_start__answers_a_run_of_days_off_one_read(self):
+        """A whole run of class days at once, each the same date asking for it singly gives,
+        and read from the semester's excluded days once however many days are wanted: the
+        progress chart asks for every class day so far (issue #2459)."""
+        with CaptureQueriesContext(connection) as one_day:
+            self.semester.get_datetimes_by_days_since_start([5])
+        with CaptureQueriesContext(connection) as twenty_days:
+            dates = self.semester.get_datetimes_by_days_since_start(range(1, 21))
+
+        self.assertEqual(dates[4:6], [self.semester.get_datetime_by_days_since_start(day) for day in (5, 6)])
+        self.assertEqual(len(twenty_days), len(one_day))
+
     def test_reset_students_xp_cached__zeroes_xp(self):
         """Students' xp_cached should be set to 0."""
         student = baker.make(User)
@@ -865,9 +879,9 @@ class CourseStudentManagerTest(ByteDeckTenantTestCase):
         splits = Counter()
         divide = CourseStudent.objects.xp_across  # bound, so the patch below can delegate to it
 
-        def counting_divide(manager, user, registrations, profile=None, up_to_date=None):
+        def counting_divide(manager, user, registrations, profile=None):
             splits[user.pk] += 1
-            return divide(user, registrations, profile=profile, up_to_date=up_to_date)
+            return divide(user, registrations, profile=profile)
 
         with patch('courses.models.CourseStudentManager.xp_across', autospec=True, side_effect=counting_divide):
             CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
@@ -1226,37 +1240,124 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
 
         self.assertEqual(old.xp(), student.profile.xp_cached)
 
-    def test_xp_to_date__answers_with_the_whole_total_for_a_registration_that_is_not_current(self):
-        """Charting a registration from a semester that is over plots the student's own total,
-        for the same reason xp() does: it is not part of the division between their courses."""
-        student = baker.make(User)
-        old = baker.make(
-            CourseStudent, user=student, course=baker.make(Course), block=baker.make(Block),
-            semester=baker.make(Semester, status=Semester.Status.ARCHIVED),
-        )
-        self._register(student, baker.make(Course))
-        self._register(student, baker.make(Course))
-        self._approved(student, xp=40)
-        today = timezone.localtime()
+    def _approved_yesterday(self, student, xp, course=None):
+        """Give a student an approved submission dated yesterday.
 
-        self.assertEqual(old.xp_to_date(today), student.profile.xp_to_date(today))
+        The date filter is on time_approved, which baker would otherwise fill with a random
+        datetime that may not be behind us.
+        """
+        submission = self._approved(student, xp=xp, course=course)
+        submission.time_approved = timezone.localtime() - timedelta(days=1)
+        submission.save()
+        return submission
 
-    def test_xp_to_date__divides_what_the_student_had_earned_by_then(self):
+    def test_xp_across_series__divides_what_the_student_had_earned_by_then(self):
         """A course's progress line is its own share as of each day, not an even share of the
-        student's whole total (issue #2453)."""
+        student's whole total (issue #2453), and the whole line is worked out in one pass
+        (issue #2459)."""
         student = baker.make(User)
         maths = baker.make(Course, title='Maths')
-        maths_registration = self._register(student, maths)
-        art_registration = self._register(student, baker.make(Course, title='Art'))
+        registrations = [self._register(student, maths), self._register(student, baker.make(Course, title='Art'))]
+        self._approved_yesterday(student, xp=40, course=maths)
         today = timezone.localtime()
-        # approved yesterday: the date filter is on time_approved, which baker would otherwise
-        # fill with a random datetime that may not be behind us
-        submission = self._approved(student, xp=40, course=maths)
-        submission.time_approved = today - timedelta(days=1)
-        submission.save()
 
-        self.assertEqual(maths_registration.xp_to_date(today), 40)
-        self.assertEqual(art_registration.xp_to_date(today), 0)
+        series = CourseStudent.objects.xp_across_series(
+            student, registrations, [today - timedelta(days=2), today])
+
+        self.assertEqual([[xp for _registration, xp in row] for row in series], [[0, 0], [40, 0]])
+
+    def test_xp_across_series__is_the_students_whole_total_when_they_have_one_course(self):
+        """Nothing to divide, so their one course carries everything they had earned by each
+        date, and carries it as the exact figure rather than a share worked out from one."""
+        student = baker.make(User)
+        registrations = [self._register(student, baker.make(Course))]
+        self._approved_yesterday(student, xp=30)
+        today = timezone.localtime()
+
+        series = CourseStudent.objects.xp_across_series(
+            student, registrations, [today - timedelta(days=2), today])
+
+        self.assertEqual([xp for row in series for _registration, xp in row], [0, 30])
+
+    def test_xp_across_series__counts_an_adjustment_at_every_date(self):
+        """A manual adjustment is not something the student earned on a day, so it stands
+        against its own course from the first point on the chart, the same as xp() counts it."""
+        student = baker.make(User)
+        maths_registration = self._register(student, baker.make(Course, title='Maths'))
+        maths_registration.xp_adjustment = 10
+        maths_registration.save()
+        registrations = [maths_registration, self._register(student, baker.make(Course, title='Art'))]
+        today = timezone.localtime()
+
+        series = CourseStudent.objects.xp_across_series(
+            student, registrations, [today - timedelta(days=2), today])
+
+        self.assertEqual([[xp for _registration, xp in row] for row in series], [[10, 0], [10, 0]])
+
+    def test_xp_across_series__counts_badge_xp_from_the_day_it_was_granted(self):
+        """Badge XP counts toward the course the badge was granted against, and appears on the
+        chart from the day it was granted rather than from the start of the term."""
+        student = baker.make(User)
+        maths = baker.make(Course, title='Maths')
+        registrations = [self._register(student, maths), self._register(student, baker.make(Course, title='Art'))]
+        assertion = baker.make(
+            BadgeAssertion, user=student, badge=baker.make(Badge, xp=20), course=maths,
+            semester=SiteConfig.get().active_semester,
+        )
+        today = timezone.localtime()
+        # timestamp is auto_now_add, so it has to be written after the assertion is made
+        BadgeAssertion.objects.filter(pk=assertion.pk).update(timestamp=today - timedelta(days=1))
+
+        series = CourseStudent.objects.xp_across_series(
+            student, registrations, [today - timedelta(days=2), today])
+
+        self.assertEqual([[xp for _registration, xp in row] for row in series], [[0, 0], [20, 0]])
+
+    def test_xp_across_series__totals_agree_with_the_students_xp_at_that_date(self):
+        """What the courses are given between them at each date is the student's whole XP as
+        of then, cap and all, so a chart drawn from the series agrees with the total the
+        student is shown. Pinned against Profile.xp_to_date(), which is where that number is
+        defined."""
+        student = baker.make(User)
+        maths = baker.make(Course, title='Maths')
+        registrations = [self._register(student, maths), self._register(student, baker.make(Course, title='Art'))]
+        # a repeatable quest taken past its cap and split across two courses, which is the case
+        # where a date's per-course figures are fractions rather than whole submissions
+        quest = baker.make(Quest, xp=10, max_xp=15, max_repeats=-1)
+        for course in (maths, None):
+            submission = baker.make(
+                QuestSubmission, user=student, quest=quest, course=course,
+                semester=SiteConfig.get().active_semester, is_completed=True, is_approved=True,
+            )
+            submission.time_approved = timezone.localtime() - timedelta(days=1)
+            submission.save()
+        dates = [timezone.localtime() - timedelta(days=2), timezone.localtime()]
+
+        series = CourseStudent.objects.xp_across_series(student, registrations, dates)
+
+        self.assertEqual(
+            [sum(xp for _registration, xp in row) for row in series],
+            [student.profile.xp_to_date(date) for date in dates],
+        )
+        self.assertEqual([sum(xp for _registration, xp in row) for row in series], [0, 15])
+
+    def test_xp_across_series__costs_the_same_however_many_dates(self):
+        """Reading each source once is the point of the series: a progress chart asks for a
+        whole semester of class days at a time, and what it costs must not grow with them
+        (issue #2459). Pinned as a comparison rather than an absolute count, so the guard
+        survives any unrelated change to how the XP is looked up."""
+        student = baker.make(User)
+        registrations = [self._register(student, baker.make(Course)), self._register(student, baker.make(Course))]
+        self._approved_yesterday(student, xp=40)
+        today = timezone.localtime()
+        dates = [today - timedelta(days=day) for day in reversed(range(20))]
+
+        with CaptureQueriesContext(connection) as one_date:
+            CourseStudent.objects.xp_across_series(student, registrations, dates[:1])
+        with CaptureQueriesContext(connection) as every_date:
+            CourseStudent.objects.xp_across_series(student, registrations, dates)
+
+        self.assertEqual(len(every_date), len(one_date))
 
     def test_xp__shares_out_work_assigned_to_a_course_the_student_has_left(self):
         """Deleting a registration must not make its XP vanish. Work assigned to a course the

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -2177,6 +2177,27 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(json.loads(response.content)['xp_for_100_percent'], self.course.xp_for_100_percent)
 
+    def test_ajax_progress_chart__costs_the_same_however_many_class_days(self):
+        """The chart is drawn from one pass over the student's work rather than a query per
+        class day (issue #2459), so a term a month in costs no more to draw than one four days
+        in. Pinned as a comparison rather than an absolute count, so the guard survives any
+        unrelated change to what the page asks for."""
+        self.client.force_login(self.student)
+        self.create_quest_and_submissions(self.base_xp, datetime.datetime(2024, 1, 2, tzinfo=self.tz))
+        url = reverse('courses:ajax_progress_chart', args=[self.student.pk])
+
+        # 2024-1-5 is a Friday, four class days in; 2024-2-1 is a Thursday, twenty-four
+        with freeze_time(datetime.datetime(2024, 1, 5, 6, tzinfo=self.tz)):
+            with CaptureQueriesContext(connection) as first_week:
+                self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        with freeze_time(datetime.datetime(2024, 2, 1, 6, tzinfo=self.tz)):
+            with CaptureQueriesContext(connection) as fifth_week:
+                response = self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        # the later chart really does plot more days, so the counts are of unequal work
+        self.assertGreater(len(json.loads(response.content)['xp_data']), 4)
+        self.assertEqual(len(fifth_week), len(first_week))
+
     def test_ajax_xp_data__correct_xp_current_day(self):
         """ tests if xp_data from ajax request holds the correct xp on different days of the week.
         uses freeze_time to test the current day as Fri, Sat, Sun, and Mon

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -2186,17 +2186,25 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
         self.create_quest_and_submissions(self.base_xp, datetime.datetime(2024, 1, 2, tzinfo=self.tz))
         url = reverse('courses:ajax_progress_chart', args=[self.student.pk])
 
-        # 2024-1-5 is a Friday, four class days in; 2024-2-1 is a Thursday, twenty-four
-        with freeze_time(datetime.datetime(2024, 1, 5, 6, tzinfo=self.tz)):
-            with CaptureQueriesContext(connection) as first_week:
+        def cost_at(when):
+            """What one chart POST costs with the clock at `when`, and what it drew."""
+            with freeze_time(when):
+                # a request neither capture counts: OwnerOnlyWhenSuspendedMiddleware asks
+                # get_current_deck() for the deck's status, which reads it from the database on
+                # a cache miss. That entry expires an hour after it is written and these two
+                # calls are a month apart on a frozen clock, so each needs its own warm-up.
                 self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        with freeze_time(datetime.datetime(2024, 2, 1, 6, tzinfo=self.tz)):
-            with CaptureQueriesContext(connection) as fifth_week:
-                response = self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+                with CaptureQueriesContext(connection) as queries:
+                    response = self.client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+            return len(queries), json.loads(response.content)
+
+        # 2024-1-5 is a Friday, four class days in; 2024-2-1 is a Thursday, twenty-four
+        first_week, _ = cost_at(datetime.datetime(2024, 1, 5, 6, tzinfo=self.tz))
+        fifth_week, later_chart = cost_at(datetime.datetime(2024, 2, 1, 6, tzinfo=self.tz))
 
         # the later chart really does plot more days, so the counts are of unequal work
-        self.assertGreater(len(json.loads(response.content)['xp_data']), 4)
-        self.assertEqual(len(fifth_week), len(first_week))
+        self.assertGreater(len(later_chart['xp_data']), 4)
+        self.assertEqual(fifth_week, first_week)
 
     def test_ajax_xp_data__correct_xp_current_day(self):
         """ tests if xp_data from ajax request holds the correct xp on different days of the week.

--- a/src/courses/tests/utils.py
+++ b/src/courses/tests/utils.py
@@ -21,7 +21,7 @@ def patch_registration_xp(xp):
     Returns:
         The patcher, for use as a decorator or a context manager.
     """
-    def split(manager, user, registrations, profile=None, up_to_date=None):
+    def split(manager, user, registrations, profile=None):
         return [(registration, xp(registration) if callable(xp) else xp) for registration in registrations]
 
     return patch('courses.models.CourseStudentManager.xp_across', autospec=True, side_effect=split)

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -1022,8 +1022,11 @@ class SemesterArchive(RefuseSemesterMixin, NonPublicOnlyViewMixin, LoginRequired
         return redirect('courses:semester_list')
 
 
-def _registration_to_chart(user, course_id):
-    """Which of a student's registrations the progress chart is being asked for.
+def _registrations_to_chart(user, course_id):
+    """A student's current registrations, and which of them the progress chart is being asked for.
+
+    All of them, not just the one being charted: dividing a student's XP between their courses
+    is one question about the whole student (issue #2440), so the answer needs the full set.
 
     Args:
         user: the student being charted.
@@ -1031,18 +1034,28 @@ def _registration_to_chart(user, course_id):
             whichever course comes first.
 
     Returns:
-        CourseStudent or None: their registration in that course, falling back to their first
-        one when the request named no course or named one they are not in. None when they are
-        in no course at all, which the caller charts as a flat zero.
+        tuple: (list[CourseStudent], index or None). The index picks out their registration in
+        the course the request named, falling back to their first when it named no course or
+        one they are not in. None when they are in no course at all, which the caller charts
+        as a flat zero.
     """
-    registrations = CourseStudent.objects.current_courses(user)
+    registrations = list(CourseStudent.objects.current_courses(user))
+    chosen = None
     try:
         # whatever the page posted: the chart asks for no course at all when the student has
         # only one, and nothing stops a request naming something that is not an id
-        chosen = registrations.filter(course_id=int(course_id)).first()
+        named = int(course_id)
     except (TypeError, ValueError):
-        chosen = None
-    return chosen if chosen is not None else registrations.first()
+        named = None
+
+    if named is not None:
+        chosen = next(
+            (index for index, registration in enumerate(registrations) if registration.course_id == named),
+            None,
+        )
+    if chosen is None and registrations:
+        chosen = 0
+    return registrations, chosen
 
 
 @xml_http_request_required
@@ -1083,57 +1096,58 @@ def ajax_progress_chart(request, user_id=0):
             # which the weekend adjustment below would then index into.
             return HttpResponse(json.dumps({"days_in_semester": 0, "xp_data": []}), content_type='application/json')
 
-        # generate a list of dates, from first date of semester to today
-        datelist = []
-        for i in range(1, sem.days_so_far() + 1):
-            # need to ignore weekends and non-class days
-            next_day_of_class = sem.get_datetime_by_days_since_start(i, add_holidays=True)
-            datelist.append(next_day_of_class)
-
-        xp_data = []
-        # generate an list of dictionary data for chart.js:
-        #   x: day into course
-        #   y: XP earned so far
-
-        # A course's own line, not an even share of the student's whole total: since #2440 the
-        # two are different numbers for a student who assigned their work (issue #2453). The
-        # course to chart comes from the request, defaulting to the first of their courses.
-        registration = _registration_to_chart(user, request.POST.get('course'))
-
-        # days_so_far == len(datelist)
-        for day in range(0, sem.days_so_far()):
-            xp = registration.xp_to_date(datelist[day]) if registration else 0
-            xp_data.append(
-                # day 0-indexed
-                {'x': day + 1, 'y': xp}
-            )
+        # the date of every class day so far, weekends and non-class days skipped, off a
+        # single read of the semester's excluded days (issue #2459)
+        datelist = sem.get_datetimes_by_days_since_start(range(1, sem.days_so_far() + 1))
 
         today = timezone.localtime()
 
         # SAT and SUN are always excluded by numpy.busday_offset
         # use today.date() because its a datetime.datetime object and we compare it to a DateField (returns datetime.date)
-        if today.weekday() in [5, 6] or today.date() in sem.excluded_days():  # SAT, SAT or a day specifically excluded
-            # according to a comment inside get_datetime_by_days_since_start:
-            #   "work done on weekend/holidays won't show up till Monday"
+        # according to a comment inside get_datetime_by_days_since_start:
+        #   "work done on weekend/holidays won't show up till Monday"
+        # so on one of those days today's XP is asked for as well, to roll what was earned
+        # since the last class day back onto it
+        off_day = today.weekday() in [5, 6] or today.date() in sem.excluded_days()
 
-            # total_xp <= xp_to_date(today) since the latest xp_data day is the last valid day (usually a friday)
-            # ie. if today is sunday: friday's total xp <= sunday's total xp
-            # (if a submission is removed then will subtract from both friday and sunday xp)
-            total_xp = xp_data[-1]['y']
-            today_xp = registration.xp_to_date(today) if registration else 0
-            difference = today_xp - total_xp
+        # A course's own line, not an even share of the student's whole total: since #2440 the
+        # two are different numbers for a student who assigned their work (issue #2453). The
+        # course to chart comes from the request, defaulting to the first of their courses.
+        registrations, charted = _registrations_to_chart(user, request.POST.get('course'))
 
-            # if true: user has earned xp during the weekend.
-            # add that xp to the last valid date
-            if difference > 0:
-                xp_data[-1]['y'] += difference
+        if charted is None:
+            # in no course at all, so there is nothing of theirs to plot
+            xp_series = [0] * len(datelist)
+            today_xp = 0
+        else:
+            # every date in one pass rather than a query per class day (issue #2459)
+            dates = datelist + [today] if off_day else datelist
+            series = CourseStudent.objects.xp_across_series(user, registrations, dates)
+            xp_series = [row[charted][1] for row in series]
+            # on a class day the last point is today, and there is nothing later to roll back
+            today_xp = xp_series.pop() if off_day else xp_series[-1]
 
+        # a list of dictionary data for chart.js:
+        #   x: day into course (1-indexed)
+        #   y: XP earned so far
+        xp_data = [{'x': day + 1, 'y': xp} for day, xp in enumerate(xp_series)]
+
+        # the last plotted day is the last valid day (usually a friday), so its total is at most
+        # today's: if today is sunday, friday's total xp <= sunday's total xp
+        # (if a submission is removed then will subtract from both friday and sunday xp)
+        difference = today_xp - xp_data[-1]['y']
+        # if true: user has earned xp during the weekend.
+        # add that xp to the last valid date
+        if difference > 0:
+            xp_data[-1]['y'] += difference
+
+        charted_course = registrations[charted].course if charted is not None else None
         progress_chart = {
             "days_in_semester": sem.num_days(),
             "xp_data": xp_data,
             # the charted course's own scale: courses can be out of different amounts, so the
             # axis and the mark lines have to be redrawn when a student switches (issue #2453)
-            "xp_for_100_percent": registration.course.xp_for_100_percent if registration and registration.course else 0,
+            "xp_for_100_percent": charted_course.xp_for_100_percent if charted_course else 0,
         }
         json_data = json.dumps(progress_chart)
 

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -2,6 +2,8 @@ import uuid
 import json
 import datetime
 
+from collections import namedtuple
+
 from django.db import IntegrityError, transaction
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
@@ -19,6 +21,58 @@ from comments.models import Comment
 from library.models import IsLibraryContentMixin
 from prerequisites.models import Prereq, IsAPrereqMixin, HasPrereqsMixin, PrereqAllConditionsMet
 from tags.models import TagsModelMixin
+
+
+#: What a set of submissions is worth: `total`, the XP altogether, and `by_course`, a course
+#: id to XP map with None collecting everything left unassigned (issue #2440).
+CappedXP = namedtuple('CappedXP', ['total', 'by_course'])
+
+
+def split_capped_xp_by_course(rows):
+    """Divide per-(quest, course) XP sums into a per-course total, capping each quest first.
+
+    A quest's `max_xp` caps what it can ever be worth, however many times it was repeated, so
+    the cap applies to the quest as a whole before the total is split up: a student who spread
+    one repeatable quest's submissions across two courses must not earn more from it than a
+    student who put them all in one. Each course therefore receives the capped total in
+    proportion to what it was assigned uncapped.
+
+    The rule lives here rather than inside the query that usually feeds it, because it is
+    also applied a date at a time when charting a course's progress (issue #2459), and one
+    implementation of it is easier to keep honest than two.
+
+    Args:
+        rows: an iterable of (quest_id, max_xp, course_id, xp_sum) tuples, one per pairing of
+            a quest with a course the student put it against. max_xp of -1 means uncapped,
+            and None means the quest has since been deleted, which is worth nothing.
+
+    Returns:
+        CappedXP: the capped XP by course, and what it comes to altogether. The total is added
+        up a whole quest at a time rather than from the per-course shares, so it stays the
+        exact number calculate_xp_to_date() reports instead of a sum of fractions.
+    """
+    rows = list(rows)
+
+    # what each quest earned in total, to apply its cap before dividing it up
+    quest_totals = {}
+    for quest_id, _max_xp, _course_id, xp_sum in rows:
+        quest_totals[quest_id] = quest_totals.get(quest_id, 0) + xp_sum
+
+    capped_totals = {}
+    for quest_id, max_xp, _course_id, _xp_sum in rows:
+        if max_xp == -1:  # no limit
+            capped_totals[quest_id] = quest_totals[quest_id]
+        else:
+            # max_xp is None when the quest was deleted
+            capped_totals[quest_id] = min(quest_totals[quest_id], max_xp or 0)
+
+    xp_by_course = {}
+    for quest_id, _max_xp, course_id, xp_sum in rows:
+        total = quest_totals[quest_id]
+        share = capped_totals[quest_id] * xp_sum / total if total else 0
+        xp_by_course[course_id] = xp_by_course.get(course_id, 0) + share
+
+    return CappedXP(total=sum(capped_totals.values()), by_course=xp_by_course)
 
 
 class CategoryManager(models.Manager):
@@ -1228,7 +1282,7 @@ class QuestSubmissionManager(models.Manager):
 
         return total_xp
 
-    def xp_by_course(self, user, up_to_date=None):
+    def xp_by_course(self, user):
         """How much of this student's quest XP they assigned to each of their courses.
 
         A quest's `max_xp` caps what it can ever be worth, however many times it was repeated,
@@ -1239,37 +1293,72 @@ class QuestSubmissionManager(models.Manager):
 
         Args:
             user: the student whose XP is being divided.
-            up_to_date (date): count only what they had earned by then, for charting their
-                progress through the semester (issue #2453). Defaults to everything.
 
         Returns:
             dict: course id to XP, with None collecting everything left unassigned. Only the
             student's own semester counts, and only quests that grant XP.
         """
-        submissions = self.all_approved(user, up_to_date=up_to_date).grant_xp().annotate(
+        submissions = self.all_approved(user).grant_xp().annotate(
             xp_earned=Greatest('quest__xp', 'xp_requested'),
         )
         per_quest_course = submissions.order_by().values(
             'quest', 'quest__max_xp', 'course',
         ).annotate(xp_sum=Sum('xp_earned'))
 
-        # what each quest earned in total, to apply its cap before dividing it up
-        quest_totals = {}
-        for row in per_quest_course:
-            quest_totals[row['quest']] = quest_totals.get(row['quest'], 0) + row['xp_sum']
+        return split_capped_xp_by_course(
+            (row['quest'], row['quest__max_xp'], row['course'], row['xp_sum'])
+            for row in per_quest_course
+        ).by_course
 
-        xp_by_course = {}
-        for row in per_quest_course:
-            total = quest_totals[row['quest']]
-            max_xp = row['quest__max_xp']
-            if max_xp == -1:  # no limit
-                capped = total
-            else:
-                capped = min(total, max_xp or 0)  # max_xp is None when the quest was deleted
-            share = capped * row['xp_sum'] / total if total else 0
-            xp_by_course[row['course']] = xp_by_course.get(row['course'], 0) + share
+    def xp_by_course_series(self, user, dates):
+        """How much of this student's quest XP counted toward each course, at each of `dates`.
 
-        return xp_by_course
+        What xp_by_course() answers for one date, answered for a whole series off a single
+        query (issue #2459). Charting a course's progress asks it once per class day, and
+        asking the database that many times over is the cost this removes.
+
+        It cannot be done as a running total, because a quest's cap applies to what it had
+        earned *by that date*: a repeatable quest over its cap is worth its cap on every date
+        after it crossed, not the sum of its submissions. So the per-quest-and-course sums are
+        accumulated in date order and the capping rule re-applied at each point.
+
+        Args:
+            user: the student whose XP is being divided.
+            dates: the dates to answer for, in ascending order.
+
+        Returns:
+            list[CappedXP]: one per date, in the order the dates were given. Each carries the
+            date's whole quest XP as well as the split, since capping makes the shares
+            fractions whose sum need not come back to the exact figure a total is quoted as.
+        """
+        submissions = self.all_approved(user, active_semester_only=True).grant_xp().filter(
+            # what get_completed_before() counts: an approved submission with no approval time
+            # belongs to no date, so it is in no date's total
+            time_approved__isnull=False,
+        ).annotate(
+            xp_earned=Greatest('quest__xp', 'xp_requested'),
+        ).order_by('time_approved').values(
+            'quest', 'quest__max_xp', 'course', 'xp_earned', 'time_approved',
+        )
+
+        # one pass over the submissions and one over the dates, walking both forward together
+        pending = list(submissions)
+        position = 0
+        running = {}  # (quest, course) -> the quest's max_xp and the XP so far
+        series = []
+        for date in dates:
+            while position < len(pending) and pending[position]['time_approved'] <= date:
+                row = pending[position]
+                key = (row['quest'], row['course'])
+                max_xp, xp_sum = running.get(key, (row['quest__max_xp'], 0))
+                running[key] = (max_xp, xp_sum + row['xp_earned'])
+                position += 1
+            series.append(split_capped_xp_by_course(
+                (quest_id, max_xp, course_id, xp_sum)
+                for (quest_id, course_id), (max_xp, xp_sum) in running.items()
+            ))
+
+        return series
 
     def adopt_unstamped_in_progress(self, user, semester):
         """Move the work `user` has on the go that belongs to no semester into `semester`.

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import localtime
 # from django.test import tag
 from freezegun import freeze_time
@@ -1067,6 +1069,88 @@ class QuestSubmissionManagerTest(ByteDeckTenantTestCase):
         )
         xp = QuestSubmission.objects.calculate_xp_to_date(self.student, datetime(2017, 10, 12, tzinfo=timezone.utc))
         self.assertEqual(xp, 3)
+
+    def _approved_on(self, date, xp, course=None, quest=None, max_xp=-1):
+        """Give the student an approved, XP-granting submission approved on `date`."""
+        quest = quest if quest is not None else baker.make(Quest, xp=xp, max_xp=max_xp, max_repeats=-1)
+        return baker.make(
+            QuestSubmission, user=self.student, quest=quest, course=course,
+            semester=self.active_semester, is_completed=True, is_approved=True, time_approved=date,
+        )
+
+    def test_xp_by_course_series__answers_each_date_with_what_had_been_earned_by_then(self):
+        """Each date gets the split as it stood then, which is what plots a course's line
+        through the semester (issue #2459)."""
+        maths = baker.make(Course)
+        art = baker.make(Course)
+        monday = datetime(2024, 1, 8, tzinfo=timezone.utc)
+        self._approved_on(monday, xp=10, course=maths)
+        self._approved_on(monday + timedelta(days=2), xp=25, course=art)
+
+        series = QuestSubmission.objects.xp_by_course_series(
+            self.student, [monday - timedelta(days=1), monday, monday + timedelta(days=2)])
+
+        self.assertEqual([entry.by_course for entry in series], [{}, {maths.id: 10}, {maths.id: 10, art.id: 25}])
+        self.assertEqual([entry.total for entry in series], [0, 10, 35])
+
+    def test_xp_by_course_series__caps_a_repeatable_quest_at_each_date(self):
+        """A quest's max_xp caps what it was worth *as of that date*, so a repeatable quest
+        that crosses its cap partway through is worth its cap from then on rather than the sum
+        of its submissions. That is why each date is capped afresh instead of the series being
+        a running total."""
+        monday = datetime(2024, 1, 8, tzinfo=timezone.utc)
+        quest = baker.make(Quest, xp=10, max_xp=15, max_repeats=-1)
+        for day in range(3):
+            self._approved_on(monday + timedelta(days=day), xp=10, quest=quest)
+
+        series = QuestSubmission.objects.xp_by_course_series(
+            self.student, [monday + timedelta(days=day) for day in range(3)])
+
+        self.assertEqual([entry.total for entry in series], [10, 15, 15])
+        self.assertEqual([entry.by_course for entry in series], [{None: 10}, {None: 15}, {None: 15}])
+
+    def test_xp_by_course_series__shares_a_capped_quest_between_the_courses_it_was_put_against(self):
+        """A repeatable quest spread across two courses cannot earn more than one kept in a
+        single course, so its cap is applied to the quest as a whole and each course credited
+        in proportion to what it was assigned."""
+        maths = baker.make(Course)
+        art = baker.make(Course)
+        monday = datetime(2024, 1, 8, tzinfo=timezone.utc)
+        quest = baker.make(Quest, xp=10, max_xp=15, max_repeats=-1)
+        self._approved_on(monday, xp=10, quest=quest, course=maths)
+        self._approved_on(monday, xp=10, quest=quest, course=art)
+
+        [entry] = QuestSubmission.objects.xp_by_course_series(self.student, [monday])
+
+        self.assertEqual(entry.total, 15)
+        self.assertEqual(entry.by_course, {maths.id: 7.5, art.id: 7.5})
+
+    def test_xp_by_course_series__leaves_out_a_submission_with_no_approval_time(self):
+        """An approved submission with no approval time belongs to no date, the same as
+        calculate_xp_to_date() leaves it out, so it counts toward no date's figure."""
+        monday = datetime(2024, 1, 8, tzinfo=timezone.utc)
+        self._approved_on(None, xp=10)
+
+        [entry] = QuestSubmission.objects.xp_by_course_series(self.student, [monday])
+
+        self.assertEqual(entry.total, 0)
+        self.assertEqual(entry.by_course, {})
+
+    def test_xp_by_course_series__costs_the_same_however_many_dates(self):
+        """Reading the submissions once is the point of the series: charting a course asks for
+        a whole semester of class days at a time, and what it costs must not grow with them
+        (issue #2459). Pinned as a comparison rather than an absolute count, so the guard
+        survives any unrelated change to how the submissions are looked up."""
+        monday = datetime(2024, 1, 8, tzinfo=timezone.utc)
+        self._approved_on(monday, xp=10)
+        dates = [monday + timedelta(days=day) for day in range(20)]
+
+        with CaptureQueriesContext(connection) as one_date:
+            QuestSubmission.objects.xp_by_course_series(self.student, dates[:1])
+        with CaptureQueriesContext(connection) as every_date:
+            QuestSubmission.objects.xp_by_course_series(self.student, dates)
+
+        self.assertEqual(len(every_date), len(one_date))
 
     def test_calculate_xp__with_xp_requested(self):
         """If student can request a custom xp value for a submission, that xp should be properly included


### PR DESCRIPTION
### What?

Finishes issue #2459 by making the XP-over-the-semester chart cost the same whatever day of the term it is drawn on. Closes #2459 (PR [#2494](https://github.com/bytedeck/bytedeck/pull/2494) did the archiving half).

On a seeded deck, one chart load on a 111 class day term drops from **1234 queries to 15**, and the JSON it returns is byte-identical before and after.

Concretely:

* `split_capped_xp_by_course()` (new, module level in `quest_manager/models.py`) holds the `max_xp` capping-and-splitting rule that `QuestSubmission.objects.xp_by_course()` used to keep inline. It returns the split and the capped total together, because the split's shares are fractions whose sum is not the exact figure a total is quoted as.
* `QuestSubmission.objects.xp_by_course_series(user, dates)` and `BadgeAssertion.objects.xp_by_course_series(user, dates)` (new) answer that question for a whole run of dates off one query each.
* `split_xp_between_registrations()` (new, module level in `courses/models.py`) is the assigned-versus-shared division `xp_across()` used to keep inline, so a per-date caller can reuse it.
* `CourseStudentManager.xp_across_series(user, registrations, dates)` (new) divides every date the way `xp_across()` divides one.
* `Semester.get_datetimes_by_days_since_start()` (new) works out a run of class-day dates off a single read of the semester's excluded days; `get_datetime_by_days_since_start()` now delegates to it.
* `courses:ajax_progress_chart` reads its line straight out of the series, and asks for today as one more date in the same walk instead of a separate `xp_to_date(today)` call for the weekend/holiday adjustment.
* `CourseStudent.xp_to_date()` and the `up_to_date` parameters that fed it are gone: the chart was their only caller, and keeping them would leave a second implementation of the rule the new helper exists to hold once.

It also carries one unrelated fix that CI turned up along the way: `SemesterManager.get_queryset()` orders semesters newest term first, and a new semester takes today as its default first day, so a deck setting up a second cohort has two starting on the same date. Ordering on the date alone left the database free to return those two in either order, which made the registration form's semester list reshuffle between page loads and failed `test_semester_field__offers_every_open_semester` on this PR's second CI run. The oldest record now comes first among semesters sharing a first day.

### Why?

The chart plots a point per class day, and each point asked the database what that course was worth on that day: two `xp_by_course()` queries plus a semester-dates query, over and over. The cost grew every day of the term, so the chart got slower the longer a class ran, which is exactly backwards.

The obvious fix (work the maps out once and reuse them) does not apply here, which is why this half was split off #2459's original plan. `xp_by_course(user, up_to_date=D)` genuinely differs for every D, and it is not a prefix sum either: a quest's `max_xp` caps what it had earned *as of that date*, so a repeatable quest past its cap is worth its cap on every later date rather than the sum of its submissions. Each point has to re-apply the cap. What can be done once is the *reading*: one submissions query and one assertions query, walked forward through the dates maintaining running per-(quest, course) sums.

### How?

Both series builders walk two cursors forward together, one over the rows (ordered by approval/grant time) and one over the dates, so the whole series costs one pass over each rather than one query per date.

The totals are kept exact rather than being summed back out of the split. For quests the capped total is added up a whole quest at a time, matching `calculate_xp_to_date()` to the integer; summing the per-course shares instead would give a sum of fractions (a quest at its cap of 15 spread over two courses is 7.5 + 7.5). A student in one course therefore still sees the same round number they saw before.

The class-day dates were their own per-day cost: `get_datetime_by_days_since_start()` reads the semester's excluded days on every call, and the view called it once per day. `numpy.busday_offset` already takes an array of offsets, so the plural version does the whole run in one call off one read.

`_registration_to_chart()` became `_registrations_to_chart()`, returning the student's whole registration list plus the index of the charted one, since dividing XP between courses is one question about the whole student and the series needs all of them anyway. It also now evaluates that list once instead of issuing two queries against it.

### Testing?

`python src/manage.py test src` (2545 tests, all passing) and `ruff check src` clean.

New tests:

* `quest_manager`: `xp_by_course_series` answers each date with what had been earned by then; caps a repeatable quest at each date (the case that rules out a running total); shares a capped quest between the courses it was put against; leaves out a submission with no approval time; costs the same however many dates.
* `badges`: `xp_by_course_series` answers each date with what had been granted by then; costs the same however many dates.
* `courses`: `xp_across_series` divides what the student had earned by then; is their whole total with one course; counts an adjustment at every date; counts badge XP from the day it was granted; its per-date totals agree with `Profile.xp_to_date()` (pinned with a repeatable quest past its cap, split across two courses, which is the case where the per-course figures are fractions); costs the same however many dates.
* `courses`: `Semester.get_datetimes_by_days_since_start()` answers a run of days off one read, agreeing with the singular method.
* `courses`: semesters sharing a first day come back oldest record first, pinning the tiebreaker the ordering fix adds.
* `courses` views: the chart endpoint costs the same however many class days.

The query-count guards are all written as a comparison (one date versus twenty) rather than an absolute number, so they survive unrelated changes to how the data is looked up while still failing if the cost goes back to growing per date. The view-level one measures through a `cost_at(when)` helper that runs an uncounted request inside each frozen clock window: `get_current_deck()` caches the deck row for an hour and `freeze_time` moves that expiry with the clock, so without it the later capture pays for a cache miss the earlier one does not.

Measured on the seeded `hackerspace` dev deck, POSTing the chart endpoint as a student in two courses, real queries only (django-tenants `SET search_path` excluded), the semester's first day moved back inside a rolled-back transaction to lengthen the term:

| class days plotted | before | after |
| --- | --- | --- |
| 11 | 134 queries, 0.06s | 15 queries, 0.01s |
| 31 | 354 queries, 0.21s | 15 queries, 0.01s |
| 71 | 794 queries, 0.47s | 15 queries, 0.01s |
| 111 | 1234 queries, 0.72s | 15 queries, 0.01s |

The chart JSON returned at each of those four term lengths is byte-identical between `develop` and this branch.

### Screenshots (if front end is affected)

Nothing about the chart changes visually, which is the point. The same student (in two courses, most of their work assigned to Mathematics 10) on `http://hackerspace.localhost:8000/courses/marks/`, captured from the running dev deck on `develop` and on this branch:

![XP progress chart, identical before and after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2459/chart.png)

The two captures are the same file: `md5 e8d9ec0f7b81a5443e0d73e541ced2be` for both, so only one is embedded.

### Anything Else?

`Profile.xp_to_date()` now has no caller in the app itself. It is left in place as the definition of "what had this student earned by then", and the new `xp_across_series` test pins the series against it, so the two cannot drift.

Follow-ups filed rather than done here: none. The remaining per-page cost on the marks page is the page itself, not the chart.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCf7tPxvnsM34aMhk6fMHz)_