### PR TITLE
fix: read every open semester's badges in the deck-wide view (#2475)

### DIFF
--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -365,12 +365,12 @@ class BadgeAssertionQuerySet(models.query.QuerySet):
     def in_open_or_no_semester(self):
         """Assertions no finished term owns: what a deck-wide staff view of current work holds.
 
-        Every open semester's, since a deck can run several at once (issue #2157 Phase 3,
-        #1781) and scoping to the deck's default would hide everything the other cohort was
-        granted. Plus the assertions stamped with no semester at all (issue #2413), which is
-        what someone registered in none is granted: a student between terms, or staff trying
-        a badge out. The submission side answers the same question the same way, so a
-        deck-wide view of badges and one of quests cover the same students.
+        Every open semester's assertions, since a deck can run several at once (issue #2157
+        Phase 3, #1781) and scoping to the deck's default would hide everything the other
+        cohort was granted. Plus the assertions stamped with no semester at all (issue
+        #2413), which is what someone registered in no semester is granted: a student between
+        terms, or staff trying a badge out. The submission side answers the same question the
+        same way, so a deck-wide view of badges and one of quests cover the same students.
 
         Returns:
             BadgeAssertionQuerySet: the assertions in an open semester or in none.

--- a/src/badges/models.py
+++ b/src/badges/models.py
@@ -362,6 +362,23 @@ class BadgeAssertionQuerySet(models.query.QuerySet):
         """
         return self.filter(semester=semester)
 
+    def in_open_or_no_semester(self):
+        """Assertions no finished term owns: what a deck-wide staff view of current work holds.
+
+        Every open semester's, since a deck can run several at once (issue #2157 Phase 3,
+        #1781) and scoping to the deck's default would hide everything the other cohort was
+        granted. Plus the assertions stamped with no semester at all (issue #2413), which is
+        what someone registered in none is granted: a student between terms, or staff trying
+        a badge out. The submission side answers the same question the same way, so a
+        deck-wide view of badges and one of quests cover the same students.
+
+        Returns:
+            BadgeAssertionQuerySet: the assertions in an open semester or in none.
+        """
+        from courses.models import Semester  # locally: courses imports this app's models
+
+        return self.filter(Q(semester__status=Semester.Status.OPEN) | Q(semester__isnull=True))
+
     def get_issued_before(self, date):
         return self.filter(timestamp__lte=date)
 
@@ -373,8 +390,11 @@ class BadgeAssertionManager(models.Manager):
         Args:
             active_semester_only (bool): limit to the current semester's assertions.
             user (User): whose semester to limit to. Their registration names it (issue
-                #2157 Phase 3). Without a user this is a deck-wide staff view, which uses
-                the deck's open semester.
+                #2157 Phase 3), and someone holding none is in no semester, so their badges
+                are the ones stamped with none. Without a user this is a deck-wide staff
+                view, which covers every open semester and the unstamped assertions besides:
+                a deck can run two cohorts on different calendars, so naming one semester
+                would drop the other cohort's badges (issue #2475).
 
         Returns:
             BadgeAssertionQuerySet: the matching assertions.
@@ -384,7 +404,7 @@ class BadgeAssertionManager(models.Manager):
         # badge/badge_type are needed almost everywhere assertions are rendered
         qs = BadgeAssertionQuerySet(self.model, using=self._db).select_related('badge__badge_type')
         if active_semester_only:
-            return qs.get_semester(semester_for(user))
+            return qs.get_semester(semester_for(user)) if user is not None else qs.in_open_or_no_semester()
         else:
             return qs
 

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -500,6 +500,32 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         self.assertNotIn(self.assertion, semester_scoped)
         self.assertIn(self.assertion, BadgeAssertion.objects.get_queryset(active_semester_only=False))
 
+    def test_get_queryset__active_semester_only_covers_every_open_semester_deck_wide(self):
+        """A deck can run two cohorts on different calendars (issue #1781), so a deck-wide
+        view of "this semester's" badges is every open semester's, not the one the deck
+        happens to point at: naming a single semester drops the other cohort's assertions
+        out of sight (issue #2475). The submission side already reads this way."""
+        second_semester = baker.make(Semester, status=Semester.Status.OPEN)
+        other_cohort = baker.make(BadgeAssertion, user=baker.make(User), semester=second_semester)
+
+        semester_scoped = BadgeAssertion.objects.get_queryset(active_semester_only=True)
+
+        self.assertNotEqual(second_semester, SiteConfig.get().open_semester)
+        self.assertIn(self.assertion, semester_scoped)
+        self.assertIn(other_cohort, semester_scoped)
+
+    def test_get_queryset__active_semester_only_leaves_out_an_archived_semester_deck_wide(self):
+        """Covering every open semester is not the same as covering every semester: a term
+        that has been archived is a finished record, so its assertions are past and stay out
+        of the deck-wide view of current work."""
+        archived = baker.make(Semester, status=Semester.Status.ARCHIVED)
+        finished = baker.make(BadgeAssertion, user=self.student, semester=archived)
+
+        semester_scoped = BadgeAssertion.objects.get_queryset(active_semester_only=True)
+
+        self.assertNotIn(finished, semester_scoped)
+        self.assertIn(finished, BadgeAssertion.objects.get_queryset(active_semester_only=False))
+
     def test_post_save_receiver__uses_badge_type_fa_icon_when_set(self):
         """The granted notification uses the badge type's own fa_icon when it has one, rather
         than the default fa-certificate (the non-default branch of post_save_receiver)."""

--- a/src/badges/tests/test_models.py
+++ b/src/badges/tests/test_models.py
@@ -504,15 +504,19 @@ class BadgeAssertionTestModel(ByteDeckTenantTestCase):
         """A deck can run two cohorts on different calendars (issue #1781), so a deck-wide
         view of "this semester's" badges is every open semester's, not the one the deck
         happens to point at: naming a single semester drops the other cohort's assertions
-        out of sight (issue #2475). The submission side already reads this way."""
+        out of sight (issue #2475). The badges belonging to no semester are in it too, since
+        someone registered in none is still granted them (issue #2413) and no finished term
+        owns their work either. The submission side already reads this way."""
         second_semester = baker.make(Semester, status=Semester.Status.OPEN)
         other_cohort = baker.make(BadgeAssertion, user=baker.make(User), semester=second_semester)
+        between_terms = baker.make(BadgeAssertion, user=baker.make(User), semester=None)
 
         semester_scoped = BadgeAssertion.objects.get_queryset(active_semester_only=True)
 
         self.assertNotEqual(second_semester, SiteConfig.get().open_semester)
         self.assertIn(self.assertion, semester_scoped)
         self.assertIn(other_cohort, semester_scoped)
+        self.assertIn(between_terms, semester_scoped)
 
     def test_get_queryset__active_semester_only_leaves_out_an_archived_semester_deck_wide(self):
         """Covering every open semester is not the same as covering every semester: a term


### PR DESCRIPTION
### What?

Closes #2475. `BadgeAssertionManager.get_queryset(active_semester_only=True, user=None)`, the deck-wide view of "this semester's" badges, now covers every open semester plus the assertions stamped with none, the same as the submission side.

* `BadgeAssertionQuerySet` gains `in_open_or_no_semester()`, the method `QuestSubmissionQuerySet` already has.
* The manager branches on `user is None` the way `QuestSubmissionManager` does.

No migration, no model change, no template change.

### Why?

A deck can run two cohorts on different calendars (#1781, delivered in #2157 Phase 3), so "this semester's work, deck-wide" means every open semester. The submission manager was changed to read that way:

```python
# src/quest_manager/models.py
qs = qs.get_semester(semester_for(user)) if user is not None else qs.in_open_or_no_semester()
```

The badge manager was not:

```python
# src/badges/models.py
if active_semester_only:
    return qs.get_semester(semester_for(user))
```

With `user=None`, `semester_for(None)` is the deck's *default* open semester, so a deck-wide badge view would show one cohort's assertions and silently drop the other's. That is exactly the scoping Phase 3 removed from the quest side, left behind on the badge side.

**This is latent, not a live bug.** Every production caller of the badge manager's semester-scoped queryset passes a user (`all_for_user`, `all_for_user_badge`, `xp_by_course`, `calculate_xp*`, `get_by_type_for_user`, ...), and for a user the read was already correct: their own registration names their semester. Only tests reach `user=None` with `active_semester_only=True`. So this closes a trap for the next deck-wide badge view somebody adds, rather than something a teacher can hit today. That is also why it is worth doing now: the two managers answering the same question differently is the kind of thing that gets copied.

### How?

The new queryset method mirrors its submission counterpart exactly, down to the `Q` it builds:

```python
def in_open_or_no_semester(self):
    from courses.models import Semester  # locally: courses imports this app's models

    return self.filter(Q(semester__status=Semester.Status.OPEN) | Q(semester__isnull=True))
```

`Q(semester__isnull=True)` is not a missing filter: an assertion granted to someone registered in no semester is stamped with none (#2413), and it is still theirs, so it belongs in the deck-wide view of current work the same way an unstamped submission does.

The `user` argument's docstring now says what the two branches mean, so the next reader does not have to infer the deck-wide case from `semester_for(None)`.

### Testing?

`python src/manage.py test src` (2631 tests, all passing), `ruff check src` clean, `manage.py check` clean, `makemigrations --check --dry-run` clean.

Two new tests on `BadgeAssertionTestModel`:

* `test_get_queryset__active_semester_only_covers_every_open_semester_deck_wide` is the regression test. Verified to fail against the code without the fix, with the second cohort's assertion missing from the queryset:

  ```
  AssertionError: <BadgeAssertion: Qvz...> not found in <BadgeAssertionQuerySet [<BadgeAssertion: aon...>]>
  ```

  It also asserts the second semester is *not* the deck's `open_semester`, so it cannot pass by accident if the pointer moves, and (after review) that an assertion belonging to no semester is in the queryset too. That last part matters because it is the only test where both halves of the OR are live at once: the neighbouring test runs with nothing open, where "open or unstamped" and "unstamped" return the same rows.
* `test_get_queryset__active_semester_only_leaves_out_an_archived_semester_deck_wide` guards the other edge: covering every open semester must not become covering every semester. This one passes with and without the fix by design, since it pins the boundary the change could plausibly overshoot rather than reproducing the bug.

The existing `test_get_queryset__active_semester_only_holds_the_unstamped_assertions_with_no_open_semester` still passes.

### Screenshots (if front end is affected)

N/A, and deliberately so rather than for want of looking: nothing visible changes. The only code path this alters is reachable solely from tests today (see Why), so there is no page whose output differs before and after.

### Anything Else?

The two managers still differ in shape elsewhere (the submission one takes `exclude_archived_quests` / `exclude_quests_not_published` / `include_related`, which have no badge equivalent). This aligns only the semester scoping, which is the part where disagreeing produces wrong answers.

CodeRabbit's review raised two points, both answered in `70396976`: the unstamped-assertion coverage described above, and the queryset docstring, whose opening fragment ("Every open semester's") is reworded. The other half of that suggestion, restating the ORM predicate in prose, is declined on the thread: the `Returns:` line and the two-line filter directly below already say it, and the paragraph's job is the *why*.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)