### PR TITLE
feat: paginate the quest tabs and move their search and sort to the server

### DIFF
--- a/src/library/templates/library/tab_library_quests.html
+++ b/src/library/templates/library/tab_library_quests.html
@@ -47,10 +47,10 @@
       <tr class="panel-heading">
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
         {% comment %}
-          The headings link to the server rather than carrying data-sortable, so they order
-          the whole Library instead of the page the browser happens to hold (#2410). Tags
-          are not sortable: a quest carries any number of them, so there is no one value to
-          order it by, and the search box already finds the quests carrying a given one.
+          The headings link back to the view, so the ordering is applied to every quest in
+          the Library before the page is cut from it (#2410). Tags is not sortable: a quest
+          carries any number of them, so there is no one value to order it by, and the
+          search box already finds the quests carrying a given one.
         {% endcomment %}
         <th class="col-sm-5 col-xs-8" data-field="name">
           {% include "snippets/sortable_column_heading.html" with column="name" label="Quest" %}

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -640,9 +640,8 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
         which is what the column headings promise the reader they can search by. Several
         words narrow the results rather than widening them: every word has to match
         something, though not all the same thing, so "recursion python" finds the quest
-        named "Recursion: base cases" that is tagged python. That is how the search box
-        behaved when it filtered rows in the browser, and it is the more useful of the two
-        readings once the Library is big enough to need narrowing.
+        named "Recursion: base cases" that is tagged python. Narrowing is the more useful
+        of the two readings once the Library is big enough to need searching at all.
 
         Args:
             search_term (str): what the user typed, or '' for no filtering.

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -5,7 +5,6 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
 from django.db import connection, transaction
-from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
@@ -25,6 +24,7 @@ from quest_manager.models import Quest, Category
 from siteconfig.models import SiteConfig
 from tenant.models import Tenant
 from tenant.tasks import send_email_message
+from quest_manager.listing import QUEST_SORT_COLUMNS, search_quests
 from utilities.sorting import apply_sort, resolve_sort
 
 from notifications.signals import notify
@@ -571,14 +571,9 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
     #: Quests per page, matching the campaigns tab.
     paginate_by = 15
 
-    #: The columns this tab can be ordered by, mapped to the field the database orders on.
-    #: Tags are deliberately absent: a quest carries any number of them, so there is no one
-    #: value to order it by, and the search box already finds the quests carrying a given one.
-    SORT_COLUMNS = {
-        'name': 'name',
-        'xp': 'xp',
-        'campaign': 'campaign__title',
-    }
+    #: The columns this tab can be ordered by, shared with the deck's own quest tabs since
+    #: both list the same model through the same columns.
+    SORT_COLUMNS = QUEST_SORT_COLUMNS
 
     def get_search_term(self):
         """The search term the user typed, from the `q` query parameter.
@@ -657,18 +652,7 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
         """
         quests = library_listable_quests().select_related('campaign').prefetch_related('tags')
 
-        for word in search_term.split():
-            quests = quests.filter(
-                Q(name__icontains=word)
-                | Q(campaign__title__icontains=word)
-                | Q(tags__name__icontains=word)
-            )
-
-        if search_term:
-            # distinct() because the tags join multiplies a quest by its matching tags
-            quests = quests.distinct()
-
-        return quests
+        return search_quests(quests, search_term)
 
     def get_context_data(self, **kwargs):
         """

--- a/src/quest_manager/listing.py
+++ b/src/quest_manager/listing.py
@@ -1,0 +1,50 @@
+"""Searching and ordering shared by the quest lists that are paginated a page at a time.
+
+The deck's quest tabs and the Library's quests tab list the same model through the same
+columns, so they search and order it the same way. Both are paginated, which is why this
+happens in the database: a page is all the browser holds, so filtering or ordering there
+answers a question about the page rather than about the list (#2379, #2410, #2582).
+"""
+from django.db.models import Q
+
+#: The columns a quest list can be ordered by, mapped to the field the database orders on.
+#: Tags are deliberately absent: a quest carries any number of them, so there is no one
+#: value to order it by, and the search box already finds the quests carrying a given one.
+QUEST_SORT_COLUMNS = {
+    'name': 'name',
+    'xp': 'xp',
+    'campaign': 'campaign__title',
+}
+
+
+def search_quests(quests, search_term):
+    """Narrow a quest list to those matching every word of a search term.
+
+    A quest matches a word on its own name, on its campaign's title, or on one of its
+    tags, which is what the column headings promise the reader they can search by.
+
+    Several words narrow the results rather than widening them: every word has to match
+    something, though not all the same thing, so "recursion python" finds the quest named
+    "Recursion: base cases" that is tagged python. That is how the search behaved when it
+    filtered rows in the browser, and it is the more useful of the two readings once a
+    list is long enough to need narrowing.
+
+    Args:
+        quests (QuerySet[Quest]): the quests to narrow.
+        search_term (str): what the user typed, or '' for no filtering.
+
+    Returns:
+        QuerySet[Quest]: the matching quests.
+    """
+    for word in search_term.split():
+        quests = quests.filter(
+            Q(name__icontains=word)
+            | Q(campaign__title__icontains=word)
+            | Q(tags__name__icontains=word)
+        )
+
+    if search_term:
+        # distinct() because the tags join multiplies a quest by its matching tags
+        quests = quests.distinct()
+
+    return quests

--- a/src/quest_manager/listing.py
+++ b/src/quest_manager/listing.py
@@ -25,9 +25,8 @@ def search_quests(quests, search_term):
 
     Several words narrow the results rather than widening them: every word has to match
     something, though not all the same thing, so "recursion python" finds the quest named
-    "Recursion: base cases" that is tagged python. That is how the search behaved when it
-    filtered rows in the browser, and it is the more useful of the two readings once a
-    list is long enough to need narrowing.
+    "Recursion: base cases" that is tagged python. Narrowing is the more useful of the two
+    readings once a list is long enough to need searching at all.
 
     Args:
         quests (QuerySet[Quest]): the quests to narrow.

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -23,10 +23,10 @@
       <tr class="panel-heading">
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
         {% comment %}
-          The headings link to the server rather than carrying data-sortable, so they order
-          the whole tab instead of the page the browser happens to hold (#2582). A column
-          only becomes a link when this tab offers it: the {group} blocks and the quest's
-          tags are many-valued, and the in-progress tabs show no time under Status.
+          The headings link back to the view, so the ordering is applied to every submission
+          in the tab before the page is cut from it (#2582). A column only becomes a link
+          when this tab offers it: the {group} blocks and the quest's tags are many-valued,
+          and the in-progress tabs show no time under Status.
         {% endcomment %}
         <th class="col-sm-4 col-xs-5" data-field="name">
           {% if "name" in sortable_columns %}{% include "snippets/sortable_column_heading.html" with column="name" label="Quest" %}{% else %}Quest{% endif %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -85,10 +85,10 @@
         {% endif %}
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
         {% comment %}
-          The headings link to the server rather than carrying data-sortable, so they order
-          the whole tab instead of the page the browser happens to hold (#2410, #2582).
-          Tags are not sortable: a quest carries any number of them, so there is no one
-          value to order it by, and the search box already finds the quests carrying one.
+          The headings link back to the view, so the ordering is applied to every quest in
+          the tab before the page is cut from it (#2410, #2582). Tags is not sortable: a
+          quest carries any number of them, so there is no one value to order it by, and
+          the search box already finds the quests carrying a given one.
         {% endcomment %}
         <th class="col-sm-5 col-xs-8" data-field="name">
           {% include "snippets/sortable_column_heading.html" with column="name" label="Quest" sort_column=quest_sort_column sort_descending=quest_sort_descending %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -9,6 +9,35 @@
 -->
 {% load static %}
 
+{% comment %}
+  Searching is done by the server so it covers the whole tab, not just the quests on this
+  page. Submitting drops any ?page=, so a new search starts at its own first page. This
+  sits above the bulk-edit form rather than inside it: nested forms are not valid HTML.
+{% endcomment %}
+<form class="form-inline list-search-form" method="get" action="">
+  <div class="form-group">
+    <label class="sr-only" for="quest-search">Search quests</label>
+    <div class="input-group">
+      <input type="search" class="form-control" id="quest-search" name="q"
+             value="{{ search_term }}" placeholder="Search quests, campaigns and {{ config.custom_name_for_tag|lower }}s">
+      <span class="input-group-btn">
+        <button class="btn btn-default" type="submit" title="Search every quest in this tab">
+          <i class="fa fa-fw fa-search"></i>
+        </button>
+        {% if search_term %}
+          <a class="btn btn-default" href="{% querystring q=None page=None %}" role="button" title="Clear this search">
+            <i class="fa fa-fw fa-times"></i>
+          </a>
+        {% endif %}
+      </span>
+    </div>
+  </div>
+</form>
+
+{% if search_term %}
+  <p class="text-muted">{{ num_matching_quests }} quest{{ num_matching_quests|pluralize }} match "{{ search_term }}".</p>
+{% endif %}
+
 {% if bulk_edit_mode %}
   <script src="{% static 'quest_manager/js/custom-quest.js' %}"></script>
 
@@ -46,20 +75,31 @@
          data-classes="table table-hover table-responsive"
          data-toggle="table"
          data-detail-view="true"
-         data-unique-id="id"
-         data-search="true"
-         data-trim-on-search="false"
-         data-custom-search="multiKeywordSearch">
+         data-unique-id="id">
     <thead>
       <tr class="panel-heading">
         {% if bulk_edit_mode %}
-          <th><input type="checkbox" id="select-all-checkbox" onclick="toggleAllCheckboxes(this)"></th>
+          {% comment %} Ticks the rows on this page, which is what the reader can see {% endcomment %}
+          <th><input type="checkbox" id="select-all-checkbox" onclick="toggleAllCheckboxes(this)"
+                     title="Select every quest on this page"></th>
         {% endif %}
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
-        <th class="col-sm-5 col-xs-8" data-field="name" data-sortable="true">Quest</th>
-        <th class="col-sm-1 text-right col-xs-2" data-field="xp" data-sortable="true">XP</th>
-        <th class="col-sm-2 text-right hidden-xs" data-field="campaign" data-sortable="true">Campaign</th>
-        <th class="col-sm-1 text-center hidden-xs" data-field="tags" data-sortable="true">{{ config.custom_name_for_tag }}s</th>
+        {% comment %}
+          The headings link to the server rather than carrying data-sortable, so they order
+          the whole tab instead of the page the browser happens to hold (#2410, #2582).
+          Tags are not sortable: a quest carries any number of them, so there is no one
+          value to order it by, and the search box already finds the quests carrying one.
+        {% endcomment %}
+        <th class="col-sm-5 col-xs-8" data-field="name">
+          {% include "snippets/sortable_column_heading.html" with column="name" label="Quest" sort_column=quest_sort_column sort_descending=quest_sort_descending %}
+        </th>
+        <th class="col-sm-1 text-right col-xs-2" data-field="xp">
+          {% include "snippets/sortable_column_heading.html" with column="xp" label="XP" sort_column=quest_sort_column sort_descending=quest_sort_descending %}
+        </th>
+        <th class="col-sm-2 text-right hidden-xs" data-field="campaign">
+          {% include "snippets/sortable_column_heading.html" with column="campaign" label="Campaign" sort_column=quest_sort_column sort_descending=quest_sort_descending %}
+        </th>
+        <th class="col-sm-1 text-center hidden-xs" data-field="tags">{{ config.custom_name_for_tag }}s</th>
         <th class="col-sm-2 hidden-xs" data-field="status_icons"><!-- status_icons --></th>
       </tr>
     </thead>
@@ -132,6 +172,11 @@
       </ul>
     </div>
   {% endfor %}
+  {% with items=quests %}
+    {% include "quest_manager/pagination_controls.html" %}
+  {% endwith %}
+{% elif search_term %}
+  <p>No quests in this tab match "{{ search_term }}".</p>
 {% else %}
   <p>No quests are available.</p>
 {% endif %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -21,10 +21,10 @@
       <tr class="panel-heading">
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
         {% comment %}
-          The headings link to the server rather than carrying data-sortable, so they order
-          the whole tab instead of the page the browser happens to hold (#2582). A column
-          only becomes a link when this tab offers it: the {group} blocks and the quest's
-          tags are many-valued, and the in-progress tabs show no time under Status.
+          The headings link back to the view, so the ordering is applied to every submission
+          in the tab before the page is cut from it (#2582). A column only becomes a link
+          when this tab offers it: the {group} blocks and the quest's tags are many-valued,
+          and the in-progress tabs show no time under Status.
         {% endcomment %}
         <th class="col-sm-4 col-xs-8" data-field="name">
           {% if "name" in sortable_columns %}{% include "snippets/sortable_column_heading.html" with column="name" label="Quest" %}{% else %}Quest{% endif %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -5179,6 +5179,149 @@ class ApproveViewTest(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class QuestTabListingTests(ByteDeckTenantTestCase):
+    """The available, drafts and archived tabs are read a page at a time.
+
+    Each was sent whole, so a deck with a few hundred quests rendered all of them into one
+    table on every request. Searching and ordering went with it: both now happen in the
+    database, so they cover the tab rather than the page the browser is holding.
+    """
+
+    #: More quests than `paginate`'s default page, so the list spills onto a second page.
+    QUEST_COUNT = 35
+
+    @classmethod
+    def setUpTestData(cls):
+        """Publish a tab's worth of quests whose names and XP run opposite ways.
+
+        Named so they sort into creation order and given XP that climbs with the name, so
+        the highest-XP quests are exactly the ones the default order leaves on page two.
+        """
+        cls.teacher = User.objects.create_user('tab_listing_teacher', is_staff=True)
+        cls.campaign = baker.make('quest_manager.Category', title='Aardvark Campaign')
+
+        # Quest.name is unique, so these can't be made in one _quantity call
+        for i in range(cls.QUEST_COUNT):
+            baker.make(Quest, name=f'Zsort quest {i:02d}', xp=i, campaign=cls.campaign)
+
+    def setUp(self):
+        """Sign the teacher in: the available tab shows every published quest to staff."""
+        super().setUp()
+        self.client.force_login(self.teacher)
+
+    def _names(self, url_name='quests:quests', **params):
+        """The quest names on a tab's current page, in the order rendered.
+
+        Args:
+            url_name (str): the tab's url name.
+            **params: query parameters for the request.
+
+        Returns:
+            list[str]: the quest names on that page, in order.
+        """
+        response = self.client.get(reverse(url_name), params)
+        return [quest.name for quest in response.context['quests']]
+
+    def test_quest_list__the_available_tab_sends_one_page_of_quests(self):
+        """The tab carries a page rather than every quest the deck has published."""
+        response = self.client.get(reverse('quests:quests'))
+
+        page = response.context['quests']
+        self.assertEqual(len(page), 30)
+        self.assertGreater(page.paginator.count, 30)
+        self.assertContains(response, 'page=2')
+
+    def test_quest_list__searching_finds_a_quest_that_is_not_on_this_page(self):
+        """The search covers the whole tab, so it reaches page two.
+
+        Filtering in the browser could only ever match the rows already sent to it.
+        """
+        last = f'Zsort quest {self.QUEST_COUNT - 1:02d}'
+        self.assertNotIn(last, self._names())
+
+        self.assertEqual(self._names(q=last), [last])
+
+    def test_quest_list__searching_matches_name_campaign_and_tag(self):
+        """A quest matches on its own name, its campaign's title, or one of its tags."""
+        tagged = baker.make(Quest, name='Recursion base cases', campaign=self.campaign)
+        tagged.tags.add('python')
+
+        self.assertIn('Recursion base cases', self._names(q='Recursion'))
+        self.assertIn('Recursion base cases', self._names(q='python'))
+        self.assertIn('Recursion base cases', self._names(q='Aardvark'))
+        # Every word has to match something, though not all the same thing
+        self.assertIn('Recursion base cases', self._names(q='recursion python'))
+        self.assertNotIn('Recursion base cases', self._names(q='recursion ruby'))
+
+    def test_quest_list__sorting_reaches_quests_that_are_not_on_the_current_page(self):
+        """Ordering by XP brings the tab's highest-XP quests onto the first page."""
+        default_first_page = self._names()
+        highest_xp_first = self._names(sort='-xp')
+
+        self.assertEqual(highest_xp_first[0], f'Zsort quest {self.QUEST_COUNT - 1:02d}')
+        self.assertNotIn(highest_xp_first[0], default_first_page)
+
+    def test_quest_list__a_search_and_a_sort_apply_together(self):
+        """Ordering a search reorders its results rather than dropping the search."""
+        names = self._names(q='Zsort', sort='-xp')
+
+        self.assertEqual(names[0], f'Zsort quest {self.QUEST_COUNT - 1:02d}')
+        for name in names:
+            self.assertTrue(name.startswith('Zsort quest'), f'{name} is not one of the searched-for quests')
+
+    def test_quest_list__a_column_this_tab_does_not_offer_is_ignored(self):
+        """A stale or hand-made `?sort=` falls back to the tab's own order, not an error."""
+        default_order = self._names()
+
+        for unknown in ('tags', 'nonsense', 'name; drop table', '-'):
+            with self.subTest(sort=unknown):
+                response = self.client.get(reverse('quests:quests'), {'sort': unknown})
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual([q.name for q in response.context['quests']], default_order)
+                self.assertEqual(response.context['quest_sort_column'], '')
+
+    def test_quest_list__the_browser_no_longer_searches_or_sorts_the_page(self):
+        """bootstrap-table's own search and sort are gone, since they only saw one page."""
+        response = self.client.get(reverse('quests:quests'))
+
+        self.assertNotContains(response, 'data-sortable="true"')
+        self.assertNotContains(response, 'data-custom-search="multiKeywordSearch"')
+        self.assertContains(response, 'name="q"')
+
+    def test_quest_list__the_drafts_and_archived_tabs_are_paginated_and_searchable(self):
+        """The other two quest tabs get the same treatment, since they share the template."""
+        # Quest.name is unique, so these can't be made in one _quantity call
+        for i in range(self.QUEST_COUNT):
+            baker.make(Quest, name=f'Zdraft quest {i:02d}', published=False)
+
+        for url_name in ('quests:drafts', 'quests:archived'):
+            with self.subTest(tab=url_name):
+                response = self.client.get(reverse(url_name))
+
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, 'name="q"')
+
+        drafts = self._names('quests:drafts')
+        self.assertEqual(len(drafts), 30)
+        self.assertEqual(self._names('quests:drafts', q='Zdraft quest 34'), ['Zdraft quest 34'])
+
+    def test_quest_list__the_badge_count_reports_the_tab_not_the_search(self):
+        """The tab's badge keeps counting what the tab holds while a search narrows it.
+
+        A count that moved with the search would leave the reader unable to tell how much
+        the tab has without clearing what they typed.
+        """
+        # The deck is seeded with quests of its own, so the badge is measured rather than
+        # assumed: what matters is that searching does not move it
+        unsearched = self.client.get(reverse('quests:quests'))
+        searched = self.client.get(reverse('quests:quests'), {'q': 'Zsort quest 00'})
+
+        self.assertEqual(searched.context['num_available'], unsearched.context['num_available'])
+        self.assertEqual(searched.context['num_matching_quests'], 1)
+        self.assertGreater(searched.context['num_available'], 1)
+
+
 class SubmissionTabSortTests(ByteDeckTenantTestCase):
     """The approvals and submissions tabs order the whole tab, not one page of it.
 

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -5182,9 +5182,9 @@ class ApproveViewTest(ByteDeckTenantTestCase):
 class QuestTabListingTests(ByteDeckTenantTestCase):
     """The available, drafts and archived tabs are read a page at a time.
 
-    Each was sent whole, so a deck with a few hundred quests rendered all of them into one
-    table on every request. Searching and ordering went with it: both now happen in the
-    database, so they cover the tab rather than the page the browser is holding.
+    Searching and ordering happen in the database, so each covers every quest in the tab
+    rather than the page that was sent to the browser. A deck with a few hundred quests
+    costs one page of rendering per request.
     """
 
     #: More quests than `paginate`'s default page, so the list spills onto a second page.
@@ -5234,7 +5234,8 @@ class QuestTabListingTests(ByteDeckTenantTestCase):
     def test_quest_list__searching_finds_a_quest_that_is_not_on_this_page(self):
         """The search covers the whole tab, so it reaches page two.
 
-        Filtering in the browser could only ever match the rows already sent to it.
+        A match on a later page is exactly what a search confined to the rendered rows
+        cannot find, and the reader is told there is nothing rather than which page to try.
         """
         last = f'Zsort quest {self.QUEST_COUNT - 1:02d}'
         self.assertNotIn(last, self._names())
@@ -5281,8 +5282,12 @@ class QuestTabListingTests(ByteDeckTenantTestCase):
                 self.assertEqual([q.name for q in response.context['quests']], default_order)
                 self.assertEqual(response.context['quest_sort_column'], '')
 
-    def test_quest_list__the_browser_no_longer_searches_or_sorts_the_page(self):
-        """bootstrap-table's own search and sort are gone, since they only saw one page."""
+    def test_quest_list__the_table_carries_no_client_side_search_or_sort(self):
+        """The tab's searching and ordering are the server's, so the table asks for neither.
+
+        bootstrap-table would filter and reorder the rows it holds, which is one page, and
+        answer a narrower question than the control appears to ask.
+        """
         response = self.client.get(reverse('quests:quests'))
 
         self.assertNotContains(response, 'data-sortable="true"')

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -41,6 +41,8 @@ from questions.models import QuestionSubmission, QuestionType
 from questions.utils import discard_draft_question_submissions, save_draft_file_answers, sync_draft_question_submissions
 from courses.models import Block, CourseStudent
 from utilities.sorting import apply_sort, resolve_sort
+
+from .listing import QUEST_SORT_COLUMNS, search_quests
 from library.utils import is_library_schema_requested, library_schema_if_requested
 from notifications.signals import notify
 from notifications.models import notify_rank_up
@@ -931,6 +933,18 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
     else:
         quests = available_quests
 
+    # The quest tabs are searched, ordered and paginated in the database, so all three
+    # cover the whole tab rather than the page the browser is holding (#2379, #2410).
+    # The counts above are taken first, so the tab badges keep reporting what the tab
+    # holds rather than what the current search matched.
+    search_term = request.GET.get('q', '').strip()
+    quests = search_quests(quests, search_term)
+    num_matching_quests = quests.count()
+
+    quest_sort_column, quest_sort_descending = resolve_sort(request, QUEST_SORT_COLUMNS)
+    quests = apply_sort(quests, QUEST_SORT_COLUMNS, quest_sort_column, quest_sort_descending, tie_break='name')
+    quests = paginate(quests, page)
+
     # Used to explain why the "Available" tab is empty, if it is
     awaiting_approval = QuestSubmission.objects.filter(
         user=request.user, is_approved=False, is_completed=True
@@ -962,6 +976,13 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
         "sortable_columns": sortable_columns,
         "sort_column": sort_column,
         "sort_descending": sort_descending,
+        # The quest tabs (available, drafts, archived) carry their own search and order,
+        # since they list quests rather than submissions
+        "search_term": search_term,
+        "num_matching_quests": num_matching_quests,
+        "quest_sortable_columns": QUEST_SORT_COLUMNS,
+        "quest_sort_column": quest_sort_column,
+        "quest_sort_descending": quest_sort_descending,
     }
     return render(request, template, context)
 


### PR DESCRIPTION
### What?

The **Available**, **Drafts** and **Archived** quest tabs are now read a page at a time, with a search box and column headings that work on the server. Searching and ordering cover the whole tab rather than the page in front of you.

### Why?

These three tabs were sent whole. A deck with a few hundred published quests rendered every one of them into a single table on every request, which is the memory and DOM cost #2379 fixed for the Library's quests tab and #2081 describes for the student list.

Their searching and ordering ran in the browser, over the rows it had been handed. That was the whole tab only because the whole tab was sent. Paginating without moving them would have reproduced the bug #2410 and #2582 were about: a control that answers a question about the current page while looking like it answers one about the list.

### How?

**The same three controls the other quest lists already use.** The `?q=` box, `snippets/sortable_column_heading.html` and `quest_manager/pagination_controls.html` come straight from the Library's quests tab and the submission tabs, so all of them now behave alike: several words narrow rather than widen, a quest matches on its name, its campaign or one of its tags, and a new search or sort starts at its own first page while keeping whatever else was applied.

**`QUEST_SORT_COLUMNS` and `search_quests()` move into `quest_manager/listing.py`**, which the Library's quests tab now uses too. Both lists show the same model through the same columns, so there is one implementation rather than a copy each. `LibraryQuestListView`'s behaviour is unchanged and its tests pass untouched.

**Tags stays unsortable**, for the reason #2410 gave: a quest carries any number of them, so no single value can order a row, and the search box already finds the quests carrying one.

**The tab badges still count what the tab holds, not what the search matched.** A badge that moved with the search would leave the reader unable to tell how much is in the tab without clearing what they typed. The number of matches is reported separately, above the table.

**In bulk-edit mode, select-all now ticks the quests on the page.** That is a real change: it used to tick every quest in the tab, because every quest was on screen. It ticks what the reader can see, and the control says so in its tooltip. The bulk actions themselves are unchanged and still apply to exactly what is ticked.

**The search form sits above the bulk-edit `<form>` rather than inside it**, since nested forms are not valid HTML.

### Testing?

Nine tests in `QuestTabListingTests`: the tab sends one page rather than everything; a search finds a quest that is not on the current page; a search matches name, campaign and tag, with several words narrowing; ordering by XP reaches quests off the current page; a search and a sort apply together; an unknown sort column falls back to the tab's own order; `data-sortable` and `data-custom-search` are gone while the `?q=` box is present; the drafts and archived tabs get the same treatment; and the tab badge stays put while a search narrows the list.

**Verified in both directions.** Reverting the two changed source files to `develop` fails all nine.

Full suite: `Ran 2742 tests ... OK`. `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean. `src/quest_manager/listing.py` and `src/utilities/sorting.py` are both at 100% coverage, and `src/library` stays at 100% through the refactor.

### Screenshots (if front end is affected)

Captured from a running dev deck (`hackerspace.localhost:8000`, signed in as the deck owner) with 40 published quests, so the tab spans two pages.

**Before**: every quest in one table, with the browser's own search and sort.

![before: the available tab, unpaginated](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/quest-tabs/before-available-tab.png)

**After**: a page at a time, with the pagination controls and the headings as links.

![after: the available tab, paginated with sortable headings](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/quest-tabs/after-available-tab.png)

**After**, searching for `dragon`. The count above the table reports the matches; these are found across the whole tab, not just page one.

![after: searching the available tab for dragon](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/quest-tabs/after-available-search.png)

**After**, ordered by XP, highest first.

![after: the available tab ordered by XP descending](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/quest-tabs/after-available-sorted.png)

### Anything Else?

**The approvals and submissions tabs still search only the current page.** They were paginated before this work and #2582 moved their *sorting* to the server, but they kept bootstrap-table's client-side search, which has exactly the defect this PR removes: searching a queue of two hundred submissions looks at the thirty on screen and reports nothing found. That is filed as #2597 rather than folded in here, because those tabs list `QuestSubmission` and need a different search (the student's username and preferred name, not just the quest), and wiring a box into seven more tabs would have roughly doubled this PR.

`multiKeywordSearch` stays in `bootstrap-table-accordion.js`: several unpaginated tables still use it.

This is the third of three. #2410 landed as PR #2593 and #2582 as PR #2594.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added server-side search across quest names, campaigns, and tags.
  - Added sortable quest-list columns with pagination across available, draft, and archived tabs.
  - Added search controls, clear-search action, result counts, and tailored empty states.

- **Bug Fixes**
  - Improved combined search and sorting behavior.
  - Prevented duplicate quest results and ensured tab counts remain accurate.
  - Added safe handling for invalid sort selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->