### PR TITLE
docs: fill the gaps in the library app's docstrings (#2406)

### DIFF
--- a/src/library/apps.py
+++ b/src/library/apps.py
@@ -3,6 +3,13 @@ from django.conf import settings
 
 
 class LibraryConfig(AppConfig):
+    """Django app config for the Shared Library.
+
+    Also holds the name of the tenant schema the Library lives in, so the rest of the
+    codebase asks the app registry for it instead of each caller reading the setting.
+    A deployment that keeps its Library in another schema sets `LIBRARY_TENANT_NAME`.
+    """
+
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'library'
 

--- a/src/library/models.py
+++ b/src/library/models.py
@@ -131,6 +131,13 @@ class ContentOrigin(models.Model):
     )
 
     class Meta:
+        """Identity is the (import_id, content_type) pair, not the import_id alone.
+
+        A quest and a campaign can in principle carry the same import_id, so the
+        uniqueness `record` relies on to refresh an attribution, rather than stack a
+        second one beside it, has to name both.
+        """
+
         constraints = [
             models.UniqueConstraint(
                 fields=['import_id', 'content_type'],

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -6,6 +6,16 @@ from django_tenants.utils import schema_context
 
 
 def get_library_schema_name():
+    """Return the name of the tenant schema the Shared Library lives in.
+
+    A function rather than a module-level constant because `apps.get_app_config`
+    needs the app registry to be populated, which it is not while modules are still
+    being imported.
+
+    Returns:
+        str: the Library's schema name, `library` unless the deployment sets
+            `LIBRARY_TENANT_NAME`.
+    """
     return apps.get_app_config('library').TENANT_NAME
 
 

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -57,9 +57,28 @@ def shared_library_enabled_view(f):
     `SiteConfig.get()` returns None on the public schema, which has no deck
     config and so has no Shared Library either: that is treated the same way, so
     this holds on its own rather than relying on running after a non-public check.
+
+    Args:
+        f (callable): the view function to guard.
+
+    Returns:
+        callable: `f` wrapped so it only runs on a deck with the Library enabled.
     """
     @functools.wraps(f)
     def wrapper(request, *args, **kwargs):
+        """Run the wrapped view only if this deck has the Shared Library on.
+
+        Args:
+            request (HttpRequest): the current request.
+            *args: positional arguments for the wrapped view.
+            **kwargs: keyword arguments for the wrapped view.
+
+        Returns:
+            HttpResponse: whatever the wrapped view returns.
+
+        Raises:
+            Http404: if the deck has the Shared Library off, or has no deck config.
+        """
         config = SiteConfig.get()
         if config is None or not config.enable_shared_library:
             raise Http404("The Shared Library is not enabled on this deck.")
@@ -71,9 +90,9 @@ def get_published_library_object(model, import_id):
     """Fetch a published object from the Shared Library by its import ID.
 
     Content lands in the Library unpublished and stays invisible to other decks
-    until a Library admin reviews and publishes it (#1949). That gate used to
-    filter only the listing pages, so a POST straight to an import URL pulled
-    unreviewed content down. Both import paths go through here instead.
+    until a Library admin reviews and publishes it (#1949). Both import paths go
+    through here, so the gate holds against a POST straight to an import URL and
+    not only against what the listing pages choose to show.
 
     Must be called from within the library schema context.
 
@@ -401,7 +420,7 @@ def email_library_staff_of_push(content_type, content_name, exported_obj, sharer
     an email address (e.g. only the ``deck_ai`` bot user is staff).
 
     Args:
-        content_type (str): "quest" or "campaign" -- used in the subject/body.
+        content_type (str): "quest" or "campaign", used in the subject/body.
         content_name (str): the human-readable name of the shared content.
         exported_obj (Quest | Category): the copy now in the library schema,
             used to build the review/publish link on the Library deck.
@@ -520,10 +539,10 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
         """
         Populate context with a page of the shared library's listable quests.
 
-        The Library is read one page at a time: the whole thing used to be loaded into
-        memory and rendered on every request, which does not survive a Library worth
-        browsing (#2379). Searching happens in the database for the same reason, so it
-        covers every quest rather than only the ones already sent to the browser.
+        The Library is read one page at a time, since loading all of it into memory on
+        every request does not survive a Library worth browsing (#2379). Searching
+        happens in the database for the same reason, so it covers every quest rather
+        than only the ones already sent to the browser.
 
         Args:
             **kwargs: keyword arguments passed through to `TemplateView.get_context_data`.


### PR DESCRIPTION
### What?

Documentation only. Adds the missing docstrings in `src/library`, and rewrites three that described the code they replaced rather than the code that is there.

Closes #2406.

### Why?

CLAUDE.md asks for a docstring on every method and class, with its purpose, parameters and return value. #2405 completed the two it actually touched and deliberately left the neighbours alone to keep that diff to its stated scope, which is what this issue was filed for.

### How?

I walked the AST of every module in `src/library` and flagged anything without a docstring, with parameters missing from an `Args:` section, or returning a value with no `Returns:` section. That found five gaps:

| Where | Gap |
|---|---|
| `apps.LibraryConfig` | no class docstring, and nothing said why the Library's schema name lives on the app config |
| `models.ContentOrigin.Meta` | no docstring on the constraint that makes re-sharing update a row rather than stack a second one |
| `utils.get_library_schema_name` | no docstring at all |
| `views.shared_library_enabled_view` | no `Args`, no `Returns` |
| the `wrapper` it returns | no docstring |

The one gap the issue names by hand, `LibraryQuestListView.get_context_data` missing an `Args` entry for `**kwargs`, was closed by a later PR before I got here. The sweep above is what was left, and the same audit now comes back clean.

Three docstrings also described the previous approach rather than the current one: "That gate used to filter only the listing pages", "the whole thing used to be loaded into memory". That is the shape CLAUDE.md rules out, because once the PR that motivated the sentence is merged the reader has no way to see what it refers to. They now state the invariant that holds. A double hyphen standing in for an em dash went with them.

### Testing?

No behaviour change, so no new tests. `python src/manage.py test src` passes (2567 tests) and `ruff check src` is clean.

### Screenshots (if front end is affected)

N/A: documentation only, nothing renders differently.

### Anything Else?

The audit script is a dozen lines and disposable, so it is not committed. If a docstring check like it would be worth having in `hackerspace_online/tests/test_conventions.py` alongside the test-naming and test-docstring checks, say so and I will open an issue for it: it would cover the whole codebase rather than one app, which is a bigger conversation than this PR.

### Review request
@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_