### PR TITLE
test: close the ajax_save_draft file-leg coverage gaps and drop its dead except (#2575)

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -15,7 +15,6 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import transaction
 from django.db.models import F, ExpressionWrapper, fields, BooleanField, Count, Exists, OuterRef, Q, Sum
@@ -2336,27 +2335,24 @@ def ajax_save_draft(request):
                     request.POST, request.FILES,
                     instance=sub, queryset=sync_draft_question_submissions(sub),
                 )
-                # a POST built by hand can omit the management form, which raises when the
-                # formset validates; text (above) still saves, the files leg just skips.
-                try:
-                    question_formset.is_valid()
-                except ValidationError:
-                    question_formset = None
-
-                if question_formset is not None:
-                    save_draft_file_answers(question_formset, request.FILES)
-                    for answer_form in question_formset.forms:
-                        field_name = answer_form.add_prefix("response_file")
-                        if field_name not in request.FILES:
-                            continue
-                        # errors first: a row that already holds a file from an earlier save
-                        # keeps it when a replacement is rejected, and reporting that stored
-                        # file as "saved" would present the rejection as a success
-                        if answer_form.errors.get("response_file"):
-                            file_errors[field_name] = " ".join(answer_form.errors["response_file"])
-                        elif answer_form.instance.pk and answer_form.instance.response_file:
-                            # the bare file name: the stored value is a whole media path
-                            saved_answer_files[field_name] = posixpath.basename(str(answer_form.instance.response_file))
+                # Validate so the per-form errors below are populated. A hand-built POST
+                # that omits the management form does not raise here: Django records a
+                # non-form error and the formset has no forms, so the loop below does
+                # nothing and the text answers (above) still save.
+                question_formset.is_valid()
+                save_draft_file_answers(question_formset, request.FILES)
+                for answer_form in question_formset.forms:
+                    field_name = answer_form.add_prefix("response_file")
+                    if field_name not in request.FILES:
+                        continue
+                    # errors first: a row that already holds a file from an earlier save
+                    # keeps it when a replacement is rejected, and reporting that stored
+                    # file as "saved" would present the rejection as a success
+                    if answer_form.errors.get("response_file"):
+                        file_errors[field_name] = " ".join(answer_form.errors["response_file"])
+                    elif answer_form.instance.pk and answer_form.instance.response_file:
+                        # the bare file name: the stored value is a whole media path
+                        saved_answer_files[field_name] = posixpath.basename(str(answer_form.instance.response_file))
 
             if request.FILES.getlist("attachments"):
                 # the same form the submit builds, so the same size and count rules apply

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -561,6 +561,52 @@ class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
         self.assertFalse(short_row.response_file)
         self.assertEqual(payload["saved_answer_files"], {})
 
+    def test_save_draft__stores_comment_attachments_on_a_quest_without_questions(self):
+        """A comment attachment draft-saves on a quest that asks no questions at all.
+
+        The files leg only builds the answer formset when the quest has questions, so
+        this pins the other side of that branch: with none, the attachment path still
+        runs and stores the file on the draft comment.
+        """
+        plain_quest = baker.make(Quest, name="Plain Quest", verification_required=True)
+        submission = baker.make(QuestSubmission, quest=plain_quest, user=self.test_student)
+        self.client.get(reverse("quests:submission", args=[submission.id]))
+        submission.refresh_from_db()
+
+        response = self.client.post(
+            reverse("quests:ajax_save_draft"),
+            data={
+                "comment": "<p>no questions here</p>",
+                "submission_id": submission.id,
+                "attachments": SimpleUploadedFile("notes.pdf", b"file_content", content_type="application/pdf"),
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        payload = json.loads(response.content)
+        self.assertEqual(payload["result"], "Draft saved")
+        self.assertEqual(payload["saved_attachments"], ["notes.pdf"])
+        documents = list(submission.draft_comment.document_set.all())
+        self.assertEqual(len(documents), 1)
+        self.assertIn("notes", documents[0].docfile.name)
+
+    def test_save_draft__reports_a_rejected_comment_attachment(self):
+        """An attachment the form refuses is not stored, and the response carries the
+        field's own error so the page can say why.
+
+        The attachments field caps each file at 16 MiB, so a file one byte over makes
+        the form error; nothing may be stored and nothing reported saved.
+        """
+        oversized = SimpleUploadedFile(
+            "huge.pdf", b"x" * (16777216 + 1), content_type="application/pdf")
+
+        response = self.save_draft({"attachments": oversized})
+
+        payload = json.loads(response.content)
+        self.assertIn("Max filesize", payload["file_errors"]["attachments"])
+        self.assertEqual(payload["saved_attachments"], [])
+        self.assertEqual(self.submission.draft_comment.document_set.count(), 0)
+
     def test_save_draft__file_without_management_form_saves_text_only(self):
         """A hand-built POST that sends a file without the formset's management form does
         not error: the text answers and comment still save, the files leg reports nothing."""


### PR DESCRIPTION
### What?
Closes #2575: the three test/coverage items in `ajax_save_draft`'s file leg.

* The dead `except ValidationError` around the answer formset's `is_valid()` is removed and its comment corrected: on Django 5.2 a missing or tampered management form does not raise, it is recorded as a non-form error and the formset simply has no forms (the existing `test_save_draft__file_without_management_form_saves_text_only` pins that behaviour).
* The two untested sides of the leg are now covered.

### Why?
Per the coverage convention the goal is 100% of the code we intend to test, and this branch was unreachable while its comment described behaviour Django no longer has. The two missing tests each protected a real failure mode: a regression assuming the formset exists would 500 only on question-less quests, and a rejected attachment's error path was never exercised.

### How?
* `src/quest_manager/views.py`: `question_formset.is_valid()` is called directly with a present-tense comment saying what a tampered management form actually does; the now-unused `ValidationError` import is dropped.
* `src/questions/tests/test_integration.py` (`DraftFileSaveTest`):
  * `test_save_draft__stores_comment_attachments_on_a_quest_without_questions`: files posted on a quest that asks no questions; the attachment still stores on the draft comment and is reported saved.
  * `test_save_draft__reports_a_rejected_comment_attachment`: an attachment one byte over the field's 16 MiB cap is refused; `file_errors["attachments"]` carries the "Max filesize..." message, `saved_attachments` is empty, and no Document row is created.

### Testing?
* `DraftFileSaveTest`: 8/8 pass; under `coverage run` the questions suite now covers the whole file leg (the previously missed except body, the question-less branch, and the attachments-error line).
* Full suite (`python src/manage.py test src`), `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` all pass locally.
* Behaviour-preserving apart from deleting the unreachable branch.

### Screenshots (if front end is affected)
N/A: test/coverage change only, no user-facing difference.

### Anything Else?
N/A

### Review request
@tylerecouture

- Claude Code (`bytedeck - github issues workflow`)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mwASxVDwGKGPHnSAC2dZy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft saving for file attachments when a quest has no questions.
  * Ensured text answers continue saving even when file-answer form data is incomplete.
  * Correctly rejects oversized comment attachments without storing them, while displaying a validation error.

* **Tests**
  * Added coverage for successful and rejected draft comment attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->