### PR TITLE
fix: recognise a recording by every name it goes by (#2492)

### DIFF
--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -67,6 +67,12 @@ FILE_MIME_TYPES = {
     'all': 'All',
 }
 
+# Python's builtin MIME table does not know `.m4a`: platforms fill the gap from
+# /etc/mime.types when that file exists, so the same recording guessed as `audio/mp4` on
+# one machine and as nothing at all on another (CI's container has no such file).
+# Register the mapping so `media_kind_of` answers the same everywhere (#2492).
+mimetypes.add_type('audio/mp4', '.m4a')
+
 # Which browser element can play a stored file, by the MIME types above. The value is the
 # kind of media, so a template can pick between an image, a video player and an audio
 # player without repeating the type lists.

--- a/src/utilities/fields.py
+++ b/src/utilities/fields.py
@@ -39,15 +39,21 @@ VIDEO_MIME_TYPES = [
     'video/x-m4v'  # M4V videos
 ]
 
+# WAV and M4A each go by two names: browsers disagree on the content type they send when
+# one is uploaded, and Python's `mimetypes` (which `media_kind_of` guesses stored files
+# with) uses `audio/x-wav` and `audio/mp4`. Both spellings of each are listed so a
+# recording is accepted and played back whichever authority names it (#2492).
 AUDIO_MIME_TYPES = [
     'audio/mpeg',  # MP3 audio
     'audio/ogg',   # OGG audio
     'audio/wav',   # WAV audio
+    'audio/x-wav',  # WAV audio
     'audio/webm',  # WebM audio
     'audio/aac',   # AAC audio
     'audio/x-aiff',  # AIFF audio
     'audio/x-ms-wma',  # WMA audio
     'audio/x-m4a',  # M4A audio
+    'audio/mp4',   # M4A audio
     'audio/flac',  # FLAC audio
 ]
 

--- a/src/utilities/tests/test_fields.py
+++ b/src/utilities/tests/test_fields.py
@@ -145,6 +145,18 @@ class RestrictedFileFormFieldTest(ByteDeckTenantTestCase):
         # ensure content type is set correctly
         self.assertEqual(self.image_file_field.content_types, ['image/jpeg', 'image/png'])
 
+    def test_validate_file__accepts_the_types_browsers_send_for_wav_and_m4a(self):
+        """An audio-restricted field takes a .wav or .m4a however the browser labels it (#2492).
+
+        Browsers disagree on these formats' content types: a .wav arrives as `audio/wav` or
+        `audio/x-wav`, and a .m4a as `audio/mp4` or `audio/x-m4a`. A question restricted to
+        Audio must accept all four, or a student's recording is refused for its spelling.
+        """
+        field = RestrictedFileFormField(content_types=FILE_MIME_TYPES["audio"])
+        for content_type in ("audio/wav", "audio/x-wav", "audio/mp4", "audio/x-m4a"):
+            with self.subTest(content_type=content_type):
+                field.validate_file(SimpleNamespace(content_type=content_type, size=1))
+
     def test_validate_file__raises_when_over_max_size(self):
         """validate_file rejects an acceptable-type file whose size exceeds max_upload_size."""
         field = RestrictedFileFormField(content_types=['image/png'], max_upload_size=10)
@@ -240,6 +252,16 @@ class MediaKindOfTest(SimpleTestCase):
     def test_media_kind_of__names_audio(self):
         """Audio is reported as audio: also playable, but with no picture to show."""
         self.assertEqual(media_kind_of("readings/chapter.mp3"), "audio")
+
+    def test_media_kind_of__names_wav_and_m4a_recordings_as_audio(self):
+        """The formats recorders actually produce are audio, whatever alias names them (#2492).
+
+        A Windows or Audacity recording is a .wav, which Python's `mimetypes` reports as
+        `audio/x-wav`, and a phone voice memo is a .m4a, reported as `audio/mp4`. Both must be
+        recognised, or the answer is offered as a bare download link instead of a player.
+        """
+        self.assertEqual(media_kind_of("recordings/interview.wav"), "audio")
+        self.assertEqual(media_kind_of("voice_memo.m4a"), "audio")
 
     def test_media_kind_of__says_nothing_about_other_files(self):
         """A file a browser cannot play is reported as nothing, and is offered as a link.


### PR DESCRIPTION
Closes #2492

### What?

A `.wav` or `.m4a` recording is now accepted by an audio-restricted question and played on the marking page, whichever of its two MIME names labels it, on every host the app runs on.

### Why?

Each of these formats answers to two names, and `AUDIO_MIME_TYPES` held only one of each. Uploading checks the content type the **browser** sends, while the page showing a stored answer guesses with **Python's `mimetypes`**, and the two authorities disagree: a `.wav` is `audio/wav` to one and `audio/x-wav` to the other, a `.m4a` is `audio/x-m4a` to one and `audio/mp4` to the other. So a recording could be refused by an Audio question for its spelling, or accepted and then offered as a bare download link instead of a player. These are not exotic formats: a `.wav` is what Windows Sound Recorder or Audacity produces, and a `.m4a` is a phone voice memo.

### How?

Two small changes in `src/utilities/fields.py`:

* Add the missing aliases to `AUDIO_MIME_TYPES`: `audio/x-wav` beside `audio/wav`, and `audio/mp4` beside `audio/x-m4a`. Upload validation (`RestrictedFileFormField.validate_file`) and playback detection (`media_kind_of`) both read this one list, so they cannot drift.
* Register `.m4a` with `mimetypes.add_type('audio/mp4', '.m4a')` at import. Python's builtin MIME table does not know `.m4a`; platforms fill the gap from `/etc/mime.types` only when that file exists, so the first CI run failed where a dev machine passed. The registration makes `media_kind_of` answer from the code rather than from the host's packaging.

Students see no copy change: the answer field shows the friendly label ("Audio"), not the MIME list.

### Testing?

Test-driven: both new tests fail on `develop` without the fix.

* `test_media_kind_of__names_wav_and_m4a_recordings_as_audio`: a stored `.wav` or `.m4a` reports as audio, so the page uses a player. (This is also the test that caught the host-dependent `.m4a` guess in CI.)
* `test_validate_file__accepts_the_types_browsers_send_for_wav_and_m4a`: an audio-restricted field takes all four spellings.

Full suite green locally (2623 tests), `ruff check src` clean, `makemigrations --check` clean (no model change: the `allowed_file_type` choices are deliberately decoupled from the MIME lists). The bare-table case was verified locally by rebuilding the MIME table with no knownfiles and importing the module fresh.

### Screenshots (if front end is affected)

The same published `.wav` answer on the hackerspace dev deck's marking page, as the teacher sees it.

Before: the recording is only a link to download.

![before: the .wav answer is a bare link](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2492/before_row.png)

After: it plays in place, like the `.mp3` above it always did.

![after: the .wav answer gets an audio player](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2492/after_row.png)

<details>
<summary>Full answers table, before and after</summary>

![before, full table](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2492/before_full.png)

![after, full table](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2492/after_full.png)

</details>

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio file support for WAV and M4A uploads, including common browser-reported MIME types.
  * WAV and M4A files are now correctly recognized as audio media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->