### PR TITLE
fix: load Library prerequisites only where a page renders them (#2529)

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2756,6 +2756,10 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
                 Quest, name="Titration Practice", campaign=cls.library_campaign, published=True,
             )
             cls.library_quest.tags.add("chemistry")
+            # A gate of the Library's own, so the pages can be checked for the right one
+            # rather than only for the absence of the wrong one.
+            cls.library_gate = baker.make(Quest, name="Library Safety Briefing", published=True)
+            Prereq.add_simple_prereq(cls.library_quest, cls.library_gate)
 
         cls.test_teacher = User.objects.create_user('lazy_queryset_teacher', is_staff=True)
 
@@ -2766,7 +2770,11 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         # a lazily-evaluated `quest.tags.all` would find after the schema switches back.
         local = baker.make(Quest, name="A Local Quest")
         Quest.objects.filter(pk=local.pk).update(id=self.library_quest.id)
-        Quest.objects.get(pk=self.library_quest.id).tags.add("local-only")
+        decoy = Quest.objects.get(pk=self.library_quest.id)
+        decoy.tags.add("local-only")
+        # and a prerequisite of its own: prereqs are keyed by the parent's object id, so a
+        # lazily-evaluated `quest.prereqs` finds this one once the schema switches back.
+        Prereq.add_simple_prereq(decoy, baker.make(Quest, name="Local Gate Quest"))
         self.client.force_login(self.test_teacher)
 
     def assertShowsLibraryTags(self, response):
@@ -2782,6 +2790,19 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "chemistry")
         self.assertNotContains(response, "local-only")
+
+    def assertShowsLibraryPrereqs(self, response):
+        """Assert a rendered page shows the Library quest's gate and not this deck's.
+
+        Args:
+            response (HttpResponse): the rendered Library page.
+
+        Raises:
+            AssertionError: if the page did not render, or shows this deck's prerequisite
+                in place of the Library's.
+        """
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Local Gate Quest")
 
     def test_LibraryQuestListView__shows_the_library_quests_own_tags(self):
         """The Library quest list renders tags read from the Library."""
@@ -2808,6 +2829,35 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         self.assertShowsLibraryTags(
             self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
         )
+
+    def test_ImportQuestView__shows_the_library_quests_own_prereqs(self):
+        """The quest import preview renders prerequisites read from the Library.
+
+        The preview exists to say what is about to arrive, and this project has decided
+        gating is the importing deck's own business (#2375), so showing them a gate that
+        is really their own, attached to a quest they do not have yet, is the most
+        misleading thing the page could do (#2529).
+        """
+        response = self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
+
+        self.assertShowsLibraryPrereqs(response)
+        self.assertContains(response, "Library Safety Briefing")
+
+    def test_ImportCampaignView__shows_the_library_quests_own_prereqs(self):
+        """The campaign import preview renders prerequisites read from the Library (#2529)."""
+        self.assertShowsLibraryPrereqs(
+            self.client.get(reverse('library:import_category', args=[self.library_campaign.import_id]))
+        )
+
+    def test_CategoryDetailView__shows_the_library_quests_own_prereqs(self):
+        """The Library campaign detail page renders prerequisites read from the Library (#2529)."""
+        self.assertShowsLibraryPrereqs(
+            self.client.get(reverse('library:category_detail_view', args=[self.library_campaign.import_id]))
+        )
+
+    def test_LibraryQuestListView__shows_the_library_quests_own_prereqs(self):
+        """The Library quest list renders prerequisites read from the Library (#2529)."""
+        self.assertShowsLibraryPrereqs(self.client.get(reverse('library:quest_list')))
 
 
 class LibraryImportCampaignPreviewTests(LibraryTenantTestCaseMixin):

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2749,7 +2749,12 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
 
     @classmethod
     def setUpTestData(cls):
-        """Publish a tagged quest and campaign in the Library, and a staff user to view them."""
+        """Publish a tagged, gated quest and its campaign in the Library, plus a staff viewer.
+
+        The Library quest carries a tag and a prerequisite on a second Library quest, so a
+        page can be checked for the Library's own values rather than only for the absence
+        of this deck's.
+        """
         with library_schema_context():
             cls.library_campaign = baker.make(Category, title="Chemistry Basics", published=True)
             cls.library_quest = baker.make(
@@ -2764,7 +2769,13 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         cls.test_teacher = User.objects.create_user('lazy_queryset_teacher', is_staff=True)
 
     def setUp(self):
-        """Give this deck a quest at the same id, tagged differently, and sign the teacher in."""
+        """Put decoys on this deck at the Library quest's id, and sign the teacher in.
+
+        Both tags and prerequisites are keyed by the object id of the quest they belong to,
+        so a local quest forced to the Library quest's id supplies exactly the wrong answer
+        to anything evaluated after the schema switches back: a tag of `local-only` and a
+        prerequisite on `Local Gate Quest`.
+        """
         super().setUp()
         # taggit keys tags by object id, so a local quest at the Library quest's id is what
         # a lazily-evaluated `quest.tags.all` would find after the schema switches back.
@@ -2790,19 +2801,6 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "chemistry")
         self.assertNotContains(response, "local-only")
-
-    def assertShowsLibraryPrereqs(self, response):
-        """Assert a rendered page shows the Library quest's gate and not this deck's.
-
-        Args:
-            response (HttpResponse): the rendered Library page.
-
-        Raises:
-            AssertionError: if the page did not render, or shows this deck's prerequisite
-                in place of the Library's.
-        """
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Local Gate Quest")
 
     def test_LibraryQuestListView__shows_the_library_quests_own_tags(self):
         """The Library quest list renders tags read from the Library."""
@@ -2831,33 +2829,22 @@ class LibraryLazyQuerysetRenderTests(LibraryTenantTestCaseMixin):
         )
 
     def test_ImportQuestView__shows_the_library_quests_own_prereqs(self):
-        """The quest import preview renders prerequisites read from the Library.
+        """The quest import preview names the Library quest's gate, not this deck's (#2529).
 
         The preview exists to say what is about to arrive, and this project has decided
         gating is the importing deck's own business (#2375), so showing them a gate that
         is really their own, attached to a quest they do not have yet, is the most
-        misleading thing the page could do (#2529).
+        misleading thing the page could do.
+
+        This is the only Library page that renders prerequisites server-side. The list and
+        campaign pages show a quest's details through a later AJAX request, which renders
+        inside its own schema context and so was never exposed to this.
         """
         response = self.client.get(reverse('library:import_quest', args=[self.library_quest.import_id]))
 
-        self.assertShowsLibraryPrereqs(response)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Library Safety Briefing")
-
-    def test_ImportCampaignView__shows_the_library_quests_own_prereqs(self):
-        """The campaign import preview renders prerequisites read from the Library (#2529)."""
-        self.assertShowsLibraryPrereqs(
-            self.client.get(reverse('library:import_category', args=[self.library_campaign.import_id]))
-        )
-
-    def test_CategoryDetailView__shows_the_library_quests_own_prereqs(self):
-        """The Library campaign detail page renders prerequisites read from the Library (#2529)."""
-        self.assertShowsLibraryPrereqs(
-            self.client.get(reverse('library:category_detail_view', args=[self.library_campaign.import_id]))
-        )
-
-    def test_LibraryQuestListView__shows_the_library_quests_own_prereqs(self):
-        """The Library quest list renders prerequisites read from the Library (#2529)."""
-        self.assertShowsLibraryPrereqs(self.client.get(reverse('library:quest_list')))
+        self.assertNotContains(response, "Local Gate Quest")
 
 
 class LibraryImportCampaignPreviewTests(LibraryTenantTestCaseMixin):

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -108,9 +108,26 @@ def load_library_quests_for_render(quests):
             `prefetch_related_objects` needs the rows to exist.
 
     Returns:
-        list[Quest]: the same list, with `tags`, `question_set` and `campaign` populated.
+        list[Quest]: the same list, with `tags`, `question_set`, `campaign` and
+        prerequisites populated.
     """
+    from prerequisites.models import Prereq
+
     prefetch_related_objects(quests, 'tags', 'question_set', 'campaign')
+
+    # Prerequisites need more than a prefetch. `prefetch_for_parents` fills the cache that
+    # `prereqs()` serves, but each row still reaches its target through a GenericForeignKey,
+    # and `Prereq.__str__` follows that plus the content type to name it. Left lazy, those
+    # lookups run once the schema has switched back and answer with this deck's rows: the
+    # import preview then shows a gate the arriving quest does not have (#2529).
+    Prereq.objects.prefetch_for_parents(quests)
+    for quest in quests:
+        for prereq in quest.prereqs():
+            # Rendering it here is what caches it: `Prereq.__str__` walks the content type
+            # and the generic target (and the OR half, when there is one), which is exactly
+            # what the template asks for, so nothing is left for it to look up later.
+            str(prereq)
+            prereq.get_prereq()  # the template also links to it, via get_absolute_url
 
     return quests
 

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -101,6 +101,10 @@ def load_library_quests_for_render(quests):
     page is mostly the viewer's own deck (their profile, their SiteConfig, their navbar),
     none of which exists in the Library schema.
 
+    Prerequisites are not included: only the quest import preview renders them, and resolving
+    each one costs a query, so `load_library_quest_prereqs_for_render` is a separate call
+    that the page showing them makes for itself.
+
     Must be called from within the library schema context, on an already-evaluated list.
 
     Args:
@@ -108,18 +112,38 @@ def load_library_quests_for_render(quests):
             `prefetch_related_objects` needs the rows to exist.
 
     Returns:
-        list[Quest]: the same list, with `tags`, `question_set`, `campaign` and
-        prerequisites populated.
+        list[Quest]: the same list, with `tags`, `question_set` and `campaign` populated.
+    """
+    prefetch_related_objects(quests, 'tags', 'question_set', 'campaign')
+
+    return quests
+
+
+def load_library_quest_prereqs_for_render(quests):
+    """Read the prerequisites a Library quest's template will name, while the schema is right.
+
+    A prefetch is not enough on its own. `prefetch_for_parents` fills the cache that
+    `prereqs()` serves, but each row still reaches its target through a GenericForeignKey,
+    and `Prereq.__str__` follows that plus the content type to name it. Left lazy, those
+    lookups run once the schema has switched back and answer with this deck's rows, so the
+    quest import preview shows a gate named after one of the viewer's own quests, on a
+    Library quest that may have no gate at all (#2529).
+
+    Separate from `load_library_quests_for_render` because resolving each target costs a
+    query, and the Library's list and campaign pages do not render prerequisites at all:
+    their quest previews are fetched by a later AJAX request that renders inside its own
+    schema context, so they are not exposed to this and should not pay for it.
+
+    Must be called from within the library schema context, on an already-evaluated list.
+
+    Args:
+        quests (list[Quest]): the quests about to be rendered.
+
+    Returns:
+        list[Quest]: the same list, with each quest's prerequisites resolved.
     """
     from prerequisites.models import Prereq
 
-    prefetch_related_objects(quests, 'tags', 'question_set', 'campaign')
-
-    # Prerequisites need more than a prefetch. `prefetch_for_parents` fills the cache that
-    # `prereqs()` serves, but each row still reaches its target through a GenericForeignKey,
-    # and `Prereq.__str__` follows that plus the content type to name it. Left lazy, those
-    # lookups run once the schema has switched back and answer with this deck's rows: the
-    # import preview then shows a gate the arriving quest does not have (#2529).
     Prereq.objects.prefetch_for_parents(quests)
     for quest in quests:
         for prereq in quest.prereqs():

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -39,6 +39,7 @@ from .utils import (
     get_library_schema_name,
     library_listable_quests,
     library_schema_context,
+    load_library_quest_prereqs_for_render,
     load_library_quests_for_render,
 )
 
@@ -699,8 +700,10 @@ class ImportQuestView(NonPublicOnlyViewMixin, View):
 
             if quest is not None:
                 # The page renders outside this context, so everything it shows has to be
-                # read in here (#2163, #2369).
+                # read in here (#2163, #2369). This preview is the one Library page that
+                # names the quest's prerequisites, so it asks for those too (#2529).
                 load_library_quests_for_render([quest])
+                load_library_quest_prereqs_for_render([quest])
 
         if quest is None:
             return redirect_awaiting_review(request, 'quest', 'library:quest_list')


### PR DESCRIPTION
### What?

The Library's quest import preview rendered a quest's prerequisites from the **viewer's own deck** instead of the Library. A Library quest with no gate could show one, named after one of the viewer's own quests; a Library quest with a gate could show the wrong one.

This adds `load_library_quest_prereqs_for_render`, called by `ImportQuestView`, which resolves each prerequisite while the Library schema is still selected.

Closes #2529

### Why?

Library views select their quests inside `library_schema_context()` and render after it has closed. Anything still lazy at that point is evaluated by the template engine, by which time the connection is back on the viewer's deck: it reads *this* deck's tables using the Library row's primary key. Nothing raises. The only symptom is that the wrong thing is on the screen. This is the same failure as #2369 and #2163, in the one relation the earlier fixes did not reach.

Prerequisites needed more than a prefetch. `Prereq.objects.prefetch_for_parents()` fills the cache that `prereqs()` serves, but each row still reaches its target through a GenericForeignKey, and `Prereq.__str__` follows that plus the content type to name it. Those were the lookups left lazy.

The teacher sees this at the moment it matters most: on the import confirmation page, deciding whether to bring the quest onto their deck. A phantom gate makes an ungated quest look like it needs something first, and a wrong gate hides the real one. Both are silent.

### How?

```python
Prereq.objects.prefetch_for_parents(quests)
for quest in quests:
    for prereq in quest.prereqs():
        str(prereq)           # walks the content type and the generic target
        prereq.get_prereq()   # the template also links to it, via get_absolute_url
```

Rendering each prereq is what caches it: `Prereq.__str__` resolves the content type and the generic target (and the OR half, when there is one), which is exactly what the template asks for, so nothing is left to look up after the schema switches back.

**This is a separate helper rather than another line in `load_library_quests_for_render`**, because only one Library page renders prerequisites. The list, campaign detail and campaign import pages show a quest's details through a later AJAX request (`quest_manager.views.ajax_quest_info`), and that view calls `render_to_string` *inside* `library_schema_if_requested(request)`, so it was never exposed to this. Priming prerequisites for them would cost a query per prerequisite on pages that never display one: `prefetch_for_parents` caches only the `Prereq` rows, and resolving each row's generic target is its own query.

### Testing?

`test_ImportQuestView__shows_the_library_quests_own_prereqs` in `LibraryLazyQuerysetRenderTests`. The fixture puts a gate on the Library quest **and** a decoy prerequisite on a local quest forced to the Library quest's primary key, then asserts both sides of the invariant: the Library's gate is named, the decoy is not.

Verified in both directions on a local run:

* with the fix: `Ran 5 tests ... OK`
* with `src/library/utils.py` and `src/library/views.py` reverted to `develop`: `FAILED (failures=1)`, that test

Full suite: `Ran 2630 tests ... OK`. `ruff check src`: clean.

Also walked on a running dev deck (`hackerspace.localhost` importing from `library.localhost`) to confirm the fix in the real app, not just under the test client.

### Screenshots (if front end is affected)

**Before.** The Library quest *Set Up Your Workspace* has **no prerequisites at all**, yet the import preview shows one. `gentle-dragon-1516` is a quest on the *importing* deck, read through the Library quest's primary key:

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2529/phantom-prereq.png)

**After.** The preview shows the Library quest's own gate. *Passwords That Survive* is gated on *Spotting a Fake Source* in the Library, and that is what renders, while the importing deck had its own unrelated prereq rows in play:

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2529/library-prereq-after.png)

The two shots are of different quests: the deck that produced the "before" capture was rebuilt during this work, so the "after" was taken on a freshly seeded deck. The before shot is the clearer demonstration of the bug (a gate appearing on a quest that has none); the after shot is the clearer demonstration of the fix (the correct Library gate surviving a deck that has decoy rows).

### Anything Else?

The first version of this PR primed prerequisites inside `load_library_quests_for_render` and added a test per Library view. CodeRabbit pointed out that the shared assertion only checked the decoy's *absence*, so it would pass on a page that rendered no prerequisites at all. Checking that against the unfixed code showed three of those four tests never failed without the fix, because those three pages do not render prerequisites at all. Hence the narrower helper and the single, genuinely failing test above.

Verifying this behaviour also turned up several other Library problems, all filed rather than fixed here:

* #2531 - sharing a quest whose name the Library already uses returns a 500
* #2532 - importing a campaign whose title a local campaign already uses gives a 404 after the quests have been written
* #2533 - the import success message's "publish the campaign (which publishes its quests)" link does not publish the quests
* #2534 - two more campaign-sharing failures reach the user as a 500
* #2535 - `NOT` prerequisites silently invert on the way across
* #2536 - the share button is missing from the "View status of all students for this quest" page

The Shared Library wiki page has also been rewritten with verified steps and screenshots. It could not be pushed from this session (the wiki is a separate repo that a GitHub App cannot reach), so the finished page and its 19 screenshots are staged on the `pr-assets` branch under `wiki/`, in two forms: `Library.md` using the wiki's own `[[/images/...]]` syntax, and `Library-raw-urls.md` whose images point at `pr-assets` raw URLs so it can be pasted in with no upload step.

### Review request
@tylerecouture

- Claude Code (`bytedeck - library import/export`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the quest import preview to display prerequisites from the library quest being imported.
  * Prevented locally matching quests from causing incorrect prerequisite names to appear.
  * Ensured prerequisite details load correctly before the import preview is rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->