### PR TITLE
fix: keep uploads when a quest's questions change mid-submission (#2428)

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1725,6 +1725,47 @@ def unarchive(request, quest_id):
 #   QUEST SUBMISSION - STUDENT VIEWS
 #
 #########################################
+def _keep_posted_uploads(request, form, question_formset, submission, followup=""):
+    """Save the POST's uploads that pass their own validation, and tell the student.
+
+    A browser never repopulates a file input, so any response that sends the student back to
+    the submission page (the re-render with validation errors, or the questions-changed
+    redirect) arrives with every file input empty: without this their uploads are gone with
+    nothing to say so (#2165, #2427, #2428). Comment attachments are kept on the draft
+    comment and file answers on their draft rows, the same places a successful completion
+    publishes them from.
+
+    Validation is run here, because the questions-changed guard calls this before the view
+    has validated anything (`is_valid` caches, so it costs nothing where it already ran),
+    and only uploads that pass are kept: a file rejected for type or size is dropped so its
+    error still applies on the retry.
+
+    Args:
+        request: the request, for its FILES and as the messages target.
+        form: the bound submission form. Forms without an attachments field keep nothing.
+        question_formset: the bound answer formset, or None when the POST involves none.
+        submission: the QuestSubmission whose draft comment holds kept attachments.
+        followup: an extra sentence for the notice. The re-render path points at its
+            inline errors with it; the redirect path passes nothing, since its own error
+            message already says what to do next.
+
+    Returns:
+        int: how many files were kept.
+    """
+    form.is_valid()
+    kept_files = save_draft_attachments(form, submission.draft_comment)
+    if question_formset is not None:
+        question_formset.is_valid()
+        kept_files += save_draft_file_answers(question_formset, request.FILES)
+    if kept_files:
+        noun, verb, pronoun = ("file", "was", "it") if kept_files == 1 else ("files", "were", "them")
+        messages.info(
+            request,
+            f"Your attached {noun} {verb} saved, so you don't need to choose {pronoun} again.{followup}",
+        )
+    return kept_files
+
+
 @non_public_only_view
 @login_required
 def complete(request, submission_id):
@@ -1809,6 +1850,9 @@ def complete(request, submission_id):
                 "This quest's questions have changed since you opened this page. "
                 "Please review and answer them, then submit again.",
             )
+            # The redirect rebuilds the page with empty file inputs, so keep the uploads
+            # that validate, just as the validation-failure path below does (#2428).
+            _keep_posted_uploads(request, form, question_formset, submission)
             return redirect(origin_path)
 
     if not form.is_valid() or (question_formset and not question_formset.is_valid()):
@@ -1819,16 +1863,10 @@ def complete(request, submission_id):
         # Keep the uploads that did validate, both the comment's attachments and the file
         # answers, since the re-rendered file inputs come back empty and the student would
         # otherwise lose them with no warning (#2165, #2427).
-        kept_files = save_draft_attachments(form, submission.draft_comment)
-        if question_formset:
-            kept_files += save_draft_file_answers(question_formset, request.FILES)
-        if kept_files:
-            noun, verb, pronoun = ("file", "was", "it") if kept_files == 1 else ("files", "were", "them")
-            messages.info(
-                request,
-                f"Your attached {noun} {verb} saved, so you don't need to choose {pronoun} again. "
-                "Fix the problems below and submit the quest again.",
-            )
+        _keep_posted_uploads(
+            request, form, question_formset, submission,
+            followup=" Fix the problems below and submit the quest again.",
+        )
 
         context = {
             "heading": submission.quest.name,

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -746,12 +746,12 @@ class CompleteSecurityTest(QuestionSubmissionFlowTestBase):
         self.assertFalse(self.submission.is_completed)
 
     def test_complete__questions_changed_keeps_comment_attachment(self):
-        """An attachment on a POST bounced by the questions-changed guard is kept (#2428).
+        """The questions-changed bounce keeps an attachment that validates (#2428).
 
-        The redirect rebuilds the page with an empty file input, so before this the upload
-        was silently gone: the same loss #2427 fixed on the validation-failure path, reached
-        through the earlier guard instead. The file lands on the draft comment, where a
-        successful completion publishes it from, and the student is told it was kept.
+        The redirect rebuilds the page with an empty file input, so the upload survives on
+        the draft comment instead: the same place the validation-failure path keeps it
+        (#2427), and the place a successful completion publishes it from. The student is
+        told it was kept.
         """
         stale_data = self.formset_data(short_text="my title")
         baker.make(Question, quest=self.quest, ordinal=3, type="short_answer", required=True)
@@ -773,10 +773,11 @@ class CompleteSecurityTest(QuestionSubmissionFlowTestBase):
         )
 
     def test_complete__questions_changed_keeps_file_answer(self):
-        """A file answer on a POST bounced by the questions-changed guard is kept (#2428).
+        """The questions-changed bounce keeps a file answer that validates (#2428).
 
-        The answer stays on its own draft row, unpublished, exactly as #2165 keeps it on the
-        validation-failure path, so the rebuilt page shows it as already attached.
+        The answer stays on its own draft row, unpublished, the same place the
+        validation-failure path keeps it (#2165), so the rebuilt page shows it as already
+        attached and a later completion publishes it.
         """
         file_question = baker.make(
             Question, quest=self.quest, ordinal=3, type="file_upload",

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -2,6 +2,7 @@ import json
 import re
 
 from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -743,6 +744,59 @@ class CompleteSecurityTest(QuestionSubmissionFlowTestBase):
         self.assertRedirects(response, self.submission.get_absolute_url())
         self.submission.refresh_from_db()
         self.assertFalse(self.submission.is_completed)
+
+    def test_complete__questions_changed_keeps_comment_attachment(self):
+        """An attachment on a POST bounced by the questions-changed guard is kept (#2428).
+
+        The redirect rebuilds the page with an empty file input, so before this the upload
+        was silently gone: the same loss #2427 fixed on the validation-failure path, reached
+        through the earlier guard instead. The file lands on the draft comment, where a
+        successful completion publishes it from, and the student is told it was kept.
+        """
+        stale_data = self.formset_data(short_text="my title")
+        baker.make(Question, quest=self.quest, ordinal=3, type="short_answer", required=True)
+        upload = SimpleUploadedFile("evidence.png", b"file_content", content_type="image/png")
+
+        response = self.client.post(
+            reverse("quests:complete", args=[self.submission.id]),
+            data={"complete": True, "comment_text": "", "attachments": upload, **stale_data})
+
+        self.assertRedirects(response, self.submission.get_absolute_url())
+        self.submission.refresh_from_db()
+        self.assertFalse(self.submission.is_completed)
+        documents = list(self.submission.draft_comment.document_set.all())
+        self.assertEqual(len(documents), 1, "the attachment was dropped on the redirect")
+        self.assertIn("evidence", documents[0].docfile.name)
+        self.assertIn(
+            "Your attached file was saved, so you don't need to choose it again.",
+            [str(message) for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_complete__questions_changed_keeps_file_answer(self):
+        """A file answer on a POST bounced by the questions-changed guard is kept (#2428).
+
+        The answer stays on its own draft row, unpublished, exactly as #2165 keeps it on the
+        validation-failure path, so the rebuilt page shows it as already attached.
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="all",
+        )
+        rows = list(sync_draft_question_submissions(self.submission))
+        stale_data = self.formset_data(short_text="my title")
+        upload = SimpleUploadedFile("my-recording.png", b"file_content", content_type="image/png")
+        stale_data[self.file_field_name(file_question)] = upload
+        baker.make(Question, quest=self.quest, ordinal=4, type="short_answer", required=True)
+
+        response = self.client.post(
+            reverse("quests:complete", args=[self.submission.id]),
+            data={"complete": True, "comment_text": "", **stale_data})
+
+        self.assertRedirects(response, self.submission.get_absolute_url())
+        row = QuestionSubmission.objects.get(quest_submission=self.submission, question=file_question)
+        self.assertIn("my-recording", row.response_file.name, "the file answer was dropped on the redirect")
+        self.assertIsNone(row.comment_id, "a kept draft answer must not be published")
+        self.assertEqual(len(rows), 3)
 
     def test_complete__optional_blank_answers_still_require_comment_when_verification_required(self):
         """A verification-required quest whose only questions are optional and left blank


### PR DESCRIPTION
Closes #2428

### What?

When a submission is bounced because the quest's questions changed while the student had the page open, the files they attached in that submit now survive: comment attachments land on the draft comment, file answers on their draft rows, and the student is told they were kept.

### Why?

This was the third and last of the three paths that silently discarded a student's uploads. #2165 and #2427 fixed the two validation-failure paths, but the questions-changed guard returns *before* validation runs, so it never reached those fixes: the redirect rebuilt the page with empty file inputs and the uploads were simply gone, with nothing saying so.

### How?

The keep-the-files logic and its "Your attached file was saved" notice move out of the invalid-form branch into one shared helper, `_keep_posted_uploads`, which both that branch and the guard now call. The helper runs `is_valid()` itself (the guard fires before the view has validated anything; where validation already ran it is cached and free), and only uploads that pass their own validation are kept, so a file rejected for type or size still shows its error on the retry. A file answer posted for a question that was just deleted has no draft row to keep it on and is dropped; the notice counts only what was kept. The re-render path's message is unchanged, character for character: the helper takes its "Fix the problems below" sentence as a parameter, which the redirect path omits since the guard's own error already says what to do next.

### Testing?

Test-driven: both new tests fail on `develop`.

* `test_complete__questions_changed_keeps_comment_attachment`: an attachment on a bounced POST ends up on the draft comment, with the notice.
* `test_complete__questions_changed_keeps_file_answer`: a file answer on a bounced POST stays on its draft row, unpublished.

`src/quest_manager`, `src/questions` and `src/comments` suites green locally, `ruff check src` clean, `makemigrations --check` clean.

### Screenshots (if front end is affected)

Captured from the hackerspace dev deck as the student: a photo attached to Question 3, the teacher adds a new question, the student submits and is bounced.

Before: only the error; the upload is gone without a trace.

![before: the bounce shows only the questions-changed error](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2428/before_notices.png)

![before: the file question comes back empty](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2428/before_question.png)

After: the same bounce says the file was kept, and the question shows it attached.

![after: the bounce also says the attached file was saved](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2428/after_notices.png)

![after: the file question shows the upload already saved](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2428/after_question.png)

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved valid comment attachments and file answers when submission validation fails or questions change.
  * Kept uploaded files available in draft submissions instead of losing them.
  * Added messaging to clarify how many attachments were retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->