### PR TITLE
test: cover the SMTPRecipientsRefused handler and mark the no-course chart guard (#2539)

### DIFF
--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -1210,8 +1210,11 @@ def ajax_progress_chart(request, user_id=0):
         # course to chart comes from the request, defaulting to the first of their courses.
         registrations, charted = _registrations_to_chart(user, request.POST.get('course'))
 
-        if charted is None:
-            # in no course at all, so there is nothing of theirs to plot
+        if charted is None:  # pragma: no cover
+            # Defensive race guard, not reachable by a plain request: semester_for() just
+            # found an open-semester registration for this user, and _registrations_to_chart
+            # reads the same registrations, so charted only comes back None if the
+            # registration is deleted between the two reads. Chart zeros rather than crash.
             xp_series = [0] * len(datelist)
             today_xp = 0
         else:

--- a/src/notifications/tests/test_tasks.py
+++ b/src/notifications/tests/test_tasks.py
@@ -222,6 +222,49 @@ class NotificationTasksTests(ByteDeckTenantTestCase):
             mock_retry.call_args.kwargs['kwargs'],
             {'root_url': root_url, 'only_usernames': [student1.username]})
 
+    def test_email_task__recipient_refused_4xx_is_retried(self):
+        """A per-recipient 4xx refusal (SMTPRecipientsRefused) counts as temporary:
+        the refused user lands in the retry set, like the one-code 4xx rejection."""
+        import smtplib
+
+        from celery.exceptions import Retry
+        from unittest.mock import Mock
+
+        student2 = self._make_two_eligible_recipients()[1]
+        root_url = f'https://{self.get_test_tenant_domain()}'
+
+        connection = Mock()
+        connection.send_messages.side_effect = [
+            1, smtplib.SMTPRecipientsRefused({student2.email: (450, b'4.2.1 mailbox busy')})]
+        task = tasks.email_notifications_to_users_on_schema
+        with patch('notifications.tasks.mail.get_connection', return_value=connection), \
+                patch.object(task, 'retry', side_effect=Retry('retry scheduled')) as mock_retry:
+            task_result = task.apply(kwargs={'root_url': root_url})
+        self.assertFalse(task_result.successful())
+        self.assertEqual(
+            mock_retry.call_args.kwargs['kwargs'],
+            {'root_url': root_url, 'only_usernames': [student2.username]})
+
+    def test_email_task__recipient_refused_5xx_drops_only_that_user(self):
+        """A per-recipient 5xx refusal (SMTPRecipientsRefused) is permanent: that
+        user's digest is logged and dropped, the rest of the batch still sends,
+        and nothing is retried."""
+        import smtplib
+        from unittest.mock import Mock
+
+        self._make_two_eligible_recipients()
+        root_url = f'https://{self.get_test_tenant_domain()}'
+
+        connection = Mock()
+        connection.send_messages.side_effect = [
+            smtplib.SMTPRecipientsRefused({self.test_student1.email: (550, b'5.1.1 user unknown')}), 1]
+        with patch('notifications.tasks.mail.get_connection', return_value=connection):
+            task_result = tasks.email_notifications_to_users_on_schema.apply(
+                kwargs={'root_url': root_url})
+        self.assertTrue(task_result.successful())
+        self.assertEqual(task_result.result, 'Sent 1 notification emails, dropped 1 permanently refused')
+        self.assertEqual(connection.send_messages.call_count, 2)
+
     def test_email_notification_to_users_on_all_schemas__runs_successfully(self):
         """The all-schemas email task completes successfully when applied."""
         task_result = tasks.email_notification_to_users_on_all_schemas.apply()


### PR DESCRIPTION
### What?
Closes #2539: the two spots keeping `develop` off an honest 100% coverage are dealt with, one with real tests and one with a reasoned exclusion.

* `src/notifications/tasks.py` (the digest task's `SMTPRecipientsRefused` handler): two new tests pin the 4xx-retry and 5xx-drop paths. The file reports 100%.
* `src/courses/views.py:1213` (the XP chart's `charted is None` arm): marked `# pragma: no cover` with the reason, because it is a defensive race guard a plain request cannot reach.

### Why?
Per the coverage convention, the goal is 100% of the code we intend to test, with anything untestable carrying an explicit pragma and a reason so the reported number stays meaningful. These two spots had neither tests nor a pragma.

On the chart branch: the issue suggested it was reachable by charting a user with no registration, but it is not. `semester_for(user)` is `CourseStudent.objects.current_semester(user)`, which reads the user's open-semester registrations, and `_registrations_to_chart` reads the same registrations. A user with none exits earlier with the empty dataset (`days_in_semester: 0`); `charted` can only come back `None` if the registration is deleted between the two reads. That is exactly the "unreachable defensive branch" case the convention says to keep and mark rather than delete or contrive a test for.

### How?
* `test_email_task__recipient_refused_4xx_is_retried`: the backend raises `SMTPRecipientsRefused({addr: (450, ...)})` for one digest; the task retries with only that user, like the one-code 4xx path.
* `test_email_task__recipient_refused_5xx_drops_only_that_user`: a `(550, ...)` refusal is dropped and logged, the rest of the batch sends, the task succeeds with the "dropped 1 permanently refused" summary.
* Both mirror the structure of the existing sibling tests (`SMTPResponseException` 550/451 and the disconnect case) in `src/notifications/tests/test_tasks.py`.
* The chart guard keeps its behaviour (a flat zero series) and gains the pragma plus a comment stating the race it guards.

### Testing?
* `src/notifications/tasks.py`: 100% statements and branches under `coverage run` on the notifications suite.
* `src/courses/views.py`: the former partial branch and its two missed lines are excluded with the pragma; the file's only remaining misses in a courses+notifications-scoped run (the semester-archive announcements branch) are covered by the announcements suite in a full run, matching the issue's report that everything else on `develop` is at 100%.
* Full suite: `python src/manage.py test src`, `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` all pass locally.

### Screenshots (if front end is affected)
N/A: tests and a coverage pragma only; no user-facing change.

### Anything Else?
If you would rather the chart guard died instead (folding "no course" into the early empty-dataset return), that is a small behaviour change to the race window's response and felt like more than this coverage issue asked for.

### Review request
@tylerecouture

- Claude Code (`bytedeck - github issues workflow`)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mwASxVDwGKGPHnSAC2dZy)_