### PR TITLE
feat: count a short answer's characters as the student types (#2482)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -245,6 +245,27 @@
                   text_area.append(msg);
             });
 
+            // Live character counter for the short answers (#2482). With JavaScript off the
+            // hint stays the server-rendered "Up to 200 characters."; here that sentence moves
+            // into a screen-reader-only span (a count re-announced on every keystroke is noise
+            // there) and a visible counter follows the student's typing, turning amber as the
+            // limit approaches. The input's maxlength does the actual enforcing either way.
+            $('.question-submission-form input[type=text][maxlength]').each(function () {
+                var input = $(this);
+                var max = parseInt(input.attr('maxlength'), 10);
+                var hint = $('#hint_' + this.id);  // crispy renders each field's help text with this id
+                if (!max || !hint.length) return;
+                hint.wrapInner('<span class="sr-only"></span>');
+                var counter = $('<span aria-hidden="true"></span>').appendTo(hint);
+                var update = function () {
+                    var used = input.val().length;
+                    counter.text(used + ' / ' + max + ' characters');
+                    counter.toggleClass('text-warning', (max - used) / max <= 0.1);
+                };
+                input.on('input', update);
+                update();
+            });
+
             // Save drafts via Ajax when button pressed
             $('#save-draft-btn').on('click', function(event){
                 event.preventDefault(); // prevent browser from reloading

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -91,17 +92,26 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
         self.assertContains(response, f"Up to {SHORT_ANSWER_MAX_LENGTH} characters.")
 
     def test_submission_page__short_answer_hint_is_the_counter_hook(self):
-        """The short answer's hint renders with the id the live counter finds it by (#2482).
+        """The short answer's input and hint render as the pair the live counter joins (#2482).
 
-        The counter script on the submission page looks up `hint_<input id>` for each
-        input carrying a maxlength, so this pins the two attributes it hangs on. If crispy's
-        hint id or the widget's maxlength ever changes shape, the counter dies silently:
-        this failure is the only thing that would say so.
+        The counter script on the submission page finds each maxlength-carrying input's hint
+        by looking up `hint_<input id>`, so this pins that exact association: the short
+        answer's own input id, the maxlength on that same tag, and a hint whose id is the
+        input's with the `hint_` prefix. If crispy's hint id or the widget's maxlength ever
+        changes shape, the counter dies silently: this failure is the only thing that would
+        say so.
         """
         response = self.assert200("quests:submission", args=[self.submission.id])
+        content = response.content.decode()
 
-        self.assertContains(response, 'id="hint_id_question_submissions-')
-        self.assertContains(response, f'maxlength="{SHORT_ANSWER_MAX_LENGTH}"')
+        rows = list(sync_draft_question_submissions(self.submission))
+        index = next(i for i, row in enumerate(rows) if row.question_id == self.short_question.id)
+        input_id = f"id_question_submissions-{index}-response_text"
+
+        input_tag = re.search(rf'<input[^>]*\bid="{input_id}"[^>]*>', content)
+        self.assertIsNotNone(input_tag, f"no input with id {input_id} on the page")
+        self.assertIn(f'maxlength="{SHORT_ANSWER_MAX_LENGTH}"', input_tag.group(0))
+        self.assertContains(response, f'id="hint_{input_id}"')
 
     def test_submission_page__summernote_assets_load_once(self):
         """The answer editors ride on the assets the comment box already loads (#2169).

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -90,6 +90,19 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
 
         self.assertContains(response, f"Up to {SHORT_ANSWER_MAX_LENGTH} characters.")
 
+    def test_submission_page__short_answer_hint_is_the_counter_hook(self):
+        """The short answer's hint renders with the id the live counter finds it by (#2482).
+
+        The counter script on the submission page looks up `hint_<input id>` for each
+        input carrying a maxlength, so this pins the two attributes it hangs on. If crispy's
+        hint id or the widget's maxlength ever changes shape, the counter dies silently:
+        this failure is the only thing that would say so.
+        """
+        response = self.assert200("quests:submission", args=[self.submission.id])
+
+        self.assertContains(response, 'id="hint_id_question_submissions-')
+        self.assertContains(response, f'maxlength="{SHORT_ANSWER_MAX_LENGTH}"')
+
     def test_submission_page__summernote_assets_load_once(self):
         """The answer editors ride on the assets the comment box already loads (#2169).
 


### PR DESCRIPTION
Closes #2482

### What?

The hint under a short answer becomes a live counter as the student types: "148 / 200 characters", turning amber over the last tenth of the limit.

### Why?

The help text from #2401 says "Up to 200 characters." and the input then enforces the limit silently, by refusing keystrokes. A student composing a longer answer reads a sentence before they start and meets a dead keyboard later, with nothing telling them how close they are. A counter shows the limit approaching rather than only arriving.

### How?

A small script in the submission page's existing `js` block, in the same progressive-enhancement shape as the question reorder (#2216):

* With JavaScript off, nothing changes: the server still renders "Up to 200 characters." and `maxlength` still enforces.
* With it on, each short answer's hint (found by crispy's `hint_<input id>`) keeps the original sentence for screen readers in an `sr-only` span, since a counter re-announced on every keystroke is noise there, and gains a visible `aria-hidden` counter that follows the `input` event.
* The amber is bootstrap's own `text-warning`, applied when a tenth or less of the limit remains, so there are no stylesheet changes and both themes keep their contrast.

The limit itself still comes from the one `SHORT_ANSWER_MAX_LENGTH` constant, read off the input's `maxlength` so the counter cannot disagree with the validation.

### Testing?

`test_submission_page__short_answer_hint_is_the_counter_hook` pins the two attributes the script hangs on (crispy's hint id and the widget's `maxlength`): renaming either would kill the counter silently, and this failure is the only thing that would say so. The counter itself is browser behaviour, exercised on the real dev deck below.

`src/questions` and `src/quest_manager` suites green locally, `ruff check src` clean, `makemigrations --check` clean.

### Screenshots (if front end is affected)

The first question of a quest on the hackerspace dev deck, as the student answering it.

Before: the static sentence from #2401.

![before: static help text reading Up to 200 characters](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2482/before.png)

After, mid-answer: the counter follows the typing.

![after: counter reading 148 / 200 characters](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2482/after_typing.png)

After, near the limit: the counter turns amber.

![after: counter reading 196 / 200 characters in amber](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2482/after_near_limit.png)

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a live character counter to short-answer fields.
  - Displays characters used against the maximum allowed.
  - Highlights the counter when nearing the limit.
  - Preserves the existing character limit and accessible guidance for screen readers.
  - Initializes counters automatically when submission pages load.

- **Tests**
  - Added coverage verifying that short-answer limits and their associated counter elements render correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->