### PR TITLE
fix: adopt a pre-registered student's work when their semester opens (#2476)

### DIFF
--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -1339,7 +1339,31 @@ def coursestudent_adopt_unstamped_work_callback(instance, created, **kwargs):
     from quest_manager.models import QuestSubmission  # locally, since quest_manager imports this module
 
     if created and instance.semester_id is not None and instance.semester.is_open:
-        QuestSubmission.objects.adopt_unstamped_in_progress(instance.user_id, instance.semester_id)
+        QuestSubmission.objects.adopt_unstamped_in_progress([instance.user_id], instance.semester_id)
+
+
+@receiver(post_save, sender=Semester)
+def semester_adopt_unstamped_work_callback(instance, **kwargs):
+    """Bring the work a pre-registered student had on the go into their semester as it opens.
+
+    The receiver on CourseStudent covers a student joining a course in a semester that is
+    already running. This covers the other order (issue #2476): a teacher registers students
+    against a semester that has not started, those students have no open registration so they
+    can do the quests marked available outside a course, and the semester is opened
+    afterwards. Nothing saves their registrations at that moment, so without this their
+    in-progress work stays unstamped, out of the in-progress list that is now their
+    semester's and out of the available list that drops a quest they already started.
+
+    Any save leaving the semester open counts, not just the one that opens it: a semester can
+    be started from the admin as well as through SiteConfig.set_active_semester(), and
+    adopting when there is nothing left to adopt moves no rows.
+    """
+    from quest_manager.models import QuestSubmission  # locally, since quest_manager imports this module
+
+    if instance.is_open:
+        QuestSubmission.objects.adopt_unstamped_in_progress(
+            CourseStudent.objects.all_for_semester(instance).values('user_id'), instance.pk
+        )
 
 
 @receiver(post_save, sender=Rank)

--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -1335,7 +1335,13 @@ def coursestudent_adopt_unstamped_work_callback(instance, created, **kwargs):
     and joining a course is the moment it gains one. Without this it would be stranded: out
     of their in-progress list, which is their new semester's, and out of their available
     list, which drops a quest they already have a submission of.
+
+    Deserializing a fixture is sat out: Django sends raw=True for those saves, and the
+    submissions this moves are read from the database, which is only part loaded then.
     """
+    if kwargs.get('raw'):
+        return
+
     from quest_manager.models import QuestSubmission  # locally, since quest_manager imports this module
 
     if created and instance.semester_id is not None and instance.semester.is_open:
@@ -1357,7 +1363,14 @@ def semester_adopt_unstamped_work_callback(instance, **kwargs):
     Any save leaving the semester open counts, not just the one that opens it: a semester can
     be started from the admin as well as through SiteConfig.set_active_semester(), and
     adopting when there is nothing left to adopt moves no rows.
+
+    Deserializing a fixture is sat out, the same as its counterpart above: Django sends
+    raw=True for those saves, and both the registrations this reads and the submissions it
+    moves come from a database that is only part loaded then.
     """
+    if kwargs.get('raw'):
+        return
+
     from quest_manager.models import QuestSubmission  # locally, since quest_manager imports this module
 
     if instance.is_open:

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db import models
-from django.db.models import Count, DateTimeField, ExpressionWrapper, F, Max, Q, Sum
+from django.db.models import Count, DateTimeField, Exists, ExpressionWrapper, F, Max, OuterRef, Q, Sum
 from django.db.models.functions import Greatest
 from django.urls import reverse
 from django.utils import timezone
@@ -1360,24 +1360,30 @@ class QuestSubmissionManager(models.Manager):
 
         return series
 
-    def adopt_unstamped_in_progress(self, user, semester):
-        """Move the work `user` has on the go that belongs to no semester into `semester`.
+    def adopt_unstamped_in_progress(self, users, semester):
+        """Move the work `users` have on the go that belongs to no semester into `semester`.
 
         Someone registered in no semester hands work in stamped with none (issue #2441): the
         welcome quest a new student does before joining a course, or a quest marked available
-        outside a course, done between terms. Once they join a course, that work is in
+        outside a course, done between terms. Once that work belongs to a semester, it is in
         neither their in-progress list (which is now their new semester's) nor their
         available list (which drops a quest they already have a submission of), so it would
         sit where nobody can reach it. Re-attaching it is what mark_returned() already does
         for a submission returned in a later semester (issue #1231).
+
+        Both orders reach this. A student joining a course that is already running arrives
+        one at a time, from the receiver on CourseStudent. A semester opening around students
+        already registered in it arrives as the whole cohort at once, from the receiver on
+        Semester (issue #2476).
 
         Only work still in progress moves. What they finished outside a semester was
         finished there, and its XP belongs to no term rather than to the one they are
         starting.
 
         Args:
-            user: the student who just registered, or their id.
-            semester: the Semester they registered in, or its id.
+            users: the students whose work should move: Users, their ids, or a queryset of
+                either.
+            semester: the Semester the work should belong to, or its id.
 
         Returns:
             int: how many submissions were moved.
@@ -1385,15 +1391,18 @@ class QuestSubmissionManager(models.Manager):
         # the base manager throughout: a submission of a quest since archived or unpublished
         # is still theirs to finish, and the default manager would leave it behind
         already_in_semester = self.model._base_manager.filter(
-            user=user, semester=semester, is_completed=False, first_time_completed__isnull=True,
-        ).values('quest_id')
+            user_id=OuterRef('user_id'), quest_id=OuterRef('quest_id'),
+            semester=semester, is_completed=False, first_time_completed__isnull=True,
+        )
         return self.model._base_manager.filter(
-            user=user, semester__isnull=True, is_completed=False,
+            user__in=users, semester__isnull=True, is_completed=False,
         ).exclude(
             # a never-completed submission can't join one already in that semester: the
             # partial unique constraint holds one per (user, quest, semester), and it is the
-            # rule this would be breaking rather than an accident to work around
-            Q(first_time_completed__isnull=True) & Q(quest_id__in=already_in_semester),
+            # rule this would be breaking rather than an accident to work around. Correlated
+            # on the user as well as the quest, since a whole cohort moves at once: one
+            # student's clash must not hold back another's submission of the same quest.
+            Q(first_time_completed__isnull=True) & Q(Exists(already_in_semester)),
         ).update(semester=semester)
 
     def remove_in_progress(self, semester=None):

--- a/src/quest_manager/tests/test_regression_2413.py
+++ b/src/quest_manager/tests/test_regression_2413.py
@@ -219,6 +219,108 @@ class AdoptUnstampedWorkOnRegistrationTest(ByteDeckTenantTestCase):
         self.assertIsNone(later.semester_id)
 
 
+class AdoptUnstampedWorkOnSemesterOpenTest(ByteDeckTenantTestCase):
+    """Opening a semester brings its students' on-the-go work into it (issue #2476)."""
+
+    def setUp(self):
+        """Create a semester that has not started and a student registered in it, the shape a
+        teacher gets by signing a cohort up ahead of the term through the admin."""
+        self.student = baker.make(User, is_staff=False)
+        self.quest = baker.make(Quest, xp=5, published=True, archived=False, available_outside_course=True)
+        self.semester = baker.make(Semester, status=Semester.Status.UPCOMING)
+        baker.make(CourseStudent, user=self.student, course=baker.make(Course), semester=self.semester)
+
+    def open_semester(self):
+        """Start the semester under test, the way the admin does."""
+        self.semester.status = Semester.Status.OPEN
+        self.semester.save()
+
+    def test_open__in_progress_work_of_a_registered_student_moves_into_the_semester(self):
+        """A student signed up before their term starts holds no open registration, so they
+        can do the quests marked available outside a course and what they hand in belongs to
+        no semester. Opening their semester is the moment that work gains one. Without it the
+        work is stranded: out of the in-progress list, which is now their semester's, and out
+        of the available list, which drops a quest they already have a submission of."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        self.assertIsNone(submission.semester_id)
+
+        self.open_semester()
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.semester_id, self.semester.id)
+        self.assertIn(submission, QuestSubmission.objects.all_not_completed(user=self.student))
+
+    def test_open__one_students_collision_does_not_hold_back_a_classmates_work(self):
+        """A whole cohort moves at once, so the rule that a student cannot hold two
+        never-completed submissions of one quest in a semester is checked per student. A
+        classmate who already has that quest on the go in this semester keeps their unstamped
+        one where it is, and that says nothing about anybody else's submission of it."""
+        classmate = baker.make(User, is_staff=False)
+        baker.make(CourseStudent, user=classmate, course=baker.make(Course), semester=self.semester)
+        baker.make(
+            QuestSubmission, user=classmate, quest=self.quest, semester=self.semester, is_completed=False,
+        )
+        theirs = baker.make(
+            QuestSubmission, user=classmate, quest=self.quest, semester=None, is_completed=False,
+        )
+        mine = QuestSubmission.objects.create_submission(self.student, self.quest)
+
+        self.open_semester()
+
+        mine.refresh_from_db()
+        theirs.refresh_from_db()
+        self.assertEqual(mine.semester_id, self.semester.id)
+        self.assertIsNone(theirs.semester_id)
+
+    def test_open__completed_work_stays_where_it_was_finished(self):
+        """Only work still in progress moves, the same rule joining a course follows: a quest
+        finished outside a semester was finished there, so its XP belongs to no term rather
+        than to the one about to start."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        submission.mark_completed()
+
+        self.open_semester()
+
+        submission.refresh_from_db()
+        self.assertIsNone(submission.semester_id)
+
+    def test_open__work_of_a_student_registered_elsewhere_is_left_alone(self):
+        """Opening one semester says nothing about the students who are not in it. A deck can
+        run two cohorts on different calendars (issue #1781), so someone waiting on the other
+        term keeps their work unstamped until that term opens."""
+        outsider = baker.make(User, is_staff=False)
+        theirs = QuestSubmission.objects.create_submission(outsider, self.quest)
+
+        self.open_semester()
+
+        theirs.refresh_from_db()
+        self.assertIsNone(theirs.semester_id)
+
+    def test_set_active_semester__adopts_the_work_of_the_students_it_starts(self):
+        """Starting a semester through the deck's own action is the path a teacher actually
+        takes, so it has to adopt as well as a direct status edit in the admin does."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+
+        SiteConfig.get().set_active_semester(self.semester)
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.semester_id, self.semester.id)
+
+    def test_open__saving_the_semester_again_disturbs_nothing(self):
+        """Adoption runs on any save that leaves the semester open, not only on the one that
+        opens it, because a semester can be started from the admin as well as through the
+        deck's action. Saving an open semester again therefore has to leave the work it
+        already adopted where it is."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        self.open_semester()
+
+        self.semester.name = 'Renamed after it started'
+        self.semester.save()
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.semester_id, self.semester.id)
+
+
 class UnstampedDoubleStartRaceTest(ByteDeckTenantTestCase):
     """The #1345 double-start race, for the submissions that name no semester."""
 

--- a/src/quest_manager/tests/test_regression_2413.py
+++ b/src/quest_manager/tests/test_regression_2413.py
@@ -19,6 +19,7 @@ from unittest import mock
 from django.apps import apps as django_apps
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, connection, transaction
+from django.db.models.signals import post_save
 from django.utils import timezone
 
 from model_bakery import baker
@@ -218,6 +219,20 @@ class AdoptUnstampedWorkOnRegistrationTest(ByteDeckTenantTestCase):
         later.refresh_from_db()
         self.assertIsNone(later.semester_id)
 
+    def test_register__a_fixture_load_adopts_nothing(self):
+        """Django sends raw=True while deserializing a fixture, when the submissions this
+        would move are read from a database that is only part loaded. Adoption sits that
+        save out and waits for a real one."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        registration = CourseStudent(
+            user=self.student, course=baker.make(Course), semester=self.semester,
+        )
+
+        post_save.send(sender=CourseStudent, instance=registration, created=True, raw=True)
+
+        submission.refresh_from_db()
+        self.assertIsNone(submission.semester_id)
+
 
 class AdoptUnstampedWorkOnSemesterOpenTest(ByteDeckTenantTestCase):
     """Opening a semester brings its students' on-the-go work into it (issue #2476)."""
@@ -319,6 +334,18 @@ class AdoptUnstampedWorkOnSemesterOpenTest(ByteDeckTenantTestCase):
 
         submission.refresh_from_db()
         self.assertEqual(submission.semester_id, self.semester.id)
+
+    def test_open__a_fixture_load_adopts_nothing(self):
+        """The same rule as the receiver on CourseStudent: a raw save is a fixture being
+        deserialized, and the registrations this reads may not be loaded yet, so it adopts
+        nothing and leaves the work for a real save to pick up."""
+        submission = QuestSubmission.objects.create_submission(self.student, self.quest)
+        self.semester.status = Semester.Status.OPEN
+
+        post_save.send(sender=Semester, instance=self.semester, created=False, raw=True)
+
+        submission.refresh_from_db()
+        self.assertIsNone(submission.semester_id)
 
 
 class UnstampedDoubleStartRaceTest(ByteDeckTenantTestCase):


### PR DESCRIPTION
### What?

Closes #2476. A cohort registered before their term starts keeps the work they did while waiting for it.

* New `post_save` receiver on `Semester`: whenever a save leaves a semester open, the unstamped in-progress work of everyone registered in it is adopted into it.
* `QuestSubmissionManager.adopt_unstamped_in_progress()` takes students rather than a student, so a whole cohort moves in one statement, and its collision guard is correlated per user.
* Both adoption receivers now sit out fixture deserialization (`raw=True`), after review.

No migration, no model change, no template change.

### Why?

#2473 (settling #2441 and #2413) established that work handed in by someone registered in no open semester belongs to no semester, and that joining a course is what gives it one. That covers a student joining a term already running. It does not cover the other order:

1. A teacher signs a cohort up against a semester that has not started. Only the admin or a bulk import can do this, since `CourseStudentForm` narrows its choices to open semesters and `CourseStudentCreate` refuses when none is open.
2. Those students hold no *open* registration, so `has_current_course` is False and they can do the quests marked available outside a course. What they hand in is stamped with no semester, correctly.
3. The teacher starts the term. Nothing saves their `CourseStudent` rows, so the receiver never fires and their in-progress work stays unstamped: out of the in-progress list, which is now their semester's, and out of the available list, which drops a quest they already have a submission of. The work is reachable from nowhere.

Not a regression. Before #2473 the same setup was wrong in a different way: `semester_for()` fell back to the deck's *current* open semester, so a pre-registered student's work was stamped with the term already running rather than the one they were about to start, and it stayed there. This is an edge that remained imperfect, not one that got worse.

### How?

The hook is a receiver on `Semester` rather than an addition to `SiteConfig.set_active_semester()`, because that is not the only way a term starts: the admin can set `status` directly. It fires on any save that leaves the semester open rather than only on the transition into it, which needs no previous-value tracking and costs nothing when there is nothing left to adopt, since the statement simply matches no rows. `test_open__saving_the_semester_again_disturbs_nothing` pins that.

Moving a cohort rather than one student is what forces the other half of the change. The guard exists to respect `unique_inprogress_submission_per_quest_semester`, one never-completed submission per user, quest and semester:

```python
already_in_semester = self.model._base_manager.filter(
    user_id=OuterRef('user_id'), quest_id=OuterRef('quest_id'),
    semester=semester, is_completed=False, first_time_completed__isnull=True,
)
return self.model._base_manager.filter(
    user__in=users, semester__isnull=True, is_completed=False,
).exclude(
    Q(first_time_completed__isnull=True) & Q(Exists(already_in_semester)),
).update(semester=semester)
```

With a single student the previous `quest_id__in` subquery was equivalent, because every row it could match was that student's. With a cohort in flight it is not: one student who already has a quest on the go in this semester would hold back *every* classmate's unstamped submission of that same quest. Correlating on `user_id` as well as `quest_id` keeps the rule per student, which is what the constraint actually says.

The whole cohort still moves in one statement: the students come from `CourseStudent.objects.all_for_semester(instance).values('user_id')` as a subquery rather than a list read back into Python, so the cost does not grow with the size of the class.

### Testing?

`python src/manage.py test src` (2652 tests, all passing, run on the head with `develop` merged in), `ruff check src` clean, `manage.py check` clean, `makemigrations --check --dry-run` clean.

Eight new tests in `AdoptUnstampedWorkOnSemesterOpenTest` and `AdoptUnstampedWorkOnRegistrationTest`. Six of them were run against the code without the fix and fail there:

| test | without the fix |
|---|---|
| `test_open__in_progress_work_of_a_registered_student_moves_into_the_semester` | `AssertionError: None != 3` |
| `test_open__one_students_collision_does_not_hold_back_a_classmates_work` | `AssertionError: None != 4` |
| `test_open__saving_the_semester_again_disturbs_nothing` | `AssertionError: None != 5` |
| `test_set_active_semester__adopts_the_work_of_the_students_it_starts` | `AssertionError: None != 7` |
| `test_open__a_fixture_load_adopts_nothing` | `AssertionError: 2 is not None` |
| `test_register__a_fixture_load_adopts_nothing` | `AssertionError: 1 is not None` |

The remaining two pin boundaries the change could plausibly overshoot, so they pass with and without it by design: completed work stays where it was finished, and a student registered in a different semester is left alone.

The per-user correlation has its own check. Swapping the `Exists`/`OuterRef` guard back to the old uncorrelated `quest_id__in` form, with everything else unchanged, fails `test_open__one_students_collision_does_not_hold_back_a_classmates_work` with `AssertionError: None != 2`: the classmate's clash strands the other student's work. So that test is load-bearing rather than incidental.

### Screenshots (if front end is affected)

N/A, and deliberately so rather than for want of looking: no template, view or URL is touched. What changes is which semester a row already in the database belongs to, and the pages that read it (the in-progress list, the available list) render exactly as they do today once the row is where it should be.

### Anything Else?

Three deliberate choices worth flagging for review.

**The receiver runs on every save of an open semester**, not only on the one that opens it. That is one `UPDATE` per semester save, and semester saves are rare (a form edit, starting a term, archiving one, which sets ARCHIVED and so skips it). The alternative, tracking the previous status to fire only on the transition, buys nothing here and adds state to the model.

**A student who is already in an open semester and somehow holds unstamped in-progress work would have it adopted** by a later save of that semester. The `CourseStudent` receiver deliberately fires only on `created`, because re-saving a registration is not a join event; for a semester, "is open" is a standing state rather than an event, and that work belongs to the term the student is in, so adopting it is the repair rather than a side effect. It cannot arise in normal operation, since a student registered in an open semester has their work stamped with it.

**Both adoption receivers skip `raw=True` saves**, from CodeRabbit's review. Django sends that while deserializing a fixture and documents that a receiver must not query other records then. The guard went on both rather than only the new one, since they are one behaviour split across the two orders a student and their semester can arrive in. It is not reachable today (`src/` has no `loaddata` call and `initial_data.json` is a single `sites.site` row whose loaders are all commented out), so the tests send the signal directly. The wider gap, that the repo's other signal receivers do not guard `raw` either, including `coursestudent_post_save_callback` which recomputes a profile's cached XP and mark from three tables, is filed as #2548 rather than grown into this PR.

### Review request
@tylerecouture

- Claude Code (`bytedeck - semester workflow redesign`)