### PR TITLE
feat: name the group and semester when a student joins a course (#2179)

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -707,8 +707,9 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_CourseStudentCreate_view__message_names_the_course_group_and_semester(self):
-        """A deck can run several courses, groups and semesters at once, so the notice a student
-        gets on joining names all three rather than the course alone (issue #2179)."""
+        """A deck can run several courses, groups and semesters at once, and the registration
+        form asks the student to pick all three, so the notice confirming it names all three
+        (issue #2179)."""
         course = baker.make(Course, title='Digital Art 11')
         block = baker.make(Block, name='Morning Block')
         self.client.force_login(self.test_student1)

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 
 from courses.forms import CourseStudentStaffForm, ExcludedDateFormset, SemesterForm
 from courses.models import Block, Course, CourseStudent, MarkRange, Semester, Rank, ExcludedDate
-from courses.views import SemesterActivate, SemesterUpdate, SerializedRegistrationMixin
+from courses.views import SemesterActivate, SemesterUpdate, SerializedRegistrationMixin, _registration_added_message
 from quest_manager.models import Quest, QuestSubmission
 from badges.models import Badge, BadgeAssertion
 from notifications.models import Notification, notify_rank_up
@@ -706,6 +706,63 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         response = self.client.post(reverse('courses:create'), data=self.valid_form_data)
         self.assertEqual(response.status_code, 403)
 
+    def test_CourseStudentCreate_view__message_names_the_course_group_and_semester(self):
+        """A deck can run several courses, groups and semesters at once, so the notice a student
+        gets on joining names all three rather than the course alone (issue #2179)."""
+        course = baker.make(Course, title='Digital Art 11')
+        block = baker.make(Block, name='Morning Block')
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(reverse('courses:create'), data={
+            'semester': self.sem.pk, 'block': block.pk, 'course': course.pk,
+        })
+
+        [message] = [str(m) for m in response.wsgi_request._messages]
+        self.assertEqual(
+            message,
+            'You have been added to the <strong>Digital Art 11</strong> course, '
+            'in the <strong>Morning Block</strong> group, '
+            f'during the <strong>{self.sem}</strong> semester.',
+        )
+
+    def test_CourseStudentCreate_view__message_uses_the_decks_own_word_for_a_group(self):
+        """A deck renames "group" to whatever suits it, and the registration form already labels
+        the field with that name, so the notice has to agree with the form the student just
+        filled in rather than saying "group" regardless."""
+        config = SiteConfig.get()
+        config.custom_name_for_group = 'Cohort'
+        config.save()
+        self.client.force_login(self.test_student1)
+
+        response = self.client.post(reverse('courses:create'), data=self.valid_form_data)
+
+        [message] = [str(m) for m in response.wsgi_request._messages]
+        self.assertIn(f'in the <strong>{self.block}</strong> cohort', message)
+
+    def test_CourseStudentCreate_view__simple_registration_message_names_all_three(self):
+        """A deck with one of everything registers the student without showing them a form at all,
+        so that path builds the notice from the registration rather than from form data. It still
+        has to say the same thing the form path says."""
+        config = SiteConfig.get()
+        config.simplified_course_registration = True
+        config.save()
+        # one active block and course left, so all three fields render hidden and the view
+        # registers the student on the GET instead of asking them anything
+        Block.objects.exclude(pk=self.block.pk).delete()
+        Course.objects.exclude(pk=self.course.pk).delete()
+        self.client.force_login(self.test_student1)
+
+        response = self.client.get(reverse('courses:create'))
+
+        self.assertRedirects(response, reverse('quests:quests'))
+        [message] = [str(m) for m in response.wsgi_request._messages]
+        self.assertEqual(
+            message,
+            f'You have been added to the <strong>{self.course}</strong> course, '
+            f'in the <strong>{self.block}</strong> group, '
+            f'during the <strong>{self.sem}</strong> semester.',
+        )
+
     def test_lock_student__selects_the_student_row_for_update(self):
         """The refusal above only helps if the two requests actually queue up, and what makes
         them queue is this lock. The row locked has to be the student's own: locking their
@@ -936,6 +993,55 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertEqual(self.test_student1.coursestudent_set.count(), 1)
         messages = [str(m) for m in response.wsgi_request._messages]
         self.assertFalse(any('added to' in m for m in messages))
+
+
+class RegistrationAddedMessageTests(CourseViewTestData, ByteDeckTenantTestCase):
+    """The notice a student gets when they are added to a course (issue #2179)."""
+
+    def test_registration_added_message__leaves_out_a_group_the_registration_has_not_got(self):
+        """A registration's group is nullable, and a sentence naming a group that is not there
+        reads worse than one that does not mention groups at all."""
+        registration = baker.make(
+            CourseStudent, user=self.test_student1, course=self.course, block=None, semester=self.sem,
+        )
+
+        message = _registration_added_message(registration)
+
+        self.assertNotIn('group', message)
+        self.assertEqual(
+            message,
+            f'You have been added to the <strong>{self.course}</strong> course, '
+            f'during the <strong>{self.sem}</strong> semester.',
+        )
+
+    def test_registration_added_message__leaves_out_a_semester_the_registration_has_not_got(self):
+        """A registration's semester is nullable too, and deleting a semester sets it to null
+        rather than deleting the registration, so a registration can outlive its term."""
+        registration = baker.make(
+            CourseStudent, user=self.test_student1, course=self.course, block=self.block, semester=None,
+        )
+
+        message = _registration_added_message(registration)
+
+        self.assertNotIn('semester', message)
+        self.assertEqual(
+            message,
+            f'You have been added to the <strong>{self.course}</strong> course, '
+            f'in the <strong>{self.block}</strong> group.',
+        )
+
+    def test_registration_added_message__escapes_the_names_a_teacher_typed(self):
+        """Messages reach the page through the messages template's `|safe`, so a course named
+        with markup would otherwise be rendered as markup rather than shown as its name."""
+        course = baker.make(Course, title='<script>alert(1)</script>')
+        registration = baker.make(
+            CourseStudent, user=self.test_student1, course=course, block=self.block, semester=self.sem,
+        )
+
+        message = _registration_added_message(registration)
+
+        self.assertNotIn('<script>', message)
+        self.assertIn('&lt;script&gt;alert(1)&lt;/script&gt;', message)
 
 
 class MarkRangeViewTests(ByteDeckTenantTestCase):

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -10,6 +10,8 @@ from django.shortcuts import Http404, HttpResponse, get_object_or_404, redirect,
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils import timezone
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.views import View
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
@@ -409,6 +411,36 @@ class CourseStudentUpdate(NonPublicOnlyViewMixin, UpdateView):
         return reverse('profiles:profile_detail', args=[self.object.user.profile.id])
 
 
+def _registration_added_message(registration):
+    """What a student is told when they have been added to a course.
+
+    Names the group and the semester alongside the course (issue #2179). A deck can run
+    several courses, several groups and several semesters at once, so naming only the course
+    leaves a student unable to tell which group they landed in or which term it counts toward.
+
+    Args:
+        registration (CourseStudent): the registration that was just created.
+
+    Returns:
+        str: the message, HTML-safe. The group and the semester are each left out when the
+        registration has none: both are nullable, and a half-written sentence is worse than a
+        shorter one.
+    """
+    # format_html escapes the names, which a teacher types and which reach the page through
+    # the messages template's `|safe`
+    parts = [format_html('You have been added to the <strong>{}</strong> course', registration.course)]
+    if registration.block:
+        parts.append(format_html(
+            'in the <strong>{}</strong> {}',
+            registration.block, SiteConfig.get().custom_name_for_group.lower(),
+        ))
+    if registration.semester:
+        parts.append(format_html('during the <strong>{}</strong> semester', registration.semester))
+
+    # safe because every name above went through format_html; the joining text is our own
+    return mark_safe(', '.join(parts) + '.')
+
+
 # Student Course Registration View
 class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequiredMixin,
                           UserPassesTestMixin, CreateView):
@@ -433,8 +465,22 @@ class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, S
     form_class = CourseStudentForm
     # fields = ['semester', 'block', 'course', 'grade']
     success_url = reverse_lazy('quests:quests')
-    success_message = "You have been added to the %(course)s course"
     template_name = 'courses/coursestudent_form.html'
+
+    def get_success_message(self, cleaned_data):
+        """The message naming what the student just joined (issue #2179).
+
+        Built from the saved registration rather than from a `success_message` template, so
+        the deck's own word for a group can be used and the same wording serves the
+        simplified-registration shortcut in get(), which has no form to interpolate.
+
+        Args:
+            cleaned_data (dict): the form's cleaned data, which this does not need.
+
+        Returns:
+            str: the message, HTML-safe.
+        """
+        return _registration_added_message(self.object)
 
     @staticmethod
     def _no_open_semester():
@@ -488,10 +534,10 @@ class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, S
                     course=Course.objects.filter(active=True).first()
             )
 
-            # after object has been created, redirect to normal success url and display normal success message
-            # fstring used instead of self.success_message because form context not available
+            # after object has been created, redirect to normal success url and display the same
+            # message the form path shows, built from the registration rather than form context
             if created:
-                messages.success(request, f"You have been added to the {obj.course} Course")
+                messages.success(request, _registration_added_message(obj))
             return redirect(self.success_url)
         else:
             return super().get(request, *args, **kwargs)


### PR DESCRIPTION
### What?

Closes #2179. The notice a student gets on joining a course now names the group and the semester as well as the course, and uses the deck's own word for a group.

Before: `You have been added to the Digital Art 11 course`
After: `You have been added to the **Digital Art 11** course, in the **Morning Block** group, during the **Fall 2026** semester.`

Concretely:

* `_registration_added_message(registration)` (new, module level in `courses/views.py`) builds the sentence from a saved `CourseStudent`.
* `CourseStudentCreate` gets a `get_success_message()` that calls it, replacing the static `success_message = "You have been added to the %(course)s course"`.
* The simplified-registration shortcut in `CourseStudentCreate.get()`, which registers a student without ever showing them a form, called the same thing by a second, slightly different name (`f"You have been added to the {obj.course} Course"`, capital C). It now calls the helper too, so there is one wording rather than two.

### Why?

A deck can run several courses, several groups and several semesters at once, and the registration form asks the student to pick all three. Being told only the course afterwards leaves them unable to confirm any of the other two choices landed the way they meant, which is the whole point of a confirmation message.

The deck's word for a group is a per-deck setting (`SiteConfig.custom_name_for_group`; the form already labels the field with it, and a deck may call it Block, Cohort or Section). A message that said "group" regardless would disagree with the form the student had just filled in. Since that word is not known until runtime, the message cannot be a static `success_message` template with `%(course)s`-style placeholders, which is why it moved to `get_success_message()`.

Building it from `self.object` rather than from `form.cleaned_data` is what lets the no-form shortcut share it: that path has a saved registration but no form to interpolate.

### How?

```python
parts = [format_html('You have been added to the <strong>{}</strong> course', registration.course)]
if registration.block:
    parts.append(format_html(
        'in the <strong>{}</strong> {}',
        registration.block, SiteConfig.get().custom_name_for_group.lower(),
    ))
if registration.semester:
    parts.append(format_html('during the <strong>{}</strong> semester', registration.semester))

return mark_safe(', '.join(parts) + '.')
```

`block` and `semester` are both nullable on `CourseStudent` (`semester` is `on_delete=SET_NULL`, so a registration outlives its term), so each clause is dropped when there is nothing to name: a sentence reading "in the None group" is worse than a shorter one. Neither can be null on either path that builds this message today, but the helper is the thing that has to hold up, not its current callers.

`format_html` rather than an f-string: `messages-snippet.html` renders every message through `|safe`, so these names go to the page unescaped. That is a live (if teacher-only) hole in the message this replaces, since a course title is free text: a course named `<script>alert(1)</script>` was rendered as markup. `format_html` escapes the interpolated names and `mark_safe` re-marks the joined result, whose connecting text is ours.

`.lower()` on the group name matches the house pattern for a custom name used mid-sentence (`badges/views.py:131` does the same with `custom_name_for_badge`).

### Testing?

`python src/manage.py test src` (2553 tests, all passing) and `ruff check src` clean.

New tests in `src/courses/tests/test_views.py`:

* `CourseStudentViewTests.test_CourseStudentCreate_view__message_names_the_course_group_and_semester` pins the whole sentence.
* `..._message_uses_the_decks_own_word_for_a_group` sets `custom_name_for_group = 'Cohort'` and checks the message follows.
* `..._simple_registration_message_names_all_three` pins the no-form shortcut against the same sentence.
* `RegistrationAddedMessageTests` (new class) covers the helper directly: a registration with no group, one with no semester, and one whose course title is markup.

Verified test-driven: with the two call sites reverted to the old wording (helper left in place so the import still resolves), the three view tests fail; with the change they pass.

### Screenshots (if front end is affected)

All three captured from the running dev deck at `http://hackerspace.localhost:8000`, logged in as a student who joined a course through the real form.

Before:

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2179/before.png)

After:

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2179/after.png)

After, on a deck that calls its groups "Cohort" (`SiteConfig.custom_name_for_group = 'Cohort'`), joining a different course and group:

![after, renamed group](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2179/after-renamed-group.png)

### Anything Else?

Two staff paths beside this one produce no message at all (`CourseAddStudent`, the teacher's "Add" button, and `CourseStudentUpdate`). Left alone: #2179 is about the student's own notice, and giving teachers one is a separate call about what they should be told.

While mapping this flow I checked #2060 (students joining with no semester open) since it was next in the queue, found it already fixed in `develop` and closed it with the evidence. Three adjacent gaps that turned up there are filed rather than fixed here: #2506 (staff get an unexplained error adding a student when no semester is open, plus one unguarded link), #2507 (a registration in an archived semester can't be edited), #2508 (em dashes left in the no-open-semester copy).

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCf7tPxvnsM34aMhk6fMHz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration success messages now identify the relevant course, group, and semester.
  * Messages adapt to custom terminology for groups.
  * Simplified auto-registration uses the same detailed confirmation message.
  * Names are safely displayed, including when group or semester details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->