### PR TITLE
fix: offer the Library export button on the quest status page too (#2536)

### DIFF
--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -63,6 +63,7 @@
             title="Archive this quest" >
             <i class="fa fa-fw fa-archive"></i>
           </a>
+          {% can_export_to_library as can_export %}
           {% if can_export %}
             <a class="btn btn-default" href="{% url 'library:export_quest' q.import_id %}" role="button"
               title="Export this quest to the Library">

--- a/src/quest_manager/templates/quest_manager/category_detail.html
+++ b/src/quest_manager/templates/quest_manager/category_detail.html
@@ -1,5 +1,6 @@
 {% extends "quest_manager/base.html" %}
 {% load crispy_forms_tags %}
+{% load quest_tags %}
 
 {% block head_title %}Campaigns | {% endblock %}
 
@@ -19,6 +20,7 @@
                 <i class="fa fa-edit"></i>
             </a>
 
+            {% can_export_to_library as can_export %}
             {% if can_export %}
               <a class="btn btn-default" role="button"
                 {% if object.quest_count != 0 %}

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -1,3 +1,6 @@
+{% load quest_tags %}
+{# asked once here, not per row: every campaign row offers the same export action #}
+{% can_export_to_library as can_export %}
 {% if is_library_view %}
   <p>
     <span class="text-danger">EXPERIMENTAL!</span>

--- a/src/quest_manager/templatetags/quest_tags.py
+++ b/src/quest_manager/templatetags/quest_tags.py
@@ -22,10 +22,9 @@ def is_hidden(quest, user):
 def can_export_to_library(context):
     """Whether the current user may export quests/campaigns to the Shared Library.
 
-    Single source of truth for the export buttons: the templates that render one ask
-    this tag themselves, so every page that includes a button bar offers the button
-    correctly by default, with nothing for its view to pass. A per-view context flag
-    is exactly what silently hid the button on the quest status page (issue #2536).
+    Single source of truth for the export buttons (issue #2536): the templates that
+    render one ask this tag themselves, so every page that includes a button bar
+    offers the button correctly by default, with nothing for its view to pass.
 
     Args:
         context (django.template.Context): the rendering context; the request is

--- a/src/quest_manager/templatetags/quest_tags.py
+++ b/src/quest_manager/templatetags/quest_tags.py
@@ -1,5 +1,7 @@
 from django import template
 
+from siteconfig.models import SiteConfig
+
 register = template.Library()
 
 
@@ -14,3 +16,27 @@ def is_hidden(quest, user):
     if not user or not quest:
         return None
     return user.profile.is_quest_hidden(quest)
+
+
+@register.simple_tag(takes_context=True)
+def can_export_to_library(context):
+    """Whether the current user may export quests/campaigns to the Shared Library.
+
+    Single source of truth for the export buttons: the templates that render one ask
+    this tag themselves, so every page that includes a button bar offers the button
+    correctly by default, with nothing for its view to pass. A per-view context flag
+    is exactly what silently hid the button on the quest status page (issue #2536).
+
+    Args:
+        context (django.template.Context): the rendering context; the request is
+            read from it, so the tag needs no arguments.
+
+    Returns:
+        bool: True if this user may export to the Shared Library from this page.
+    """
+    request = context.get('request')
+    if request is None:
+        # Rendered without a request (no RequestContext): there is no user to
+        # allow, so offer no export button rather than raise.
+        return False
+    return SiteConfig.get().can_user_export_to_library(request.user)

--- a/src/quest_manager/tests/test_templatetags.py
+++ b/src/quest_manager/tests/test_templatetags.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from quest_manager.templatetags.quest_tags import is_hidden
+from quest_manager.templatetags.quest_tags import can_export_to_library, is_hidden
 
 
 class QuestTagsIsHiddenTest(SimpleTestCase):
@@ -13,3 +13,15 @@ class QuestTagsIsHiddenTest(SimpleTestCase):
     def test_is_hidden__returns_none_when_quest_missing(self):
         """With no quest, is_hidden short-circuits to None without touching the profile."""
         self.assertIsNone(is_hidden(None, object()))
+
+
+class QuestTagsCanExportToLibraryTest(SimpleTestCase):
+    """Tests for the can_export_to_library tag's missing-request guard.
+
+    The tag's real answer (per user, per SiteConfig, per schema) is exercised through
+    full page renders in the view tests; only the guard needs a direct call.
+    """
+
+    def test_can_export_to_library__returns_false_without_request(self):
+        """Rendered without a RequestContext there is no user to allow, so no export button."""
+        self.assertFalse(can_export_to_library({}))

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2189,6 +2189,36 @@ class QuestUserStatusViewTests(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['scope'], 'active')
 
+    def test_quest_user_status__export_button_shown_when_user_can_export(self):
+        """A user who may export to the Shared Library gets the export button on the status page.
+
+        This page includes the same quest button bar as the detail page, but its view set
+        no export flag, so the button was silently missing here even with the feature
+        fully enabled (issue #2536). The bar now asks the `can_export_to_library` tag
+        itself, so it is consistent wherever it appears.
+        """
+        site_config = SiteConfig.get()
+        site_config.allow_staff_export = True
+        site_config.enable_shared_library = True
+        site_config.full_clean()
+        site_config.save()
+
+        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]))
+
+        self.assertContains(response, 'Export this quest to the Library')
+
+    def test_quest_user_status__export_button_hidden_when_library_disabled(self):
+        """With the Shared Library turned off, the status page offers no export button."""
+        site_config = SiteConfig.get()
+        site_config.enable_shared_library = False
+        site_config.full_clean()
+        site_config.save()
+
+        response = self.client.get(reverse('quests:quest_user_status', args=[self.quest.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Export this quest to the Library')
+
 
 class QuestCRUDViewsTest(ByteDeckTenantTestCase):
     """ Tests for:
@@ -4002,6 +4032,58 @@ class CategoryViewTests(ByteDeckTenantTestCase):
         self.assertNotContains(response, 'Import this Campaign into your Deck')
         self.assertNotContains(response, 'EXPERIMENTAL!')
 
+    def test_CategoryList_view__export_button_follows_export_permission(self):
+        """The campaign list renders each campaign's Library export button only for a user
+        who may export.
+
+        The templates ask the `can_export_to_library` tag themselves rather than reading
+        a per-view context flag (issue #2536), so this guards the campaign table's copy.
+        """
+        campaign = baker.make(Category, published=True)
+        baker.make(Quest, campaign=campaign, published=True)
+        self.client.force_login(self.test_teacher)
+
+        site_config = SiteConfig.get()
+        site_config.allow_staff_export = True
+        site_config.enable_shared_library = True
+        site_config.full_clean()
+        site_config.save()
+
+        response = self.client.get(reverse('quests:categories'))
+        self.assertContains(response, 'Export this Campaign to the Library')
+
+        # with the Shared Library off nobody may export, so the button goes away
+        site_config.enable_shared_library = False
+        site_config.full_clean()
+        site_config.save()
+
+        response = self.client.get(reverse('quests:categories'))
+        self.assertNotContains(response, 'Export this Campaign to the Library')
+
+    def test_CategoryDetail_view__export_button_follows_export_permission(self):
+        """The campaign detail page renders its Library export button only for a user who
+        may export (issue #2536, same tag as the campaign list)."""
+        campaign = baker.make(Category, published=True)
+        baker.make(Quest, campaign=campaign, published=True)
+        self.client.force_login(self.test_teacher)
+
+        site_config = SiteConfig.get()
+        site_config.allow_staff_export = True
+        site_config.enable_shared_library = True
+        site_config.full_clean()
+        site_config.save()
+
+        response = self.client.get(reverse('quests:category_detail', args=[campaign.id]))
+        self.assertContains(response, 'Export this Campaign to the Library')
+
+        # with the Shared Library off nobody may export, so the button goes away
+        site_config.enable_shared_library = False
+        site_config.full_clean()
+        site_config.save()
+
+        response = self.client.get(reverse('quests:category_detail', args=[campaign.id]))
+        self.assertNotContains(response, 'Export this Campaign to the Library')
+
     def test_CategoryDetail_view__staff_see_unpublished_quests_of_unpublished_campaign(self):
         """Staff must see a campaign's unpublished quests on the campaign detail page
         regardless of whether the campaign itself is published; only archived quests
@@ -4650,10 +4732,13 @@ class DetailViewTest(ByteDeckTenantTestCase):
         # Should redirect them to the submission's page
         self.assertRedirects(response, reverse('quests:submission', args=[sub.id]))
 
-    def test_detail__can_export_context(self):
-        """
-        Verify 'can_export' context variable is correctly set in quest detail view
-        for staff and students, and that it is disabled in the library schema.
+    def test_detail__export_button_follows_export_permission(self):
+        """The detail page renders the Library export button for a user who may export,
+        and not for one who may not.
+
+        The button bar asks the `can_export_to_library` template tag itself rather than
+        reading a per-view context flag (issue #2536), so this exercises the tag through
+        a full page render.
         """
         # Make a staff user
         self.client.force_login(self.test_teacher)
@@ -4664,19 +4749,14 @@ class DetailViewTest(ByteDeckTenantTestCase):
         site_config.full_clean()
         site_config.save()
 
-        # Staff user in a normal tenant schema
+        # Staff user in a normal tenant schema, with staff export allowed
         response = self.assert200('quests:quest_detail', args=[self.quest.id])
+        self.assertContains(response, 'Export this quest to the Library')
 
-        # Should be in the context
-        self.assertIn('can_export', response.context)
-
-        # Since staff and export allowed, should be True
-        self.assertTrue(response.context['can_export'])
-
-        # Now test as normal student
+        # A student may not export, so they get no export button
         self.client.force_login(self.test_student)
         response = self.assert200('quests:quest_detail', args=[self.quest.id])
-        self.assertFalse(response.context['can_export'])
+        self.assertNotContains(response, 'Export this quest to the Library')
 
 
 class ApproveViewTest(ByteDeckTenantTestCase):

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -2192,10 +2192,9 @@ class QuestUserStatusViewTests(ByteDeckTenantTestCase):
     def test_quest_user_status__export_button_shown_when_user_can_export(self):
         """A user who may export to the Shared Library gets the export button on the status page.
 
-        This page includes the same quest button bar as the detail page, but its view set
-        no export flag, so the button was silently missing here even with the feature
-        fully enabled (issue #2536). The bar now asks the `can_export_to_library` tag
-        itself, so it is consistent wherever it appears.
+        This page includes the same quest button bar as the detail page, and the bar
+        asks the `can_export_to_library` tag itself, so the export button appears here
+        exactly as it does everywhere else the bar renders (issue #2536).
         """
         site_config = SiteConfig.get()
         site_config.allow_staff_export = True
@@ -4036,8 +4035,8 @@ class CategoryViewTests(ByteDeckTenantTestCase):
         """The campaign list renders each campaign's Library export button only for a user
         who may export.
 
-        The templates ask the `can_export_to_library` tag themselves rather than reading
-        a per-view context flag (issue #2536), so this guards the campaign table's copy.
+        The campaign table asks the `can_export_to_library` tag itself (issue #2536),
+        and this guards the table's copy of the button.
         """
         campaign = baker.make(Category, published=True)
         baker.make(Quest, campaign=campaign, published=True)
@@ -4062,7 +4061,7 @@ class CategoryViewTests(ByteDeckTenantTestCase):
 
     def test_CategoryDetail_view__export_button_follows_export_permission(self):
         """The campaign detail page renders its Library export button only for a user who
-        may export (issue #2536, same tag as the campaign list)."""
+        may export, via the same `can_export_to_library` tag as the campaign list (issue #2536)."""
         campaign = baker.make(Category, published=True)
         baker.make(Quest, campaign=campaign, published=True)
         self.client.force_login(self.test_teacher)
@@ -4736,9 +4735,8 @@ class DetailViewTest(ByteDeckTenantTestCase):
         """The detail page renders the Library export button for a user who may export,
         and not for one who may not.
 
-        The button bar asks the `can_export_to_library` template tag itself rather than
-        reading a per-view context flag (issue #2536), so this exercises the tag through
-        a full page render.
+        The button bar asks the `can_export_to_library` template tag itself (issue
+        #2536), so this exercises the tag through a full page render.
         """
         # Make a staff user
         self.client.force_login(self.test_teacher)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -116,19 +116,17 @@ class CategoryList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
             dict: the template context, with
                 - available_tab_active (bool): the Available tab is the one being shown.
                 - inactive_tab_active (bool): the Inactive tab is the one being shown.
-                - can_export (bool): this user may push a campaign to the Shared Library,
-                    so the export action is offered.
                 - is_library_view (bool): False. The campaign table is shared with the
                     Library's campaign list, and this is the deck's own copy, so it shows
                     the local actions rather than the Library's import action.
+
+        The export action's flag is not set here: the template asks the
+        `can_export_to_library` tag itself.
         """
         context_data = super().get_context_data(*args, **kwargs)
 
-        can_export = SiteConfig.get().can_user_export_to_library(self.request.user)
-
         context_data['available_tab_active'] = self.available_tab_active
         context_data['inactive_tab_active'] = self.inactive_tab_active
-        context_data['can_export'] = can_export
         # these are the deck's own campaigns, so the shared campaign table shows the
         # local actions (edit, publish, export, delete) rather than the Library's import action
         context_data['is_library_view'] = False
@@ -155,7 +153,7 @@ class CategoryDetail(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
 
         Returns:
             dict: Context info containing the appropriate quests for the user to view,
-            including "category_displayed_quests" and "can_export".
+            including "category_displayed_quests".
         """
         if self.request.user.is_staff:
             quests = Quest.objects.filter(campaign=self.object)
@@ -177,7 +175,6 @@ class CategoryDetail(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
         )
 
         kwargs['category_displayed_quests'] = quests
-        kwargs['can_export'] = SiteConfig.get().can_user_export_to_library(self.request.user)
 
         return super().get_context_data(**kwargs)
 
@@ -981,7 +978,6 @@ def ajax_quest_info(request, quest_id=None):
 
         with library_schema_if_requested(request):
             is_library_view = is_library_schema_requested(request)
-            can_export = SiteConfig.get().can_user_export_to_library(request.user)
 
             if quest_id:
                 if request.user.is_staff:
@@ -989,8 +985,11 @@ def ajax_quest_info(request, quest_id=None):
                 else:
                     quest = get_object_or_404(Quest, pk=quest_id)
 
+                # The export button's can_export_to_library tag runs during this render,
+                # so it still answers for the schema selected above: on a Library preview
+                # it sees the Library schema and offers no export button.
                 quest_info_html = render_to_string(template,
-                                                   {'q': quest, 'is_library_view': is_library_view, 'can_export': can_export},
+                                                   {'q': quest, 'is_library_view': is_library_view},
                                                    request=request)
 
                 data = {'quest_info_html': quest_info_html}
@@ -1090,14 +1089,11 @@ def detail(request, quest_id):
             # No submission either, so display quest flagged as unavailable
             available = False
 
-    can_export = SiteConfig.get().can_user_export_to_library(request.user)
-
     context = {
         "heading": q.name,
         "q": q,
         "available": available,
         "maps": CytoScape.objects.get_related_maps(q),
-        "can_export": can_export,
     }
 
     return render(request, "quest_manager/detail.html", context)

--- a/src/siteconfig/models.py
+++ b/src/siteconfig/models.py
@@ -425,7 +425,10 @@ class SiteConfig(models.Model):
         if current_schema == get_library_schema_name():
             return False
 
-        if user == self.deck_owner:
+        # Compared by id (a local column) rather than fetching the owner: the export
+        # buttons ask this per rendered page, and a cached SiteConfig instance would
+        # otherwise run a query for the owner on every call.
+        if user.pk == self.deck_owner_id:
             return True
 
         return self.allow_staff_export and user.is_staff


### PR DESCRIPTION
### What?
Closes #2536: the "View status of all students for this quest" page now shows the "Export this quest to the Library" button, like every other page that renders the quest action button bar.

Rather than patching the one view that forgot to set the bar's `can_export` context flag, this makes the export buttons correct by default: a new `can_export_to_library` template tag answers the question inside the templates themselves, and the four per-view `can_export` plumbing sites are removed.

### Why?
The button bar (`quest_manager/buttons.html`) renders the export button behind `{% if can_export %}`, and each including view had to put that flag in its own context. The quest status view never did, so the button was silently absent there, even for the deck owner with the Shared Library fully enabled. Four call sites setting the same flag for the same shared template is exactly what let this slip (as issue #2536 notes), so the fix removes the pattern rather than adding a fifth call site.

### How?
* New `can_export_to_library` simple tag in `quest_manager/templatetags/quest_tags.py`: reads the request from the rendering context and returns `SiteConfig.get().can_user_export_to_library(request.user)`. Returns False when rendered without a request rather than raising.
* `buttons.html` asks the tag itself, so every page that includes it (quest detail, the ajax quest preview, and the status page) offers the button correctly by default. The ajax preview renders inside `library_schema_if_requested`, so on a Library preview the tag still sees the Library schema and offers no export button (the existing test for that keeps passing).
* The campaign tables (`tab_campaigns_list.html`, `category_detail.html`) use the same tag for their campaign export button. In the campaign list it is asked once above the table, not per row.
* The four views that set `can_export` in context (`CategoryList`, `CategoryDetail`, `ajax_quest_info`, `detail`) no longer do.
* `SiteConfig.can_user_export_to_library` compares the deck owner by `deck_owner_id` instead of fetching the owner row: `SiteConfig.get()` returns a fresh cache-deserialized instance per call and `deck_owner` is not `select_related`, so the old comparison cost one query per call. With the tag asked per rendered page, the check is now query free.

The issue floated a context processor or mixin as alternatives. A context processor would also run on public-tenant pages (where `SiteConfig` does not exist) and on every page that never renders the button, and a mixin cannot reach the function-based views (`detail`, `quest_user_status`, `ajax_quest_info`), so a template tag scoped to the templates that actually render the buttons seemed like the cleanest "correct by default" shape.

### Testing?
Test driven: `test_quest_user_status__export_button_shown_when_user_can_export` fails without the fix (verified by running it against the unfixed code) and passes with it.

* New: status page shows the button for a user who may export, and hides it with the Shared Library off.
* New: campaign list and campaign detail render their campaign export button only for a user who may export (guards the template change on those pages).
* New: direct tag test for the missing-request guard.
* Updated: the quest detail test asserts the rendered button rather than the removed `can_export` context variable.
* Existing ajax preview tests (student, staff, Library schema) pass unchanged, covering the ajax path's behaviour.
* Full suite: `python src/manage.py test src` and `ruff check src` pass locally (plus `manage.py check` and `makemigrations --check --dry-run`).

### Screenshots (if front end is affected)
Captured from the running dev app (`hackerspace.localhost:8000`, seeded via `initdb` + `generate_content`, logged in as the deck owner `owner` with the Shared Library enabled), on the ByteDeck Class Contract quest's status page.

Before (no export button in the bar):

![before: the status page's button bar has no export button](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2536/before.png)

After (the upload/export button appears, matching the quest detail page):

![after: the status page's button bar offers Export this quest to the Library](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2536/after.png)

### Anything Else?
`user == self.deck_owner` was the method's only per-call query; if you would rather keep that comparison exactly as it was, the id comparison can be dropped without affecting the fix (the tag would just cost one query per page render, like the old per-view flag did).

### Review request
@tylerecouture

- Claude Code (`bytedeck - github issues workflow`)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mwASxVDwGKGPHnSAC2dZy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export controls now appear consistently only when Shared Library export is enabled and the viewer has permission.
  * Corrected export visibility across quest, campaign, category, and preview pages.
  * Improved authorization checks while preserving existing access outcomes.

* **Tests**
  * Added coverage for export-button visibility and permission scenarios.
  * Added validation for contexts where export permissions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->