### PR TITLE
fix: carry a prerequisite's whole condition to and from the Library (#2535)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -66,7 +66,7 @@ def clone_quests_into_library(*, source_schema, quests):
             taken_names.add(name)
             writes.append((snapshot, False, {'import_id': uuid4(), 'name': name}))
 
-        return write_quests(writes, with_campaign=True)
+        return write_quests(writes, with_campaign=True, refresh_matched_prereqs=True)
 
 
 def export_quest_to_library(*, source_schema, quest_import_id):
@@ -97,7 +97,7 @@ def export_quest_to_library(*, source_schema, quest_import_id):
         snapshot = snapshot_quest(quest)
 
     with library_schema_context():
-        return write_quests([(snapshot, False, None)], with_campaign=False)
+        return write_quests([(snapshot, False, None)], with_campaign=False, refresh_matched_prereqs=True)
 
 
 def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import_ids=None):
@@ -147,7 +147,7 @@ def export_campaign_to_library(*, source_schema, campaign_import_id, skip_import
         snapshots = [snapshot_quest(quest) for quest in quests]
 
     with library_schema_context():
-        exported = write_quests([(snapshot, False, None) for snapshot in snapshots], with_campaign=True)
+        exported = write_quests([(snapshot, False, None) for snapshot in snapshots], with_campaign=True, refresh_matched_prereqs=True)
 
         # The campaign is only created unpublished; force it back to draft in case the
         # Library already holds a published copy under this import_id.

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -475,6 +475,65 @@ class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
             self.assertTrue(arrived[0].prereq_invert)
             self.assertIsNone(arrived[0].get_or_prereq())
 
+    def test_export_quest_to_library__resharing_refreshes_a_changed_condition(self):
+        """Re-sharing a quest carries a corrected condition onto the Library's existing gate.
+
+        The single-quest push updates the Library's copy in place, and it refreshes a
+        matched gate's flags the way it already refreshes the quest's own fields, so an
+        author who fixes a wrong NOT or count and shares again is not left with a stale
+        Library copy (#2535). (A campaign re-push is different: it clones conflicting
+        quests rather than touching the Library's existing rows.)
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+        prereq = Prereq.add_simple_prereq(quest, inside)
+
+        export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        prereq.prereq_invert = True
+        prereq.prereq_count = 2
+        prereq.full_clean()
+        prereq.save()
+
+        export_quest_to_library(source_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            arrived = list(library_quest.prereqs())
+            self.assertEqual(len(arrived), 1)
+            self.assertTrue(arrived[0].prereq_invert)
+            self.assertEqual(arrived[0].prereq_count, 2)
+
+    def test_import_campaign_to__keeps_the_decks_own_adjustment_to_a_gate(self):
+        """A campaign re-import leaves the deck's adjusted copy of a gate alone.
+
+        The imported copy is the teacher's to adjust, so the import side stays add-only:
+        only the Library push refreshes matched gates. Without this split, re-importing
+        for upstream updates would silently undo the teacher's own gating changes.
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+        prereq = Prereq.add_simple_prereq(quest, inside)
+        prereq.prereq_invert = True
+        prereq.full_clean()
+        prereq.save()
+
+        export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        # the teacher decides their deck's copy should not be inverted after all
+        prereq.prereq_invert = False
+        prereq.prereq_count = 5
+        prereq.full_clean()
+        prereq.save()
+
+        import_campaign_to(
+            destination_schema=connection.schema_name,
+            quest_import_ids=[quest.import_id, inside.import_id],
+            campaign_import_id=campaign.import_id,
+        )
+
+        adjusted = Prereq.objects.get(pk=prereq.pk)
+        self.assertFalse(adjusted.prereq_invert)
+        self.assertEqual(adjusted.prereq_count, 5)
+
     def test_export_campaign_and_copy_quests__drops_the_or_half_that_is_not_shareable_content(self):
         """An OR half pointing at a rank is dropped alone, like a main gate on one (#2450).
 

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -15,6 +15,7 @@ or a regression, and the failure is where the decision gets recorded.
 import datetime
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from model_bakery import baker
@@ -315,7 +316,8 @@ class LibraryTransferContractTests(LibraryTenantTestCaseMixin):
 
 
 class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
-    """Pin which prerequisites survive a transfer and which are silently discarded."""
+    """Pin which prerequisite conditions survive a transfer, and which targets are
+    dropped and named in the sharer's warning."""
 
     def _campaign_with_two_quests(self):
         """Create a published campaign holding a quest and a second quest to depend on.
@@ -344,14 +346,12 @@ class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
         self.assertEqual(names, ["Prereq Inside Campaign"])
 
     def test_export_campaign_and_copy_quests__discards_a_prereq_whose_target_is_outside_the_campaign(self):
-        """A prerequisite pointing outside the pushed campaign is destroyed on the push (#2399).
+        """A prerequisite pointing outside the pushed campaign is dropped on the push (#2399).
 
         The Library never receives the target, so the link cannot be rebuilt there, and a
         deck pulling this campaign cannot recover it either. The quest arrives with weaker
-        gating than its author wrote and nothing reports the loss, even when the importing
-        deck happens to have the prerequisite quest itself.
-
-        When this is fixed the sharer should be told which prerequisites will not travel.
+        gating than its author wrote; the sharer's warning names the target that stayed
+        behind, which is the only place the loss is visible.
         """
         campaign, quest, _ = self._campaign_with_two_quests()
         outside = Quest.objects.create(name="Prereq Outside Campaign", xp=1)
@@ -387,6 +387,113 @@ class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
         with library_schema_context():
             library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
             self.assertEqual(list(library_quest.prereqs()), [])
+
+    def _attach_alternate(self, prereq, alternate, *, invert=False, count=1):
+        """Give a prerequisite an OR half pointing at `alternate`, with its own flags.
+
+        Args:
+            prereq (Prereq): the row to extend.
+            alternate: the model instance the OR half points at.
+            invert (bool): the OR half's NOT flag.
+            count (int): the OR half's required count.
+        """
+        prereq.or_prereq_content_type = ContentType.objects.get_for_model(alternate)
+        prereq.or_prereq_object_id = alternate.id
+        prereq.or_prereq_invert = invert
+        prereq.or_prereq_count = count
+        prereq.full_clean()
+        prereq.save()
+
+    def test_export_campaign_and_copy_quests__carries_the_not_flag_and_count(self):
+        """A gate's NOT flag and required count arrive exactly as the author wrote them.
+
+        The invert flag is the load-bearing one (issue #2535): a quest gated on
+        "NOT Placement Test" is for students who have not done the placement test, and a
+        copy whose gate lost its NOT would admit exactly the opposite students.
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+        prereq = Prereq.add_simple_prereq(quest, inside)
+        prereq.prereq_invert = True
+        prereq.prereq_count = 3
+        prereq.full_clean()
+        prereq.save()
+
+        export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            arrived = list(library_quest.prereqs())
+            self.assertEqual(len(arrived), 1)
+            self.assertTrue(arrived[0].prereq_invert)
+            self.assertEqual(arrived[0].prereq_count, 3)
+
+    def test_export_campaign_and_copy_quests__carries_the_or_half_when_its_target_travels(self):
+        """A condition's OR half travels when its target is in the pushed campaign too.
+
+        The alternate is a second generic target on the same row, so it crosses under the
+        same rule as the main one, keeping its own NOT flag and count (issue #2535).
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+        alternate = Quest.objects.create(name="Alternate Inside Campaign", xp=1, campaign=campaign)
+        Quest.objects.filter(pk=alternate.pk).update(published=True)
+        alternate = Quest.objects.get(pk=alternate.pk)
+        prereq = Prereq.add_simple_prereq(quest, inside)
+        self._attach_alternate(prereq, alternate, invert=True, count=2)
+
+        export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            arrived = list(library_quest.prereqs())
+            self.assertEqual(len(arrived), 1)
+            self.assertEqual(arrived[0].get_or_prereq().import_id, alternate.import_id)
+            self.assertTrue(arrived[0].or_prereq_invert)
+            self.assertEqual(arrived[0].or_prereq_count, 2)
+
+    def test_export_campaign_and_copy_quests__drops_only_the_or_half_when_its_target_stays_behind(self):
+        """An OR half whose target is outside the push is dropped alone, and named.
+
+        The main half still arrives with its own flags, so the copy is gated more
+        strictly than written rather than less, and the sharer's warning names the
+        alternate that stayed behind (issue #2535).
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+        outside = Quest.objects.create(name="Alternate Outside Campaign", xp=1)
+        prereq = Prereq.add_simple_prereq(quest, inside)
+        prereq.prereq_invert = True
+        prereq.full_clean()
+        prereq.save()
+        self._attach_alternate(prereq, outside)
+
+        result = export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        self.assertIn(str(outside), result.unmet_prereqs)
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            arrived = list(library_quest.prereqs())
+            self.assertEqual(len(arrived), 1)
+            self.assertTrue(arrived[0].prereq_invert)
+            self.assertIsNone(arrived[0].get_or_prereq())
+
+    def test_export_campaign_and_copy_quests__drops_the_or_half_that_is_not_shareable_content(self):
+        """An OR half pointing at a rank is dropped alone, like a main gate on one (#2450).
+
+        A rank has no identity on another schema, so the alternate cannot be expressed on
+        the far side; the main half still arrives, and the rank is named in the warning.
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+        rank = baker.make(Rank, name="Digital Novice")
+        prereq = Prereq.add_simple_prereq(quest, inside)
+        self._attach_alternate(prereq, rank)
+
+        result = export_campaign_and_copy_quests(source_schema=connection.schema_name, campaign_import_id=campaign.import_id)
+
+        self.assertIn(str(rank), result.unmet_prereqs)
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            arrived = list(library_quest.prereqs())
+            self.assertEqual(len(arrived), 1)
+            self.assertIsNone(arrived[0].get_or_prereq())
 
 
 class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -27,6 +27,7 @@ Two rules hold everywhere below:
 
 from typing import NamedTuple
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 
@@ -195,9 +196,10 @@ def snapshot_quest(quest):
 
     Returns:
         dict: with keys `fields` (the quest's own values), `tags` (tag names), `campaign`
-        (a campaign snapshot or None), `prereqs` (the shareable things it requires, each as
-        an import_id and a name), `questions` (its submission questions) and
-        `common_data_title` (the General Info block it uses, which does not travel).
+        (a campaign snapshot or None), `prereqs` (the conditions gating it, each a target
+        with its NOT/count flags and optional OR half), `questions` (its submission
+        questions) and `common_data_title` (the General Info block it uses, which does
+        not travel).
     """
     return {
         'fields': {name: _read_field(quest, name) for name in _copied_field_names(Quest, QUEST_FIELDS_NOT_COPIED)},
@@ -234,8 +236,29 @@ def _snapshot_questions(quest):
     return [{name: _read_field(question, name) for name in copied} for question in quest.question_set.all()]
 
 
+def _snapshot_target(target, invert, count):
+    """One side of a prerequisite condition, as a portable id with its own flags.
+
+    Args:
+        target: the model instance this side of the condition points at.
+        invert (bool): the side's NOT flag.
+        count (int): how many times the target must be met.
+
+    Returns:
+        dict: `import_id` (UUID, or None for a target that can never travel), `name`,
+        `invert` and `count`.
+    """
+    shareable = IsLibraryContentMixin.is_shareable_model(type(target))
+    return {
+        'import_id': target.import_id if shareable else None,
+        'name': str(target),
+        'invert': invert,
+        'count': count,
+    }
+
+
 def _snapshot_prereqs(quest):
-    """The shareable prerequisites of a quest, as portable ids with readable names.
+    """The shareable prerequisites of a quest, as portable conditions with readable names.
 
     A prerequisite is a generic foreign key, so it can point at any prerequisite model.
     Only those marked with `IsLibraryContentMixin` (quests, campaigns and badges) have an
@@ -247,24 +270,31 @@ def _snapshot_prereqs(quest):
     say which requirement it ended up without: one it cannot express (#2450) and one it
     simply does not have (#2399) are the same loss from the teacher's side.
 
+    The whole condition travels, not just the target: the NOT flag, the required count,
+    and the alternate OR half (with its own flags) are part of what the author wrote, and
+    a gate stripped of its NOT would mean the opposite of what it said (#2535).
+
     Must be called from within the source schema context.
 
     Args:
         quest (Quest): the quest whose prerequisites to read.
 
     Returns:
-        list[dict]: one `{'import_id': UUID | None, 'name': str}` per prerequisite. A
-        `None` import_id marks one that can never travel, so the destination reports it
-        as missing rather than looking for something that was never sent.
+        list[dict]: one entry per prerequisite: `import_id` (UUID | None), `name`,
+        `invert`, `count`, and `alternate` (None, or those same four keys for the OR
+        half). A `None` import_id marks a target that can never travel, so the
+        destination reports it as missing rather than looking for something that was
+        never sent.
     """
     prereqs = []
     for prereq in quest.prereqs():
-        target = prereq.get_prereq()
-        shareable = IsLibraryContentMixin.is_shareable_model(type(target))
-        prereqs.append({
-            'import_id': target.import_id if shareable else None,
-            'name': str(target),
-        })
+        entry = _snapshot_target(prereq.get_prereq(), prereq.prereq_invert, prereq.prereq_count)
+        or_target = prereq.get_or_prereq()
+        entry['alternate'] = (
+            _snapshot_target(or_target, prereq.or_prereq_invert, prereq.or_prereq_count)
+            if or_target is not None else None
+        )
+        prereqs.append(entry)
 
     return prereqs
 
@@ -323,17 +353,23 @@ def _write_prereqs(quest, prereqs):
     upstream lingers here, which leaves the quest more gated than intended: that fails
     closed and the teacher can undo it, where deleting their own gating would not.
 
+    The whole condition is rebuilt, not just the link: the NOT flag, the required count,
+    and the alternate OR half travel with the row (#2535). The OR half needs a target of
+    its own here, under the same rule as the main one. When that target is missing, the
+    row is written without its alternate, which fails *closed* (the gate is stricter than
+    written, not looser), and the alternate is named with the rest so the loss is still
+    visible. When the main target is missing, the whole condition is unbuildable and only
+    the main target is named: the row it identifies never arrives, alternate and all.
+
     Must be called from within the destination schema context.
 
     Args:
         quest (Quest): the freshly written quest.
-        prereqs (list[dict]): `{'import_id', 'name'}` entries from `_snapshot_prereqs`.
+        prereqs (list[dict]): condition entries from `_snapshot_prereqs`.
 
     Returns:
-        list[str]: the names of the prerequisites this deck does not have.
+        list[str]: the names of the prerequisite targets this deck does not have.
     """
-    from badges.models import Badge
-
     already_required = {p.get_prereq() for p in quest.prereqs()}
     unmet = []
 
@@ -344,19 +380,59 @@ def _write_prereqs(quest, prereqs):
             unmet.append(prereq['name'])
             continue
 
-        target = Quest.objects.all_including_archived().filter(import_id=prereq['import_id']).first()
-        if target is None:
-            target = Category.objects.filter(import_id=prereq['import_id']).first()
-        if target is None:
-            target = Badge.objects.filter(import_id=prereq['import_id']).first()
-
+        target = _find_prereq_target(prereq['import_id'])
         if target is None:
             unmet.append(prereq['name'])
-        elif target not in already_required:
-            Prereq.add_simple_prereq(quest, target)
-            already_required.add(target)
+            continue
+        if target in already_required:
+            continue
+
+        alternate = prereq['alternate']
+        or_target = None
+        if alternate is not None:
+            if alternate['import_id'] is not None:
+                or_target = _find_prereq_target(alternate['import_id'])
+            if or_target is None:
+                unmet.append(alternate['name'])
+
+        new_prereq = Prereq(
+            parent_content_type=ContentType.objects.get_for_model(quest),
+            parent_object_id=quest.id,
+            prereq_content_type=ContentType.objects.get_for_model(target),
+            prereq_object_id=target.id,
+            prereq_invert=prereq['invert'],
+            prereq_count=prereq['count'],
+        )
+        if or_target is not None:
+            new_prereq.or_prereq_content_type = ContentType.objects.get_for_model(or_target)
+            new_prereq.or_prereq_object_id = or_target.id
+            new_prereq.or_prereq_invert = alternate['invert']
+            new_prereq.or_prereq_count = alternate['count']
+        new_prereq.full_clean()
+        new_prereq.save()
+        already_required.add(target)
 
     return unmet
+
+
+def _find_prereq_target(import_id):
+    """The destination's row for a prerequisite target, whichever shareable model it is.
+
+    Args:
+        import_id (UUID): the target's cross-schema identity.
+
+    Returns:
+        Quest | Category | Badge | None: the local row, or None when this deck does not
+        have it.
+    """
+    from badges.models import Badge
+
+    target = Quest.objects.all_including_archived().filter(import_id=import_id).first()
+    if target is None:
+        target = Category.objects.filter(import_id=import_id).first()
+    if target is None:
+        target = Badge.objects.filter(import_id=import_id).first()
+    return target
 
 
 def _write_questions(quest, questions):

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -336,7 +336,7 @@ def _write_campaign(snapshot):
     return campaign
 
 
-def _write_prereqs(quest, prereqs):
+def _write_prereqs(quest, prereqs, *, refresh_matched=False):
     """Rebuild the prerequisites whose targets exist on this deck, and report the rest.
 
     A prerequisite can only point at a row that is actually here, so one whose target the
@@ -345,13 +345,13 @@ def _write_prereqs(quest, prereqs):
     That matters because the loss fails *open*: a quest that arrives with its gate missing
     is more available than its author intended, not less (#2399).
 
-    This only ever adds. It deliberately does not reconcile the destination's prerequisites
+    This never deletes. It deliberately does not reconcile the destination's prerequisites
     with the source's, because they are not a copy of each other: once a quest is on a
     deck, the teacher gates it into their own map with prerequisites that exist only there
     and appear in no snapshot. Removing whatever is absent from the source would delete
-    exactly those, silently. The cost of adding only is that a prerequisite removed
-    upstream lingers here, which leaves the quest more gated than intended: that fails
-    closed and the teacher can undo it, where deleting their own gating would not.
+    exactly those, silently. The cost is that a prerequisite removed upstream lingers
+    here, which leaves the quest more gated than intended: that fails closed and the
+    teacher can undo it, where deleting their own gating would not.
 
     The whole condition is rebuilt, not just the link: the NOT flag, the required count,
     and the alternate OR half travel with the row (#2535). The OR half needs a target of
@@ -361,16 +361,24 @@ def _write_prereqs(quest, prereqs):
     visible. When the main target is missing, the whole condition is unbuildable and only
     the main target is named: the row it identifies never arrives, alternate and all.
 
+    `refresh_matched` decides what happens to a gate the destination already has on the
+    same target. The push into the Library refreshes it, so re-sharing updates the
+    condition's flags the way it already updates the quest's own fields. An import into a
+    deck leaves it alone: that copy is the teacher's to adjust, and their adjustments
+    must survive a campaign re-import.
+
     Must be called from within the destination schema context.
 
     Args:
         quest (Quest): the freshly written quest.
         prereqs (list[dict]): condition entries from `_snapshot_prereqs`.
+        refresh_matched (bool): update the condition of an existing gate on the same
+            target, rather than leaving it as the destination has it.
 
     Returns:
         list[str]: the names of the prerequisite targets this deck does not have.
     """
-    already_required = {p.get_prereq() for p in quest.prereqs()}
+    existing_by_target = {p.get_prereq(): p for p in quest.prereqs()}
     unmet = []
 
     for prereq in prereqs:
@@ -384,7 +392,10 @@ def _write_prereqs(quest, prereqs):
         if target is None:
             unmet.append(prereq['name'])
             continue
-        if target in already_required:
+
+        row = existing_by_target.get(target)
+        if row is not None and not refresh_matched:
+            # the destination's own copy of this gate stays as the teacher has it
             continue
 
         alternate = prereq['alternate']
@@ -395,22 +406,30 @@ def _write_prereqs(quest, prereqs):
             if or_target is None:
                 unmet.append(alternate['name'])
 
-        new_prereq = Prereq(
-            parent_content_type=ContentType.objects.get_for_model(quest),
-            parent_object_id=quest.id,
-            prereq_content_type=ContentType.objects.get_for_model(target),
-            prereq_object_id=target.id,
-            prereq_invert=prereq['invert'],
-            prereq_count=prereq['count'],
-        )
+        if row is None:
+            row = Prereq(
+                parent_content_type=ContentType.objects.get_for_model(quest),
+                parent_object_id=quest.id,
+                prereq_content_type=ContentType.objects.get_for_model(target),
+                prereq_object_id=target.id,
+            )
+        row.prereq_invert = prereq['invert']
+        row.prereq_count = prereq['count']
         if or_target is not None:
-            new_prereq.or_prereq_content_type = ContentType.objects.get_for_model(or_target)
-            new_prereq.or_prereq_object_id = or_target.id
-            new_prereq.or_prereq_invert = alternate['invert']
-            new_prereq.or_prereq_count = alternate['count']
-        new_prereq.full_clean()
-        new_prereq.save()
-        already_required.add(target)
+            row.or_prereq_content_type = ContentType.objects.get_for_model(or_target)
+            row.or_prereq_object_id = or_target.id
+            row.or_prereq_invert = alternate['invert']
+            row.or_prereq_count = alternate['count']
+        else:
+            # the condition has no (buildable) alternate, so a refreshed row sheds any
+            # stale one and a new row gets the fields' defaults
+            row.or_prereq_content_type = None
+            row.or_prereq_object_id = None
+            row.or_prereq_invert = False
+            row.or_prereq_count = 1
+        row.full_clean()
+        row.save()
+        existing_by_target[target] = row
 
     return unmet
 
@@ -485,7 +504,7 @@ def _write_questions(quest, questions):
     Question.objects.filter(pk__in=[question.pk for question in superseded.values()]).delete()
 
 
-def write_quests(writes, *, with_campaign):
+def write_quests(writes, *, with_campaign, refresh_matched_prereqs=False):
     """Write several snapshotted quests into the current schema, then link them up.
 
     Prerequisites are linked in a second pass, once every quest in the batch exists. A
@@ -502,6 +521,9 @@ def write_quests(writes, *, with_campaign):
             conflict-copy path to give a copy its own `import_id` and name).
         with_campaign (bool): whether to attach (and if needed create) each quest's
             campaign.
+        refresh_matched_prereqs (bool): update the condition of gates the destination
+            already has on the same target (the Library push does; a deck import does
+            not, see `_write_prereqs`).
 
     Returns:
         TransferResult: the written quests, the names of any prerequisites the destination
@@ -522,7 +544,7 @@ def write_quests(writes, *, with_campaign):
         # whichever order they were written in.
         unmet = []
         for (snapshot, _, _), quest in zip(writes, written):
-            unmet.extend(_write_prereqs(quest, snapshot['prereqs']))
+            unmet.extend(_write_prereqs(quest, snapshot['prereqs'], refresh_matched=refresh_matched_prereqs))
 
     dropped_common_data = sorted({
         snapshot['common_data_title'] for snapshot, _, _ in writes if snapshot['common_data_title']


### PR DESCRIPTION
### What?
Closes #2535: a prerequisite now crosses to and from the Library as the whole condition its author wrote. The NOT flag (`prereq_invert`), the required count (`prereq_count`), and the alternate OR half (with its own NOT and count) all travel with the row. Previously the transfer rebuilt every gate as a bare single-target requirement, so "NOT Placement Test" arrived as "Placement Test": the gate did not just weaken, it admitted exactly the opposite students.

Re-sharing a quest also refreshes the condition on the Library's existing gate, the way it already refreshes the quest's own fields, so a corrected gate propagates; deck imports stay add-only so a campaign re-import cannot undo the importing teacher's own adjustments.

### Why?
The rebuild went through `Prereq.add_simple_prereq`, which by design writes a plain requirement and drops the rest of the condition. Of the three dropped parts, the count and the OR half degrade the gate; the invert flips its meaning, which is the dangerous one (issue #2535). The issue offered three resolutions (warn, carry, or refuse); this carries, which makes the warning-about-simplification class disappear entirely because nothing is simplified any more.

### How?
* `_snapshot_prereqs` (`src/library/transfer.py`) snapshots the full condition: each entry carries `invert`, `count`, and an `alternate` (the OR half's target, name, invert and count), via a shared `_snapshot_target` helper. The OR half follows the same shareability rule as the main target (quests, campaigns and badges travel; ranks and courses cannot).
* `_write_prereqs` rebuilds the row with all fields (constructed directly with `full_clean` + save; `add_simple_prereq` stays as it is for its other callers). Target lookup is factored into `_find_prereq_target`, used for both halves.
* Direction-aware handling of a gate the destination already has on the same target (`refresh_matched`): the exporter's pushes into the Library refresh its flags and OR half, so a re-shared correction lands; imports into a deck leave it alone, protecting the teacher's local adjustments. (Raised in review; a campaign re-push is unaffected either way, since it clones conflicting quests rather than touching the Library's existing rows.)
* Loss handling keeps today's fail-direction rules and naming:
  * Main target missing: the whole condition cannot be rebuilt; the main target is named (unchanged behaviour, fails open with a warning).
  * OR target missing or unshareable: the row is written without its alternate, which fails *closed* (stricter than written, not looser), and the alternate's name joins the sharer's existing "did not travel" warning.
* The sharer warning's wording needed no change: "this content was gated on X, so the copy is not gated on it" is exactly true of a dropped alternate.

### Testing?
Test driven: the four condition-carrying contract tests fail on the unfixed transfer (verified by stashing the fix: 3 failures + 1 error), and the re-share refresh test fails without the refresh commit; all pass with the fixes.

* `test_export_campaign_and_copy_quests__carries_the_not_flag_and_count`: the flagship case, a NOT x3 gate arrives as NOT x3.
* `...__carries_the_or_half_when_its_target_travels`: OR half arrives pointing at the destination's copy, keeping its own NOT and count.
* `...__drops_only_the_or_half_when_its_target_stays_behind`: main half arrives with its flags, the alternate is dropped and named in `unmet_prereqs`.
* `...__drops_the_or_half_that_is_not_shareable_content`: a rank as the alternate is dropped and named, like a main gate on one (#2450).
* `test_export_quest_to_library__resharing_refreshes_a_changed_condition`: export, correct the condition, re-share the quest; the Library's gate carries the correction.
* `test_import_campaign_to__keeps_the_decks_own_adjustment_to_a_gate`: a campaign re-import leaves the deck's adjusted gate alone (the add-only side of the split).
* Two stale docstrings in the same contract-test class were corrected to present tense (they described the sharer warning as not existing; it does).
* `src/library/transfer.py` and `src/library/exporter.py` both report 100% statements and branches under `coverage run` over the library + prerequisites suites.
* Full suite: `python src/manage.py test src`, `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` all pass locally.

### Screenshots (if front end is affected)
The import preview now tells the truth about the gate. Captured from the running dev app (`hackerspace.localhost:8000`, logged in as the deck owner): a quest "Secret Mission" gated on **NOT** "Placement Test" was shared to the Library, and its import preview (`/library/import-quest/...`) shows the prerequisite the Library copy really has.

Before (the NOT is silently gone, so the gate means the opposite):

![before: the import preview shows the gate as plain Placement Test](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2535/before.png)

After (the condition survives as written):

![after: the import preview shows NOT (quest) Placement Test](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2535/after.png)

### Anything Else?
* A Library copy whose gate was simplified before this fix stays as it is until its quest is re-shared individually (the single-quest push refreshes in place; a campaign re-push clones conflicts by design).
* The importer still hears nothing about gates that did not travel; issue #2535 flagged that as a decision rather than a bug (the tests assert the silence deliberately), so it is tracked separately in #2544 rather than bundled here.

### Review request
@tylerecouture

- Claude Code (`bytedeck - github issues workflow`)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mwASxVDwGKGPHnSAC2dZy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prerequisite conditions now preserve NOT, count, and OR-branch settings when quests are shared.
  * Existing prerequisite conditions are refreshed when quests are re-shared.
  * Missing or unsupported prerequisite targets are excluded while the remaining condition is retained.
  * Warnings now identify prerequisite targets that could not be transferred.
* **Bug Fixes**
  * Local prerequisite adjustments remain unchanged when importing shared campaign content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->