### PR TITLE
feat: sort the Library's quests on the server, not just the current page (#2410)

### DIFF
--- a/src/library/templates/library/tab_library_quests.html
+++ b/src/library/templates/library/tab_library_quests.html
@@ -46,10 +46,22 @@
     <thead>
       <tr class="panel-heading">
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
-        <th class="col-sm-5 col-xs-8" data-field="name" data-sortable="true">Quest</th>
-        <th class="col-sm-1 text-right col-xs-2" data-field="xp" data-sortable="true">XP</th>
-        <th class="col-sm-2 text-right hidden-xs" data-field="campaign" data-sortable="true">Campaign</th>
-        <th class="col-sm-1 text-center hidden-xs" data-field="tags" data-sortable="true">{{ config.custom_name_for_tag }}s</th>
+        {% comment %}
+          The headings link to the server rather than carrying data-sortable, so they order
+          the whole Library instead of the page the browser happens to hold (#2410). Tags
+          are not sortable: a quest carries any number of them, so there is no one value to
+          order it by, and the search box already finds the quests carrying a given one.
+        {% endcomment %}
+        <th class="col-sm-5 col-xs-8" data-field="name">
+          {% include "snippets/sortable_column_heading.html" with column="name" label="Quest" %}
+        </th>
+        <th class="col-sm-1 text-right col-xs-2" data-field="xp">
+          {% include "snippets/sortable_column_heading.html" with column="xp" label="XP" %}
+        </th>
+        <th class="col-sm-2 text-right hidden-xs" data-field="campaign">
+          {% include "snippets/sortable_column_heading.html" with column="campaign" label="Campaign" %}
+        </th>
+        <th class="col-sm-1 text-center hidden-xs" data-field="tags">{{ config.custom_name_for_tag }}s</th>
         <th class="col-sm-2 hidden-xs" data-field="status_icons"></th>
       </tr>
     </thead>

--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2879,6 +2879,168 @@ class LibrarySharerWarningTests(LibraryTenantTestCaseMixin):
         )
 
 
+class LibraryQuestSortTests(LibraryTenantTestCaseMixin):
+    """The quests tab's column headings order the whole Library, not one page of it.
+
+    The list is paginated, so the browser holds a page rather than the Library. A sort
+    applied there answers a question about that page: which of these fifteen is worth the
+    most XP, rather than which quests in the Library are (#2410). Every assertion below
+    narrows to this class's own quests with the search box, because the Library tenant is
+    seeded with quests of its own.
+    """
+
+    #: Enough quests to fill a page and spill onto a second one.
+    QUEST_COUNT = LibraryQuestListView.paginate_by + 5
+
+    @classmethod
+    def setUpTestData(cls):
+        """Fill the Library with quests whose name order is the reverse of their XP order.
+
+        Named so they sort into the order they were created and given ascending XP, so the
+        highest-XP quests are exactly the ones the default order pushes onto page two. A
+        sort that only reached the current page could not bring them forward.
+        """
+        cls.test_teacher = User.objects.create_user('sort_teacher', is_staff=True)
+
+        with library_schema_context():
+            cls.campaign = baker.make(Category, title="Sortable Campaign", published=True)
+            # Quest.name is unique, so these can't be made in one _quantity call
+            for i in range(cls.QUEST_COUNT):
+                baker.make(
+                    Quest, name=f'Zsort quest {i:02d}', campaign=cls.campaign, published=True, xp=i,
+                )
+
+    def _sorted_names(self, **params):
+        """The names on the first page of this class's quests, in the order rendered.
+
+        Args:
+            **params: query parameters, added to the `q=Zsort` that narrows the list.
+
+        Returns:
+            list[str]: the quest names on that page, in order.
+        """
+        params.setdefault('q', 'Zsort')
+        response = self.client.get(reverse('library:quest_list'), params)
+        return [quest.name for quest in response.context['library_quests']]
+
+    def setUp(self):
+        """Sign the teacher in, since every quests-tab request needs staff."""
+        super().setUp()
+        self.client.force_login(self.test_teacher)
+
+    def test_LibraryQuestListView__sorting_reaches_quests_that_are_not_on_the_current_page(self):
+        """Sorting by XP brings the Library's highest-XP quests onto the first page.
+
+        This is the whole point of the issue: those quests sit on page two in the default
+        order, so a sort confined to the rows the browser holds could never surface them.
+        """
+        default_first_page = self._sorted_names()
+        highest_xp_first = self._sorted_names(sort='-xp')
+
+        self.assertEqual(highest_xp_first[0], f'Zsort quest {self.QUEST_COUNT - 1:02d}')
+        self.assertNotIn(highest_xp_first[0], default_first_page)
+
+    def test_LibraryQuestListView__a_sort_applies_ascending_and_reverses_with_a_leading_minus(self):
+        """`?sort=xp` runs lowest first and `?sort=-xp` highest first."""
+        ascending = self._sorted_names(sort='xp')
+        descending = self._sorted_names(sort='-xp')
+
+        self.assertEqual(ascending[0], 'Zsort quest 00')
+        self.assertEqual(descending[0], f'Zsort quest {self.QUEST_COUNT - 1:02d}')
+
+    def test_LibraryQuestListView__sorting_keeps_the_search_applied(self):
+        """Reordering a search shows the same quests in a new order, not the whole Library."""
+        names = self._sorted_names(sort='-xp')
+
+        self.assertEqual(len(names), LibraryQuestListView.paginate_by)
+        for name in names:
+            self.assertTrue(name.startswith('Zsort quest'), f'{name} is not one of the searched-for quests')
+
+    def test_LibraryQuestListView__a_column_this_tab_does_not_offer_is_ignored(self):
+        """A stale or hand-made `?sort=` falls back to the Library's own order, not an error.
+
+        Tags are the live case: the column is rendered but deliberately not sortable, so a
+        link someone kept from elsewhere names a column this tab will not order by.
+        """
+        default_order = self._sorted_names()
+
+        for unknown in ('tags', 'nonsense', 'name; drop table', '-'):
+            with self.subTest(sort=unknown):
+                response = self.client.get(reverse('library:quest_list'), {'q': 'Zsort', 'sort': unknown})
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual([quest.name for quest in response.context['library_quests']], default_order)
+                self.assertEqual(response.context['sort_column'], '')
+                self.assertFalse(response.context['sort_descending'])
+
+    def test_LibraryQuestListView__quests_with_no_campaign_sort_last_in_both_directions(self):
+        """A quest with no campaign goes to the end whichever way the campaign column runs.
+
+        Postgres orders NULLs first on a descending sort, which would fill the first page
+        with blanks for a reader who asked to see the Library by campaign.
+        """
+        # Named to sort first by name, which is both the Library's default order and the
+        # tie-break here, so landing last can only come from the campaign ordering itself
+        with library_schema_context():
+            baker.make(Quest, name='Zsort AAA no campaign', campaign=None, published=True, xp=1)
+
+        self.assertEqual(self._sorted_names()[0], 'Zsort AAA no campaign')
+
+        for direction in ('campaign', '-campaign'):
+            with self.subTest(sort=direction):
+                names = self._sorted_names(sort=direction, page=2)
+
+                self.assertEqual(names[-1], 'Zsort AAA no campaign')
+
+    def test_LibraryQuestListView__paging_a_sorted_list_shows_each_quest_exactly_once(self):
+        """Quests sharing a sort value keep a settled order, so paging neither skips nor repeats.
+
+        Ordering by a column alone leaves rows that tie in no defined order, and the
+        database is free to return them differently per query, which is what lets a quest
+        show up on two pages or on neither.
+        """
+        # Enough to span three pages, so the tie is carried across two page boundaries
+        tie_count = LibraryQuestListView.paginate_by * 2 + 5
+        with library_schema_context():
+            # Quest.name is unique, so these can't be made in one _quantity call
+            for i in range(tie_count):
+                baker.make(Quest, name=f'Ztie quest {i:02d}', campaign=self.campaign, published=True, xp=7)
+
+        seen = []
+        for page in (1, 2, 3):
+            seen += self._sorted_names(q='Ztie', sort='xp', page=page)
+
+        self.assertEqual(len(seen), tie_count)
+        self.assertEqual(sorted(seen), sorted(set(seen)), 'a quest appeared on more than one page')
+
+    def test_LibraryQuestListView__the_headings_link_to_the_server_and_start_a_new_first_page(self):
+        """A heading is a link carrying `sort=`, keeping the search and dropping the page.
+
+        Page 3 of the Library by name holds different quests than page 3 of it by XP, so
+        carrying the number across would land the reader somewhere they did not ask to be.
+        """
+        response = self.client.get(reverse('library:quest_list'), {'q': 'Zsort', 'page': 2})
+
+        self.assertContains(response, 'sort=xp')
+        self.assertContains(response, 'q=Zsort')
+        self.assertNotContains(response, 'sort=xp&amp;page=2')
+        # bootstrap-table's own sort would reorder the page underneath the link
+        self.assertNotContains(response, 'data-sortable="true"')
+
+    def test_LibraryQuestListView__the_applied_heading_offers_the_reverse(self):
+        """Once a column is applied, its heading links to the same column reversed."""
+        response = self.client.get(reverse('library:quest_list'), {'q': 'Zsort', 'sort': 'xp'})
+
+        self.assertEqual(response.context['sort_column'], 'xp')
+        self.assertFalse(response.context['sort_descending'])
+        self.assertContains(response, 'sort=-xp')
+
+        reversed_response = self.client.get(reverse('library:quest_list'), {'q': 'Zsort', 'sort': '-xp'})
+
+        self.assertEqual(reversed_response.context['sort_column'], 'xp')
+        self.assertTrue(reversed_response.context['sort_descending'])
+
+
 class LibraryListingWindowTests(LibraryTenantTestCaseMixin):
     """The Library lists what it holds, not what the sharing deck's timetable allows.
 

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
 from django.db import connection, transaction
-from django.db.models import Q
+from django.db.models import F, Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
@@ -570,6 +570,15 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
     #: Quests per page, matching the campaigns tab.
     paginate_by = 15
 
+    #: The columns this tab can be ordered by, mapped to the field the database orders on.
+    #: Tags are deliberately absent: a quest carries any number of them, so there is no one
+    #: value to order it by, and the search box already finds the quests carrying a given one.
+    SORT_COLUMNS = {
+        'name': 'name',
+        'xp': 'xp',
+        'campaign': 'campaign__title',
+    }
+
     def get_search_term(self):
         """The search term the user typed, from the `q` query parameter.
 
@@ -597,6 +606,58 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             return max(int(requested), 1)
         except (TypeError, ValueError):
             return requested
+
+    def get_sort(self):
+        """The column the list is ordered by and its direction, from the `sort` parameter.
+
+        A leading '-' asks for the reverse, which is Django's own `order_by` spelling and
+        what the heading links carry. A column this tab does not offer is ignored rather
+        than refused, so a stale or hand-made link falls back to the Library's own order
+        instead of erroring.
+
+        Returns:
+            tuple[str, bool]: the column key, '' when none applies, and whether it was
+            asked for in reverse.
+        """
+        requested = self.request.GET.get('sort', '')
+        descending = requested.startswith('-')
+        column = requested[1:] if descending else requested
+
+        if column not in self.SORT_COLUMNS:
+            return '', False
+
+        return column, descending
+
+    def sort_library_quests(self, quests, column, descending):
+        """Order the quests by the chosen column, before the page is cut from them.
+
+        Ordering has to happen here rather than in the browser, because the browser only
+        holds one page: sorting there answers a question about the page, not about the
+        Library.
+
+        `name` is appended as a tie-break so the ordering is total. Without it, rows
+        sharing an XP value have no defined order between them, and Postgres is free to
+        return them differently on each query, which lets a quest appear on two pages or
+        on neither as the reader pages through.
+
+        Quests with no campaign sort last either way, rather than filling the first page
+        with blanks when the reader asked to see the list by campaign.
+
+        Args:
+            quests (QuerySet[Quest]): the quests to order.
+            column (str): the column key, or '' to keep the Library's own order.
+            descending (bool): whether to reverse the chosen column.
+
+        Returns:
+            QuerySet[Quest]: the ordered quests.
+        """
+        if not column:
+            return quests
+
+        field = F(self.SORT_COLUMNS[column])
+        ordering = field.desc(nulls_last=True) if descending else field.asc(nulls_last=True)
+
+        return quests.order_by(ordering, 'name')
 
     def get_library_quests(self, search_term):
         """The listable Library quests, narrowed by the search term.
@@ -638,9 +699,9 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
         Populate context with a page of the shared library's listable quests.
 
         The Library is read one page at a time, since loading all of it into memory on
-        every request does not survive a Library worth browsing (#2379). Searching
-        happens in the database for the same reason, so it covers every quest rather
-        than only the ones already sent to the browser.
+        every request does not survive a Library worth browsing (#2379). Searching and
+        sorting happen in the database for the same reason, so they cover every quest
+        rather than only the ones already sent to the browser (#2410).
 
         Args:
             **kwargs: keyword arguments passed through to `TemplateView.get_context_data`.
@@ -653,6 +714,9 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
                     related Campaign and tags prefetched.
                 - page_obj (Page): The current page, for the pagination controls.
                 - search_term (str): What the user searched for, to keep the box filled in.
+                - sort_column (str): The column the list is ordered by, '' for the Library's
+                    own order. Read by the sortable column headings.
+                - sort_descending (bool): Whether that column is applied in reverse.
                 - num_matching_quests (int): How many quests the search matched, across
                     every page.
                 - num_quests (int): Number of listable quests in the Library, used for the UI
@@ -667,8 +731,11 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         search_term = self.get_search_term()
 
+        sort_column, sort_descending = self.get_sort()
+
         with library_schema_context():
             quests = self.get_library_quests(search_term)
+            quests = self.sort_library_quests(quests, sort_column, sort_descending)
             paginator = Paginator(quests, self.paginate_by)
             # get_page (rather than page) turns a junk or out-of-range ?page= into the
             # nearest real page instead of raising
@@ -696,6 +763,8 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
             'library_quests': page_quests,
             'page_obj': page,
             'search_term': search_term,
+            'sort_column': sort_column,
+            'sort_descending': sort_descending,
             'viewer_is_library_staff': viewer_is_library_staff(self.request),
             'num_matching_quests': paginator.count,
             'num_quests': num_quests,

--- a/src/templates/snippets/sortable_column_heading.html
+++ b/src/templates/snippets/sortable_column_heading.html
@@ -1,0 +1,36 @@
+{% comment %}
+  A column heading that sorts the whole list, for any table paginated on the server.
+
+  bootstrap-table's own `data-sortable` reorders the rows the browser is holding, which on
+  a paginated table is one page. This links back to the view instead, so the ordering is
+  applied to every row before the page is cut from it.
+
+  Requires in the context:
+    sort_column (str): the column key currently ordering the list, '' when the list is in
+      its own default order.
+    sort_descending (bool): whether that column is applied in reverse.
+
+  Takes:
+    column (str): this column's key, one of those the view offers.
+    label (str): the heading text.
+
+  `page` is dropped from every link, because page 3 of a list ordered by name holds
+  different rows than page 3 of the same list ordered by XP: carrying the number over
+  would land the reader somewhere they did not ask to be. Every other parameter is kept,
+  so a search stays applied while its results are reordered.
+{% endcomment %}
+{% if column != sort_column %}
+  <a href="{% querystring sort=column page=None %}" title="Sort by {{ label }}">
+    {{ label }} <i class="fa fa-fw fa-sort text-muted"></i>
+  </a>
+{% elif sort_descending %}
+  <a href="{% querystring sort=column page=None %}" title="Sorted by {{ label }}, reversed. Click to restore the order.">
+    {{ label }} <i class="fa fa-fw fa-sort-desc"></i>
+  </a>
+{% else %}
+  {% with reversed_column="-"|add:column %}
+    <a href="{% querystring sort=reversed_column page=None %}" title="Sorted by {{ label }}. Click to reverse the order.">
+      {{ label }} <i class="fa fa-fw fa-sort-asc"></i>
+    </a>
+  {% endwith %}
+{% endif %}


### PR DESCRIPTION
### What?

The Library's quests tab now sorts on the server. The Quest, XP and Campaign headings are links carrying `?sort=`, so clicking one orders every listable quest in the Library rather than the fifteen the browser happens to be holding. Clicking the applied column again reverses it.

Closes #2410

### Why?

The tab was paginated server-side in #2408, and kept bootstrap-table's client-side column sort. That sort reorders the rows in the DOM, which after pagination is one page. So "XP" answered *which of these fifteen is worth the most*, while looking like it answered *which quests in the Library are worth the most*. The control promised something it could not do.

Tags is the other half of that. A quest carries any number of tags, so there is no single value to order it by; the heading offered a sort that could only ever be arbitrary. It is now plain text, and the search box already finds the quests carrying a given tag.

### How?

**The heading is a shared snippet, not a Library-specific one.** `src/templates/snippets/sortable_column_heading.html` takes a column key and a label, and reads `sort_column` and `sort_descending` from the context. #2410 called for solving this once for the shared accordion table rather than per page, and the approvals and submissions tabs carry the same combination: #2582 is next and reuses this snippet.

**Each link drops `?page=` and keeps everything else.** Page 3 of the Library ordered by name holds different quests than page 3 of it ordered by XP, so carrying the number across would land the reader somewhere they did not ask to be. Every other parameter survives, so a search stays applied while its results are reordered.

**A column the tab does not offer is ignored, not refused.** A stale link, or one someone typed, falls back to the Library's own order rather than erroring. `sort=tags` is the live case, since that column is rendered but deliberately not sortable.

**Ordering appends `name` as a tie-break, so it is total.** Rows that tie on the chosen column otherwise have no defined order between them, and the database is free to return them differently per query, which is what lets a quest appear on two pages or on neither as the reader pages through.

**Quests with no campaign sort last in both directions** (`nulls_last`), rather than Postgres putting the blanks first on a descending sort and filling page one with them.

### Testing?

Eight tests in `LibraryQuestSortTests`. The central one is `..._sorting_reaches_quests_that_are_not_on_the_current_page`: the fixture gives quests ascending XP in name order, so the highest-XP quests sit on page two, and a sort confined to the rendered rows could never surface them.

The others cover: ascending and reversed; the search staying applied through a reorder; an unknown column falling back; quests with no campaign sorting last either way; paging a sorted list showing each quest exactly once; the headings carrying `sort=` while dropping `page=` and no longer carrying `data-sortable`; and the applied heading offering its own reverse.

**Verified in both directions.** Reverting the two changed source files to `develop` fails six of the eight. The two that still pass are honest about what they are:

* `..._sorting_keeps_the_search_applied` is a regression guard on search scoping, which this must not change.
* `..._paging_a_sorted_list_shows_each_quest_exactly_once` passes without the `name` tie-break too, because Postgres happens to return a consistent order at this size. The tie-break is there because that consistency is not guaranteed, not because a test forces it; the test guards the user-visible property rather than the mechanism.

Full suite: `Ran 2722 tests ... OK (skipped=5)`. `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean. `src/library` is at 100% coverage: 740 statements, 138 branches, 0 misses and 0 partial branches.

### Screenshots (if front end is affected)

Captured from a running dev deck (`hackerspace.localhost:8000`, signed in as the deck owner), with a Library holding 26 published quests across three campaigns, so the list spans two pages.

**Before**: bootstrap-table's arrows on all four columns, including Tags. This is page one in the default order, so the XP column reads 65, 25, 60, 22, 20, ... and sorting it would only shuffle those.

![before: the quests tab with client-side sort arrows on every column](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2410/before-quests-tab.png)

**After**, same page: Quest, XP and Campaign are links, Tags is plain text.

![after: the quests tab with the three sortable columns as links](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2410/after-quests-tab.png)

**After**, having clicked XP twice to get highest first. The top two, *Version Control with Git* (80) and *Publishing Your Game* (70), include a quest that was on page two before: that is the difference the issue is about.

![after: the Library ordered by XP descending, highest first](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2410/after-sorted-by-xp.png)

### Anything Else?

The campaigns tab is left alone. It is paginated but its headings were never sortable, so it makes no promise to break.

This is the first of three: #2582 applies the same snippet and plumbing to the quest approvals and submissions tabs, and the remaining quest views then get pagination plus server-side search and sort on the same pattern.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sortable Library quest columns for name, XP, and campaign.
  * Sorting now supports ascending and descending order, preserves search filters, and resets pagination when changed.
  * Quests without campaigns are consistently placed at the end of results.
* **Bug Fixes**
  * Improved sorting behavior across paginated quest lists, including stable ordering for tied values.
  * Unsupported sort options are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->