### PR TITLE
fix: stop one SMTP rejection from killing a deck's whole digest batch

### DIFF
--- a/src/notifications/tasks.py
+++ b/src/notifications/tasks.py
@@ -1,3 +1,5 @@
+import logging
+import smtplib
 from datetime import timedelta
 from email.utils import formataddr
 from urllib.parse import urlsplit
@@ -18,6 +20,8 @@ from notifications.models import Notification
 from profile_manager.models import Profile
 
 User = get_user_model()
+
+logger = logging.getLogger(__name__)
 
 
 @app.task(name='notifications.tasks.delete_old_notifications_for_all_tenants')
@@ -47,25 +51,100 @@ def email_notification_to_users_on_all_schemas():
     return "Scheduled email_notifications_to_users_on_schema for all schemas"
 
 
-@app.task(name='notifications.tasks.email_notifications_to_users_on_schema')
-def email_notifications_to_users_on_schema(root_url):
+@app.task(name='notifications.tasks.email_notifications_to_users_on_schema', bind=True, max_retries=5)
+def email_notifications_to_users_on_schema(self, root_url, only_usernames=None):
+    """Email each user's unread-notification digest for one deck, one message at a time.
 
-    notification_emails = get_notification_emails(root_url)
+    Sending per message keeps one rejected message from aborting the rest of
+    the deck's batch (a mid-batch SMTP error used to lose every digest after
+    it). Failures are sorted by SMTP class: a permanent (5xx) refusal drops
+    that user's digest with a log line, while a temporary one (4xx, like
+    Gmail's 451 rate-limit rejection, or a dropped connection or timeout)
+    collects the user for a retry of the UNSENT remainder only, with
+    exponential backoff, so nobody already emailed gets a duplicate. If the
+    retries run out, celery surfaces the failure to monitoring, and the
+    affected notifications remain unread, so they roll into the next daily
+    digest rather than being lost.
+
+    Args:
+        root_url: The deck's root URL; names the deck in the subject and sender.
+        only_usernames: Retry plumbing: build digests only for these users.
+            None (the nightly run) means every eligible user.
+
+    Returns:
+        str: A short summary for the worker log.
+    """
+    notification_emails = get_notification_emails(root_url, only_usernames=only_usernames)
+    # one backend instance; each send opens and closes its own short SMTP
+    # session, so a connection killed by one failure can't poison the next send
     connection = mail.get_connection()
-    connection.send_messages(notification_emails)
-    # send_email_notification_tenant.delay(root_url)
+    sent = 0
+    dropped = 0
+    retry_usernames = []
+    for email in notification_emails:
+        try:
+            connection.send_messages([email])
+            sent += 1
+        except smtplib.SMTPResponseException as e:
+            # one status code for the message: 4xx means "try again later"
+            if 400 <= e.smtp_code < 500:
+                retry_usernames.append(email.recipient_username)
+            else:
+                dropped += 1
+                logger.warning(
+                    "notification email to %s permanently refused: %s %s",
+                    email.to, e.smtp_code, e.smtp_error)
+        except smtplib.SMTPRecipientsRefused as e:
+            # every recipient refused, each with its own status (a digest has
+            # exactly one recipient, but the exception is shaped as a mapping)
+            codes = [code for code, _ in e.recipients.values()]
+            if any(400 <= code < 500 for code in codes):
+                retry_usernames.append(email.recipient_username)
+            else:
+                dropped += 1
+                logger.warning("notification email to %s refused: %s", email.to, e.recipients)
+        except (smtplib.SMTPException, ConnectionError, TimeoutError) as e:
+            # the session itself failed (disconnected, timed out): temporary
+            logger.info("notification email to %s hit a transient send failure: %s", email.to, e)
+            retry_usernames.append(email.recipient_username)
 
-    return f"Sent {len(notification_emails)} notification emails"
+    summary = f"Sent {sent} notification emails"
+    if dropped:
+        summary += f", dropped {dropped} permanently refused"
+    if retry_usernames:
+        # 5, 10, 20, 40, then 80 minutes; raises Retry, so the summary so far
+        # travels in the retry's own log line
+        raise self.retry(
+            kwargs={'root_url': root_url, 'only_usernames': retry_usernames},
+            countdown=300 * (2 ** self.request.retries),
+        )
+    return summary
 
 
-def get_notification_emails(root_url):
+def get_notification_emails(root_url, only_usernames=None):
+    """Build the digest emails for every user on the deck's notification mailing list.
+
+    Args:
+        root_url: The deck's root URL, passed through to the per-user builder.
+        only_usernames: When given, build only these users' digests (the send
+            task's retry path re-sends just the users whose sends failed
+            temporarily). None means the whole mailing list.
+
+    Returns:
+        list: EmailMultiAlternatives objects, each tagged with the recipient's
+        username as ``recipient_username`` so a failed send can name the user
+        to retry without reverse-mapping their email address.
+    """
     users_to_email = Profile.objects.get_mailing_list(for_notification_email=True)
 
     notification_emails = []
 
     for user in users_to_email:
+        if only_usernames is not None and user.username not in only_usernames:
+            continue
         email = generate_notification_email(user, root_url)
         if email:
+            email.recipient_username = user.username
             notification_emails.append(email)
 
     return notification_emails

--- a/src/notifications/tasks.py
+++ b/src/notifications/tasks.py
@@ -60,11 +60,14 @@ def email_notifications_to_users_on_schema(self, root_url, only_usernames=None):
     it). Failures are sorted by SMTP class: a permanent (5xx) refusal drops
     that user's digest with a log line, while a temporary one (4xx, like
     Gmail's 451 rate-limit rejection, or a dropped connection or timeout)
-    collects the user for a retry of the UNSENT remainder only, with
-    exponential backoff, so nobody already emailed gets a duplicate. If the
-    retries run out, celery surfaces the failure to monitoring, and the
-    affected notifications remain unread, so they roll into the next daily
-    digest rather than being lost.
+    collects the user for a retry of the failed remainder only, with
+    exponential backoff. Delivery contract: a message the server REFUSED with a
+    status (4xx/5xx) cannot duplicate, since refusal is unambiguous; a session
+    that died mid-send (disconnect, timeout) is retried AT-LEAST-ONCE, because
+    SMTP cannot say whether the server accepted first, and for a digest a rare
+    duplicate beats a silently lost day. If the retries run out, celery
+    surfaces the failure to monitoring, and the affected notifications remain
+    unread, so they roll into the next daily digest rather than being lost.
 
     Args:
         root_url: The deck's root URL; names the deck in the subject and sender.
@@ -104,7 +107,9 @@ def email_notifications_to_users_on_schema(self, root_url, only_usernames=None):
                 dropped += 1
                 logger.warning("notification email to %s refused: %s", email.to, e.recipients)
         except (smtplib.SMTPException, ConnectionError, TimeoutError) as e:
-            # the session itself failed (disconnected, timed out): temporary
+            # the session itself failed (disconnected, timed out). The server
+            # may have accepted the message before the connection died, so this
+            # retry is deliberately at-least-once (see the docstring's contract)
             logger.info("notification email to %s hit a transient send failure: %s", email.to, e)
             retry_usernames.append(email.recipient_username)
 

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -158,7 +158,7 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         import smtplib
         from unittest.mock import Mock
 
-        student1, _student2 = self._make_two_eligible_recipients()
+        self._make_two_eligible_recipients()
         root_url = f'https://{self.get_test_tenant_domain()}'
 
         connection = Mock()
@@ -180,7 +180,7 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         from celery.exceptions import Retry
         from unittest.mock import Mock
 
-        student1, student2 = self._make_two_eligible_recipients()
+        student2 = self._make_two_eligible_recipients()[1]
         root_url = f'https://{self.get_test_tenant_domain()}'
 
         connection = Mock()
@@ -204,7 +204,7 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         from celery.exceptions import Retry
         from unittest.mock import Mock
 
-        student1, student2 = self._make_two_eligible_recipients()
+        student1 = self._make_two_eligible_recipients()[0]
         root_url = f'https://{self.get_test_tenant_domain()}'
 
         connection = Mock()

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -115,6 +115,109 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
         self.assertEqual(len(emails), 1)
         self.assertEqual(emails[0].to, [self.test_student2.email])
 
+    def _make_two_eligible_recipients(self):
+        """Give both students an unread notification, a verified email, an enrollment,
+        and the email-notifications preference, so the digest task builds two emails.
+
+        Returns:
+            tuple: (student1, student2), in mailing-list order.
+        """
+        from allauth.account.models import EmailAddress
+
+        course = baker.make('courses.Course')
+        semester = SiteConfig.get().active_semester
+        user_ct = ContentType.objects.get_for_model(User)
+        for student in (self.test_student1, self.test_student2):
+            baker.make(
+                Notification, recipient=student,
+                sender_content_type=user_ct, sender_object_id=self.test_teacher.id,
+            )
+            EmailAddress.objects.create(user=student, email=student.email, verified=True, primary=True)
+            baker.make('courses.CourseStudent', user=student, course=course, semester=semester)
+            student.profile.get_notifications_by_email = True
+            student.profile.save()
+        return self.test_student1, self.test_student2
+
+    def test_get_notification_emails__only_usernames_filters_and_tags(self):
+        """The retry filter builds just the named users' digests, and every built
+        email carries its recipient's username for the send task's retry plumbing."""
+        student1, student2 = self._make_two_eligible_recipients()
+        root_url = f'https://{self.get_test_tenant_domain()}'
+
+        emails = get_notification_emails(root_url)
+        self.assertEqual(len(emails), 2)
+        self.assertEqual({e.recipient_username for e in emails}, {student1.username, student2.username})
+
+        emails = get_notification_emails(root_url, only_usernames=[student2.username])
+        self.assertEqual(len(emails), 1)
+        self.assertEqual(emails[0].recipient_username, student2.username)
+
+    def test_email_task__permanent_refusal_drops_only_that_user(self):
+        """A 5xx refusal for one user's digest is logged and skipped: the rest of
+        the batch still sends, the task succeeds, and nothing is retried."""
+        import smtplib
+        from unittest.mock import Mock
+
+        student1, _student2 = self._make_two_eligible_recipients()
+        root_url = f'https://{self.get_test_tenant_domain()}'
+
+        connection = Mock()
+        connection.send_messages.side_effect = [
+            smtplib.SMTPResponseException(550, b'no such user'), 1]
+        with patch('notifications.tasks.mail.get_connection', return_value=connection):
+            task_result = tasks.email_notifications_to_users_on_schema.apply(
+                kwargs={'root_url': root_url})
+        self.assertTrue(task_result.successful())
+        self.assertEqual(task_result.result, 'Sent 1 notification emails, dropped 1 permanently refused')
+        self.assertEqual(connection.send_messages.call_count, 2)
+
+    def test_email_task__temporary_failure_retries_only_the_unsent(self):
+        """A 4xx rejection (Gmail's 451 throttle) never aborts the batch: the other
+        digests still send, and the task retries with ONLY the throttled users, so
+        nobody already emailed gets a duplicate (production find, 2026-08-18)."""
+        import smtplib
+
+        from celery.exceptions import Retry
+        from unittest.mock import Mock
+
+        student1, student2 = self._make_two_eligible_recipients()
+        root_url = f'https://{self.get_test_tenant_domain()}'
+
+        connection = Mock()
+        connection.send_messages.side_effect = [
+            1, smtplib.SMTPDataError(451, b'4.3.0 Mail server temporarily rejected message')]
+        task = tasks.email_notifications_to_users_on_schema
+        with patch('notifications.tasks.mail.get_connection', return_value=connection), \
+                patch.object(task, 'retry', side_effect=Retry('retry scheduled')) as mock_retry:
+            task_result = task.apply(kwargs={'root_url': root_url})
+        self.assertFalse(task_result.successful())
+        mock_retry.assert_called_once()
+        kwargs = mock_retry.call_args.kwargs
+        self.assertEqual(kwargs['kwargs'], {'root_url': root_url, 'only_usernames': [student2.username]})
+        self.assertEqual(kwargs['countdown'], 300)
+
+    def test_email_task__disconnect_is_retried_as_temporary(self):
+        """A dead SMTP session (disconnect mid-batch) counts as temporary: the
+        affected user lands in the retry set rather than losing their digest."""
+        import smtplib
+
+        from celery.exceptions import Retry
+        from unittest.mock import Mock
+
+        student1, student2 = self._make_two_eligible_recipients()
+        root_url = f'https://{self.get_test_tenant_domain()}'
+
+        connection = Mock()
+        connection.send_messages.side_effect = [smtplib.SMTPServerDisconnected('gone'), 1]
+        task = tasks.email_notifications_to_users_on_schema
+        with patch('notifications.tasks.mail.get_connection', return_value=connection), \
+                patch.object(task, 'retry', side_effect=Retry('retry scheduled')) as mock_retry:
+            task_result = task.apply(kwargs={'root_url': root_url})
+        self.assertFalse(task_result.successful())
+        self.assertEqual(
+            mock_retry.call_args.kwargs['kwargs'],
+            {'root_url': root_url, 'only_usernames': [student1.username]})
+
     def test_email_notification_to_users_on_all_schemas__runs_successfully(self):
         """The all-schemas email task completes successfully when applied."""
         task_result = tasks.email_notification_to_users_on_all_schemas.apply()

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -198,7 +198,11 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
 
     def test_email_task__disconnect_is_retried_as_temporary(self):
         """A dead SMTP session (disconnect mid-batch) counts as temporary: the
-        affected user lands in the retry set rather than losing their digest."""
+        affected user lands in the retry set rather than losing their digest.
+        This path is deliberately at-least-once: the server may have accepted
+        the message before the connection died, and a rare duplicate digest
+        beats a silently lost one (the status-rejection paths cannot
+        duplicate, since a refusal is unambiguous)."""
         import smtplib
 
         from celery.exceptions import Retry


### PR DESCRIPTION
### What?

The nightly per-deck notification digests now send one message at a time with failure sorting and a targeted retry, in `notifications.tasks.email_notifications_to_users_on_schema`.

### Why?

A production failure (2026-08-18): Gmail's SMTP returned `451 4.3.0 Mail server temporarily rejected message` mid-batch, and the task sent every digest for the deck through a single `connection.send_messages(...)` call with no retry. The exception aborted the batch, so every user after the failing message silently lost that day's digest, and celery just logged the failure. The 451 is a temporary throttle, but the batch-abort-no-retry shape turned it into lost mail, and it will recur as volume grows.

### How?

* **One message per send** over the backend (each send opens and closes its own short SMTP session), so one rejection cannot poison the rest of the deck's batch.
* **Failures sorted by SMTP class**: permanent refusals (5xx) are logged and dropped; temporary ones (4xx like the 451 throttle, disconnects, timeouts) collect the affected users.
* **Targeted retry**: the task retries via celery with exponential backoff (`300s * 2^retries`, max 5, so 5/10/20/40/80 minutes) passing `only_usernames` back, so only the failed remainder is retried. `get_notification_emails` tags each email with `recipient_username` so a failed send can name its user without reverse-mapping the address.
* **Delivery contract** (documented in the task docstring, sharpened by review): a message the server *refused with a status* (4xx/5xx) cannot duplicate, since refusal is unambiguous. A session that *died mid-send* (disconnect, timeout) is retried **at-least-once**: SMTP cannot say whether the server accepted first, and for a digest a rare duplicate beats a silently lost day. Durable per-digest idempotency was considered and rejected: a marker written before the send trades to at-most-once (silent loss on a real failure), and one written after sits in the same ambiguity window.
* **Exhausted retries fail loudly** to monitoring, and the affected notifications remain unread, so they roll into the next daily digest rather than being lost.

### Testing?

* `test_get_notification_emails__only_usernames_filters_and_tags`: the retry filter builds only the named users' digests, and every email carries its recipient's username.
* `test_email_task__permanent_refusal_drops_only_that_user`: a 550 drops one digest, the rest send, the task succeeds and reports the drop, nothing retries.
* `test_email_task__temporary_failure_retries_only_the_unsent`: the production 451 case: the other digests still send, and retry is invoked with exactly the throttled user and a 300s countdown.
* `test_email_task__disconnect_is_retried_as_temporary`: a dead SMTP session lands its user in the retry set instead of losing the digest, documented as the deliberate at-least-once path.

Full suite green locally (2535 tests OK), `ruff check src` clean.

### Screenshots (if front end is affected)

N/A (backend task resilience only; no user-facing change).

### Anything Else?

If the production 451 turns out to be daily *quota* rather than burst throttling as deck count grows, retries will bump into it too; the structural answer at that point is a transactional email provider, which belongs with the deliverability work around issue #2351 rather than this fix.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)