### PR TITLE
fix: refuse a clashing share with a message instead of a 500 (#2531, #2534)

### DIFF
--- a/src/library/templates/library/confirm_export_campaign.html
+++ b/src/library/templates/library/confirm_export_campaign.html
@@ -17,6 +17,18 @@
     <div class="alert alert-danger">
       You cannot export a campaign with no published quests.
     </div>
+  {% elif colliding_title %}
+    <div class="alert alert-danger">
+      The Library already has a different campaign called <strong>{{ colliding_title }}</strong>, and two
+      campaigns there cannot share a title. Rename yours and share it again.
+    </div>
+  {% elif colliding_names %}
+    <div class="alert alert-danger">
+      The Library already has {{ colliding_names|length|pluralize:"a different quest,different quests" }} called
+      {% for name in colliding_names %}<strong>{{ name }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %},
+      and two quests there cannot share a name. Rename
+      {{ colliding_names|length|pluralize:"the one,the ones" }} in this campaign and share it again.
+    </div>
   {% else %}
     <p>Please read and agree to the following license before sharing this campaign:</p>
 

--- a/src/library/templates/library/confirm_export_quest.html
+++ b/src/library/templates/library/confirm_export_quest.html
@@ -10,6 +10,12 @@
     <div class="alert alert-danger">
       A quest with the same import ID already exists in the shared library. Exporting again is not allowed.
     </div>
+  {% elif colliding_names %}
+    <div class="alert alert-danger">
+      The Library already has a different quest called <strong>{{ colliding_names.0 }}</strong>, and two
+      quests there cannot share a name. Rename yours and share it again. A name of its own also makes it
+      easier for other decks to tell the two apart when browsing.
+    </div>
   {% else %}
     <p>Please read and agree to the following license before sharing this quest:</p>
 

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -783,7 +783,7 @@ class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):
 class LibraryTransferErrorMessageTests(SimpleTestCase):
     """How a failed copy is described to the caller."""
 
-    def test_describe__renders_a_validation_error_without_a_field(self):
+    def test_describe_validation_error__renders_a_validation_error_without_a_field(self):
         """An error not tied to a field still reads as a sentence.
 
         `full_clean` reports per-field errors, so this covers the other shape a
@@ -791,7 +791,7 @@ class LibraryTransferErrorMessageTests(SimpleTestCase):
         """
         self.assertEqual(describe_validation_error(ValidationError("Something was wrong.")), "Something was wrong.")
 
-    def test_describe__renders_a_field_error_with_its_field_name(self):
+    def test_describe_validation_error__renders_a_field_error_with_its_field_name(self):
         """A per-field error names the field, which is what makes a clash readable."""
         self.assertEqual(
             describe_validation_error(ValidationError({'name': ["Quest with this Name already exists."]})),

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -27,7 +27,7 @@ from taggit.models import Tag
 from library.exporter import export_campaign_and_copy_quests, export_quest_to_library
 from library.importer import import_campaign_to, import_quest_to
 from library.models import IsLibraryContentMixin
-from library.transfer import LibraryTransferError, _describe
+from library.transfer import LibraryTransferError, describe_validation_error
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from library.tests.test_views import LibraryTenantTestCaseMixin
 from library.utils import library_schema_context
@@ -789,12 +789,12 @@ class LibraryTransferErrorMessageTests(SimpleTestCase):
         `full_clean` reports per-field errors, so this covers the other shape a
         `ValidationError` can take, raised with a bare message and no field mapping.
         """
-        self.assertEqual(_describe(ValidationError("Something was wrong.")), "Something was wrong.")
+        self.assertEqual(describe_validation_error(ValidationError("Something was wrong.")), "Something was wrong.")
 
     def test_describe__renders_a_field_error_with_its_field_name(self):
         """A per-field error names the field, which is what makes a clash readable."""
         self.assertEqual(
-            _describe(ValidationError({'name': ["Quest with this Name already exists."]})),
+            describe_validation_error(ValidationError({'name': ["Quest with this Name already exists."]})),
             "name: Quest with this Name already exists.",
         )
 

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2352,9 +2352,9 @@ class LibraryShareRefusalTests(LibraryTenantTestCaseMixin):
 
     A quest name and a campaign title are unique per schema, so content whose name is
     already taken in the Library cannot be written there. The sharer cannot see that from
-    their own deck, and until #2531 nothing told them: the write raised, the exception
-    escaped the view, and they met a server error page after reading and agreeing to the
-    Creative Commons licence.
+    their own deck: the Library is another schema, and their own deck's pages say nothing
+    about what is in it. Refusing with a reason is the only thing standing between them
+    and a failure they cannot interpret, after they have agreed to the licence (#2531).
     """
 
     @classmethod
@@ -2444,11 +2444,33 @@ class LibraryShareRefusalTests(LibraryTenantTestCaseMixin):
             f"expected the raised failure to be reported, got {texts}",
         )
 
+    def test_export_quest__the_refusal_escapes_markup_in_the_clashing_name(self):
+        """A clashing name carrying HTML is escaped in the refusal message.
+
+        The name in this message comes from the *Library*, so it was written on a deck
+        other than the one reading it. That makes it the one part of the message its
+        reader has no control over, and worth pinning: messages are rendered through
+        `_message_body.html`, which escapes a plain string and only lets markup through
+        when it was built with `format_html` (#2498).
+        """
+        local = baker.make(Quest, name="Clean Quest Name", published=True)
+        self._take_the_name_in_the_library("Clean Quest Name")
+        with library_schema_context():
+            Quest.objects.filter(name="Clean Quest Name").update(name="<img src=x onerror=alert(1)>")
+        Quest.objects.filter(pk=local.pk).update(name="<img src=x onerror=alert(1)>")
+
+        response = self.client.post(
+            reverse('library:export_quest', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertNotContains(response, "<img src=x onerror=alert(1)>")
+        self.assertContains(response, "&lt;img src=x onerror=alert(1)&gt;")
+
     def test_export_campaign__post_is_refused_when_the_title_is_taken(self):
         """A campaign whose title the Library already uses is refused, not 500 (#2534).
 
-        The clash is on `Category.title`, which `full_clean` rejects, so before this the
-        push raised a bare ValidationError out of the view.
+        The clash is on `Category.title`, which is unique per schema, so `full_clean`
+        rejects the write and the refusal has to come from the view rather than the page.
         """
         campaign = baker.make(Category, title="Digital Citizenship", published=True)
         quest = baker.make(Quest, name="A Quest Of Its Own", campaign=campaign, published=True)

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2347,6 +2347,172 @@ class LibraryImportPrereqBehaviourTests(LibraryTenantTestCaseMixin):
         )
 
 
+class LibraryShareRefusalTests(LibraryTenantTestCaseMixin):
+    """A share the Library would reject is refused with a reason, not a 500.
+
+    A quest name and a campaign title are unique per schema, so content whose name is
+    already taken in the Library cannot be written there. The sharer cannot see that from
+    their own deck, and until #2531 nothing told them: the write raised, the exception
+    escaped the view, and they met a server error page after reading and agreeing to the
+    Creative Commons licence.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create a staff user to share content from this deck."""
+        cls.test_teacher = User.objects.create_user('share_refusal_teacher', is_staff=True)
+
+    def setUp(self):
+        """Let any staff user share, and sign the teacher in."""
+        super().setUp()
+        config = SiteConfig.get()
+        config.allow_staff_export = True
+        config.save()
+        self.client.force_login(self.test_teacher)
+
+    def _take_the_name_in_the_library(self, name):
+        """Put an unrelated quest into the Library under `name`.
+
+        A different quest, not the one being shared: same name, its own import_id, which
+        is what makes it a clash rather than the same content arriving again.
+
+        Args:
+            name (str): the quest name to occupy.
+        """
+        with library_schema_context():
+            baker.make(Quest, name=name, published=True)
+
+    def test_export_quest__get_warns_that_the_name_is_taken(self):
+        """The share confirmation page names the clash before the licence is agreed to.
+
+        Refusing at this point costs the teacher a rename; refusing after the POST costs
+        them the same rename plus a server error page they cannot interpret (#2531).
+        """
+        local = baker.make(Quest, name="Photoshop Basics", published=True)
+        self._take_the_name_in_the_library("Photoshop Basics")
+
+        response = self.client.get(reverse('library:export_quest', args=[local.import_id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "already has a different quest called")
+        # No licence form on a page that cannot go through.
+        self.assertNotContains(response, 'id="export-form"')
+
+    def test_export_quest__post_is_refused_with_a_message(self):
+        """Submitting a share whose name is taken redirects with the reason (#2531).
+
+        Nothing reaches the Library, and the message names the quest so the teacher knows
+        which one to rename.
+        """
+        local = baker.make(Quest, name="Photoshop Basics", published=True)
+        self._take_the_name_in_the_library("Photoshop Basics")
+
+        response = self.client.post(
+            reverse('library:export_quest', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("Photoshop Basics" in text and "could not be completed" in text for text in texts),
+            f"expected a refusal naming the quest, got {texts}",
+        )
+        with library_schema_context():
+            self.assertFalse(Quest.objects.filter(import_id=local.import_id).exists())
+
+    def test_export_quest__a_clash_arriving_mid_push_is_still_refused(self):
+        """A failure the pre-check could not have seen is refused, not raised (#2531).
+
+        The guard runs before the write, so between the two another deck can take the name.
+        Patching the push to raise is how that race is reached deterministically: the point
+        is that the exception is turned into a message rather than escaping as a 500.
+        """
+        local = baker.make(Quest, name="Racing The Library", published=True)
+
+        with patch(
+            'library.views.export_quest_to_library',
+            side_effect=LibraryTransferError("'Racing The Library' could not be copied: name: already exists."),
+        ):
+            response = self.client.post(
+                reverse('library:export_quest', args=[local.import_id]), {'agree_license': 'on'}, follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("Racing The Library" in text and "could not be completed" in text for text in texts),
+            f"expected the raised failure to be reported, got {texts}",
+        )
+
+    def test_export_campaign__post_is_refused_when_the_title_is_taken(self):
+        """A campaign whose title the Library already uses is refused, not 500 (#2534).
+
+        The clash is on `Category.title`, which `full_clean` rejects, so before this the
+        push raised a bare ValidationError out of the view.
+        """
+        campaign = baker.make(Category, title="Digital Citizenship", published=True)
+        quest = baker.make(Quest, name="A Quest Of Its Own", campaign=campaign, published=True)
+        with library_schema_context():
+            baker.make(Category, title="Digital Citizenship", published=True)
+
+        response = self.client.post(
+            reverse('library:export_category', args=[campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("Digital Citizenship" in text and "could not be completed" in text for text in texts),
+            f"expected a refusal naming the campaign, got {texts}",
+        )
+        with library_schema_context():
+            self.assertFalse(Category.objects.filter(import_id=campaign.import_id).exists())
+            self.assertFalse(Quest.objects.filter(import_id=quest.import_id).exists())
+
+    def test_export_campaign__post_is_refused_when_a_quest_name_is_taken(self):
+        """A campaign carrying a quest whose name is taken is refused as a whole (#2534).
+
+        The push is atomic, so a clash on one quest stops the campaign: better to say which
+        name is in the way than to leave half of it in the Library.
+        """
+        campaign = baker.make(Category, title="Soldering Skills", published=True)
+        baker.make(Quest, name="Tin Your Iron", campaign=campaign, published=True)
+        self._take_the_name_in_the_library("Tin Your Iron")
+
+        response = self.client.post(
+            reverse('library:export_category', args=[campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("Tin Your Iron" in text for text in texts),
+            f"expected a refusal naming the quest, got {texts}",
+        )
+        with library_schema_context():
+            self.assertFalse(Category.objects.filter(import_id=campaign.import_id).exists())
+
+    def test_export_campaign__post_with_no_published_quests_is_refused(self):
+        """POSTing a share for a campaign with nothing publishable is refused (#2534).
+
+        The button for this is disabled in the UI, but the URL is not, so a stale tab or a
+        resubmit reached the exporter and raised. Nothing about a disabled button stops a
+        POST.
+        """
+        campaign = baker.make(Category, title="Empty Campaign", published=True)
+
+        response = self.client.post(
+            reverse('library:export_category', args=[campaign.import_id]), {'agree_license': 'on'}, follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        texts = self._message_texts(response)
+        self.assertTrue(
+            any("could not be completed" in text for text in texts),
+            f"expected a refusal rather than a server error, got {texts}",
+        )
+
+
 class LibrarySharerWarningTests(LibraryTenantTestCaseMixin):
     """What the Library tells the sharer it could not carry.
 

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -494,7 +494,7 @@ def _write_questions(quest, questions):
                 question.save()
         except ValidationError as error:
             raise LibraryTransferError(
-                f"'{quest.name}' could not be copied: question {fields['ordinal']}: {_describe(error)}"
+                f"'{quest.name}' could not be copied: question {fields['ordinal']}: {describe_validation_error(error)}"
             ) from error
         except IntegrityError as error:
             raise LibraryTransferError(
@@ -593,7 +593,7 @@ def _write_quest_row(snapshot, *, published, with_campaign, field_overrides=None
             quest.full_clean(exclude=['campaign'])
             quest.save()
     except ValidationError as error:
-        raise LibraryTransferError(f"'{fields['name']}' could not be copied: {_describe(error)}") from error
+        raise LibraryTransferError(f"'{fields['name']}' could not be copied: {describe_validation_error(error)}") from error
     except IntegrityError as error:
         raise LibraryTransferError(f"'{fields['name']}' could not be copied: {error}") from error
 
@@ -603,7 +603,7 @@ def _write_quest_row(snapshot, *, published, with_campaign, field_overrides=None
     return quest
 
 
-def _describe(error):
+def describe_validation_error(error):
     """Render a ValidationError as one readable sentence.
 
     Args:

--- a/src/library/utils.py
+++ b/src/library/utils.py
@@ -156,31 +156,40 @@ def load_library_quest_prereqs_for_render(quests):
     return quests
 
 
-def get_colliding_quest_names(library_quests):
-    """The names among `library_quests` that a different quest on this deck already uses.
+def get_colliding_quest_names(arriving_quests):
+    """The names among `arriving_quests` that a different quest in *this* schema already uses.
 
-    A name clash is what the importing teacher cannot see for themselves: the Library page
-    shows what is on offer, not what is already on their own deck, so without this the
-    first they hear of it is after clicking Import. The import handles the clash by
-    renaming the arriving copy, and naming the clash up front is what makes that a choice
-    rather than a surprise (#2364, #2397).
+    A name clash is the thing neither side can see for itself: each page shows what is on
+    offer, not what is already on the other deck, so without this the first anyone hears of
+    it is after they have committed. Naming the clash up front is what makes it a choice
+    rather than a surprise (#2364, #2397, #2531).
 
-    Matching is on name and *not* import_id: a quest this deck already holds under the same
-    import_id is the same quest arriving again, which is an overwrite rather than a clash.
+    The two directions then do different things with the answer, because a quest name is
+    unique per schema and only one of them can rename its way out:
 
-    Must be called from within the destination (local) schema context.
+    * importing renames the arriving copy and says so, so the clash is a note;
+    * sharing cannot rename the sharer's own quest on their behalf, so the clash is a
+      refusal, and this is what lets it be refused before the licence is agreed to rather
+      than by an exception afterwards (#2531).
+
+    Matching is on name and *not* import_id: a quest the destination already holds under
+    the same import_id is the same quest arriving again, which is an overwrite or a
+    refusal-to-reshare rather than a clash.
+
+    Must be called from within the destination schema context, whichever direction that is:
+    the local deck when importing, the Library when sharing.
 
     Args:
-        library_quests (Iterable[Quest]): the quests being offered for import, read from
-            the Library schema.
+        arriving_quests (Iterable[Quest]): the quests about to be written, read from the
+            source schema.
 
     Returns:
-        list[str]: the clashing names, sorted, empty when nothing on this deck collides.
+        list[str]: the clashing names, sorted, empty when nothing in this schema collides.
     """
     from quest_manager.models import Quest
 
-    wanted_names = [quest.name for quest in library_quests]
-    arriving_ids = [quest.import_id for quest in library_quests]
+    wanted_names = [quest.name for quest in arriving_quests]
+    arriving_ids = [quest.import_id for quest in arriving_quests]
 
     return sorted(
         Quest.objects.all_including_archived()

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -1106,9 +1106,10 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
                     record_push_origin(ContentOrigin.QUEST, [quest.import_id], request, source_deck_url)
         except (LibraryTransferError, ValidationError) as error:
             # The guard above catches the clash this is usually raised for, so reaching here
-            # means something the confirmation page could not have known: a name taken
-            # between the two requests, or a field the Library rejects. Refusing with the
-            # reason beats the 500 the sharer used to get after agreeing to the licence.
+            # means something neither the confirmation page nor that guard could know: a
+            # name taken between the two requests, or a field the Library rejects. The
+            # sharer has already agreed to the licence by this point, so the failure is
+            # worth a reason they can act on.
             return redirect_failed_export(request, _describe_transfer_failure(error), 'quests:quests')
 
         # Success message displayed on local deck

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -1,7 +1,7 @@
 import functools
 
 from django.contrib import messages
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
 from django.db import connection, transaction
 from django.db.models import Q
@@ -32,7 +32,7 @@ from .exporter import export_quest_to_library, export_campaign_and_copy_quests
 from .forms import ShareLicenceForm
 from .importer import import_campaign_to, import_quest_to
 from .models import ContentOrigin
-from .transfer import LibraryTransferError
+from .transfer import LibraryTransferError, describe_validation_error
 from .utils import (
     get_colliding_quest_names,
     get_library_conflicting_quests,
@@ -214,6 +214,58 @@ def redirect_already_imported(request, local_object, content_type, redirect_to):
             "copy first if you want the Library's version instead.",
             content_type, local_object.get_absolute_url(), local_object.name, content_type,
         )
+    )
+    return redirect(redirect_to)
+
+
+def _describe_transfer_failure(error):
+    """One readable sentence for either kind of failure a push can raise.
+
+    Two exception types reach the same place. `LibraryTransferError` already reads as a
+    sentence naming the content and the clash. A `ValidationError` does not: it carries a
+    dict or list that renders with Django's punctuation, so it goes through the same
+    formatting the transfer layer uses for the errors it wraps.
+
+    Args:
+        error (LibraryTransferError | ValidationError): the failure.
+
+    Returns:
+        str: the reason, ending in a full stop so it reads inside the surrounding message.
+    """
+    described = describe_validation_error(error) if isinstance(error, ValidationError) else str(error)
+
+    return described if described.endswith('.') else f"{described}."
+
+
+def redirect_failed_export(request, error, redirect_to):
+    """Send the sharer back, explaining why their content did not reach the Library.
+
+    A push can fail on something the sharer cannot see from their own deck, because the
+    Library is another schema: a quest name or a campaign title that something else there
+    already uses. Nothing was written when this runs, since the push is atomic.
+
+    The mirror of `redirect_failed_import`, and it exists for the same reason: without it
+    the failure escapes the view as an exception and the sharer meets a 500 page, after
+    they have read and agreed to the licence, with nothing naming the cause (#2531, #2534).
+
+    Renaming is the sharer's move to make rather than ours. The import direction resolves a
+    clash by renaming the arriving copy, but that copy is a stranger to the receiving deck;
+    here the clashing name is the sharer's own, on their own quest, and silently publishing
+    it to every other deck under a name they did not choose is not a favour. Two quests
+    called the same thing is also exactly what makes a Library hard to browse.
+
+    Args:
+        request (HttpRequest): the current request, for the message framework.
+        error (Exception): the failure, whose message names the content and the clash.
+        redirect_to (str): the URL name to redirect to.
+
+    Returns:
+        HttpResponseRedirect: a redirect carrying the error message.
+    """
+    messages.error(
+        request,
+        f"That share could not be completed, so nothing was added to the Library. {error} "
+        "Renaming your copy and sharing again should clear it."
     )
     return redirect(redirect_to)
 
@@ -954,10 +1006,12 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
 
         with library_schema_context():
             library_quest = Quest.objects.all_including_archived().filter(import_id=quest.import_id).first()
+            colliding_names = get_colliding_quest_names([quest])
 
         return render(request, self.template_name, {
             'quest': quest,
             'library_quest': library_quest,
+            'colliding_names': colliding_names,
             'licence_form': ShareLicenceForm(),
         })
 
@@ -1005,40 +1059,57 @@ class ExportQuestView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
 
         with library_schema_context():
             already_shared = Quest.objects.all_including_archived().filter(import_id=quest.import_id).exists()
+            colliding_names = get_colliding_quest_names([quest])
 
         if already_shared:
             return redirect_already_shared(request, quest, 'quest', 'quests:quests')
 
+        if colliding_names:
+            # Checked here as well as on the confirmation page, because that page can be
+            # minutes old: another deck may have shared the name in between (#2531).
+            return redirect_failed_export(
+                request,
+                f"The Library already has a different quest called '{colliding_names[0]}'.",
+                'quests:quests',
+            )
+
         # One transaction over the push, the notification it raises and the origin row it
         # records: a reviewer told to come and look at content, or an attribution pointing
         # at content, must not outlive a failure that rolled the content back (#2372).
-        with transaction.atomic():
-            shared = export_quest_to_library(source_schema=source_schema, quest_import_id=quest.import_id)
+        try:
+            with transaction.atomic():
+                shared = export_quest_to_library(source_schema=source_schema, quest_import_id=quest.import_id)
 
-            with library_schema_context():
-                # Get the newly exported quest
-                exported_quest = Quest.objects.get(import_id=quest.import_id)
+                with library_schema_context():
+                    # Get the newly exported quest
+                    exported_quest = Quest.objects.get(import_id=quest.import_id)
 
-                config = SiteConfig.get()
-                sender = config.deck_ai
+                    config = SiteConfig.get()
+                    sender = config.deck_ai
 
-                recipients = User.objects.filter(is_active=True, is_staff=True)
+                    recipients = User.objects.filter(is_active=True, is_staff=True)
 
-                # Notification sent to all active Library staff about the export
-                notify.send(
-                    sender=sender,
-                    recipient=None,
-                    affected_users=list(recipients),
-                    verb=f"{request.user} exported a quest to the library from {source_schema}:",
-                    action=quest,
-                    target=exported_quest,
-                    icon="<i class='fa fa-book'></i>"
-                )
+                    # Notification sent to all active Library staff about the export
+                    notify.send(
+                        sender=sender,
+                        recipient=None,
+                        affected_users=list(recipients),
+                        verb=f"{request.user} exported a quest to the library from {source_schema}:",
+                        action=quest,
+                        target=exported_quest,
+                        icon="<i class='fa fa-book'></i>"
+                    )
 
-                # Email active Library staff so they know there's a quest to review/publish (#1949).
-                email_library_staff_of_push("quest", quest.name, exported_quest, request.user, source_deck_url)
+                    # Email active Library staff so they know there's a quest to review/publish (#1949).
+                    email_library_staff_of_push("quest", quest.name, exported_quest, request.user, source_deck_url)
 
-                record_push_origin(ContentOrigin.QUEST, [quest.import_id], request, source_deck_url)
+                    record_push_origin(ContentOrigin.QUEST, [quest.import_id], request, source_deck_url)
+        except (LibraryTransferError, ValidationError) as error:
+            # The guard above catches the clash this is usually raised for, so reaching here
+            # means something the confirmation page could not have known: a name taken
+            # between the two requests, or a field the Library rejects. Refusing with the
+            # reason beats the 500 the sharer used to get after agreeing to the licence.
+            return redirect_failed_export(request, _describe_transfer_failure(error), 'quests:quests')
 
         # Success message displayed on local deck
         messages.success(
@@ -1085,6 +1156,16 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         # Get existing campaign in library (if any)
         with library_schema_context():
             existing_campaign = Category.objects.filter(import_id=campaign.import_id).first()
+            # Clashes the Library would reject the push for, which the sharer cannot see
+            # from their own deck. A title match on a *different* campaign is a clash;
+            # the same campaign arriving again is `existing_campaign` above (#2534).
+            colliding_title = (
+                Category.objects.filter(title=campaign.title)
+                .exclude(import_id=campaign.import_id)
+                .values_list('title', flat=True)
+                .first()
+            )
+            colliding_names = get_colliding_quest_names(quests)
 
         library_quest_import_ids = get_library_conflicting_quests(quests)
 
@@ -1099,6 +1180,8 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
             'category_published': campaign.published,
             'category_displayed_quests': quests,
             'library_quest_import_ids': library_quest_import_ids,
+            'colliding_title': colliding_title,
+            'colliding_names': colliding_names,
             'licence_form': licence_form,
         }
         return render(request, self.template_name, context)
@@ -1158,40 +1241,77 @@ class ExportCampaignView(NonPublicOnlyViewMixin, ExportPermissionMixin, View):
         if already_shared:
             return redirect_already_shared(request, campaign, 'campaign', 'quests:categories')
 
-        # One transaction over the push, the notification it raises and the origin rows it
-        # records, for the same reason as the quest push above (#2372).
-        with transaction.atomic():
-            shared = export_campaign_and_copy_quests(source_schema=source_schema, campaign_import_id=campaign.import_id)
+        # Read this deck's quests before switching schemas: evaluated inside the Library
+        # context the queryset would list the Library's quests for that campaign instead,
+        # and report no clash at all (the lazy-evaluation trap of #2369 and #2529).
+        quests = list(campaign.current_quests())
 
-            with library_schema_context():
-                exported_campaign = Category.objects.get(import_id=campaign.import_id)
+        with library_schema_context():
+            colliding_title = (
+                Category.objects.filter(title=campaign.title)
+                .exclude(import_id=campaign.import_id)
+                .values_list('title', flat=True)
+                .first()
+            )
+            colliding_names = get_colliding_quest_names(quests)
 
-                config = SiteConfig.get()
-                sender = config.deck_ai
-                recipients = User.objects.filter(is_active=True, is_staff=True)
+        # Re-checked here as well as on the confirmation page, which can be minutes old
+        # by the time it is submitted (#2534).
+        if colliding_title:
+            return redirect_failed_export(
+                request,
+                f"The Library already has a different campaign called '{colliding_title}'.",
+                'quests:categories',
+            )
 
-                notify.send(
-                    sender=sender,
-                    recipient=None,
-                    affected_users=list(recipients),
-                    verb=f"{request.user} exported a campaign to the library from {source_schema}:",
-                    action=campaign,
-                    target=exported_campaign,
-                    icon="<i class='fa fa-book'></i>",
-                )
+        if colliding_names:
+            return redirect_failed_export(
+                request,
+                f"The Library already has a different quest called '{colliding_names[0]}', "
+                "which is in this campaign.",
+                'quests:categories',
+            )
 
-                # Email active Library staff so they know there's a campaign to review/publish (#1949).
-                email_library_staff_of_push("campaign", campaign.name, exported_campaign, request.user, source_deck_url)
+        try:
+            # One transaction over the push, the notification it raises and the origin rows it
+            # records, for the same reason as the quest push above (#2372).
+            with transaction.atomic():
+                shared = export_campaign_and_copy_quests(source_schema=source_schema, campaign_import_id=campaign.import_id)
 
-                record_push_origin(ContentOrigin.CAMPAIGN, [campaign.import_id], request, source_deck_url)
-                # ...and each quest that travelled with it, so a quest imported on its own still
-                # says where it came from
-                record_push_origin(
-                    ContentOrigin.QUEST,
-                    exported_campaign.quest_set.values_list('import_id', flat=True),
-                    request,
-                    source_deck_url,
-                )
+                with library_schema_context():
+                    exported_campaign = Category.objects.get(import_id=campaign.import_id)
+
+                    config = SiteConfig.get()
+                    sender = config.deck_ai
+                    recipients = User.objects.filter(is_active=True, is_staff=True)
+
+                    notify.send(
+                        sender=sender,
+                        recipient=None,
+                        affected_users=list(recipients),
+                        verb=f"{request.user} exported a campaign to the library from {source_schema}:",
+                        action=campaign,
+                        target=exported_campaign,
+                        icon="<i class='fa fa-book'></i>",
+                    )
+
+                    # Email active Library staff so they know there's a campaign to review/publish (#1949).
+                    email_library_staff_of_push("campaign", campaign.name, exported_campaign, request.user, source_deck_url)
+
+                    record_push_origin(ContentOrigin.CAMPAIGN, [campaign.import_id], request, source_deck_url)
+                    # ...and each quest that travelled with it, so a quest imported on its own still
+                    # says where it came from
+                    record_push_origin(
+                        ContentOrigin.QUEST,
+                        exported_campaign.quest_set.values_list('import_id', flat=True),
+                        request,
+                        source_deck_url,
+                    )
+        except (LibraryTransferError, ValidationError) as error:
+            # Reached when the Library rejects something the confirmation page could not
+            # foresee: a name taken between the two requests, or a campaign left with no
+            # publishable quest. Either way nothing landed, and saying so beats a 500.
+            return redirect_failed_export(request, _describe_transfer_failure(error), 'quests:categories')
 
         messages.success(
             request,


### PR DESCRIPTION
### What?

Sharing content whose name the Library already holds now refuses with an explanation, on the confirmation page and again on submit, instead of raising out of the view as a server error.

Closes #2531
Closes #2534

### Why?

A quest name and a campaign title are unique per schema, so content the Library already has under that name cannot be written there. The sharer cannot see that from their own deck, and nothing told them: the write raised, the exception escaped the view, and they met a server error page **after** reading and agreeing to the Creative Commons licence.

Three failures did this:

| Failure | Raised | Issue |
|---|---|---|
| Quest name already taken | `LibraryTransferError` from `_write_quest_row` | #2531 |
| Campaign title already taken | `ValidationError` from `library_campaign.full_clean()` | #2534 |
| POST for a campaign with no publishable quest | `ValidationError` from `export_campaign_to_library` | #2534 |

The third is reachable even though its button is disabled, because a disabled button does not stop a POST from a stale tab or a resubmit.

### How?

**Check on the confirmation page**, so the clash is named before the teacher agrees to anything, and **again in the POST**, since that page can be minutes old by the time it is submitted. Behind both, **catch the two exception types** so a clash that lands between the check and the write is still a message rather than a 500.

`get_colliding_quest_names` already ran the right query for either direction (it asks the *active* schema for the names, excluding the arriving import_ids), so it is documented and named for both rather than duplicated. `transfer._describe` becomes `describe_validation_error` now that the views format the same errors.

**Renaming is deliberately left to the sharer.** The import direction resolves a clash by renaming the arriving copy, and `build_library_clone_name` exists, so renaming on the way out was the obvious alternative. It is the wrong call here: on import the copy is a stranger to the receiving deck, but on share the clashing name is the sharer's own, on their own quest, and publishing it to every other deck under a name they did not choose is not a favour. Two quests called the same thing is also exactly what makes a Library hard to browse.

### Testing?

Seven new tests in `LibraryShareRefusalTests`, covering the confirmation page, both quest and campaign submits, the empty-campaign POST, the mid-push race (patched to raise, since that path is a race by definition), and escaping.

Verified in both directions: reverting the five changed source files to `develop` fails them, `FAILED (failures=1, errors=4)` before the race and escaping tests were added, the four errors being the uncaught exceptions this fixes.

Full suite: `Ran 2670 tests ... OK`. `ruff check src`: clean. `src/library/` is at 100% coverage, 0 misses and 0 partial branches.

**Coverage caught a real bug in this PR's own first draft.** The campaign guard evaluated `campaign.current_quests()` *inside* `library_schema_context()`, so the queryset listed the Library's quests for that campaign rather than this deck's, and reported no clash at all. The tests still passed, because the exception backstop caught the failure a few lines later and produced a message with the right name in it. What exposed it was an uncovered line: the guard's `return` was never reached. This is the same lazy-evaluation trap as #2369 and #2529, which is worth noting given how recently that ground was covered.

### Screenshots (if front end is affected)

Captured on a running dev deck (`hackerspace.localhost:8000`, signed in as the deck owner). The deck holds a quest called *Photoshop Basics* and a campaign called *Design Basics*; the Library holds a different quest and campaign of the same names.

**Before**, submitting the share (this is a `DEBUG=True` dev page; in production it is a plain 500):

![before: LibraryTransferError at /library/export-quest/...](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2531/before-quest-result.png)

**After**, the confirmation page says so before the licence is agreed to:

![after: the share page names the clash](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2531/after-quest-confirm.png)

**After**, submitting anyway (a stale tab, or a name taken since the page loaded):

![after: a message explaining the refusal](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2531/after-quest-result.png)

**After**, the campaign equivalent:

![after: the campaign share page names the title clash](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2531/after-campaign-confirm.png)

### Anything Else?

Both issues are closed together because they are one behaviour with three triggers, and splitting them would have added the same helper and the same `try` to the same two views twice.

One thing this does not do: a campaign whose title clashes is refused as a whole, rather than offering to share it under a different title. That is a larger question about whether the Library should let two decks publish same-named content at all, which is really #2376's territory.

**From review.** CodeRabbit flagged the failure message as an escaping risk, on the basis that messages render through `|safe`. They do not: `_message_body.html` renders `{{ message.message }}` by default, which escapes, and only lets markup through for a message built with `format_html` or one that opts in with `extra_tags='safe'` (that arrangement being the fix for #2498). So the plain string this helper builds is already escaped, and the suggested change was declined. The accompanying request for a test was right, and the input it named is the interesting one: the clashing name comes from the *Library*, so it was written on another deck and is the one part of the message its reader does not control. `test_export_quest__the_refusal_escapes_markup_in_the_clashing_name` now pins it. Two nitpicks were also taken: the formatter tests are renamed after the method, and three comments that described the replaced behaviour are rewritten in the present tense.

### Review request
@tylerecouture

- Claude Code (`bytedeck - library import/export`)