### PR TITLE
fix: say what a mark that is not a number means, and where it comes from (#2486)

### DIFF
--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -1308,9 +1308,21 @@ class CourseStudent(models.Model):
 
 @receiver(post_save, sender=CourseStudent)
 def coursestudent_post_save_callback(instance, **kwargs):
-    """
-    This model's objects are edited by teachers using the admin menu.
-    If they make a manual XP adjustment we need to invalidate the user's xp_cache to recalculate xp
+    """Work out the student's cached XP and mark again, because their registrations decide both.
+
+    Teachers edit these rows in the admin, and a manual xp_adjustment there counts toward the
+    student's XP, so the cache has to follow. Joining or leaving a course moves the mark as
+    well: it is a percentage of the XP counting toward one course, so a student with no
+    registration has no mark at all.
+
+    That makes CourseStudent.xp() part of what saving a CourseStudent does, through
+    Profile.mark(). A test patching the XP split therefore has to patch before it saves a
+    registration, not just before the thing it is testing (issue #2486);
+    courses.tests.utils.patch_registration_xp() is the seam to use.
+
+    Archiving does not come through here. calc_semester_grades() writes its registrations
+    with bulk_update, which fires no post_save, and invalidates once per student afterwards
+    rather than once per registration (issue #2459).
     """
     instance.user.profile.xp_invalidate_cache()
 

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1134,12 +1134,17 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         config.cap_marks_at_100_percent = False
         config.save()
 
-    def test_coursestudent_post_save__refreshes_the_students_cached_xp_and_mark(self):
+    @patch('courses.models.Semester.fraction_complete', return_value=0.5)
+    def test_coursestudent_post_save__refreshes_the_students_cached_xp_and_mark(self, fraction_complete):
         """Saving a registration is what keeps a student's cached XP and mark following their
         courses. Joining one gives them a mark where they had none, since a mark is a
         percentage of the XP counting toward a course, and a teacher's manual xp_adjustment
         counts toward their XP. That is why CourseStudent.xp() is on the write path of every
-        registration save (issue #2486)."""
+        registration save (issue #2486).
+
+        Both cached values are asserted at both saves: refreshing the XP and leaving the mark
+        behind would be the same bug from the student list's point of view, since that is the
+        column it sorts and colours by."""
         student = baker.make(User)
         self._approved(student, xp=40)
         student.profile.xp_invalidate_cache()
@@ -1148,15 +1153,17 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
 
         registration = self._register(student, baker.make(Course, xp_for_100_percent=1000))
 
+        # halfway through the semester, 40 XP projects to 80, out of the course's 1000
         student.profile.refresh_from_db()
         self.assertEqual(student.profile.xp_cached, 40)
-        self.assertIsNotNone(student.profile.mark_cached)
+        self.assertEqual(student.profile.mark_cached, 8)
 
         registration.xp_adjustment = 15
         registration.save()
 
         student.profile.refresh_from_db()
         self.assertEqual(student.profile.xp_cached, 55)
+        self.assertEqual(student.profile.mark_cached, 11)
 
     def test_xp__is_the_whole_total_for_a_student_with_one_course(self):
         """Nothing to divide, so their one course carries everything they earned."""

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1134,6 +1134,30 @@ class CourseStudentModelTest(ByteDeckTenantTestCase):
         config.cap_marks_at_100_percent = False
         config.save()
 
+    def test_coursestudent_post_save__refreshes_the_students_cached_xp_and_mark(self):
+        """Saving a registration is what keeps a student's cached XP and mark following their
+        courses. Joining one gives them a mark where they had none, since a mark is a
+        percentage of the XP counting toward a course, and a teacher's manual xp_adjustment
+        counts toward their XP. That is why CourseStudent.xp() is on the write path of every
+        registration save (issue #2486)."""
+        student = baker.make(User)
+        self._approved(student, xp=40)
+        student.profile.xp_invalidate_cache()
+        student.profile.refresh_from_db()
+        self.assertIsNone(student.profile.mark_cached)
+
+        registration = self._register(student, baker.make(Course, xp_for_100_percent=1000))
+
+        student.profile.refresh_from_db()
+        self.assertEqual(student.profile.xp_cached, 40)
+        self.assertIsNotNone(student.profile.mark_cached)
+
+        registration.xp_adjustment = 15
+        registration.save()
+
+        student.profile.refresh_from_db()
+        self.assertEqual(student.profile.xp_cached, 55)
+
     def test_xp__is_the_whole_total_for_a_student_with_one_course(self):
         """Nothing to divide, so their one course carries everything they earned."""
         student = baker.make(User)

--- a/src/profile_manager/models.py
+++ b/src/profile_manager/models.py
@@ -370,11 +370,39 @@ class Profile(models.Model):
     #################################
 
     def xp_invalidate_cache(self):
+        """Work out this student's XP and mark again, and store both on the profile.
+
+        Called whenever something either is worked out from changes: a submission approved,
+        a badge granted, a registration saved. The mark is cached alongside the XP because
+        it is a percentage of it, and the student list sorts and colours by it, so it has to
+        be a column rather than something worked out per row.
+
+        Raises:
+            TypeError: when mark() gives something that is neither a number nor None, which
+                only a test can arrange (see the check below).
+
+        Returns:
+            int: the XP just cached.
+        """
         xp = QuestSubmission.objects.calculate_xp(self.user)
         xp += BadgeAssertion.objects.calculate_xp(self.user)
         xp += CourseStudent.objects.calculate_xp(self.user)
         self.xp_cached = xp
-        self.mark_cached = self.mark()
+
+        mark = self.mark()
+        # Checked before it is stored, because the failure it otherwise causes names the
+        # wrong thing (issue #2486): a MagicMock reaching mark_cached raises "Aggregate
+        # functions are not allowed in this query" from the save below, pointing at the
+        # profile rather than at the patch that produced it.
+        if mark is not None and not isinstance(mark, (int, float)):
+            raise TypeError(
+                f"Profile.mark() gave {mark!r}, which is not a mark. A test patching "
+                "CourseStudent.xp() or CourseStudentManager.xp_across() must have the patch "
+                "in place before it saves a CourseStudent, since saving one asks for the "
+                "mark: use courses.tests.utils.patch_registration_xp()."
+            )
+        self.mark_cached = mark
+
         self.save()
         return xp
 

--- a/src/profile_manager/tests/test_models.py
+++ b/src/profile_manager/tests/test_models.py
@@ -375,6 +375,28 @@ class ProfileTestModel(ByteDeckTenantTestCase):
         self.assertEqual(self.profile.xp_cached, 50)
         self.assertEqual(self.profile.mark_cached, 10)
 
+    def test_xp_invalidate_cache__names_the_patch_behind_a_mark_that_is_not_a_number(self):
+        """A mark that is not a number cannot be stored, and the error says why.
+
+        Saving a CourseStudent refreshes the cached mark, and the mark reaches
+        CourseStudent.xp(), so a test that patches the XP split after it has already created
+        a registration puts a MagicMock into mark_cached. What that produces on its own is
+        "FieldError: Aggregate functions are not allowed in this query", raised from
+        Profile.save() and naming nothing that led there (issue #2486). The check names the
+        cause and the helper that avoids it."""
+        with patch('profile_manager.models.Profile.mark', return_value=Mock()):
+            with self.assertRaisesMessage(TypeError, 'patch_registration_xp'):
+                self.profile.xp_invalidate_cache()
+
+    def test_xp_invalidate_cache__stores_a_mark_of_none(self):
+        """None is a mark in its own right, not a failed one: a student in no course has no
+        percentage, and so does one whose every course is run on XP alone (issue #403). The
+        check on the mark has to let it through rather than treating it as a bad value."""
+        self.profile.xp_invalidate_cache()
+
+        self.profile.refresh_from_db()
+        self.assertIsNone(self.profile.mark_cached)
+
     @patch('courses.models.Semester.fraction_complete', return_value=0.5)
     def test_mark__skips_a_course_run_on_xp_alone(self, fraction_complete):
         """A course can be run on XP alone and have no mark at all (issue #403). A student who


### PR DESCRIPTION
### What?

Closes #2486. When a mark that is not a number reaches `Profile.mark_cached`, the failure now names the cause instead of surfacing as an unrelated ORM error.

* `Profile.xp_invalidate_cache()` checks the mark before storing it and raises a `TypeError` naming both what happened and the test helper that avoids it. It also gains a docstring, having had none.
* `coursestudent_post_save_callback`'s docstring says what it recomputes and why, that this puts `CourseStudent.xp()` on the write path of every registration save, and that archiving deliberately does not come through it.
* Three tests: two on `xp_invalidate_cache()`, one pinning the signal's behaviour so a later reader can see why the recompute is there.

No migration, no model change, no template change.

### Why?

Saving a `CourseStudent` recomputes the student's cached XP and mark:

```
CourseStudent.save()
  -> coursestudent_post_save_callback
    -> Profile.xp_invalidate_cache()
      -> Profile.mark() -> CourseStudent.mark() -> CourseStudent.xp()
```

So `CourseStudent.xp()` is on the write path of every registration save. A test that patches the XP split *after* it has already created a registration puts a `MagicMock` into `mark_cached`, and what comes out is:

```
django.core.exceptions.FieldError: Aggregate functions are not allowed in this query
(mark_cached=<Mock name='mock.resolve_expression().resolve_expression()' id='...'>)
```

raised from `Profile.save()`. Nothing in that message or its traceback mentions the patch, the signal, or `CourseStudent.xp()`, and nothing in the test or the signal says the two are coupled. That cost real time once already: it took `develop` red and every open PR's CI with it, and was diagnosed from an unrelated Shared Library PR.

The red-CI symptom itself was fixed in #2485 by moving one line (setting `return_value` before the first `baker.make`). This is the shape that produced it, which is what #2486 was filed to track.

### How?

The mark is checked where it is stored, because that is the last point where the cause is still known:

```python
mark = self.mark()
# Checked before it is stored, because the failure it otherwise causes names the
# wrong thing (issue #2486): a MagicMock reaching mark_cached raises "Aggregate
# functions are not allowed in this query" from the save below, pointing at the
# profile rather than at the patch that produced it.
if mark is not None and not isinstance(mark, (int, float)):
    raise TypeError(
        f"Profile.mark() gave {mark!r}, which is not a mark. A test patching "
        "CourseStudent.xp() or CourseStudentManager.xp_across() must have the patch "
        "in place before it saves a CourseStudent, since saving one asks for the "
        "mark: use courses.tests.utils.patch_registration_xp()."
    )
self.mark_cached = mark
```

`None` still stores: a student in no course has no mark, and so does one whose every course is run on XP alone (#403). `(int, float)` is the full range a mark can be, since `CourseStudent.calc_mark()` returns either the integer `0` or a float.

The issue offers three options. This takes the first (say it at the signal) and a stricter reading of the second:

* **Option 2 as written**, skipping or not persisting a non-numeric mark, would turn a confusing error into a silent one. The value is still wrong; only the symptom moves. Raising says the same thing loudly and points at the fix.
* **Option 3**, not refreshing the cached mark from the signal at all, is declined because the refresh is load-bearing. A mark is a percentage of the XP counting toward one course, so joining or leaving a course changes it (a student with no registration has no mark at all), and `mark_cached` is what the student list sorts and colours by, so it has to be a stored column rather than something worked out per row. Narrowing the receiver to "only when `xp_adjustment` changed" would be wrong for the same reason. `test_coursestudent_post_save__refreshes_the_students_cached_xp_and_mark` pins that, so anyone revisiting option 3 finds out what it costs.

### Testing?

`python src/manage.py test src` (2637 tests, all passing, run on the head with `develop` merged in), `ruff check src` clean, `manage.py check` clean, `makemigrations --check --dry-run` clean.

Three new tests:

* `test_xp_invalidate_cache__names_the_patch_behind_a_mark_that_is_not_a_number` is the regression test. Verified by removing the check and re-running it, where it errors with exactly the message from the issue:

  ```
  django.core.exceptions.FieldError: Aggregate functions are not allowed in this query
  (mark_cached=<Mock name='mock.resolve_expression().resolve_expression()' id='...'>)
  ```

* `test_xp_invalidate_cache__stores_a_mark_of_none` guards the boundary the new check could overshoot: `None` is a mark in its own right, not a bad value.
* `test_coursestudent_post_save__refreshes_the_students_cached_xp_and_mark` covers the signal itself, which had no test of its own. It asserts both cached values at both saves, since refreshing the XP and leaving the mark behind would be the same bug from the student list's point of view. `Semester.fraction_complete` is patched to 0.5 to make the arithmetic deterministic: 40 XP gives a mark of 8 against a course out of 1000, and a later `xp_adjustment` of 15 moves those to 55 and 11. Confirmed the mark assertions bite by stopping `xp_invalidate_cache()` from writing the mark, which fails with `AssertionError: None != 8`.

### Screenshots (if front end is affected)

N/A, and deliberately so rather than for want of looking: nothing visible changes. The check only fires on a value that cannot occur outside a test, and the rest of the diff is docstrings and tests.

### Anything Else?

The error message names a test helper from production code, which is unusual. It earns its place: `courses.tests.utils.patch_registration_xp()` is the only correct way to patch this, its own docstring already explains the ordering hazard, and the branch is unreachable except from a test, so a reader seeing this message is by definition writing one.

CodeRabbit's review raised two points. The test-coverage one is taken, described above. The other, adding `Args` / `**kwargs` / `Returns` to the `post_save` receiver's docstring, is declined on the thread: `src/` holds 26 signal receivers, 17 with docstrings and **0** documenting either, so this would be the only one; and the suggested text restates the decorator, describes kwargs the handler never reads, and documents a return value Django discards.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)