### PR TITLE
fix: explain a course registration refused for want of an open semester (#2506, #2507, #2508)

### DIFF
--- a/src/courses/forms.py
+++ b/src/courses/forms.py
@@ -223,6 +223,25 @@ class CourseStudentForm(forms.ModelForm):
 
 
 class CourseStudentStaffForm(CourseStudentForm):
+    """The registration form as staff edit an existing registration, rather than create one."""
+
+    def __init__(self, *args, **kwargs):
+        """Keep the registration's own semester among the choices.
+
+        Offering only the open semesters is right for creating a registration: a student is
+        registered into a term that is running. But an archived semester keeps its
+        registrations, and a form that does not offer a field's current value cannot be saved
+        at all, so correcting the course or the group on a past registration failed validation
+        on the semester and there was no way through it (issue #2507).
+
+        This only adds the "leave it where it is" choice. Every open semester was already
+        offered, so it does not newly allow moving a registration from one term to another.
+        """
+        super().__init__(*args, **kwargs)
+        if self.instance.semester_id is not None:
+            self.fields['semester'].queryset = (
+                self.fields['semester'].queryset | Semester.objects.filter(pk=self.instance.semester_id)
+            )
 
     class Meta:
         model = CourseStudent

--- a/src/courses/templates/courses/coursestudent_form.html
+++ b/src/courses/templates/courses/coursestudent_form.html
@@ -7,7 +7,13 @@
 
 {% if no_open_semester %}
   <div class="alert alert-warning">
-    <p>No semesters are currently open. Your teacher needs to open a semester before you can join a course.</p>
+    {% if request.user.is_staff %}
+      <p><strong>No semester is open:</strong> nobody can be registered in a course until you create
+        and activate one.</p>
+      <p><a href="{% url 'courses:semester_list' %}">Manage semesters</a> to open one, then come back.</p>
+    {% else %}
+      <p>No semesters are currently open. Your teacher needs to open a semester before you can join a course.</p>
+    {% endif %}
   </div>
 {% elif deck_at_capacity %}
   <div class="alert alert-warning">

--- a/src/courses/templates/courses/coursestudent_form.html
+++ b/src/courses/templates/courses/coursestudent_form.html
@@ -24,7 +24,7 @@
       <p><a href="{% url 'courses:archive_students_help' %}">Free up seats</a> by ending the semester or archiving
         past students, or <a href="{{ deck_subscribe_url }}">upgrade your subscription</a> for a higher limit.</p>
     {% else %}
-      <p>This deck has reached its limit of current students, so you can't join a course right now &mdash;
+      <p>This deck has reached its limit of current students, so you can't join a course right now:
         please let your teacher know.</p>
     {% endif %}
   </div>

--- a/src/courses/templates/courses/mark_calculations.html
+++ b/src/courses/templates/courses/mark_calculations.html
@@ -16,8 +16,13 @@ for {{user}}
   <p>Hello {{ user.profile.get_preferred_name }},
     {% if not courses %}
       I can't calculate your mark because you haven't joined a course for this
-      semester yet. Please <a href="{% url 'courses:create' %}">go here</a>
-      and join your course.</p>
+      semester yet.
+      {% if config.has_no_open_semester %}
+        No semester is open yet, so you can't join one: ask your teacher to open one.</p>
+      {% else %}
+        Please <a href="{% url 'courses:create' %}">go here</a>
+        and join your course.</p>
+      {% endif %}
     {% elif obj.semester.days_so_far < 0 %}
       I can't calculate your mark because semester hasn't started yet!  According
       to my records, the semester is scheduled to start on

--- a/src/courses/tests/test_forms.py
+++ b/src/courses/tests/test_forms.py
@@ -6,7 +6,7 @@ from django_select2.forms import Select2Widget
 from model_bakery import baker
 
 from badges.forms import BadgeAssertionForm
-from courses.forms import CourseStudentForm, SemesterForm
+from courses.forms import CourseStudentForm, CourseStudentStaffForm, SemesterForm
 from courses.models import Block, Course, CourseStudent, Semester
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.forms import SubmissionQuickReplyFormStudent
@@ -91,6 +91,59 @@ class CourseStudentFormTest(ByteDeckTenantTestCase):
         form = CourseStudentForm(student_registration=True)
 
         self.assertIsInstance(form.fields['semester'].widget, forms.HiddenInput)
+
+
+class CourseStudentStaffFormTest(ByteDeckTenantTestCase):
+    """The registration form as staff edit an existing registration (issue #2507)."""
+
+    def _registration(self, status):
+        """A registration in a semester with the given status."""
+        return baker.make(
+            CourseStudent, user=baker.make(User), course=baker.make(Course),
+            block=baker.make(Block), semester=baker.make(Semester, status=status),
+        )
+
+    def test_semester_field__offers_the_registrations_own_archived_semester(self):
+        """A semester is archived while its registrations live on, and a field that does not
+        offer its own current value can never validate, so a past registration could not be
+        edited at all."""
+        registration = self._registration(Semester.Status.ARCHIVED)
+
+        form = CourseStudentStaffForm(instance=registration)
+
+        self.assertIn(registration.semester, form.fields['semester'].queryset)
+
+    def test_semester_field__still_offers_every_open_semester(self):
+        """Keeping the registration's own semester must not cost the choices that were already
+        there: a registration can still be moved between the terms that are running."""
+        another = baker.make(Semester, status=Semester.Status.OPEN)
+        registration = self._registration(Semester.Status.ARCHIVED)
+
+        form = CourseStudentStaffForm(instance=registration)
+
+        self.assertIn(SiteConfig.get().active_semester, form.fields['semester'].queryset)
+        self.assertIn(another, form.fields['semester'].queryset)
+
+    def test_semester_field__leaves_out_other_semesters_that_are_not_open(self):
+        """Only this registration's own semester is added back. An archived semester some other
+        registration is in is still not somewhere to move this one."""
+        someone_elses = baker.make(Semester, status=Semester.Status.ARCHIVED)
+        registration = self._registration(Semester.Status.ARCHIVED)
+
+        form = CourseStudentStaffForm(instance=registration)
+
+        self.assertNotIn(someone_elses, form.fields['semester'].queryset)
+
+    def test_semester_field__unchanged_for_a_registration_in_an_open_semester(self):
+        """The usual case is a registration in a running term, where its own semester is among
+        the open ones already and nothing is added."""
+        registration = self._registration(Semester.Status.OPEN)
+
+        form = CourseStudentStaffForm(instance=registration)
+
+        self.assertEqual(
+            set(form.fields['semester'].queryset), set(Semester.objects.open()),
+        )
 
 
 class SemesterFormTest(ByteDeckTenantTestCase):

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -638,9 +638,10 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
 
     def test_CourseStudentUpdate_view__staff_can_update_a_registration_in_an_archived_semester(self):
         """A registration outlives the semester it is in, so a teacher spotting a wrong course
-        on a past one has to be able to correct it. The form offers only open semesters, which
-        left the registration's own value off the list and made the form unsaveable, whatever
-        else was being changed (issue #2507)."""
+        on a past one has to be able to correct it. The staff form has to keep the
+        registration's own archived semester among its choices for that: a field whose current
+        value is not on its list cannot validate, and the form is then unsaveable whatever else
+        is being changed (issue #2507)."""
         archived = baker.make(Semester, status=Semester.Status.ARCHIVED)
         course_student = baker.make(
             CourseStudent, user=self.test_student1, course=self.course, block=self.block,
@@ -919,7 +920,7 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertNotContains(response, 'not one of the available choices')
         self.assertEqual(self.test_student1.coursestudent_set.count(), 0)
 
-    def test_no_open_semester__refusal_is_worded_for_whoever_is_looking(self):
+    def test_NoOpenSemesterMixin__refusal_is_worded_for_whoever_is_looking(self):
         """A student is told to ask their teacher, because that is all they can do about it. The
         teacher is the one who can fix it, so they are told what to fix instead (issue #2506)."""
         self._close_active_semester()
@@ -934,7 +935,7 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertContains(to_student, 'Your teacher needs to open a semester')
         self.assertNotContains(to_student, self.REFUSAL_TO_STAFF)
 
-    def test_no_open_semester__mark_calculations_does_not_send_a_student_to_the_join_page(self):
+    def test_mark_calculations__does_not_link_to_the_join_page_with_no_open_semester(self):
         """The marks page tells a student with no course to go and join one. With no semester
         open that link only leads to a refusal, so it says why in place instead, the same as the
         quests page and the profile page already do (issue #2506)."""

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -862,6 +862,71 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         self.assertContains(response, 'No semesters are currently open')
         self.assertEqual(self.test_student1.coursestudent_set.count(), 0)
 
+    # the staff banner also says "No semester is open" on every page, so these assert on the
+    # refusal page's own wording rather than on anything the banner could be supplying
+    REFUSAL_TO_STAFF = 'nobody can be registered in a course until you create'
+
+    def test_CourseAddStudent_view__blocked_when_no_open_semester__get(self):
+        """Staff adding a student need a semester to add them into just as much as a student
+        joining does (issue #2506). With none open the form's semester field has no choices, so
+        the page explains the reason rather than rendering a form that could only fail."""
+        self.client.force_login(self.test_teacher)
+        self._close_active_semester()
+
+        response = self.client.get(reverse('courses:join', args=[self.test_student1.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.REFUSAL_TO_STAFF)
+        self.assertNotContains(response, 'id="coursestudentform"')
+
+    def test_CourseAddStudent_view__blocked_when_no_open_semester__post(self):
+        """The refusal covers the POST too: the GET-side check alone would not stop a teacher
+        submitting the same URL directly (issue #2506). Without it the submission fails anyway,
+        on the semester field's empty queryset, but says only "not one of the available
+        choices"."""
+        self.client.force_login(self.test_teacher)
+        self._close_active_semester()
+
+        response = self.client.post(
+            reverse('courses:join', args=[self.test_student1.id]), data=self.valid_form_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.REFUSAL_TO_STAFF)
+        self.assertNotContains(response, 'not one of the available choices')
+        self.assertEqual(self.test_student1.coursestudent_set.count(), 0)
+
+    def test_no_open_semester__refusal_is_worded_for_whoever_is_looking(self):
+        """A student is told to ask their teacher, because that is all they can do about it. The
+        teacher is the one who can fix it, so they are told what to fix instead (issue #2506)."""
+        self._close_active_semester()
+
+        self.client.force_login(self.test_teacher)
+        to_staff = self.client.get(reverse('courses:join', args=[self.test_student1.id]))
+        self.client.force_login(self.test_student1)
+        to_student = self.client.get(reverse('courses:create'))
+
+        self.assertContains(to_staff, 'Manage semesters</a> to open one, then come back')
+        self.assertNotContains(to_staff, 'Your teacher needs to open a semester')
+        self.assertContains(to_student, 'Your teacher needs to open a semester')
+        self.assertNotContains(to_student, self.REFUSAL_TO_STAFF)
+
+    def test_no_open_semester__mark_calculations_does_not_send_a_student_to_the_join_page(self):
+        """The marks page tells a student with no course to go and join one. With no semester
+        open that link only leads to a refusal, so it says why in place instead, the same as the
+        quests page and the profile page already do (issue #2506)."""
+        student = User.objects.create_user('markless_student')  # no CourseStudent registration
+        config = SiteConfig.get()
+        config.display_marks_calculation = True  # off by default, and the page 404s a student when off
+        config.save()
+        self._close_active_semester()
+        self.client.force_login(student)
+
+        response = self.client.get(reverse('courses:my_marks'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'ask your teacher to open one')
+        self.assertNotContains(response, reverse('courses:create'))
+
     def test_no_open_semester__student_join_button_replaced_by_message(self):
         """A student with no course sees a 'no semester open' note instead of the Join a Course
         button when the deck has no open semester (issue #2060)."""

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -636,6 +636,30 @@ class CourseStudentViewTests(CourseViewTestData, ByteDeckTenantTestCase):
         course_student.refresh_from_db()
         self.assertEqual(course_student.course.pk, new_course.pk)
 
+    def test_CourseStudentUpdate_view__staff_can_update_a_registration_in_an_archived_semester(self):
+        """A registration outlives the semester it is in, so a teacher spotting a wrong course
+        on a past one has to be able to correct it. The form offers only open semesters, which
+        left the registration's own value off the list and made the form unsaveable, whatever
+        else was being changed (issue #2507)."""
+        archived = baker.make(Semester, status=Semester.Status.ARCHIVED)
+        course_student = baker.make(
+            CourseStudent, user=self.test_student1, course=self.course, block=self.block,
+            semester=archived, active=False,
+        )
+        new_course = baker.make(Course)
+
+        form_data = model_to_form_data(course_student, CourseStudentStaffForm)
+        form_data['course'] = new_course.pk
+
+        self.client.force_login(self.test_teacher)
+        response = self.client.post(reverse('courses:update', args=[course_student.pk]), data=form_data)
+
+        self.assertRedirects(response, reverse('profiles:profile_detail', args=[course_student.user.profile.pk]))
+        course_student.refresh_from_db()
+        self.assertEqual(course_student.course.pk, new_course.pk)
+        # and it stayed in its own term rather than being dragged into a running one
+        self.assertEqual(course_student.semester, archived)
+
     def test_CourseAddStudent_view__staff_can_add(self):
         '''Staff can add a student to a course'''
 

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -340,11 +340,56 @@ class SerializedRegistrationMixin:
             return self.form_invalid(form)
 
 
+class NoOpenSemesterMixin:
+    """The refusal a registration view gives while the deck has no semester open (issue #2060).
+
+    Registering anyone in a course needs a semester to register them into. With none open the
+    form's semester field has no choices at all, so rendering it can only produce a submission
+    that fails on `Select a valid choice`, which says nothing about the actual reason or what
+    to do about it.
+
+    Both views that create a registration check this first, before their other guards, and
+    both check it on POST as well as GET: the GET-side check alone would not stop a direct
+    submission to the same URL.
+
+    Attributes:
+        no_open_semester_heading (str): how the refusal page titles itself. The two views are
+            refusing different things, so each names its own.
+    """
+
+    no_open_semester_heading = ''
+
+    @staticmethod
+    def no_open_semester():
+        """Whether there is no semester open to register anyone into.
+
+        Returns:
+            bool: True when the deck has no open semester.
+        """
+        return SiteConfig.get().has_no_open_semester()
+
+    def no_open_semester_response(self, request):
+        """Render the page with the explanation in place of a form that could only fail.
+
+        Args:
+            request: the request being refused.
+
+        Returns:
+            HttpResponse: the registration template, which words the explanation for a student
+            or for staff depending on who is looking.
+        """
+        return render(request, self.template_name, {
+            'heading': self.no_open_semester_heading,
+            'no_open_semester': True,
+        })
+
+
 @method_decorator(staff_member_required, name='dispatch')
-class CourseAddStudent(SerializedRegistrationMixin, NonPublicOnlyViewMixin, CreateView):
+class CourseAddStudent(SerializedRegistrationMixin, NoOpenSemesterMixin, NonPublicOnlyViewMixin, CreateView):
     model = CourseStudent
     form_class = CourseStudentForm
     template_name = 'courses/coursestudent_form.html'
+    no_open_semester_heading = 'Add student to course'
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -366,12 +411,17 @@ class CourseAddStudent(SerializedRegistrationMixin, NonPublicOnlyViewMixin, Crea
         return render(request, self.template_name, {'heading': 'Add student to course', 'deck_at_capacity': True})
 
     def get(self, request, *args, **kwargs):
+        if self.no_open_semester():
+            return self.no_open_semester_response(request)
+
         if self._deck_at_capacity_for_target():
             return self._deck_at_capacity_response(request)
         return super().get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         # block the direct POST too, or the cap could be bypassed by submitting the form URL
+        if self.no_open_semester():
+            return self.no_open_semester_response(request)
         if self._deck_at_capacity_for_target():
             return self._deck_at_capacity_response(request)
         return super().post(request, *args, **kwargs)
@@ -442,8 +492,8 @@ def _registration_added_message(registration):
 
 
 # Student Course Registration View
-class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, SuccessMessageMixin, LoginRequiredMixin,
-                          UserPassesTestMixin, CreateView):
+class CourseStudentCreate(SerializedRegistrationMixin, NoOpenSemesterMixin, NonPublicOnlyViewMixin,
+                          SuccessMessageMixin, LoginRequiredMixin, UserPassesTestMixin, CreateView):
 
     def test_func(self):
         """Allow the registration view only when the student is not already actively registered
@@ -466,6 +516,7 @@ class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, S
     # fields = ['semester', 'block', 'course', 'grade']
     success_url = reverse_lazy('quests:quests')
     template_name = 'courses/coursestudent_form.html'
+    no_open_semester_heading = 'Join a course'
 
     def get_success_message(self, cleaned_data):
         """The message naming what the student just joined (issue #2179).
@@ -482,17 +533,6 @@ class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, S
         """
         return _registration_added_message(self.object)
 
-    @staticmethod
-    def _no_open_semester():
-        """Whether there is no semester open for a student to join a course into (issue #2060)."""
-        return SiteConfig.get().has_no_open_semester()
-
-    def _no_open_semester_response(self, request):
-        """Render the join page with a message explaining that no semester is open, instead of the
-        registration form, so a student can't join a course when there's nowhere to join (#2060).
-        """
-        return render(request, self.template_name, {'heading': 'Join a course', 'no_open_semester': True})
-
     def _deck_at_capacity(self):
         """Whether the deck's current-student cap blocks this user from registering (#1729 PR 4)."""
         from tenant.limits import can_add_current_student
@@ -507,8 +547,8 @@ class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, S
         return render(request, self.template_name, {'heading': 'Join a course', 'deck_at_capacity': True})
 
     def get(self, request, *args, **kwargs):
-        if self._no_open_semester():
-            return self._no_open_semester_response(request)
+        if self.no_open_semester():
+            return self.no_open_semester_response(request)
 
         if self._deck_at_capacity():
             return self._deck_at_capacity_response(request)
@@ -545,8 +585,8 @@ class CourseStudentCreate(SerializedRegistrationMixin, NonPublicOnlyViewMixin, S
     def post(self, request, *args, **kwargs):
         # Also block the POST: without this a student could still submit a registration into the
         # closed active semester by posting directly (the form's only semester choice) (#2060).
-        if self._no_open_semester():
-            return self._no_open_semester_response(request)
+        if self.no_open_semester():
+            return self.no_open_semester_response(request)
         # ...and the same for the capacity cap: the GET-side guard alone wouldn't stop a direct POST
         if self._deck_at_capacity():
             return self._deck_at_capacity_response(request)

--- a/src/profile_manager/templates/profile_manager/profile_detail.html
+++ b/src/profile_manager/templates/profile_manager/profile_detail.html
@@ -112,7 +112,7 @@
             {% else %}
               You have not joined a course yet this semester.
               {% if config.has_no_open_semester %}
-                <br><em>No semester is open yet, so you can’t join a course — ask your teacher to open one.</em>
+                <br><em>No semester is open yet, so you can’t join a course: ask your teacher to open one.</em>
               {% else %}
                 <a href="{% url 'courses:create' %}">Join a Course</a>
               {% endif %}
@@ -174,7 +174,7 @@
           {% else %}
             <li class="list-group-item">You have not joined a course yet for this semester.
               {% if config.has_no_open_semester %}
-                <br><em>No semester is open yet, so you can’t join a course — ask your teacher to open one.</em>
+                <br><em>No semester is open yet, so you can’t join a course: ask your teacher to open one.</em>
               {% else %}
                 <a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a>
               {% endif %}

--- a/src/quest_manager/templates/quest_manager/quests.html
+++ b/src/quest_manager/templates/quest_manager/quests.html
@@ -94,7 +94,7 @@ back to its original look.
       {% if not request.user.profile.has_current_course and not request.user.is_staff %}
         <p>You have not joined a course yet for this semester.</p>
         {% if config.has_no_open_semester %}
-          <p><em>No semester is open yet, so you can’t join a course — ask your teacher to open one.</em></p>
+          <p><em>No semester is open yet, so you can’t join a course: ask your teacher to open one.</em></p>
         {% else %}
           <p><a href="{% url 'courses:create' %}" class="btn btn-info" role="button">Join a Course</a></p>
         {% endif %}


### PR DESCRIPTION
### What?

Three small fixes around course registration, all found while verifying #2060 (which turned out to be fixed already, and is now closed). One commit each, so they can be read separately.

* **Closes #2506.** A student who tries to join a course with no semester open is told why. A teacher adding a student was told nothing: `CourseAddStudent` had no such check, so it rendered a form whose semester field had no choices and submitting it failed with Django's stock `Select a valid choice. That choice is not one of the available choices.` They now get the reason and a link to the semesters page. The check and its page move into a `NoOpenSemesterMixin` both registration views use. Also guards the one link to the join page that was missing it, on the marks page.
* **Closes #2507.** `CourseStudentStaffForm` inherits a semester queryset of `Semester.objects.open()`, so a registration whose semester has been archived had its own value missing from the choices and the form could never validate. A teacher could not correct a wrong course or group on a past registration at all, whatever they were changing.
* **Closes #2508.** Four em dashes left in student-facing copy, which CLAUDE.md bans.

### Why?

**#2506.** The app already knows exactly why the registration cannot go through, and says so clearly to students. Saying nothing to the person who can actually fix it is the wrong way round: a teacher gets a field error about "available choices" with no hint that the answer is to open a semester. The staff banner does say "No semester is open" at the top of every page, but it reads as unrelated to the form that just refused them.

**#2507.** A registration outlives its semester. Marks get recorded, terms get archived, and a teacher later spots that someone was in the wrong course. Today that is uncorrectable through the UI, only through the Django admin.

Worth being precise about what changed, because it sounds more permissive than it is: every open semester was **already** offered on that form. So you could already move an archived registration into a running term; the one thing you could not do was leave it where it was. This adds the "no change" option, nothing else.

### How?

`NoOpenSemesterMixin` holds the predicate and the response. The two views differ only in what the page calls itself, so that is the one thing the mixin takes as an attribute. Both keep their explicit calls in `get()` and `post()` rather than the mixin overriding them, which keeps the ordering against each view's other guards visible at the call site (and there is a note in `RefuseSemesterMixin` warning against `dispatch()` overrides in this module, since one would run before `NonPublicOnlyViewMixin`'s and query a tenant-only table on the public schema).

`coursestudent_form.html` words the explanation for a student or for staff, the same way its at-capacity notice already does.

For #2507, the edit form widens the queryset by union rather than rebuilding the filter, so it stays defined in terms of `Semester.objects.open()`:

```python
if self.instance.semester_id is not None:
    self.fields['semester'].queryset = (
        self.fields['semester'].queryset | Semester.objects.filter(pk=self.instance.semester_id)
    )
```

### Testing?

`python src/manage.py test src` (2582 tests, all passing) and `ruff check src` clean. Each commit's tests were verified to fail against the code without it.

New tests:

* `courses` views: the staff add-student page explains itself on GET and on POST; the refusal is worded differently for staff and for a student; the marks page does not send a student to a join page that would only refuse them.
* `courses` forms: a new `CourseStudentStaffFormTest` covers the edit form offering the registration's own archived semester, still offering every open one, not offering somebody else's archived one, and being unchanged for a registration in an open semester.
* `courses` views: staff can update a registration in an archived semester, and it stays in its own term rather than being dragged into a running one.

One thing worth flagging about the staff tests: the staff banner also renders "No semester is open" on every page, so two of them passed against unfixed code at first. They now assert on the refusal page's own wording (`nobody can be registered in a course until you create...`) and on the absence of the raw field error, which the banner cannot supply.

#2508 needed no new test: the existing `test_no_open_semester__student_join_button_replaced_by_message` already asserts on the part of the sentence that did not change.

### Screenshots (if front end is affected)

Copy-only changes to text a teacher sees when a deck has no open semester, and to four student-facing sentences. The exact strings are in the diff and asserted in the tests; the staff refusal reads:

> **No semester is open:** nobody can be registered in a course until you create and activate one.
> [Manage semesters](#) to open one, then come back.

### Anything Else?

The two `&mdash;` uses next to the ones replaced are deliberately left: `profile_detail.html:142` uses one as a placeholder for an absent last-login date and `quests.html:119` as a dash before a list caption. Neither is prose.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCf7tPxvnsM34aMhk6fMHz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Staff can edit registrations while retaining their original archived semester.
  - Registration actions are blocked when no semester is open, with guidance tailored to students and staff.
  - Marks pages now clearly explain when no semester is available instead of directing users to register.

- **Bug Fixes**
  - Prevented invalid registrations during closed-semester periods.
  - Improved messaging and punctuation across course, profile, and quest pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->