### PR TITLE
feat: save the files on the page when a draft is saved (#1459)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -98,7 +98,7 @@
       {% if request.user.is_staff %}
         <form method="POST" enctype="multipart/form-data" action="{% url 'quests:approve' submission.id%}">
       {% else %}
-        <form method="POST" enctype="multipart/form-data" action="{% url 'quests:complete' submission.id%}">
+        <form id="submission-main-form" method="POST" enctype="multipart/form-data" action="{% url 'quests:complete' submission.id%}">
       {% endif %}
 
         {% csrf_token %}
@@ -284,8 +284,8 @@
             draftComment = $summernoteEditor.html()
             xpRequested = $('#id_xp_requested').val()
 
-            // Collect draft answers to the quest's questions (text answers only; files
-            // upload on submit). Pairs each row's hidden id with its response text.
+            // Collect draft answers to the quest's questions. Pairs each row's hidden id
+            // with its response text; chosen files ride along in the FormData below (#1459).
             var answers = {};
             $('.question-submission-form [name^="question_submissions-"]').each(function() {
                 var name = $(this).attr('name');
@@ -314,19 +314,28 @@
                 $draftText.hide(0) // no delay
                 $draftSpin.show()
 
+                // The whole form goes as FormData so any files chosen on the page (comment
+                // attachments and file answers) are saved with the draft too (#1459). The
+                // named keys below are what the server reads; the rest (the formset's
+                // management form, row ids and files) come from the form itself.
+                var mainForm = document.getElementById('submission-main-form');
+                var formData = mainForm ? new FormData(mainForm) : new FormData();
+                formData.set('csrfmiddlewaretoken', '{{ csrf_token }}');
+                formData.set('comment', draftComment);
+                formData.set('submission_id', '{{ submission.id }}');
+                formData.set('xp_requested', xpRequested || '');
+                formData.set('answers', JSON.stringify(answers));
+
                 $.ajax({
                     url : "{% url 'quests:ajax_save_draft' %}",
                     type : "POST", // http method
-                    data : {
-                      csrfmiddlewaretoken: "{{ csrf_token }}",
-                      comment: draftComment,
-                      submission_id: {{ submission.id }},
-                      xp_requested: xpRequested,
-                      answers: JSON.stringify(answers)
-                    }, // data sent with the post request
+                    data : formData,
+                    processData : false, // hand jQuery the FormData as-is
+                    contentType : false, // let the browser set the multipart boundary
 
                     // handle a successful response
                     success : function(json) {
+                      show_saved_files(json);
                       hide_check_show_text();
                     },
 
@@ -340,6 +349,39 @@
                 });
             }
 
+        }
+
+        function show_saved_files(json) {
+            // A saved file is stored with the draft, so its input is cleared: the file no
+            // longer needs re-choosing, and the next autosave must not upload it again. A
+            // note under the input says where it went. A rejected file is cleared too, with
+            // the validation error in its place, so the student re-chooses knowing why.
+            $.each(json.saved_answer_files || {}, function(field_name, file_name) {
+                file_note($('[name="' + field_name + '"]'),
+                    '<i class="fa fa-paperclip fa-fw"></i> Attached: ' + $('<i>').text(file_name).html() +
+                    ' <small>(saved with your draft)</small>');
+            });
+            if ((json.saved_attachments || []).length) {
+                var names = json.saved_attachments.map(function(name) { return $('<i>').text(name).html(); });
+                file_note($('#submission-main-form input[name="attachments"]'),
+                    '<i class="fa fa-paperclip fa-fw"></i> Attached: ' + names.join(', ') +
+                    ' <small>(saved with your draft)</small>');
+            }
+            $.each(json.file_errors || {}, function(field_name, error_text) {
+                file_note($('[name="' + field_name + '"]'),
+                    '<span class="text-danger">' + $('<i>').text(error_text).html() + '</span>');
+            });
+        }
+
+        function file_note(input, html) {
+            if (!input.length) return;
+            input.val('');
+            var note = input.closest('.form-group').find('.draft-file-note');
+            if (!note.length) {
+                note = $('<p class="help-block draft-file-note"></p>');
+                input.closest('.form-group').append(note);
+            }
+            note.html(html);
         }
 
         function hide_check_show_text() {

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -175,7 +175,7 @@
         {% else %}
           {% if submission.quest.published %}
             <a id='save-draft-btn' class='btn btn-default'
-               title="Your draft autosaves about every minute, but you can force a save now with this button. Note: attached files are NOT saved in a draft.">
+               title="Your draft autosaves about every minute, but you can force a save now with this button. Chosen files are saved with it too.">
               <span id="draft-text">Save Draft</span>
               <span id="draft-spin" style="display:none"><i class="fa fa-spinner fa-spin fa-fw"></i><span class="sr-only">Saving draft...</span></span>
               <span id="draft-check" style="display:none" class="text-success"><i class="fa fa-check fa-fw"></i><span class="sr-only">Draft saved successfully</span></span>

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2230,11 +2230,21 @@ def skipped(request, quest_id):
 @non_public_only_view
 @login_required
 def ajax_save_draft(request):
-    """Autosave the requesting student's own draft comment and draft question answers.
+    """Autosave the requesting student's own draft comment, answers, and chosen files.
 
     Scoped to the submission's owner: a draft is the student's own work in progress, and
     the draft form is only ever rendered for them (staff get the marking form instead), so
     any other user's submission id is a 404.
+
+    The POST carries `submission_id`, the comment HTML as `comment`, text answers as an
+    `answers` JSON object of the formset's field names, and, when files were chosen, the
+    formset's own fields (management form, row ids, files) plus the comment's
+    `attachments`, as the page sends the whole form as FormData (#1459).
+
+    Returns a JSON object: `result` ("Draft saved" or "No changes"), and, when the POST
+    carried files, `saved_answer_files` (file field name to the stored file's bare name),
+    `saved_attachments` (the accepted upload names), and `file_errors` (field name to the
+    validation message for a rejected file).
     """
     if request.POST:
         response_data = {
@@ -2343,11 +2353,14 @@ def ajax_save_draft(request):
                         field_name = answer_form.add_prefix("response_file")
                         if field_name not in request.FILES:
                             continue
-                        if answer_form.instance.pk and answer_form.instance.response_file:
+                        # errors first: a row that already holds a file from an earlier save
+                        # keeps it when a replacement is rejected, and reporting that stored
+                        # file as "saved" would present the rejection as a success
+                        if answer_form.errors.get("response_file"):
+                            file_errors[field_name] = " ".join(answer_form.errors["response_file"])
+                        elif answer_form.instance.pk and answer_form.instance.response_file:
                             # the bare file name: the stored value is a whole media path
                             saved_answer_files[field_name] = posixpath.basename(str(answer_form.instance.response_file))
-                        elif answer_form.errors.get("response_file"):
-                            file_errors[field_name] = " ".join(answer_form.errors["response_file"])
 
             if request.FILES.getlist("attachments"):
                 # the same form the submit builds, so the same size and count rules apply

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1,4 +1,5 @@
 import json
+import posixpath
 import re
 import uuid
 
@@ -14,6 +15,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import transaction
 from django.db.models import F, ExpressionWrapper, fields, BooleanField, Count, Exists, OuterRef, Q, Sum
@@ -30,7 +32,7 @@ from hackerspace_online.decorators import staff_member_required, xml_http_reques
 from badges.models import BadgeAssertion
 from comments.models import Comment, Document
 from comments.sanitize import sanitize_comment_html
-from comments.utils import save_draft_attachments
+from comments.utils import accepted_attachments, save_draft_attachments
 from questions.forms import QuestionSubmissionFormsetFactory
 from questions.models import QuestionSubmission, QuestionType
 from questions.utils import discard_draft_question_submissions, save_draft_file_answers, sync_draft_question_submissions
@@ -2261,9 +2263,9 @@ def ajax_save_draft(request):
             response_data["result"] = "Draft saved"
             draft_comment.save()
 
-        # Autosave draft answers to the quest's questions (text answers only; file answers
-        # upload when the quest is submitted). Sent as a JSON object of the formset's field
-        # names, pairing each row's hidden id with its response_text.
+        # Autosave draft answers to the quest's questions. Text answers arrive as a JSON
+        # object of the formset's field names, pairing each row's hidden id with its
+        # response_text; file answers arrive in request.FILES and are handled below.
         answers_json = request.POST.get("answers")
         if answers_json and sub.quest.question_set.exists():
             try:
@@ -2310,6 +2312,57 @@ def ajax_save_draft(request):
                     row.full_clean()
                     row.save()
                     response_data["result"] = "Draft saved"
+
+        # Draft-save any files in the POST (#1459). The Save Draft button posts the whole
+        # form as FormData, so a chosen comment attachment or file answer arrives here just
+        # as it would on submit, is validated by the same forms, and is stored by the same
+        # helpers in the same places (the draft comment, the draft rows): a draft-saved
+        # file and one kept from a failed submit are indistinguishable, and both publish
+        # with the completion. The response names what was saved and what was rejected, so
+        # the page can clear those inputs and show the outcome without a reload.
+        if request.FILES:
+            saved_answer_files = {}
+            saved_attachments = []
+            file_errors = {}
+
+            if sub.quest.question_set.exists():
+                question_formset = QuestionSubmissionFormsetFactory(
+                    request.POST, request.FILES,
+                    instance=sub, queryset=sync_draft_question_submissions(sub),
+                )
+                # a POST built by hand can omit the management form, which raises when the
+                # formset validates; text (above) still saves, the files leg just skips.
+                try:
+                    question_formset.is_valid()
+                except ValidationError:
+                    question_formset = None
+
+                if question_formset is not None:
+                    save_draft_file_answers(question_formset, request.FILES)
+                    for answer_form in question_formset.forms:
+                        field_name = answer_form.add_prefix("response_file")
+                        if field_name not in request.FILES:
+                            continue
+                        if answer_form.instance.pk and answer_form.instance.response_file:
+                            # the bare file name: the stored value is a whole media path
+                            saved_answer_files[field_name] = posixpath.basename(str(answer_form.instance.response_file))
+                        elif answer_form.errors.get("response_file"):
+                            file_errors[field_name] = " ".join(answer_form.errors["response_file"])
+
+            if request.FILES.getlist("attachments"):
+                # the same form the submit builds, so the same size and count rules apply
+                form = SubmissionForm(request.POST, request.FILES, student=request.user)
+                form.is_valid()
+                saved_attachments = [upload.name for upload in accepted_attachments(form)]
+                save_draft_attachments(form, draft_comment)
+                if form.errors.get("attachments"):
+                    file_errors["attachments"] = " ".join(form.errors["attachments"])
+
+            if saved_answer_files or saved_attachments:
+                response_data["result"] = "Draft saved"
+            response_data["saved_answer_files"] = saved_answer_files
+            response_data["saved_attachments"] = saved_attachments
+            response_data["file_errors"] = file_errors
 
         return HttpResponse(json.dumps(response_data), content_type="application/json")
 

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -448,7 +448,15 @@ class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
 
     def save_draft(self, extra=None):
         """POST an ajax draft save carrying the answer formset's fields, as the Save Draft
-        button does now that it sends the whole form as FormData."""
+        button does now that it sends the whole form as FormData.
+
+        Args:
+            extra: a dict merged over the default payload, adding or overriding fields
+                (how a test attaches its files).
+
+        Returns:
+            The view's response, whose JSON body is the draft-save contract.
+        """
         data = {
             "comment": "<p>draft words</p>",
             "submission_id": self.submission.id,
@@ -511,6 +519,31 @@ class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
         self.assertFalse(row.response_file, "a rejected file must not be stored")
         self.assertNotIn(field_name, payload["saved_answer_files"])
         self.assertIn("Filetype not supported", payload["file_errors"][field_name])
+
+    def test_save_draft__rejected_replacement_reports_the_error_not_the_kept_file(self):
+        """Rejecting a replacement upload reports the rejection, while the earlier file stays.
+
+        The row keeps the file an earlier draft save stored, so the response must not
+        present that kept file as this save's success: the student chose a new file and
+        needs to hear why it was refused.
+        """
+        image_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="image",
+        )
+        sync_draft_question_submissions(self.submission)
+        field_name = self.file_field_name(image_question)
+        self.save_draft(
+            {field_name: SimpleUploadedFile("first.png", b"file_content", content_type="image/png")})
+
+        response = self.save_draft(
+            {field_name: SimpleUploadedFile("replacement.txt", b"file_content", content_type="text/plain")})
+
+        payload = json.loads(response.content)
+        self.assertIn("Filetype not supported", payload["file_errors"][field_name])
+        self.assertNotIn(field_name, payload["saved_answer_files"])
+        row = QuestionSubmission.objects.get(quest_submission=self.submission, question=image_question)
+        self.assertIn("first", row.response_file.name, "the earlier draft-saved file must survive")
 
     def test_save_draft__file_on_a_text_answer_row_is_ignored(self):
         """A file crafted onto a text question's row is ignored: the form for a text row

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -443,6 +443,117 @@ class AnswerAutosaveTest(QuestionSubmissionFlowTestBase):
         self.assertEqual(row.datetime_last_edit, last_edit)
 
 
+class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
+    """Saving a draft stores the files chosen on the page, not only the text (#1459)."""
+
+    def save_draft(self, extra=None):
+        """POST an ajax draft save carrying the answer formset's fields, as the Save Draft
+        button does now that it sends the whole form as FormData."""
+        data = {
+            "comment": "<p>draft words</p>",
+            "submission_id": self.submission.id,
+            **self.formset_data(short_text="draft title"),
+        }
+        data.update(extra or {})
+        return self.client.post(
+            reverse("quests:ajax_save_draft"), data=data,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+    def test_save_draft__stores_a_file_answer(self):
+        """A file chosen on a file-upload question is stored on its draft row by Save Draft,
+        unpublished, and the response names it so the page can show it was kept."""
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="all",
+        )
+        sync_draft_question_submissions(self.submission)
+        field_name = self.file_field_name(file_question)
+
+        response = self.save_draft(
+            {field_name: SimpleUploadedFile("sketch.png", b"file_content", content_type="image/png")})
+
+        payload = json.loads(response.content)
+        self.assertEqual(payload["result"], "Draft saved")
+        row = QuestionSubmission.objects.get(quest_submission=self.submission, question=file_question)
+        self.assertIn("sketch", row.response_file.name)
+        self.assertIsNone(row.comment_id, "a draft-saved answer must not be published")
+        self.assertIn("sketch", payload["saved_answer_files"][field_name])
+
+    def test_save_draft__stores_comment_attachments(self):
+        """A file chosen in the comment's Attach files field is stored on the draft comment
+        by Save Draft, where completing the quest publishes it from."""
+        response = self.save_draft(
+            {"attachments": SimpleUploadedFile("notes.pdf", b"file_content", content_type="application/pdf")})
+
+        payload = json.loads(response.content)
+        self.assertEqual(payload["result"], "Draft saved")
+        documents = list(self.submission.draft_comment.document_set.all())
+        self.assertEqual(len(documents), 1)
+        self.assertIn("notes", documents[0].docfile.name)
+        self.assertEqual(payload["saved_attachments"], ["notes.pdf"])
+
+    def test_save_draft__rejects_a_file_the_question_does_not_accept(self):
+        """A file whose type the question refuses is not stored, and the response carries
+        the field's own error so the page can say why."""
+        image_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="image",
+        )
+        sync_draft_question_submissions(self.submission)
+        field_name = self.file_field_name(image_question)
+
+        response = self.save_draft(
+            {field_name: SimpleUploadedFile("notes.txt", b"file_content", content_type="text/plain")})
+
+        payload = json.loads(response.content)
+        row = QuestionSubmission.objects.get(quest_submission=self.submission, question=image_question)
+        self.assertFalse(row.response_file, "a rejected file must not be stored")
+        self.assertNotIn(field_name, payload["saved_answer_files"])
+        self.assertIn("Filetype not supported", payload["file_errors"][field_name])
+
+    def test_save_draft__file_on_a_text_answer_row_is_ignored(self):
+        """A file crafted onto a text question's row is ignored: the form for a text row
+        has no file field, so nothing is stored and nothing is reported saved."""
+        rows = list(sync_draft_question_submissions(self.submission))
+        index = next(i for i, row in enumerate(rows) if row.question_id == self.short_question.id)
+        field_name = f"question_submissions-{index}-response_file"
+
+        response = self.save_draft(
+            {field_name: SimpleUploadedFile("sneak.png", b"file_content", content_type="image/png")})
+
+        payload = json.loads(response.content)
+        short_row = QuestionSubmission.objects.get(
+            quest_submission=self.submission, question=self.short_question)
+        self.assertFalse(short_row.response_file)
+        self.assertEqual(payload["saved_answer_files"], {})
+
+    def test_save_draft__file_without_management_form_saves_text_only(self):
+        """A hand-built POST that sends a file without the formset's management form does
+        not error: the text answers and comment still save, the files leg reports nothing."""
+        rows = list(sync_draft_question_submissions(self.submission))
+        response = self.client.post(
+            reverse("quests:ajax_save_draft"),
+            data={
+                "comment": "<p>still saves</p>",
+                "submission_id": self.submission.id,
+                "answers": json.dumps({
+                    "question_submissions-0-id": str(rows[0].id),
+                    "question_submissions-0-response_text": "still saves",
+                }),
+                "question_submissions-0-response_file":
+                    SimpleUploadedFile("orphan.png", b"file_content", content_type="image/png"),
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        payload = json.loads(response.content)
+        self.assertEqual(payload["result"], "Draft saved")
+        self.assertEqual(payload["saved_answer_files"], {})
+        self.submission.draft_comment.refresh_from_db()
+        self.assertEqual(self.submission.draft_comment.text, "<p>still saves</p>")
+
+
 class AnswerDisplayTest(QuestionSubmissionFlowTestBase):
     """Published answers display with their comment for students and markers."""
 

--- a/src/questions/utils.py
+++ b/src/questions/utils.py
@@ -2,14 +2,15 @@ from .models import QuestionSubmission
 
 
 def save_draft_file_answers(question_formset, uploaded_files):
-    """Persist the file answers of an invalid formset onto their draft rows, and return how
-    many were saved.
+    """Persist a bound formset's file answers onto their draft rows, and return how many
+    were saved.
 
-    A browser never repopulates a file input, so when the answer formset fails validation the
-    re-rendered page comes back with every file field empty. Without this the student's upload
-    is gone with nothing to say so: a required file question demands a file they did attach,
-    and an optional one publishes empty (#2165). Keeping the upload on the draft row means it
-    survives the round trip, exactly as autosaved text answers already do.
+    A browser never repopulates a file input, so any response that rebuilds the page comes
+    back with every file field empty. Without this the student's upload is gone with nothing
+    to say so: a required file question demands a file they did attach, and an optional one
+    publishes empty (#2165). Keeping the upload on the draft row means it survives the round
+    trip, exactly as autosaved text answers do; the Save Draft flow stores files through the
+    same helper (#1459), so a draft-saved answer and a kept one are the same thing.
 
     Only rows whose own file validated are saved: a file rejected for type or size never
     reaches ``cleaned_data``, so its error stands and nothing is stored. Rows the student did
@@ -17,7 +18,7 @@ def save_draft_file_answers(question_formset, uploaded_files):
     re-submit that left the field alone.
 
     Args:
-        question_formset: the bound, invalid answer formset.
+        question_formset: the bound answer formset, with validation already run.
         uploaded_files: the request's ``FILES``, used to tell a fresh upload from an untouched
             field (the field is absent from ``FILES`` when nothing new was chosen).
 


### PR DESCRIPTION
Closes #1459

### What?

Save Draft (and the minute autosave) now stores the files chosen on the page, not only the text: a comment attachment lands on the draft comment, a file answer on its draft row, and a note under each field says it was saved. Reopening the page later shows them as already attached, and completing the quest publishes them, exactly as if they had been sent with the submit.

### Why?

The button says Save Draft, but a chosen file lived only in the browser until the quest was submitted: close the tab, or come back tomorrow, and it was gone. #1459 has asked for this since the multi-question feature was first planned; with the three keep-on-failure paths done (#2165, #2427, #2428) the storage half already existed, and this wires the draft save into it.

### How?

* **The page** posts the whole form as `FormData` (`processData`/`contentType` false), so the formset's management form, row ids, and any chosen files ride along with the keys the server already reads. On the response it clears each saved input (a stored file must not re-upload on every autosave) and notes the outcome under the field; a rejected file is also cleared, with the validation error shown, so the student re-chooses knowing why.
* **The server** (`ajax_save_draft`) gains a files leg that reuses the submit path wholesale: the same `SubmissionForm` and answer formset validate the files, and the same helpers (`save_draft_attachments`, `save_draft_file_answers`) store them, so a draft-saved file and one kept from a failed submit are indistinguishable and the rules cannot drift. The response names what was saved and what was rejected. A POST built by hand without the management form saves its text and skips the files leg rather than erroring, and a file crafted onto a text question's row is ignored, since that form has no file field.

### Testing?

Test-driven: all five new tests fail on `develop` (2 failures, 3 errors).

* `test_save_draft__stores_a_file_answer` and `test_save_draft__stores_comment_attachments`: the two storage paths, with the response naming the file.
* `test_save_draft__rejects_a_file_the_question_does_not_accept`: a type the question refuses is not stored and the field's error is reported.
* `test_save_draft__file_on_a_text_answer_row_is_ignored`: no bypass through a crafted field name.
* `test_save_draft__file_without_management_form_saves_text_only`: a hand-built POST cannot 500 the view.

Full suite green locally (2639 tests), `ruff check src` clean, `makemigrations --check` clean.

### Screenshots (if front end is affected)

Captured from the hackerspace dev deck as the student: choose a photo on Question 3 and a recording in Attach files, click **Save Draft**, then reload the page.

Before: reloading shows the draft saved none of it; the files are gone.

![before: after saving a draft and reloading, no file is attached](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1459/before_after_reload.png)

After, the moment the draft saves: each field notes what was stored and its input is cleared.

![after: the file answer notes it was saved with the draft](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1459/after_question_saved.png)

![after: the comment attachment notes it was saved with the draft](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1459/after_attachments_saved.png)

After, reloading: the server-rendered page shows the file already attached.

![after: reloading shows the answer already attached](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/1459/after_after_reload.png)

### Review request

@tylerecouture

- Claude Code (Bytedeck - multiple submission types)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptw8gWroqLnsLWieBaY67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Draft autosave now preserves valid question-answer files and comment attachments.
  - Uploaded files are validated and saved with draft responses.
  - The interface displays file save status and validation errors beneath upload fields.
  - Text answers and comments continue to autosave even when file metadata is incomplete.

- **Bug Fixes**
  - Invalid file types are rejected without being stored.
  - Files attached to text-only answer fields are ignored safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->