### PR TITLE
fix: return the course scale in the empty progress-chart response (#403)

### DIFF
--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -2280,7 +2280,14 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
             reverse('courses:ajax_progress_chart', args=[self.student.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {'days_in_semester': 0, 'xp_data': []})
+        # no points to plot, but the chart is still told the charted course's scale so its axis
+        # and mark lines set up correctly (issue #403): the response shape is the same either way
+        self.assertEqual(json.loads(response.content), {
+            'days_in_semester': 0,
+            'xp_data': [],
+            'xp_for_100_percent': self.course.xp_for_100_percent,
+            'uses_marks': self.course.uses_marks,
+        })
 
     def test_ajax_xp_data__empty_with_no_open_semester(self):
         """Between semesters there is no semester to chart progress through, so the chart gets
@@ -2292,7 +2299,13 @@ class TestAjax_ProgressChart(ByteDeckTenantTestCase):
             reverse('courses:ajax_progress_chart', args=[self.student.pk]), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {'days_in_semester': 0, 'xp_data': []})
+        # with no open semester there is no course to chart, so the scale falls back to no marks
+        self.assertEqual(json.loads(response.content), {
+            'days_in_semester': 0,
+            'xp_data': [],
+            'xp_for_100_percent': 0,
+            'uses_marks': False,
+        })
 
     @freeze_time('2024-02-01')
     def test_ajax_progress_chart__charts_the_students_own_semester(self):

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -1184,12 +1184,23 @@ def ajax_progress_chart(request, user_id=0):
         # (issue #1781).
         sem = semester_for(user)
 
+        # The course being charted (from the request, defaulting to the student's first), worked
+        # out up front so the chart is told its scale even when there is nothing to plot yet: the
+        # mark lines and percent axis come from the course, not the data (issue #403, #2453).
+        registrations, charted = _registrations_to_chart(user, request.POST.get('course'))
+        charted_course = registrations[charted].course if charted is not None else None
+
         if sem is None or sem.days_so_far() <= 0:
             # Nothing to plot: either the student is in no open semester, or theirs has no
-            # class days behind it yet (a semester with no dates set has none at all). Hand
-            # the chart an empty dataset rather than building one from an empty date list,
-            # which the weekend adjustment below would then index into.
-            return HttpResponse(json.dumps({"days_in_semester": 0, "xp_data": []}), content_type='application/json')
+            # class days behind it yet (a semester with no dates set has none at all). Hand the
+            # chart an empty dataset, but still the charted course's scale, so the axis and mark
+            # lines set up correctly and the response has the same shape as when there is data.
+            return HttpResponse(json.dumps({
+                "days_in_semester": 0,
+                "xp_data": [],
+                "xp_for_100_percent": charted_course.xp_for_100_percent if charted_course else 0,
+                "uses_marks": charted_course.uses_marks if charted_course else False,
+            }), content_type='application/json')
 
         # the date of every class day so far, weekends and non-class days skipped, off a
         # single read of the semester's excluded days (issue #2459)
@@ -1206,10 +1217,7 @@ def ajax_progress_chart(request, user_id=0):
         off_day = today.weekday() in [5, 6] or today.date() in sem.excluded_days()
 
         # A course's own line, not an even share of the student's whole total: since #2440 the
-        # two are different numbers for a student who assigned their work (issue #2453). The
-        # course to chart comes from the request, defaulting to the first of their courses.
-        registrations, charted = _registrations_to_chart(user, request.POST.get('course'))
-
+        # two are different numbers for a student who assigned their work (issue #2453).
         if charted is None:  # pragma: no cover
             # Defensive race guard, not reachable by a plain request: semester_for() just
             # found an open-semester registration for this user, and _registrations_to_chart
@@ -1239,7 +1247,6 @@ def ajax_progress_chart(request, user_id=0):
         if difference > 0:
             xp_data[-1]['y'] += difference
 
-        charted_course = registrations[charted].course if charted is not None else None
         progress_chart = {
             "days_in_semester": sem.num_days(),
             "xp_data": xp_data,


### PR DESCRIPTION
### What?
Makes `courses.views.ajax_progress_chart` return the charted course's scale (`uses_marks` and `xp_for_100_percent`) in its **empty** response, so the chart JSON has one consistent shape whether or not there is data to plot.

### Why?
`develop` currently fails `courses.tests.test_views.MarkCalculationsViewTests.test_ajax_progress_chart__reports_whether_the_charted_course_uses_marks` with `KeyError: 'uses_marks'`. Root cause is a semantic merge:
- The view's early-return path (no open semester, or a semester with no class days behind it yet) was added by `#2412` and returned only `days_in_semester` + `xp_data`.
- `uses_marks` (and the test asserting it) were added later by `#2524`/[#403](https://github.com/bytedeck/bytedeck/issues/403), but only on the **main** return path.

So the response shape depended on whether there was data to chart. `#2524`'s test passed when it merged (its fixture semester still had class days), but its semester is time-relative, so once no class days were behind it the request hit the early return and the key was gone. This also affected real students: someone at the very start of term (no class days yet) got a chart response missing the keys the front end reads.

This was found when merging `develop` into `staging` for the 1.32.0 release (staging CI went red on this one test); the fix has already been applied directly on `staging` to unblock the release, and this PR forward-ports it so `develop` is not left broken.

### How?
- Work out the charted course once, up front, so it is available to both paths.
- Include `uses_marks` and `xp_for_100_percent` in the early-return dict (falling back to `False` / `0` when there is no course to chart, e.g. no open semester).
- Removed the now-duplicate `_registrations_to_chart` call and the later `charted_course` recompute.
- Updated the two tests that pinned the old minimal empty shape (`TestAjax_ProgressChart.test_ajax_xp_data__empty_*`) to the new shape, referencing the fixture's own course values so they don't depend on model-bakery's field randomization.

### Testing?
`python src/manage.py test courses` passes (335 tests), including the previously-failing test and the two updated pin tests; `ruff check src` is clean.

### Screenshots (if front end is affected)
N/A (the change is a JSON response shape; no visual change, and it prevents a broken chart for a start-of-term student).

### Anything Else?
Straight forward-port of the staging fix (same commit). No behavior change for a student who has data to plot.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - integrations and automations`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMPt54dgApiXjk6TXqD2fi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Progress charts now consistently display the selected course’s scoring scale and marks settings, even when no chart data or dated class days are available.
  - Empty charts without a selected course correctly show a zero scale with marks disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->