### PR TITLE
fix: carry a prerequisite's NOT, count and OR half across the Library (#2535)

### DIFF
--- a/src/library/exporter.py
+++ b/src/library/exporter.py
@@ -259,6 +259,7 @@ def _push_campaign(source_schema, campaign_import_id):
     return TransferResult(
         quests=exported.quests + cloned.quests,
         unmet_prereqs=sorted(set(exported.unmet_prereqs) | set(cloned.unmet_prereqs)),
+        unmet_alternates=sorted(set(exported.unmet_alternates) | set(cloned.unmet_alternates)),
         skipped_quests=skipped_quests,
         dropped_common_data=sorted(set(exported.dropped_common_data) | set(cloned.dropped_common_data)),
     )

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -15,6 +15,7 @@ or a regression, and the failure is where the decision gets recorded.
 import datetime
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from model_bakery import baker
@@ -387,6 +388,183 @@ class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
         with library_schema_context():
             library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
             self.assertEqual(list(library_quest.prereqs()), [])
+
+
+    def _gated_quest(self, **prereq_kwargs):
+        """Create a campaign whose second quest is gated on its first.
+
+        Gating between quests of the same campaign is the case that survives a transfer,
+        so it is the one that can show what the gate looks like on arrival.
+
+        Args:
+            **prereq_kwargs: field values for the `Prereq`, e.g. `prereq_invert=True`.
+
+        Returns:
+            tuple[Category, Quest, Prereq]: the campaign, the gated quest, and the
+            prerequisite gating it.
+        """
+        campaign, quest, inside = self._campaign_with_two_quests()
+
+        prereq = Prereq.add_simple_prereq(quest, inside)
+        for field, value in prereq_kwargs.items():
+            setattr(prereq, field, value)
+        prereq.save()
+
+        return campaign, quest, prereq
+
+    def _push_and_pull(self, campaign, quest):
+        """Push a campaign to the Library, publish it there, then pull it back.
+
+        The local copies are deleted in between, so the pull takes the path a deck seeing
+        the campaign for the first time would.
+
+        Args:
+            campaign (Category): the campaign to push.
+            quest (Quest): the quest within it whose prerequisites are being checked.
+
+        Returns:
+            Quest: that quest as it exists on this deck after being imported back.
+        """
+        local_schema = connection.schema_name
+        export_campaign_and_copy_quests(source_schema=local_schema, campaign_import_id=campaign.import_id)
+
+        with library_schema_context():
+            Quest.objects.all_including_archived().update(published=True)
+            Category.objects.filter(import_id=campaign.import_id).update(published=True)
+
+        Quest.objects.all_including_archived().filter(campaign=campaign).delete()
+        Category.objects.filter(import_id=campaign.import_id).delete()
+        self._import_campaign(local_schema, campaign)
+
+        return Quest.objects.all_including_archived().get(import_id=quest.import_id)
+
+    def _import_campaign(self, destination_schema, campaign):
+        """Import every quest the Library holds for a campaign, as the import view does.
+
+        Args:
+            destination_schema (str): the deck to import into.
+            campaign (Category): the campaign, identified across schemas by its import_id.
+
+        Returns:
+            TransferResult: what arrived, and what could not be rebuilt.
+        """
+        with library_schema_context():
+            library_campaign = Category.objects.get(import_id=campaign.import_id)
+            quest_import_ids = list(
+                Quest.objects.all_including_archived()
+                .filter(campaign=library_campaign)
+                .values_list('import_id', flat=True)
+            )
+
+        return import_campaign_to(
+            destination_schema=destination_schema,
+            quest_import_ids=quest_import_ids,
+            campaign_import_id=campaign.import_id,
+        )
+
+    def test_push_and_pull__a_NOT_prereq_arrives_still_inverted(self):
+        """A NOT gate keeps its inversion across the Library (#2535).
+
+        This is the one loss that changes a rule rather than weakening it. "Available
+        unless you have done the placement test" and "available once you have done the
+        placement test" admit opposite sets of students, so an inverted gate that arrived
+        positive would quietly show the quest to exactly the students it was written to
+        keep away from it.
+        """
+        campaign, quest, _ = self._gated_quest(prereq_invert=True)
+
+        imported = self._push_and_pull(campaign, quest)
+
+        arrived = list(imported.prereqs())
+        self.assertEqual([p.get_prereq().name for p in arrived], ["Prereq Inside Campaign"])
+        self.assertTrue(arrived[0].prereq_invert)
+
+    def test_push_and_pull__a_repeat_count_arrives_intact(self):
+        """A gate requiring the target several times keeps its count (#2535).
+
+        A count of 3 arriving as 1 opens the quest after a third of the work its author
+        asked for, and the page reads as though that was always the requirement.
+        """
+        campaign, quest, _ = self._gated_quest(prereq_count=3)
+
+        imported = self._push_and_pull(campaign, quest)
+
+        arrived = list(imported.prereqs())
+        self.assertEqual([p.prereq_count for p in arrived], [3])
+
+    def test_push_and_pull__an_OR_alternative_arrives_intact(self):
+        """The alternate half of an OR gate travels with the requirement (#2535).
+
+        Losing it removes a way to satisfy the gate, so students who took the route the
+        author offered second find the quest closed to them.
+        """
+        campaign, quest, prereq = self._gated_quest()
+        alternate = Quest.objects.create(name="Prior Experience Form", xp=5, campaign=campaign)
+        Quest.objects.filter(pk=alternate.pk).update(published=True)
+        prereq.or_prereq_content_type = ContentType.objects.get_for_model(Quest)
+        prereq.or_prereq_object_id = alternate.pk
+        prereq.or_prereq_count = 2
+        prereq.or_prereq_invert = True
+        prereq.save()
+
+        imported = self._push_and_pull(campaign, quest)
+
+        arrived = list(imported.prereqs())
+        self.assertEqual(len(arrived), 1)
+        self.assertEqual(arrived[0].get_or_prereq().name, "Prior Experience Form")
+        self.assertEqual(arrived[0].or_prereq_count, 2)
+        self.assertTrue(arrived[0].or_prereq_invert)
+
+    def test_push_and_pull__an_OR_alternative_this_deck_lacks_is_dropped_and_named(self):
+        """An alternate half whose target is missing is reported, and the gate survives.
+
+        The requirement is still expressible without its alternative, just with one fewer
+        way to satisfy it, so it is kept rather than discarded: that leaves the quest more
+        gated than its author wrote, which the teacher can loosen, rather than less.
+        """
+        campaign, quest, prereq = self._gated_quest()
+        # Outside the campaign, so the push leaves it behind and the far side has nothing
+        # to point the OR half at.
+        alternate = Quest.objects.create(name="Alternative Nobody Else Has", xp=5)
+        Quest.objects.filter(pk=alternate.pk).update(published=True)
+        prereq.or_prereq_content_type = ContentType.objects.get_for_model(Quest)
+        prereq.or_prereq_object_id = alternate.pk
+        prereq.save()
+
+        local_schema = connection.schema_name
+        pushed = export_campaign_and_copy_quests(source_schema=local_schema, campaign_import_id=campaign.import_id)
+
+        # The loss happens on the way out, which is where it can still be acted on: the
+        # sharer is the only one who can widen what they share to include the alternative.
+        self.assertIn("Alternative Nobody Else Has", pushed.unmet_prereqs)
+
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            in_library = list(library_quest.prereqs())
+            self.assertEqual([p.get_prereq().name for p in in_library], ["Prereq Inside Campaign"])
+            self.assertIsNone(in_library[0].get_or_prereq())
+
+    def test_import_twice__does_not_stack_a_second_copy_of_the_same_gate(self):
+        """Importing the same gated quest again leaves one prerequisite, not two.
+
+        De-duplication compares the whole requirement, both halves included, so a repeat
+        import recognises the gate it wrote last time instead of adding a duplicate.
+        """
+        campaign, quest, _ = self._gated_quest(prereq_invert=True, prereq_count=2)
+        local_schema = connection.schema_name
+        export_campaign_and_copy_quests(source_schema=local_schema, campaign_import_id=campaign.import_id)
+        with library_schema_context():
+            Quest.objects.all_including_archived().update(published=True)
+            Category.objects.filter(import_id=campaign.import_id).update(published=True)
+
+        self._import_campaign(local_schema, campaign)
+        self._import_campaign(local_schema, campaign)
+
+        imported = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+        arrived = list(imported.prereqs())
+        self.assertEqual(len(arrived), 1)
+        self.assertTrue(arrived[0].prereq_invert)
+        self.assertEqual(arrived[0].prereq_count, 2)
 
 
 class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -536,13 +536,41 @@ class LibraryTransferPrereqContractTests(LibraryTenantTestCaseMixin):
 
         # The loss happens on the way out, which is where it can still be acted on: the
         # sharer is the only one who can widen what they share to include the alternative.
-        self.assertIn("Alternative Nobody Else Has", pushed.unmet_prereqs)
+        # Reported apart from `unmet_prereqs` because the gate survived: the copy is
+        # stricter than the author wrote, not open to everyone.
+        self.assertEqual(pushed.unmet_alternates, ["Alternative Nobody Else Has"])
+        self.assertEqual(pushed.unmet_prereqs, [])
 
         with library_schema_context():
             library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
             in_library = list(library_quest.prereqs())
             self.assertEqual([p.get_prereq().name for p in in_library], ["Prereq Inside Campaign"])
             self.assertIsNone(in_library[0].get_or_prereq())
+
+    def test_export_campaign__a_gate_that_cannot_travel_takes_its_alternative_with_it(self):
+        """When the main half cannot cross, the whole requirement goes, alternative included.
+
+        Both names are reported as missing gating rather than as a lost alternative: what
+        arrives is a quest with no gate at all, not a gate that lost one of its routes, so
+        the sharer is told the stronger of the two things (#2535).
+        """
+        campaign, quest, prereq = self._gated_quest()
+        # A rank has no import_id, so this half can never cross (#2450).
+        prereq.prereq_content_type = ContentType.objects.get_for_model(Rank)
+        prereq.prereq_object_id = baker.make(Rank, name="Digital Novice").pk
+        prereq.or_prereq_content_type = ContentType.objects.get_for_model(Quest)
+        prereq.or_prereq_object_id = Quest.objects.get(name="Prereq Inside Campaign").pk
+        prereq.save()
+
+        pushed = export_campaign_and_copy_quests(
+            source_schema=connection.schema_name, campaign_import_id=campaign.import_id,
+        )
+
+        self.assertEqual(pushed.unmet_prereqs, ["Digital Novice", "Prereq Inside Campaign"])
+        self.assertEqual(pushed.unmet_alternates, [])
+        with library_schema_context():
+            library_quest = Quest.objects.all_including_archived().get(import_id=quest.import_id)
+            self.assertEqual(list(library_quest.prereqs()), [])
 
     def test_import_twice__does_not_stack_a_second_copy_of_the_same_gate(self):
         """Importing the same gated quest again leaves one prerequisite, not two.

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from datetime import date
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages import get_messages
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError, connection
@@ -2385,6 +2386,36 @@ class LibrarySharerWarningTests(LibraryTenantTestCaseMixin):
         self.assertTrue(
             any("Digital Novice" in text for text in self._message_texts(response)),
             f"expected the sharer to be told, got {self._message_texts(response)}",
+        )
+
+    def test_export_quest__warns_the_sharer_that_an_OR_alternative_could_not_travel(self):
+        """Sharing a quest whose gate offers an alternative says the copy lost that route.
+
+        A separate warning from the ungated one, because it is the opposite problem: the
+        gate survived, so the Library copy is stricter than its author wrote rather than
+        open to everyone, and the fix is to share the alternative too (#2535).
+        """
+        gate = baker.make(Quest, name="The Main Route", published=True)
+        alternative = baker.make(Quest, name="The Other Route", published=True)
+        local = baker.make(Quest, name="Quest With Two Routes In", published=True)
+        prereq = Prereq.add_simple_prereq(local, gate)
+        prereq.or_prereq_content_type = ContentType.objects.get_for_model(Quest)
+        prereq.or_prereq_object_id = alternative.pk
+        prereq.save()
+        # The gate is already there, so only the alternative is missing on the far side.
+        with library_schema_context():
+            baker.make(Quest, name="The Main Route", import_id=gate.import_id, published=True)
+        self._allow_staff_export()
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.post(
+            reverse('library:export_quest', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("The Other Route" in text and "lost an alternative" in text for text in texts),
+            f"expected the sharer to be told the alternative did not travel, got {texts}",
         )
 
     def test_export_quest__stays_quiet_when_the_gate_is_already_in_the_library(self):

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -47,9 +47,11 @@ class TransferResult(NamedTuple):
     they share, or decide the gap is fine. The views turn these into a warning on the push.
 
     `unmet_prereqs` names gating that did not travel, which fails open: the copy in the
-    Library ends up less gated than its author wrote. `skipped_quests` names quests that
-    were left out of a shared campaign altogether. `dropped_common_data` names the shared
-    General Info blocks the copy arrives without.
+    Library ends up less gated than its author wrote. `unmet_alternates` is the milder
+    version of that: the gate itself survived, but an alternative way of satisfying it did
+    not, so the copy is gated more tightly than its author wrote rather than less.
+    `skipped_quests` names quests that were left out of a shared campaign altogether.
+    `dropped_common_data` names the shared General Info blocks the copy arrives without.
 
     `renamed_quests` is the odd one out: nothing was lost, but a name was changed to get
     the copy in, so it is reported to whoever is standing in front of it (#2364).
@@ -57,6 +59,7 @@ class TransferResult(NamedTuple):
 
     quests: list
     unmet_prereqs: list
+    unmet_alternates: list = ()
     skipped_quests: list = ()
     dropped_common_data: list = ()
     renamed_quests: list = ()
@@ -418,12 +421,14 @@ def _write_prereqs(quest, prereqs):
         prereqs (list[dict]): `{'main', 'alternate'}` entries from `_snapshot_prereqs`.
 
     Returns:
-        list[str]: the names of the prerequisite targets this deck does not have. An
-        alternate half whose target is missing is named too: the requirement survives
-        without it, but with one fewer way to satisfy it.
+        tuple[list[str], list[str]]: the names of the prerequisite targets this deck does
+        not have, and separately the names of alternate halves it does not have. They are
+        reported apart because they are different losses: the first leaves the quest
+        ungated, the second leaves it gated with one fewer way through.
     """
     already_required = {_prereq_signature(p) for p in quest.prereqs()}
     unmet = []
+    unmet_alternates = []
 
     for prereq in prereqs:
         main = _find_prereq_target(prereq['main'])
@@ -433,6 +438,8 @@ def _write_prereqs(quest, prereqs):
             # and naming it is what tells the teacher (#2450, #2399).
             unmet.append(prereq['main']['name'])
             if prereq['alternate'] is not None:
+                # The whole requirement went, so its alternative went with it: that is a
+                # missing gate, not a gate missing an option.
                 unmet.append(prereq['alternate']['name'])
             continue
 
@@ -440,7 +447,7 @@ def _write_prereqs(quest, prereqs):
         if prereq['alternate'] is not None:
             alternate = _find_prereq_target(prereq['alternate'])
             if alternate is None:
-                unmet.append(prereq['alternate']['name'])
+                unmet_alternates.append(prereq['alternate']['name'])
 
         new_prereq = Prereq(
             parent_content_type=ContentType.objects.get_for_model(quest),
@@ -462,7 +469,7 @@ def _write_prereqs(quest, prereqs):
             new_prereq.save()
             already_required.add(signature)
 
-    return unmet
+    return unmet, unmet_alternates
 
 
 def _write_questions(quest, questions):
@@ -551,8 +558,11 @@ def write_quests(writes, *, with_campaign):
         # Second pass, so a prerequisite between two quests of this batch is linked
         # whichever order they were written in.
         unmet = []
+        unmet_alternates = []
         for (snapshot, _, _), quest in zip(writes, written):
-            unmet.extend(_write_prereqs(quest, snapshot['prereqs']))
+            missing, missing_alternates = _write_prereqs(quest, snapshot['prereqs'])
+            unmet.extend(missing)
+            unmet_alternates.extend(missing_alternates)
 
     dropped_common_data = sorted({
         snapshot['common_data_title'] for snapshot, _, _ in writes if snapshot['common_data_title']
@@ -561,6 +571,7 @@ def write_quests(writes, *, with_campaign):
     return TransferResult(
         quests=written,
         unmet_prereqs=sorted(set(unmet)),
+        unmet_alternates=sorted(set(unmet_alternates) - set(unmet)),
         dropped_common_data=dropped_common_data,
     )
 

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -27,6 +27,7 @@ Two rules hold everywhere below:
 
 from typing import NamedTuple
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 
@@ -234,14 +235,45 @@ def _snapshot_questions(quest):
     return [{name: _read_field(question, name) for name in copied} for question in quest.question_set.all()]
 
 
-def _snapshot_prereqs(quest):
-    """The shareable prerequisites of a quest, as portable ids with readable names.
+def _snapshot_prereq_half(target, count, invert):
+    """One side of a prerequisite, as a portable id with its readable name and modifiers.
 
     A prerequisite is a generic foreign key, so it can point at any prerequisite model.
     Only those marked with `IsLibraryContentMixin` (quests, campaigns and badges) have an
     identity that survives the crossing; the rest describe the deck rather than the
     content, and a rank or a course on another deck is not the same rank or course. Those
     are stripped, because there is nothing on the far side for them to point at (#2450).
+
+    Must be called from within the source schema context.
+
+    Args:
+        target (IsAPrereqMixin): what this side of the prerequisite points at.
+        count (int): how many times it must be met.
+        invert (bool): whether meeting it is what *disqualifies* the student.
+
+    Returns:
+        dict: `{'import_id': UUID | None, 'name': str, 'count': int, 'invert': bool}`. A
+        `None` import_id marks a target that can never travel, so the destination reports
+        it as missing rather than looking for something that was never sent.
+    """
+    shareable = IsLibraryContentMixin.is_shareable_model(type(target))
+
+    return {
+        'import_id': target.import_id if shareable else None,
+        'name': str(target),
+        'count': count,
+        'invert': invert,
+    }
+
+
+def _snapshot_prereqs(quest):
+    """The shareable prerequisites of a quest, as portable ids with readable names.
+
+    Each prerequisite travels with its `count` and `invert` flags, and with its alternate
+    "OR" half when it has one, because those are the requirement, not decoration on it.
+    Sending only the target inverts the meaning of a NOT gate: "available unless you have
+    done X" arrives as "available once you have done X", which is the opposite rule about
+    who may see the quest, and nothing on either deck says so (#2535).
 
     Every prerequisite is listed either way, because the name is what lets the destination
     say which requirement it ended up without: one it cannot express (#2450) and one it
@@ -253,17 +285,18 @@ def _snapshot_prereqs(quest):
         quest (Quest): the quest whose prerequisites to read.
 
     Returns:
-        list[dict]: one `{'import_id': UUID | None, 'name': str}` per prerequisite. A
-        `None` import_id marks one that can never travel, so the destination reports it
-        as missing rather than looking for something that was never sent.
+        list[dict]: one entry per prerequisite, each `{'main': half, 'alternate': half |
+        None}`, where a half is as described by `_snapshot_prereq_half`.
     """
     prereqs = []
     for prereq in quest.prereqs():
-        target = prereq.get_prereq()
-        shareable = IsLibraryContentMixin.is_shareable_model(type(target))
+        alternate = prereq.get_or_prereq()
         prereqs.append({
-            'import_id': target.import_id if shareable else None,
-            'name': str(target),
+            'main': _snapshot_prereq_half(prereq.get_prereq(), prereq.prereq_count, prereq.prereq_invert),
+            'alternate': (
+                _snapshot_prereq_half(alternate, prereq.or_prereq_count, prereq.or_prereq_invert)
+                if alternate is not None else None
+            ),
         })
 
     return prereqs
@@ -306,6 +339,56 @@ def _write_campaign(snapshot):
     return campaign
 
 
+def _find_prereq_target(half):
+    """This deck's copy of what one side of a prerequisite points at, or None.
+
+    Matched by `import_id`, the only identity a row keeps across schemas. Archived quests
+    count: a gate on one is still a gate, and the arriving quest should not quietly lose
+    it because the target is put away.
+
+    Must be called from within the destination schema context.
+
+    Args:
+        half (dict): a `{'import_id', 'name', 'count', 'invert'}` entry.
+
+    Returns:
+        Quest | Category | Badge | None: the target on this deck, or None when the
+        prerequisite was stripped on the way out or this deck simply does not have it.
+    """
+    from badges.models import Badge
+
+    if half['import_id'] is None:
+        return None
+
+    for model in (Quest.objects.all_including_archived(), Category.objects, Badge.objects):
+        target = model.filter(import_id=half['import_id']).first()
+        if target is not None:
+            return target
+
+    return None
+
+
+def _prereq_signature(prereq):
+    """What makes two prerequisites the same requirement, for de-duplication.
+
+    Both halves, in full: "X" and "NOT X" gate a quest for opposite sets of students, and
+    "X x3" is not "X", so the target alone cannot say whether a requirement is already
+    there (#2535).
+
+    Args:
+        prereq (Prereq): a saved or unsaved prerequisite.
+
+    Returns:
+        tuple: comparable across instances, using content type ids rather than the generic
+        objects so an unsaved prerequisite compares equal to a stored one.
+    """
+    return (
+        prereq.prereq_content_type_id, prereq.prereq_object_id, prereq.prereq_count, prereq.prereq_invert,
+        prereq.or_prereq_content_type_id, prereq.or_prereq_object_id,
+        prereq.or_prereq_count, prereq.or_prereq_invert,
+    )
+
+
 def _write_prereqs(quest, prereqs):
     """Rebuild the prerequisites whose targets exist on this deck, and report the rest.
 
@@ -323,38 +406,61 @@ def _write_prereqs(quest, prereqs):
     upstream lingers here, which leaves the quest more gated than intended: that fails
     closed and the teacher can undo it, where deleting their own gating would not.
 
+    A prerequisite's `count` and `invert` flags travel with it, and so does its alternate
+    "OR" half. Rebuilding the target alone would change what the gate means rather than
+    weaken it: a NOT gate would arrive as a plain requirement and admit exactly the
+    students it was written to keep out (#2535).
+
     Must be called from within the destination schema context.
 
     Args:
         quest (Quest): the freshly written quest.
-        prereqs (list[dict]): `{'import_id', 'name'}` entries from `_snapshot_prereqs`.
+        prereqs (list[dict]): `{'main', 'alternate'}` entries from `_snapshot_prereqs`.
 
     Returns:
-        list[str]: the names of the prerequisites this deck does not have.
+        list[str]: the names of the prerequisite targets this deck does not have. An
+        alternate half whose target is missing is named too: the requirement survives
+        without it, but with one fewer way to satisfy it.
     """
-    from badges.models import Badge
-
-    already_required = {p.get_prereq() for p in quest.prereqs()}
+    already_required = {_prereq_signature(p) for p in quest.prereqs()}
     unmet = []
 
     for prereq in prereqs:
-        if prereq['import_id'] is None:
-            # Stripped on the way out because its target cannot cross at all (a rank, a
-            # course). Still worth naming: the gate is gone either way (#2450).
-            unmet.append(prereq['name'])
+        main = _find_prereq_target(prereq['main'])
+        if main is None:
+            # Either stripped on the way out because its target cannot cross at all (a
+            # rank, a course), or simply not on this deck. Either way the gate is gone,
+            # and naming it is what tells the teacher (#2450, #2399).
+            unmet.append(prereq['main']['name'])
+            if prereq['alternate'] is not None:
+                unmet.append(prereq['alternate']['name'])
             continue
 
-        target = Quest.objects.all_including_archived().filter(import_id=prereq['import_id']).first()
-        if target is None:
-            target = Category.objects.filter(import_id=prereq['import_id']).first()
-        if target is None:
-            target = Badge.objects.filter(import_id=prereq['import_id']).first()
+        alternate = None
+        if prereq['alternate'] is not None:
+            alternate = _find_prereq_target(prereq['alternate'])
+            if alternate is None:
+                unmet.append(prereq['alternate']['name'])
 
-        if target is None:
-            unmet.append(prereq['name'])
-        elif target not in already_required:
-            Prereq.add_simple_prereq(quest, target)
-            already_required.add(target)
+        new_prereq = Prereq(
+            parent_content_type=ContentType.objects.get_for_model(quest),
+            parent_object_id=quest.id,
+            prereq_content_type=ContentType.objects.get_for_model(main),
+            prereq_object_id=main.id,
+            prereq_count=prereq['main']['count'],
+            prereq_invert=prereq['main']['invert'],
+        )
+        if alternate is not None:
+            new_prereq.or_prereq_content_type = ContentType.objects.get_for_model(alternate)
+            new_prereq.or_prereq_object_id = alternate.id
+            new_prereq.or_prereq_count = prereq['alternate']['count']
+            new_prereq.or_prereq_invert = prereq['alternate']['invert']
+
+        signature = _prereq_signature(new_prereq)
+        if signature not in already_required:
+            new_prereq.full_clean()
+            new_prereq.save()
+            already_required.add(signature)
 
     return unmet
 

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -378,6 +378,36 @@ def warn_sharer_about_unmet_prereqs(request, unmet_prereqs):
     )
 
 
+def warn_sharer_about_unmet_alternates(request, unmet_alternates):
+    """Tell the sharer which OR alternatives did not travel with the content they shared.
+
+    Separate from `warn_sharer_about_unmet_prereqs` because it is the opposite kind of
+    loss. A gate whose target did not travel is dropped, and the copy arrives open to
+    everyone. A gate that merely lost the alternative half of an OR still gates the quest:
+    it just no longer accepts the second route its author offered, so the copy arrives
+    *stricter* than intended and some students cannot reach it at all.
+
+    Telling the sharer which is which matters, because the fix differs: an ungated quest
+    needs re-gating on the far side, while a narrowed one needs the alternative shared
+    alongside it (#2535).
+
+    Args:
+        request (HttpRequest): the current request, for the message framework.
+        unmet_alternates (list[str]): names of the alternatives that did not travel.
+    """
+    if not unmet_alternates:
+        return
+
+    names = ', '.join(f"'{name}'" for name in unmet_alternates)
+    messages.warning(
+        request,
+        f"A gate kept its requirement but lost an alternative: {names} is not in the "
+        "Library, so where the gating offered it as another way through, the copy no "
+        "longer does. Anyone importing this gets the stricter version. Share the "
+        "alternative too if both routes should be available."
+    )
+
+
 def record_push_origin(content_type, import_ids, request, source_deck_url):
     """Record which deck and which user shared this content to the Library (#2377).
 
@@ -1050,6 +1080,7 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
             )
         )
         warn_sharer_about_unmet_prereqs(request, shared.unmet_prereqs)
+        warn_sharer_about_unmet_alternates(request, shared.unmet_alternates)
         warn_sharer_about_dropped_common_data(request, shared.dropped_common_data)
         return redirect('quests:quests')
 
@@ -1202,6 +1233,7 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
             )
         )
         warn_sharer_about_unmet_prereqs(request, shared.unmet_prereqs)
+        warn_sharer_about_unmet_alternates(request, shared.unmet_alternates)
         warn_sharer_about_skipped_quests(request, shared.skipped_quests)
         warn_sharer_about_dropped_common_data(request, shared.dropped_common_data)
         return redirect('quests:categories')


### PR DESCRIPTION
### What?

A prerequisite crossing the Library was rebuilt from its target alone, dropping three parts of the gate: `prereq_invert` (the NOT), `prereq_count` (the xN), and the alternate OR half.

Those now travel with it, and a lost alternative is reported separately from a lost gate.

Closes #2535

### Why?

The count and the OR half degrade into a weaker gate, which is bad but at least visible if someone looks. **The invert is worse: it flips the meaning.**

A quest gated on `NOT Placement Test`, available only to students who have *not* done the placement test, arrived gated on `Placement Test`, available only to students who *have*. The gate was not lost; it meant the opposite. Nothing on either deck said so, and the rule about who may see the quest silently inverted.

`_write_prereqs` rebuilt every gate through `Prereq.add_simple_prereq`, which by design writes a plain positive single-target requirement:

```python
new_prereq = cls(
    parent_content_type=..., parent_object_id=...,
    prereq_content_type=..., prereq_object_id=...,
)
```

There is no field for the invert, the count, or the alternative, so all three were dropped at the moment of writing.

### How?

**Snapshot both halves.** `_snapshot_prereqs` now returns `{'main': half, 'alternate': half | None}`, where each half carries `import_id`, `name`, `count` and `invert`. A new `_snapshot_prereq_half` applies the existing shareable-target rule (quests, campaigns and badges cross; ranks, grades, blocks and courses cannot) to each half independently.

**Rebuild the row rather than calling `add_simple_prereq`.** The alternate half travels under the same rule as the main one: rebuilt when the destination holds its target, reported when it does not.

**De-duplicate on the whole requirement.** `_prereq_signature` compares both halves in full, because `X` and `NOT X` gate a quest for opposite sets of students and `X x3` is not `X`, so the target alone cannot say whether a requirement is already present. This keeps the existing add-only behaviour (a repeat import does not stack a second copy) correct now that gates differ by more than their target.

**Report the two losses apart.** The existing warning says the copy "is not gated on it and anyone importing it will get it ungated". True for a gate whose target could not travel; false when only the alternative was lost, since the gate survives and the copy ends up *stricter* than its author wrote. `TransferResult` gains `unmet_alternates`, with a warning of its own:

> A gate kept its requirement but lost an alternative: 'The Other Route' is not in the Library, so where the gating offered it as another way through, the copy no longer does. Anyone importing this gets the stricter version. Share the alternative too if both routes should be available.

The fix a teacher needs differs between the two: an ungated quest needs re-gating on the far side, a narrowed one needs the alternative shared alongside it.

### Testing?

Six new tests. Five in `LibraryTransferPrereqContractTests`, all round-tripping through a campaign push and import (the path where gating survives at all):

* `test_push_and_pull__a_NOT_prereq_arrives_still_inverted`
* `test_push_and_pull__a_repeat_count_arrives_intact`
* `test_push_and_pull__an_OR_alternative_arrives_intact`
* `test_push_and_pull__an_OR_alternative_this_deck_lacks_is_dropped_and_named`
* `test_export_campaign__a_gate_that_cannot_travel_takes_its_alternative_with_it`

Plus `test_export_quest__warns_the_sharer_that_an_OR_alternative_could_not_travel` in `LibrarySharerWarningTests`, covering the new message end to end through the export view.

Verified in both directions: reverting `src/library/transfer.py` to `develop` fails four of them (`FAILED (failures=3, errors=1)`). The fifth and sixth exercise paths the old code did not reach; `test_import_twice__does_not_stack_a_second_copy_of_the_same_gate` passes either way by design, guarding the new signature-based de-duplication against regression rather than demonstrating the bug.

Full suite: `Ran 2651 tests ... OK`. `ruff check src`: clean. Coverage on `src/library/` is 100% (0 misses, 0 partial branches).

### Screenshots (if front end is affected)

N/A: no template or styling changes. The only user-visible change is the new warning message, quoted verbatim above and asserted by `test_export_quest__warns_the_sharer_that_an_OR_alternative_could_not_travel`.

### Anything Else?

**One deliberate non-change.** When the *main* half cannot be rebuilt but the alternative could be, the whole requirement is still dropped rather than promoting the alternative to main. Promoting would silently rewrite which requirement is primary, and the existing contract for a gate that cannot be rebuilt is to report it rather than guess. `test_export_campaign__a_gate_that_cannot_travel_takes_its_alternative_with_it` pins that, and both names are reported as missing gating so the sharer sees the stronger of the two facts.

**The wiki already warns teachers about this.** The Shared Library page staged on `pr-assets` lists "Prerequisites are simplified on the way across" under Known Limitations. That line can come out once this merges.

### Review request
@tylerecouture

- Claude Code (`bytedeck - library import/export`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eLMGnFA8TUAJnM2ewfTXv)_