### PR TITLE
fix: keep the odd XP when a student's total is split between courses (#2490)

### DIFF
--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -468,6 +468,24 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
 
         self.assertIsNone(new_assertion.semester_id)
 
+    def test_create_assertion__a_badge_granted_between_semesters_does_not_follow_the_student(self):
+        """A badge granted between terms recognises what the student did between terms, so it
+        belongs to no term and stays that way when they join a course (issue #2474). Joining
+        adopts the quests they had on the go, which would otherwise be stranded out of both
+        their in-progress list and their available list (issue #2441); an assertion is an
+        award already made, so there is nothing to strand and its XP counts toward no
+        semester, the same rule XP already follows when it resets each term."""
+        from courses.models import Course, CourseStudent
+
+        Semester.objects.complete_semester()
+        unstamped = BadgeAssertion.objects.create_assertion(self.student, baker.make(Badge), issued_by=self.teacher)
+
+        new_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=new_semester)
+
+        unstamped.refresh_from_db()
+        self.assertIsNone(unstamped.semester_id)
+
     def test_get_queryset__active_semester_only_holds_the_unstamped_assertions_with_no_open_semester(self):
         """With no semester open, "this semester" is the work that belongs to none: a badge
         granted between terms is stamped with no semester (issue #2413) and is still the

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -1,3 +1,4 @@
+import math
 from datetime import date, datetime, timedelta
 
 from django.conf import settings
@@ -29,16 +30,18 @@ def split_xp_between_registrations(registrations, total, xp_by_course):
     assign one, and is still what happens to badge XP, to work handed in while the deck had
     the setting off, and to anything from before the choice existed.
 
+    Every share is whole XP, and they add up to the student's total: see whole_xp_shares().
+
     Args:
         registrations (list[CourseStudent]): the registrations to divide the XP between. They
             should all be one student's, and from one semester: the shared pool is split by
             how many there are.
-        total (float): the student's whole deck-wide XP, including their adjustments.
+        total (int): the student's whole deck-wide XP, including their adjustments.
         xp_by_course (dict): course id to the XP assigned to it, with None collecting
             everything left unassigned.
 
     Returns:
-        list[tuple]: (CourseStudent, xp) in the order given.
+        list[tuple]: (CourseStudent, xp) in the order given, the XP whole in each.
     """
     if len(registrations) <= 1:
         return [(registration, total) for registration in registrations]
@@ -56,15 +59,54 @@ def split_xp_between_registrations(registrations, total, xp_by_course):
     adjustments = sum(registration.xp_adjustment for registration in registrations)
     shared = (total - assigned - adjustments) / len(registrations)
 
-    return [
-        (
-            registration,
-            (xp_by_course.get(registration.course_id, 0) if registration.course_id else 0)
-            + registration.xp_adjustment
-            + shared,
-        )
+    exact = [
+        (xp_by_course.get(registration.course_id, 0) if registration.course_id else 0)
+        + registration.xp_adjustment
+        + shared
         for registration in registrations
     ]
+    return list(zip(registrations, whole_xp_shares(registrations, exact)))
+
+
+def whole_xp_shares(registrations, exact_shares):
+    """Round a student's exact per-course XP to whole XP that still adds up to their total.
+
+    Two things make a share fractional: the pool nobody assigned is divided evenly between
+    the courses, and a repeatable quest taken past its `max_xp` gives each course the capped
+    total in proportion to what it was assigned uncapped (issue #2440). Rounding each share
+    on its own then loses the odd XP, because rounding down is what an integer field does
+    with it: two courses sharing 5 XP came to 2 and 2, and `CourseStudent.final_xp` recorded
+    that permanently when the semester was archived (issue #2490).
+
+    So the odd XP is handed out a whole point at a time to the shares that came closest to
+    earning it (the largest-remainder method), leaving every course within 1 XP of its exact
+    share and the shares adding up to what the student actually earned. Ties go to the
+    registration made first, so a student is divided the same way however and whenever they
+    are asked about: what they are shown all term is what gets archived.
+
+    Args:
+        registrations (list[CourseStudent]): the registrations the shares belong to, in the
+            same order, for a stable tiebreak.
+        exact_shares (list[float]): each registration's exact share.
+
+    Returns:
+        list[int]: the same shares in whole XP, adding up to the exact shares' total.
+    """
+    whole = [math.floor(share) for share in exact_shares]
+    # what rounding down left over, which is a whole number of XP because the total being
+    # divided is: every source of XP the student has is counted in whole points
+    odd_xp = round(sum(exact_shares)) - sum(whole)
+
+    # the shares with the most of their own XP still to be given back come first, since
+    # whole - exact is the negative of what each one is owed
+    owed_most_first = sorted(
+        range(len(exact_shares)),
+        key=lambda index: (whole[index] - exact_shares[index], registrations[index].pk),
+    )
+    for index in owed_most_first[:odd_xp]:
+        whole[index] += 1
+
+    return whole
 
 
 class MarkRangeManager(models.Manager):
@@ -1208,7 +1250,7 @@ class CourseStudent(models.Model):
                 the previous total. Defaults to reading the profile.
 
         Returns:
-            float: this registration's share of the student's XP, including its own
+            int: this registration's share of the student's XP, including its own
             xp_adjustment. Their whole total when this is their only course.
         """
         profile = profile if profile is not None else self.user.profile

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -73,24 +73,27 @@ def whole_xp_shares(registrations, exact_shares):
 
     Two things make a share fractional: the pool nobody assigned is divided evenly between
     the courses, and a repeatable quest taken past its `max_xp` gives each course the capped
-    total in proportion to what it was assigned uncapped (issue #2440). Rounding each share
-    on its own then loses the odd XP, because rounding down is what an integer field does
-    with it: two courses sharing 5 XP came to 2 and 2, and `CourseStudent.final_xp` recorded
-    that permanently when the semester was archived (issue #2490).
+    total in proportion to what it was assigned uncapped (issue #2440). `CourseStudent.final_xp`
+    is an integer field, so a share rounded on its own drops the odd XP from the record
+    archiving writes, permanently: two courses sharing 5 XP have 2.5 each, and 2 and 2 is not
+    what the student earned (issue #2490).
 
-    So the odd XP is handed out a whole point at a time to the shares that came closest to
-    earning it (the largest-remainder method), leaving every course within 1 XP of its exact
-    share and the shares adding up to what the student actually earned. Ties go to the
-    registration made first, so a student is divided the same way however and whenever they
-    are asked about: what they are shown all term is what gets archived.
+    Rounding the shares together is what keeps them honest. Each is rounded down, and the odd
+    XP is handed back a whole point at a time to the shares that came closest to earning it
+    (the largest-remainder method), so every course lands within 1 XP of its exact share and
+    the shares add up to the student's total. Shares owed equally are settled by the lowest
+    CourseStudent.pk, the registration made first: that keeps the division a property of the
+    student rather than of the order the caller holds them in, so what a student is shown all
+    term is what gets archived.
 
     Args:
         registrations (list[CourseStudent]): the registrations the shares belong to, in the
-            same order, for a stable tiebreak.
+            same order as exact_shares, for the tiebreak between equally owed shares.
         exact_shares (list[float]): each registration's exact share.
 
     Returns:
-        list[int]: the same shares in whole XP, adding up to the exact shares' total.
+        list[int]: the same shares in whole XP, in the order given, adding up to the exact
+        shares' total.
     """
     whole = [math.floor(share) for share in exact_shares]
     # what rounding down left over, which is a whole number of XP because the total being

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1525,6 +1525,87 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         self.assertEqual(maths_registration.final_xp, 60)
         self.assertEqual(art_registration.final_xp, 0)
 
+    def test_calc_semester_grades__records_the_odd_xp_rather_than_dropping_it(self):
+        """final_xp is a whole number of XP, so a share that is not whole was rounded down on
+        its own and the rest of the student's work vanished from their record for good (issue
+        #2490): 5 XP shared between two courses was archived as 2 and 2. The odd XP now goes
+        to one of them, so what is recorded adds up to what the student earned."""
+        student = baker.make(User)
+        registrations = [
+            self._register(student, baker.make(Course, title='Maths')),
+            self._register(student, baker.make(Course, title='Art')),
+        ]
+        self._approved(student, xp=5)
+        student.profile.xp_invalidate_cache()
+
+        CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
+
+        for registration in registrations:
+            registration.refresh_from_db()
+        self.assertEqual(sum(registration.final_xp for registration in registrations), 5)
+        self.assertEqual(sorted(registration.final_xp for registration in registrations), [2, 3])
+
+    def test_calc_semester_grades__hands_the_odd_xp_out_a_point_at_a_time(self):
+        """Three courses sharing 10 XP are archived as 4, 3 and 3 rather than 3 each: the odd
+        XP goes to the share closest to earning it, so no course ends up more than 1 XP from
+        its exact share and none of the 10 is lost (issue #2490)."""
+        student = baker.make(User)
+        registrations = [
+            self._register(student, baker.make(Course, title=title))
+            for title in ('Maths', 'Art', 'Music')
+        ]
+        self._approved(student, xp=10)
+        student.profile.xp_invalidate_cache()
+
+        CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
+
+        for registration in registrations:
+            registration.refresh_from_db()
+        self.assertEqual(sum(registration.final_xp for registration in registrations), 10)
+        self.assertEqual(sorted(registration.final_xp for registration in registrations), [3, 3, 4])
+
+    def test_calc_semester_grades__records_the_xp_the_student_was_shown_all_term(self):
+        """The division is the same one whoever asks it, so the XP a student is shown against
+        a course during the term is the number recorded against it for good. Without that,
+        7 XP split two ways would read as 3.5 all term and archive as something else."""
+        student = baker.make(User)
+        registrations = [
+            self._register(student, baker.make(Course, title='Maths')),
+            self._register(student, baker.make(Course, title='Art')),
+        ]
+        self._approved(student, xp=7)
+        student.profile.xp_invalidate_cache()
+        shown = [registration.xp() for registration in registrations]
+
+        CourseStudent.objects.calc_semester_grades(SiteConfig.get().active_semester)
+
+        for registration in registrations:
+            registration.refresh_from_db()
+        self.assertEqual([registration.final_xp for registration in registrations], shown)
+        self.assertEqual(shown, [4, 3])
+
+    def test_xp_across__gives_whole_xp_when_a_capped_quest_is_split_between_courses(self):
+        """A repeatable quest taken past its max_xp gives each course the capped total in
+        proportion to what it was assigned uncapped (issue #2440), which is a fraction even
+        with nothing shared between the courses. Those shares are whole XP too, and still add
+        up to the student's total (issue #2490)."""
+        student = baker.make(User)
+        maths = baker.make(Course, title='Maths')
+        art = baker.make(Course, title='Art')
+        registrations = [self._register(student, maths), self._register(student, art)]
+        quest = baker.make(Quest, xp=10, max_xp=15, max_repeats=-1)
+        for course in (maths, art):
+            baker.make(
+                QuestSubmission, user=student, quest=quest, course=course,
+                semester=SiteConfig.get().active_semester, is_completed=True, is_approved=True,
+            )
+        student.profile.xp_invalidate_cache()
+
+        shares = [xp for _registration, xp in CourseStudent.objects.xp_across(student, registrations)]
+
+        self.assertEqual(sum(shares), 15)
+        self.assertEqual(sorted(shares), [7, 8])
+
     def test_clean__refuses_a_student_in_two_open_semesters(self):
         """A student belongs to one semester at a time (#1781): they can take several courses
         within it, but being in two open semesters at once would make "which semester did they

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1526,10 +1526,10 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         self.assertEqual(art_registration.final_xp, 0)
 
     def test_calc_semester_grades__records_the_odd_xp_rather_than_dropping_it(self):
-        """final_xp is a whole number of XP, so a share that is not whole was rounded down on
-        its own and the rest of the student's work vanished from their record for good (issue
-        #2490): 5 XP shared between two courses was archived as 2 and 2. The odd XP now goes
-        to one of them, so what is recorded adds up to what the student earned."""
+        """Archiving records whole XP that adds up to what the student earned. final_xp is an
+        integer field, so a share of 2.5 rounded on its own drops the odd XP from the record
+        for good: 5 XP shared between two courses has to archive as 2 and 3, not 2 and 2
+        (issue #2490)."""
         student = baker.make(User)
         registrations = [
             self._register(student, baker.make(Course, title='Maths')),
@@ -1546,9 +1546,9 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         self.assertEqual(sorted(registration.final_xp for registration in registrations), [2, 3])
 
     def test_calc_semester_grades__hands_the_odd_xp_out_a_point_at_a_time(self):
-        """Three courses sharing 10 XP are archived as 4, 3 and 3 rather than 3 each: the odd
-        XP goes to the share closest to earning it, so no course ends up more than 1 XP from
-        its exact share and none of the 10 is lost (issue #2490)."""
+        """The odd XP goes whole to the share closest to earning it, rather than being split
+        again or dropped: three courses sharing 10 XP archive as 4, 3 and 3, which keeps every
+        course within 1 XP of its exact share and all 10 XP in the record (issue #2490)."""
         student = baker.make(User)
         registrations = [
             self._register(student, baker.make(Course, title=title))
@@ -1566,8 +1566,8 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
 
     def test_calc_semester_grades__records_the_xp_the_student_was_shown_all_term(self):
         """The division is the same one whoever asks it, so the XP a student is shown against
-        a course during the term is the number recorded against it for good. Without that,
-        7 XP split two ways would read as 3.5 all term and archive as something else."""
+        a course during the term is the number recorded against it for good: 7 XP split two
+        ways reads as 4 and 3 on the marks page and archives as 4 and 3."""
         student = baker.make(User)
         registrations = [
             self._register(student, baker.make(Course, title='Maths')),


### PR DESCRIPTION
### What?

Closes #2490. A student in more than one course keeps every XP they earned when their semester is archived.

* New `whole_xp_shares()` in `src/courses/models.py` rounds a student's per-course shares once for the student as a whole, by the largest-remainder method, so the shares are whole XP that still add up to the student's total. `split_xp_between_registrations()` finishes with it, which puts it on every path that divides XP: the marks page, the per-course ranks in the navbar, the XP progress chart, and `calc_semester_grades()`.
* Also closes #2474, with a regression test rather than a code change: a badge granted between semesters does not follow the student into the term they join. That is what the code already does and nothing pinned it down, so widening the adoption receiver from quests to badges would not have failed anything.

No migration, no model change.

### Why?

Reported by @doudou868. `CourseStudent.final_xp` is a `PositiveIntegerField`, and the share written into it is often not a whole number, so Django's `int()` rounded each row down on its own and the rest of the student's work vanished from their permanent record with no error and no warning.

Two courses sharing 5 XP archived as 2 and 2. Three sharing 10 archived as 3, 3 and 3. The loss is deterministic, not an occasional floating-point artifact, and the existing tests missed it because they used amounts that divide evenly (60, 500).

Two things make a share fractional, and the issue names the first:

1. XP the student did not assign to a particular course is shared evenly between the courses they hold.
2. A repeatable quest taken past its `max_xp` gives each course the capped total in proportion to what it was assigned uncapped (#2440). That is a fraction even when nothing is being shared: a quest capped at 15 with 10 XP against each of two courses gives 7.5 and 7.5, which archived as 7 and 7.

Rounding at the point of writing `final_xp` would have fixed the record and left the deck disagreeing with itself, because the same fractions are what the student is shown all term. Rounding the division itself fixes both at once, and means the number a student sees against a course during the term is the number archived against it for good.

### How?

The shares are worked out exactly as before, then handed to `whole_xp_shares()`, which rounds each one down and gives the odd XP back a point at a time to the shares that came closest to earning it:

```python
whole = [math.floor(share) for share in exact_shares]
odd_xp = round(sum(exact_shares)) - sum(whole)

owed_most_first = sorted(
    range(len(exact_shares)),
    key=lambda index: (whole[index] - exact_shares[index], registrations[index].pk),
)
for index in owed_most_first[:odd_xp]:
    whole[index] += 1
```

That leaves every course within 1 XP of its exact share and the shares adding up to the student's total. `math.floor` rather than `int` because a share can be negative (a large enough negative `xp_adjustment`), and truncating toward zero there would hand out XP nobody earned.

Ties break on `pk`, the registration made first, rather than on the order the caller passed. That matters because the live path (`current_courses()`) and the archive path (`get_semester()`) can order registrations differently: keying on the row itself makes the division a property of the student rather than of the question asked, so the marks page and the archived record cannot disagree about which course got the odd point. The returned list keeps the order it was given, which `split_xp_between_registrations()` relies on to zip the shares back onto their registrations; both that and the tie-break rule are stated in the docstring.

### Testing?

`python src/manage.py test src` (2628 tests, all passing), `ruff check src` clean, `manage.py check` clean, `makemigrations --check --dry-run` clean. `courses/models.py` is at 99% line coverage with the three misses pre-existing and outside this diff; `whole_xp_shares()` is fully covered, and Codecov reports every modified line covered with project coverage unchanged at 99.93%.

Five new tests. The four for #2490 were each run against the code without the fix and fail there, with exactly the losses the issue describes:

| test | without the fix |
|---|---|
| `test_calc_semester_grades__records_the_odd_xp_rather_than_dropping_it` | `4 != 5` |
| `test_calc_semester_grades__hands_the_odd_xp_out_a_point_at_a_time` | `9 != 10` |
| `test_calc_semester_grades__records_the_xp_the_student_was_shown_all_term` | `[3, 3] != [3.5, 3.5]` |
| `test_xp_across__gives_whole_xp_when_a_capped_quest_is_split_between_courses` | `[7.5, 7.5] != [7, 8]` |

The fifth, `test_create_assertion__a_badge_granted_between_semesters_does_not_follow_the_student`, is a lock-in test for the #2474 decision rather than a bug fix, so it passes both with and without this diff by design.

Walked through the running dev deck as well: a student on 175 XP in two courses, archived before and after the change (screenshots below).

### Screenshots (if front end is affected)

All captured from the running dev deck at `http://hackerspace.localhost:8000`, logged in as a student registered in Mathematics 10 and Digital Art 11 with 175 XP, none of it assigned to a particular course.

**The permanent record**, on their profile after the semester is archived. This is the bug: they earned 175 and the record says 174.

Before, 87 + 87:

![archived record before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2490/before-record.png)

After, 87 + 88:

![archived record after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2490/after-record.png)

**The marks page**, during the term. The same fractions that were being lost at archiving were also what the student was reading all term.

Before, both courses on 87.5 XP and the same 67.3%:

![marks page before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2490/before.png)

After, 87 and 88, and the two courses no longer report an identical mark:

![marks page after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2490/after.png)

### Anything Else?

Every XP figure a student sees against a course is now a whole number, which is a visible change beyond the archived record: the marks page, the per-course ranks in the navbar and the XP progress chart all showed `87.5` and now show `87` or `88`. That reads as a correction rather than a regression (XP is a whole-point currency everywhere else in the app, and no other screen has ever shown a fraction of one), but it is worth knowing it is deliberate.

The alternative the issue raises, making `final_xp` a `DecimalField`, is not taken: it would change the field's meaning for every consumer and leave the student's own view of their XP fractional, which is the part they actually read.

One pre-existing oddity is left alone rather than widened into this PR: if a student somehow holds two registrations for the *same* course in one semester (`unique_together` allows it when the grades differ), each is credited with that course's whole assigned total, so the shares can add up to more than the student earned. `whole_xp_shares()` rounds to the exact shares' own total rather than to `xp_cached`, so it stays honest about whatever it is given instead of quietly absorbing that.

CodeRabbit's review raised two documentation points, both taken in `2fd55ffa`: the tie-break and order contract described above, and four docstrings (the function's own plus three of the new tests) that described the rounding as a change from the previous behaviour rather than as the invariant they hold, which stops meaning anything once this squash-merges. `develop` is merged in, so the branch is current.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * XP earned across multiple course registrations is now allocated in whole numbers while preserving the correct total.
  * Remaining XP is distributed consistently when allocations cannot be divided evenly.
  * Capped quest XP now displays and distributes accurate whole-number shares.
  * Badge assertions created between semesters remain unstamped after later enrollment.

* **Tests**
  * Added regression coverage for XP allocation and cross-semester badge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->