### PR TITLE
fix: stop telling a cancelled Maintenance deck it will never expire, and name the tenant tests after what they test

### DIFF
--- a/src/tenant/templates/tenant/subscription_detail.html
+++ b/src/tenant/templates/tenant/subscription_detail.html
@@ -30,9 +30,13 @@
   <p><span class="label label-primary">{{ deck.subscription_status_label }}</span>
     This deck is on a maintenance subscription{% if plan_summary %}
     (<strong>{{ plan_summary.name }}</strong>{% if plan_summary.renewal_phrase %}, {{ plan_summary.renewal_phrase }}{% endif %}){% endif %}
-    through <strong>{{ deck.paid_until }}</strong>
-    ({% if renews_phrase %}automatically {{ renews_phrase }}{% else %}{{ paid_until_phrase }}{% endif %}): it won't expire,
-    be suspended, or time out for deletion, but registration stays capped at the trial limit
+    {# "it won't expire" holds only while the subscription renews: one that has been cancelled runs out like any other (#2589) #}
+    {% if renews_phrase %}through <strong>{{ deck.paid_until }}</strong>
+    (automatically {{ renews_phrase }}): it won't expire, be suspended, or time out for deletion,
+    but registration stays capped{% else %}paid through <strong>{{ deck.paid_until }}</strong>
+    ({{ paid_until_phrase }}): unless it is renewed, the deck then gets the usual
+    {{ grace_days }}-day grace period and is suspended after that. Until then registration
+    stays capped{% endif %} at the trial limit
     (max {{ deck.effective_max_active_users }} current student{{ deck.effective_max_active_users|pluralize }}).
     Upgrade any time to raise the cap.</p>
 {% elif deck.subscription_status == 'subscribed' %}

--- a/src/tenant/tests/test_notices.py
+++ b/src/tenant/tests/test_notices.py
@@ -39,23 +39,23 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         """Shorthand: evaluate today's due notices for this deck."""
         return evaluate_deck_notices(self.tenant)
 
-    def test_evaluate__nothing_due_far_from_any_deadline(self):
+    def test_evaluate_deck_notices__nothing_due_far_from_any_deadline(self):
         """A quiet trial deck far from its deadline produces no notices."""
         self.assertEqual(self.due(), [])
 
-    def test_evaluate__expiry_milestones_fire_once_each(self):
+    def test_evaluate_deck_notices__expiry_milestones_fire_once_each(self):
         """Entering the 30/14/7-day windows fires each milestone exactly once."""
         self.set_deck(trial_end_date=TODAY + timedelta(days=30))
         self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'd30', str(TODAY + timedelta(days=30)))])
         process_deck_notices(self.tenant)
         self.assertEqual(self.due(), [])  # d30 recorded; nothing more due today
 
-    def test_evaluate__late_first_sight_fires_only_most_specific_milestone(self):
+    def test_evaluate_deck_notices__late_first_sight_fires_only_most_specific_milestone(self):
         """A deck first evaluated 10 days out gets ONE notice (d14), not a d30+d14 double."""
         self.set_deck(trial_end_date=TODAY + timedelta(days=10))
         self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'd14', str(TODAY + timedelta(days=10)))])
 
-    def test_evaluate__d1_is_the_last_notice_and_the_grace_window_is_quiet(self):
+    def test_evaluate_deck_notices__d1_is_the_last_notice_and_the_grace_window_is_quiet(self):
         """d1 is the end of the cadence: the day before the deadline is the last
         reminder, and the deck hears nothing more about that deadline, neither on
         the days between milestones nor through the grace window that follows."""
@@ -78,7 +78,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         with freeze_time("2026-08-28 20:00:00"):
             self.assertEqual(self.due(), [])
 
-    def test_evaluate__beat_outage_catches_up_with_one_notice(self):
+    def test_evaluate_deck_notices__beat_outage_catches_up_with_one_notice(self):
         """If beat is down for days, the next run sends one catch-up notice, not a backlog."""
         self.set_deck(trial_end_date=TODAY + timedelta(days=6))
         # no runs happen for 4 days...
@@ -86,7 +86,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
             due = self.due()
             self.assertEqual(len(due), 1)  # just d7 (the unfired milestone), never a backlog
 
-    def test_evaluate__renewal_re_arms_the_cadence(self):
+    def test_evaluate_deck_notices__renewal_re_arms_the_cadence(self):
         """Advancing paid_until (a renewal) re-arms the milestones via the new period_key."""
         deadline = TODAY + timedelta(days=20)
         self.set_deck(trial_end_date=None, paid_until=deadline)
@@ -100,7 +100,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         with freeze_time("2027-08-10 20:00:00"):  # 25 days before the renewed deadline
             self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'd30', str(renewed))])
 
-    def test_evaluate__limit_warnings_at_80_and_100_re_armed_monthly(self):
+    def test_evaluate_deck_notices__limit_warnings_at_80_and_100_re_armed_monthly(self):
         """The 80% warning fires once per month; hitting 100% fires the stronger notice."""
         self.set_deck(active_user_count=4)  # trial cap is 5 -> 80%
         self.assertEqual(self.due(), [(DeckNotice.KIND_LIMIT, 'pct80', '2026-08')])
@@ -127,7 +127,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         self.assertFalse(DeckNotice.objects.filter(
             tenant=self.tenant, kind=DeckNotice.KIND_PAYMENT_FAILED).exists())
 
-    def test_evaluate__deletion_request_mutes_all_notices(self):
+    def test_evaluate_deck_notices__deletion_request_mutes_all_notices(self):
         """A deck with a standing deletion request gets no notices at all, not
         even the suspension notice: asking for deletion is the strongest possible
         do-not-nag signal (#2330). Withdrawing the request turns the cadence back
@@ -140,7 +140,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         self.set_deck(deletion_requested_on=None, deletion_requested_by='')
         self.assertEqual(self.due(), [(DeckNotice.KIND_SUSPENDED, 'suspended', str(lapsed))])
 
-    def test_evaluate__suspended_deck_gets_no_limit_warnings(self):
+    def test_evaluate_deck_notices__suspended_deck_gets_no_limit_warnings(self):
         """A suspended deck never warns about student seats: students cannot sign
         in there at all, so the warning is wrong, and it would reach an owner who
         may have walked away. The deck here is suspended while carrying a stale
@@ -161,7 +161,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         self.set_deck(paid_until=TODAY + timedelta(days=90))
         self.assertEqual(self.due(), [(DeckNotice.KIND_LIMIT, 'pct100', '2026-08')])
 
-    def test_evaluate__auto_renewing_deck_gets_one_renewal_notice_not_the_expiry_cadence(self):
+    def test_evaluate_deck_notices__auto_renewing_deck_gets_one_renewal_notice_not_the_expiry_cadence(self):
         """An auto-renewing deck never gets the "renew or lose access" cadence:
         nothing is expiring on it. It gets exactly ONE heads-up inside the
         renewal window, and silence on every later day of that period (#2586)."""
@@ -176,7 +176,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         with freeze_time(f"{renews_on} 20:00:00"):  # the renewal day itself
             self.assertEqual(self.due(), [])
 
-    def test_evaluate__renewal_notice_waits_for_its_window_and_re_arms_next_period(self):
+    def test_evaluate_deck_notices__renewal_notice_waits_for_its_window_and_re_arms_next_period(self):
         """Outside the window a renewing deck hears nothing at all (no d30/d14
         milestones), and the next period's renewal gets its own notice because
         the ledger key is the date being renewed."""
@@ -193,7 +193,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
             self.set_deck(paid_until=next_renewal)
             self.assertEqual(self.due(), [(DeckNotice.KIND_RENEWAL, 'upcoming', str(next_renewal))])
 
-    def test_evaluate__renewal_notice_counts_to_the_billing_date_not_a_longer_trial(self):
+    def test_evaluate_deck_notices__renewal_notice_counts_to_the_billing_date_not_a_longer_trial(self):
         """On a deck carrying a trial date that outlasts its paid period, the
         renewal notice follows paid_until: that is the day Stripe charges, while
         the governing deadline (the trial) is only when access would end. It
@@ -205,7 +205,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         self.assertEqual(self.tenant.governing_deadline, TODAY + timedelta(days=90))  # the trial governs access
         self.assertEqual(self.due(), [(DeckNotice.KIND_RENEWAL, 'upcoming', str(renews_on))])
 
-    def test_evaluate__expiry_cadence_returns_when_the_subscription_stops_renewing(self):
+    def test_evaluate_deck_notices__expiry_cadence_returns_when_the_subscription_stops_renewing(self):
         """Cancelling at period end (or a renewal that starts failing) clears the
         Stripe flag, and the deck goes straight back onto the expiry cadence so
         its owner is warned before access ends."""
@@ -216,12 +216,12 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         self.set_deck(stripe_auto_renews=False)
         self.assertEqual(self.due(), [(DeckNotice.KIND_EXPIRY, 'd7', str(deadline))])
 
-    def test_evaluate__unlimited_deck_gets_no_limit_warnings(self):
+    def test_evaluate_deck_notices__unlimited_deck_gets_no_limit_warnings(self):
         """The -1 unlimited sentinel disables limit warnings entirely."""
         self.set_deck(max_active_users=-1, paid_until=TODAY + timedelta(days=90), active_user_count=999)
         self.assertEqual(self.due(), [])
 
-    def test_evaluate__expiry_key_uses_the_governing_trial_deadline(self):
+    def test_evaluate_deck_notices__expiry_key_uses_the_governing_trial_deadline(self):
         """With an in-grace paid date and a LATER governing trial date, the expiry
         notice is keyed to the governing trial deadline (the one the email
         reports), so milestones recorded under the stale paid key can never
@@ -235,7 +235,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
             tenant=self.tenant, kind=DeckNotice.KIND_EXPIRY, threshold='d30', period_key=str(trial)).exists())
         self.assertEqual(self.due(), [])  # recorded under the governing key: nothing more due
 
-    def test_evaluate__suspension_notice_once_per_episode(self):
+    def test_evaluate_deck_notices__suspension_notice_once_per_episode(self):
         """A suspended deck gets exactly one suspension notice (keyed to the lapsed deadline),
         and no expiry cadence. The trial must be lapsed past the unified grace
         window (#1734 B4) to be suspended at all."""
@@ -247,7 +247,7 @@ class DeckNoticeCadenceTest(ByteDeckTenantTestCase):
         with freeze_time("2026-09-15 20:00:00"):
             self.assertEqual(self.due(), [])  # still just the one
 
-    def test_evaluate__lapsed_trial_stays_on_expiry_cadence_through_grace(self):
+    def test_evaluate_deck_notices__lapsed_trial_stays_on_expiry_cadence_through_grace(self):
         """A lapsed trial inside its grace window is NOT suspended: it is still on
         the expiry cadence, exactly like a lapsed paid deck (#1734 B4), so a deck
         that was never reminded still gets the final milestone (d1). Once that is
@@ -311,7 +311,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
             config.save()
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__renewal_email_says_it_renews_and_asks_for_nothing(self):
+    def test_process_deck_notices__renewal_email_says_it_renews_and_asks_for_nothing(self):
         """The renewal email states the date and that nothing is required, and
         carries none of the expiry cadence's "subscribe or lose access" pressure
         (#2586). Its in-app notification says the same in one line.
@@ -348,7 +348,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
             recipient=SiteConfig.get().deck_owner, verb__contains='renewal reminder')
         self.assertIn(f'renews automatically on {date_format(renews_on)}', notification.verb)
 
-    def test_process__report_only_by_default_sends_and_records_nothing(self):
+    def test_process_deck_notices__report_only_by_default_sends_and_records_nothing(self):
         """With DECK_NOTICES_ENABLED off (the default), the engine only reports."""
         summary = process_deck_notices(self.tenant)
         self.assertIn('REPORT-ONLY', summary)
@@ -357,7 +357,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__records_ledger_and_delivers_both_channels(self):
+    def test_process_deck_notices__records_ledger_and_delivers_both_channels(self):
         """When enabled, a due notice writes its ledger row, emails the deck owner, and
         creates an in-app notification (sender choice has its own tests below)."""
         summary = self.run_engine_with_inline_email()
@@ -391,7 +391,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(notification.target_link_text, 'subscription details page.')
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__notification_comes_from_support_admin_when_present(self):
+    def test_process_deck_notices__notification_comes_from_support_admin_when_present(self):
         """The in-app notice's sender is the ByteDeck support account when the deck
         has one, so it renders as "Bytedeck sent a ..." instead of coming from a
         deck user's own account (maintainer request, 2026-07-31)."""
@@ -410,7 +410,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('Bytedeck sent a current-student limit warning:', notification.get_link())
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__notification_sender_falls_back_to_deck_ai(self):
+    def test_process_deck_notices__notification_sender_falls_back_to_deck_ai(self):
         """Decks without a usable support account (older decks predate it; here it
         is deactivated) still get their notice: the sender falls back to the deck
         AI user."""
@@ -495,7 +495,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertTrue(detail.endswith('the grace period has run out.'))
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__second_run_sends_nothing_new(self):
+    def test_process_deck_notices__second_run_sends_nothing_new(self):
         """Running the engine twice on the same day delivers exactly once."""
         self.run_engine_with_inline_email()
         summary = self.run_engine_with_inline_email()
@@ -504,7 +504,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__concurrent_run_race_skips_delivery(self):
+    def test_process_deck_notices__concurrent_run_race_skips_delivery(self):
         """If another run records the ledger row between evaluation and get_or_create
         (a lost race), this run skips delivery instead of double-sending."""
         from unittest.mock import patch
@@ -519,7 +519,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__failed_delivery_rolls_back_ledger_so_next_run_retries(self):
+    def test_process_deck_notices__failed_delivery_rolls_back_ledger_so_next_run_retries(self):
         """If delivery raises after the ledger write, the row rolls back (and no email
         is queued -- the enqueue is sequenced after the in-app notification), so the
         notice isn't recorded-but-never-sent: the next run retries."""
@@ -537,7 +537,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__broker_failure_rolls_back_ledger_and_notification(self):
+    def test_process_deck_notices__broker_failure_rolls_back_ledger_and_notification(self):
         """If the email enqueue itself fails (broker down), the ledger row AND the
         in-app notification roll back together, so the next run retries the whole
         notice instead of leaving it recorded with the email never handed off."""
@@ -561,7 +561,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertTrue(notice_notifications.exists())
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__owner_without_email_still_gets_in_app_notification(self):
+    def test_process_deck_notices__owner_without_email_still_gets_in_app_notification(self):
         """A deck whose owner has no email at all skips the email channel but still
         records the notice and creates the in-app notification."""
         from django.contrib.auth import get_user_model
@@ -577,7 +577,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertTrue(Notification.objects.filter(recipient=owner, verb__contains='limit warning').exists())
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__grace_period_email_states_suspension_ahead(self):
+    def test_process_deck_notices__grace_period_email_states_suspension_ahead(self):
         """The grace-period expiry email tells the owner what follows the grace
         window: suspension, with only the deck owner able to sign in and the
         365-day deletion countdown starting (suspension redesign, 2026-07-30) --
@@ -598,7 +598,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('365-day countdown to deck deletion', body)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__grace_email_includes_dates_seats_and_logo(self):
+    def test_process_deck_notices__grace_email_includes_dates_seats_and_logo(self):
         """The grace-period expiry email states every date the owner needs -- when
         the subscription expired and how long ago, when the grace period ends and
         how many days remain -- plus current seat usage and the ByteDeck wordmark
@@ -623,7 +623,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn(f'alt="[Logo]" src="{settings.PUBLIC_EMAIL_LOGO_URL}" width="255" height="64"', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__comped_deck_limit_email_renders_without_any_dates(self):
+    def test_process_deck_notices__comped_deck_limit_email_renders_without_any_dates(self):
         """A comped/managed-manually deck (both date fields blank, days_until_expiry
         None) can still hit its student cap; its limit email must render with no
         expiry dates to lean on -- covering the dateless arms of the new context."""
@@ -664,7 +664,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('free trial ended on <strong>Aug. 10, 2026</strong> and the deck is in its grace period', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__suspended_email_states_when_and_why_with_logo(self):
+    def test_process_deck_notices__suspended_email_states_when_and_why_with_logo(self):
         """The suspension email says when the suspension began, which clock ran
         out (trial or paid, plus the unified grace window, #1734 B4), current
         seat usage, and carries the logo."""
@@ -718,7 +718,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertIn('awesome app?_ _[Contact us](mailto:contact@bytedeck.com)!_', plain_text)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__suspended_email_follows_the_governing_trial_clock(self):
+    def test_process_deck_notices__suspended_email_follows_the_governing_trial_clock(self):
         """With BOTH dates set and the trial the LATER clock (an admin-extended
         trial on a deck whose paid period lapsed earlier), the suspension email
         explains the TRIAL clock: the governing deadline picks the wording, not
@@ -767,7 +767,7 @@ class DeckNoticeDeliveryTest(ByteDeckTenantTestCase):
         self.assertNotIn('subscription expired', html)
 
     @override_settings(DECK_NOTICES_ENABLED=True)
-    def test_process__suspended_email_paid_clock_and_legacy_full_year(self):
+    def test_process_deck_notices__suspended_email_paid_clock_and_legacy_full_year(self):
         """A deck suspended after a PAID subscription lapsed explains the paid
         clock (paid-through and grace-end dates) in its suspension email, with the
         bottom line carried by the plain-text part too. A LEGACY deck whose dates
@@ -873,7 +873,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         from tenant.notices import close_semester_on_new_suspension
         return close_semester_on_new_suspension(self.tenant)
 
-    def test_close__fresh_suspension_closes_semester_once(self):
+    def test_close_semester_on_new_suspension__fresh_suspension_closes_semester_once(self):
         """A fresh suspension returns the awaiting-approval submission (unblocking
         the close, which then sweeps it with the rest of the in-progress work, as
         any semester close does), closes the semester, and drops the
@@ -908,7 +908,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
 
         self.assertEqual(self.close(), 'semester close already handled this episode')
 
-    def test_close__closes_every_open_semester(self):
+    def test_close_semester_on_new_suspension__closes_every_open_semester(self):
         """Suspension stops the whole deck, so a second open semester closes with the first
         (issue #2157 Phase 3). Its own pending approvals are returned first: leaving them
         would make its close report QUEST_AWAITING_APPROVAL and roll the whole suspension
@@ -938,7 +938,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         self.assertIsNone(SiteConfig.get().active_semester)
         self.assertFalse(Semester.objects.open().exists())
 
-    def test_close__no_op_paths(self):
+    def test_close_semester_on_new_suspension__no_op_paths(self):
         """Unsuspended decks are untouched (no ledger row); a suspended deck whose
         semester is already closed records the episode without changes."""
         from courses.models import Semester
@@ -955,7 +955,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         self.assertEqual(self.close(), 'no open semester to close')
         self.assertEqual(self.close(), 'semester close already handled this episode')
 
-    def test_close__clamps_negative_xp_to_zero(self):
+    def test_close_semester_on_new_suspension__clamps_negative_xp_to_zero(self):
         """A student with a negative XP balance doesn't block the auto-close: the
         final XP is recorded as zero (maintainer decision, 2026-07-30)."""
         from unittest.mock import patch
@@ -978,7 +978,7 @@ class SuspensionSemesterCloseTest(ByteDeckTenantTestCase):
         self.assertEqual(registration.final_xp, 0)
         self.assertFalse(registration.active)
 
-    def test_close__failed_close_rolls_back_the_episode_ledger(self):
+    def test_close_semester_on_new_suspension__failed_close_rolls_back_the_episode_ledger(self):
         """If the close unexpectedly refuses (the defensive sentinel path), the
         episode's ledger row rolls back with it, so the next nightly run retries
         instead of recording a close that never happened."""

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -995,7 +995,7 @@ class DeckDeletionRequestViewTest(ByteDeckTenantTestCase):
         self.tenant.refresh_from_db()
         self.assertIsNotNone(self.tenant.deletion_requested_on)
 
-    def test_page__shows_the_request_panel_and_pending_state(self):
+    def test_SubscriptionDetail__shows_the_request_panel_and_pending_state(self):
         """The subscription page offers the request to the owner (button + the
         review-first explanation); once a request stands it shows who asked and
         when, the nothing-deleted reassurance, and the cancel action instead."""
@@ -1012,7 +1012,7 @@ class DeckDeletionRequestViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Cancel deletion request')
         self.assertNotContains(response, 'Request deck deletion')
 
-    def test_page__non_owner_staff_see_disabled_buttons(self):
+    def test_SubscriptionDetail__non_owner_staff_see_disabled_buttons(self):
         """Other staff see the section with the action disabled and the owner
         named in its popup, mirroring the manage-subscription button."""
         from django.utils.timezone import localdate
@@ -1060,7 +1060,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         response = self.assert200('decks:subscription')
         return response
 
-    def test_page__staff_only(self):
+    def test_SubscriptionDetail__staff_only(self):
         """Anonymous users are redirected to login; students get 403; staff get 200."""
         self.client.logout()
         self.assertRedirectsLogin('decks:subscription')
@@ -1071,7 +1071,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.client.force_login(self.staff)
         self.get_page()
 
-    def test_page__auto_renewing_deck_reads_as_renewing_not_expiring(self):
+    def test_SubscriptionDetail__auto_renewing_deck_reads_as_renewing_not_expiring(self):
         """An auto-renewing subscription says what actually happens on its date:
         it renews and the card is charged, with the Dates row labelled "Renews
         on" rather than "Paid until" (#2586). The same deck set to cancel goes
@@ -1092,7 +1092,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Paid until')
         self.assertNotContains(response, 'Renews automatically on')
 
-    def test_page__shows_dates_seats_and_status(self):
+    def test_SubscriptionDetail__shows_dates_seats_and_status(self):
         """A subscribed deck shows its status, the governing date, days remaining,
         and the three seat rows (maximum / current / remaining)."""
         response = self.get_page()
@@ -1104,7 +1104,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Remaining students')
         self.assertContains(response, '30')
 
-    def test_page__dates_show_relative_time_in_every_state(self):
+    def test_SubscriptionDetail__dates_show_relative_time_in_every_state(self):
         """Every Dates row carries a relative phrase: time remaining while the date
         is ahead, or how long ago it passed -- for Paid until, the grace period's
         end, and Trial ends alike (maintainer request from staging live testing)."""
@@ -1143,7 +1143,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.set_deck(trial_end_date=None, paid_until=localdate() - timedelta(days=30))  # final grace day
         self.assertIn('(ends today)', ' '.join(self.get_page().content.decode().split()))
 
-    def test_page__dates_show_only_the_governing_deadline(self):
+    def test_SubscriptionDetail__dates_show_only_the_governing_deadline(self):
         """The Dates table shows ONE deadline row -- the governing (LATEST) clock's
         (#1734 B4): Paid until when the paid clock governs, Trial ends when the
         trial clock governs (even with both dates set), and a never-expires row
@@ -1169,7 +1169,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertNotContains(response, 'Trial ends')
         self.assertNotContains(response, 'Paid until')
 
-    def test_page__extended_trial_outlasting_an_old_paid_date_reads_as_trial(self):
+    def test_SubscriptionDetail__extended_trial_outlasting_an_old_paid_date_reads_as_trial(self):
         """With BOTH dates set and the trial the LATER clock (an admin-extended
         trial on a deck whose paid period lapsed earlier), the grace status and
         the Dates table follow the governing trial clock: trial wording,
@@ -1188,7 +1188,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Trial ends')
         self.assertNotContains(response, 'Paid until')
 
-    def test_page__remaining_seats_counts_down_and_clamps_at_zero(self):
+    def test_SubscriptionDetail__remaining_seats_counts_down_and_clamps_at_zero(self):
         """Remaining students = cap minus the LIVE current-student count, clamped
         at 0 when over the limit; None (rendered "Unlimited") on unlimited decks."""
         from model_bakery import baker
@@ -1207,7 +1207,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.set_deck(max_active_users=-1)
         self.assertIsNone(self.get_page().context['remaining_seats'])
 
-    def test_page__grace_period_states_suspension_ahead(self):
+    def test_SubscriptionDetail__grace_period_states_suspension_ahead(self):
         """A deck in its paid grace window gets its own DANGER "Grace period" label --
         never the green "Subscribed" badge (maintainer review find) -- and explains
         what follows: suspension, with only the deck owner able to sign in and the
@@ -1225,7 +1225,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertIn('otherwise the deck will be suspended (only the deck owner will be able to sign in, '
                       'and the 365-day countdown to deck deletion begins)', text)
 
-    def test_page__lapsed_trial_gets_the_same_grace_status(self):
+    def test_SubscriptionDetail__lapsed_trial_gets_the_same_grace_status(self):
         """A lapsed trial lands in the SAME grace state (#1734 B4): the danger
         "Grace period" label, trial-specific wording ("free trial ended",
         subscribe rather than renew), and the trial Dates rows with the grace
@@ -1243,7 +1243,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertIn('subscribe to keep full access', text)
         self.assertIn('extends 30 days after your trial ends (ends in 25 days)', text)
 
-    def test_page__suspended_deck_states_owner_only_and_deletion_countdown(self):
+    def test_SubscriptionDetail__suspended_deck_states_owner_only_and_deletion_countdown(self):
         """A suspended deck's status copy states the suspension rules -- only
         the deck owner can sign in, and the 365-day deletion countdown -- while
         the seats table still shows the ADMIN-SET cap, whatever it is (the
@@ -1263,7 +1263,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         text = ' '.join(response.content.decode().split())
         self.assertIn('<th>Maximum allowed</th> <td>1</td>', text)
 
-    def test_page__lifecycle_overview_lists_every_stage(self):
+    def test_SubscriptionDetail__lifecycle_overview_lists_every_stage(self):
         """The "How subscriptions work" section walks the owner through the whole
         lifecycle -- valid subscription, grace period, suspension (owner-only
         sign-in + deletion countdown), deletion -- and pitches the Maintenance
@@ -1278,7 +1278,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertIn('Only the deck owner can sign in, and the 365-day countdown to deck deletion begins', text)
         self.assertIn('max 5 current students', text)  # the Maintenance pitch states the trial cap
 
-    def test_page__maintenance_subscription_gets_its_own_status(self):
+    def test_SubscriptionDetail__maintenance_subscription_gets_its_own_status(self):
         """A paid deck whose cap sits at the trial limit is on MAINTENANCE: its own
         status label and copy (kept alive, capped, upgradable) instead of the
         plain green Subscribed badge -- while a paid deck with a higher cap keeps
@@ -1297,7 +1297,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         # the lifecycle overview always PITCHES Maintenance, so pin the status label only
         self.assertNotContains(response, 'Maintenance</span>')
 
-    def test_page__trial_suspended_and_manual_states(self):
+    def test_SubscriptionDetail__trial_suspended_and_manual_states(self):
         """The status section adapts to trial, suspended, and never-expires decks."""
         from datetime import date, timedelta
 
@@ -1312,12 +1312,12 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.set_deck(trial_end_date=None, paid_until=None)
         self.assertContains(self.get_page(), 'Managed manually')
 
-    def test_page__unlimited_cap_shown_as_unlimited(self):
+    def test_SubscriptionDetail__unlimited_cap_shown_as_unlimited(self):
         """The -1 unlimited sentinel renders as "Unlimited" rather than -1."""
         self.set_deck(max_active_users=-1)
         self.assertContains(self.get_page(), 'Unlimited')
 
-    def test_page__mid_trial_checkout_note_promises_no_lost_trial_time(self):
+    def test_SubscriptionDetail__mid_trial_checkout_note_promises_no_lost_trial_time(self):
         """While the deck is on trial (with enough trial left for checkout to
         preserve it), the subscribe button's help text says the card isn't
         charged until the trial ends; a paid deck gets the plain portal/checkout
@@ -1337,7 +1337,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
             text = ' '.join(self.get_page().content.decode().split())
             self.assertNotIn("won't cut your free trial short", text)
 
-    def test_page__not_configured_falls_back_to_public_subscribe_page(self):
+    def test_SubscriptionDetail__not_configured_falls_back_to_public_subscribe_page(self):
         """Without Stripe keys the page says billing isn't configured and links the
         public subscribe page instead of rendering the checkout form."""
         from tenant.utils import get_public_subscribe_url
@@ -1347,7 +1347,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, get_public_subscribe_url())
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
-    def test_page__configured_shows_checkout_portal_or_manual_note(self):
+    def test_SubscriptionDetail__configured_shows_checkout_portal_or_manual_note(self):
         """With Stripe configured: an unlinked trial deck gets "Subscribe now", a
         linked deck gets "Manage subscription" (billing portal), and an unlinked
         deck still inside its paid period gets the managed-manually note instead
@@ -1367,7 +1367,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'managed manually')
         self.assertNotContains(response, 'Subscribe now')
 
-    def test_page__status_names_the_plan_after_the_subscribed_badge(self):
+    def test_SubscriptionDetail__status_names_the_plan_after_the_subscribed_badge(self):
         """A linked, subscribed deck's status line names the Stripe plan and its
         renewal terms after the badge -- "Subscribed to <product>, renewed
         annually at $75.00 per year. Paid through ..." (maintainer request,
@@ -1387,7 +1387,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
             text = ' '.join(self.get_page().content.decode().split())
         self.assertIn('Subscribed</span> Paid through', text)
 
-    def test_page__maintenance_status_names_the_plan_when_known(self):
+    def test_SubscriptionDetail__maintenance_status_names_the_plan_when_known(self):
         """A maintenance deck's status parenthesizes its plan when Stripe data is
         available: "on a maintenance subscription (<product>, renewed annually
         at $10.00 per year) through ..."."""
@@ -1402,7 +1402,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         )
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
-    def test_page__manage_button_shows_at_top_and_bottom_owner_only(self):
+    def test_SubscriptionDetail__manage_button_shows_at_top_and_bottom_owner_only(self):
         """The manage action appears TWICE -- under Status and in Upgrade-or-renew
         (maintainer request, 2026-08-09). Staff who are not the deck owner get
         both copies disabled with a popup naming who can act; the owner gets the
@@ -1432,7 +1432,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertNotContains(response, 'disabled')
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
-    def test_page__lapsed_linked_deck_button_says_renew(self):
+    def test_SubscriptionDetail__lapsed_linked_deck_button_says_renew(self):
         """A linked deck past its governing deadline (grace or suspended) labels
         the manage action "Renew subscription" with renewal help text: the POST
         routes such a deck to renewal, so the button says so up front
@@ -1457,7 +1457,7 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         self.assertContains(response, 'Renew subscription', count=2)
         self.assertNotContains(response, 'Manage subscription')
 
-    def test_page__contact_copy_links_the_support_address(self):
+    def test_SubscriptionDetail__contact_copy_links_the_support_address(self):
         """Copy that says to contact ByteDeck links the support address as a
         mailto (maintainer request, 2026-08-09): the managed-manually status, the
         manual-billing note, and the activating page's check-later copy."""

--- a/src/tenant/tests/test_views.py
+++ b/src/tenant/tests/test_views.py
@@ -1297,6 +1297,24 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
         # the lifecycle overview always PITCHES Maintenance, so pin the status label only
         self.assertNotContains(response, 'Maintenance</span>')
 
+    def test_SubscriptionDetail__maintenance_promises_no_expiry_only_while_it_renews(self):
+        """A maintenance subscription that renews is the one case where the page
+        can say the deck won't expire, be suspended, or time out for deletion.
+        Cancel it and that promise is false, so the page states what really
+        happens instead: paid through the date, then the grace period, then
+        suspension. The trial-limit cap applies either way (#2589)."""
+        self.set_deck(max_active_users=5, stripe_auto_renews=True)  # paid 100 days out from setUp
+        response = self.get_page()
+        self.assertContains(response, 'automatically renews in 100 days')
+        self.assertContains(response, "it won't expire")
+
+        self.set_deck(stripe_auto_renews=False)  # cancelled, or a renewal that started failing
+        response = self.get_page()
+        self.assertNotContains(response, "it won't expire")
+        self.assertContains(response, 'paid through')
+        self.assertContains(response, 'grace period and is suspended after that')
+        self.assertContains(response, 'capped at the trial limit')
+
     def test_SubscriptionDetail__trial_suspended_and_manual_states(self):
         """The status section adapts to trial, suspended, and never-expires decks."""
         from datetime import date, timedelta
@@ -1390,16 +1408,23 @@ class SubscriptionDetailViewTest(ByteDeckTenantTestCase):
     def test_SubscriptionDetail__maintenance_status_names_the_plan_when_known(self):
         """A maintenance deck's status parenthesizes its plan when Stripe data is
         available: "on a maintenance subscription (<product>, renewed annually
-        at $10.00 per year) through ..."."""
+        at $10.00 per year) paid through ..." (the renewing deck reads "through",
+        since its date is a renewal rather than an end, #2589)."""
         self.set_deck(max_active_users=5, stripe_customer_id='cus_9', stripe_subscription_id='sub_9')
         summary = {'name': 'Bytedeck Maintenance', 'renewal_phrase': 'renewed annually at $10.00 per year'}
         with patch('tenant.billing.subscription_plan_summary', return_value=summary):
             text = ' '.join(self.get_page().content.decode().split())
         self.assertIn(
             'maintenance subscription (<strong>Bytedeck Maintenance</strong>, '
-            'renewed annually at $10.00 per year) through',
+            'renewed annually at $10.00 per year) paid through',
             text,
         )
+
+        self.set_deck(stripe_auto_renews=True)
+        with patch('tenant.billing.subscription_plan_summary', return_value=summary):
+            text = ' '.join(self.get_page().content.decode().split())
+        self.assertIn(
+            'renewed annually at $10.00 per year) through <strong>', text)
 
     @override_settings(STRIPE_SECRET_KEY='sk_test_123', STRIPE_PRICE_ID='price_123')
     def test_SubscriptionDetail__manage_button_shows_at_top_and_bottom_owner_only(self):


### PR DESCRIPTION
### What?

Two small follow-ups from the review of PR #2588, in one PR:

* The Maintenance status line no longer tells a **cancelled** Maintenance deck that it will never expire. Closes #2589.
* The tenant app's test families are named after the callable they exercise. Closes #2590.

Both build on #2588, which has since merged, so this branch sits directly on `develop` and its diff is just the two commits below.

### Why?

**#2589.** The Maintenance branch of the status line stated flatly that the deck "won't expire, be suspended, or time out for deletion". That is a property of the subscription *renewing*, not of the tier. A Maintenance subscription that has been cancelled (or whose renewal is failing) runs out on its paid-through date like any other, then gets the usual grace period, then suspension. The page was reassuring the one owner who most needs to act.

**#2590.** CLAUDE.md asks for `test_method_or_class_name__specific_case_being_tested`. Two families in the tenant app used a shorthand that does not lead back to the code under test, which is what a reader greps when CI reports a failure. It also came up in review on #2588, where renaming a single new test would have made it the odd one out; a whole-family sweep is the way to fix it.

### How?

* **#2589**: the Maintenance status line splits on whether the subscription renews. Renewing keeps the promise and the renewal phrasing ("through *date* (automatically renews in N days): it won't expire, be suspended, or time out for deletion"). Not renewing names the paid-through date and what follows it ("paid through *date* (99 days remaining): unless it is renewed, the deck then gets the usual 30-day grace period and is suspended after that"). The trial-limit cap and the upgrade invitation are stated either way, so nothing is lost from the cancelled case.
* **#2590**: `test_page__*` (24 tests, in `SubscriptionDetailViewTest` and the two deletion-request tests that render the same page) becomes `test_SubscriptionDetail__*`; `test_evaluate__*` becomes `test_evaluate_deck_notices__*`, `test_process__*` becomes `test_process_deck_notices__*`, and `test_close__*` becomes `test_close_semester_on_new_suspension__*`. Renames only, no assertion or behaviour changes. `test_deliver__*` already names the `_deliver` helper, and `test_record_and_deliver_payment_failure__*` was already correct, so both stay as they are. Nothing outside those two files referred to the old names.

The two are separate commits, so the rename sweep can be read (or dropped) on its own.

### Testing?

* New: a Maintenance deck that renews still says "it won't expire"; the same deck once cancelled says it instead, names the paid-through date, states the grace period and suspension, and keeps the trial-limit cap.
* Updated, not weakened: the existing plan-naming test now asserts the cancelled deck reads "...) paid through" and the renewing deck reads "...) through", so the wording of both arms is pinned.
* The rename commit is verifiable by test count: same tests, same assertions, new names.

Full suite green locally (2714 tests), `ruff check src` clean, `makemigrations --check --dry-run` clean.

### Screenshots (if front end is affected)

Subscription page of a Maintenance deck paid through Nov. 30, 2026, captured from the running dev deck signed in as the deck owner.

**Before**, with the subscription cancelled: promises the deck will never expire or be suspended, which is exactly what is about to happen to it.

![before](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2589/before.png)

**After**, same cancelled deck: says what really happens next.

![after](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2589/after.png)

**After**, the same deck while it renews: the original promise is kept, since here it is true.

![after renewing](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2589/after-renewing.png)

### Anything Else?

* A Maintenance deck with no Stripe subscription at all (comped, or managed by hand) also takes the not-renewing arm. The wording is deliberately neutral there: "unless it is renewed" is true whether the renewal would come from Stripe or from an admin extending the date, so no separate branch is needed.
* #2587 is the same naming problem in `library/tests/test_views.py`. Untouched here to keep this PR to one app; happy to take it next.

### Review request
@tylerecouture

- Claude Code (`Bytedeck - payments integration`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAo12812TYt3GJgpZi7Pmn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription status messages now clearly distinguish auto-renewing subscriptions from cancelled or non-renewing subscriptions.
  * Renewal dates, paid-through dates, grace periods, and suspension behavior are displayed with clearer wording.

* **Tests**
  * Expanded coverage for renewal and cancellation scenarios.
  * Improved test naming for clearer identification of covered subscription and notice behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->