### PR TITLE
feat: search the approvals and submissions tabs on the server (#2597)

### DIFF
--- a/src/quest_manager/listing.py
+++ b/src/quest_manager/listing.py
@@ -1,9 +1,12 @@
-"""Searching and ordering shared by the quest lists that are paginated a page at a time.
+"""Searching and ordering for the quest lists that are paginated a page at a time.
 
 The deck's quest tabs and the Library's quests tab list the same model through the same
-columns, so they search and order it the same way. Both are paginated, which is why this
-happens in the database: a page is all the browser holds, so filtering or ordering there
-answers a question about the page rather than about the list (#2379, #2410, #2582).
+columns, so they search and order it the same way. The approvals and submissions tabs list
+submissions of those quests, and search them by what their own columns show.
+
+All of it happens in the database because all of these lists are paginated: a page is what
+the browser holds, so filtering or ordering there answers a question about the page rather
+than about the list (#2379, #2410, #2582, #2597).
 """
 from django.db.models import Q
 
@@ -47,3 +50,50 @@ def search_quests(quests, search_term):
         quests = quests.distinct()
 
     return quests
+
+
+def search_submissions(submissions, search_term, *, campaign=False, user=False):
+    """Narrow a submission list to those matching every word of a search term.
+
+    Each tab searches what its own columns show, which is why the two flags exist: the
+    approvals tabs name the student and the submissions tabs name the campaign and tags.
+    Searching a column a tab does not display would return rows whose match the reader
+    cannot see, which reads as the list ignoring what they typed.
+
+    The student is matched on the two things the User column shows: their username, and
+    the preferred full name under it, which is `preferred_name` (falling back to the
+    account's first name) plus the last name. All four are searched, so a teacher who
+    types a surname finds the submission whether or not that student set a preferred name.
+
+    Several words narrow the results rather than widening them, matching the quest lists.
+
+    Args:
+        submissions (QuerySet[QuestSubmission]): the submissions to narrow.
+        search_term (str): what the user typed, or '' for no filtering.
+        campaign (bool): whether this tab shows the quest's campaign and tags.
+        user (bool): whether this tab shows whose submission it is.
+
+    Returns:
+        QuerySet[QuestSubmission]: the matching submissions.
+    """
+    for word in search_term.split():
+        matches = Q(quest__name__icontains=word)
+
+        if campaign:
+            matches |= Q(quest__campaign__title__icontains=word) | Q(quest__tags__name__icontains=word)
+
+        if user:
+            matches |= (
+                Q(user__username__icontains=word)
+                | Q(user__profile__preferred_name__icontains=word)
+                | Q(user__first_name__icontains=word)
+                | Q(user__last_name__icontains=word)
+            )
+
+        submissions = submissions.filter(matches)
+
+    if search_term and campaign:
+        # distinct() because the tags join multiplies a submission by its matching tags
+        submissions = submissions.distinct()
+
+    return submissions

--- a/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_approvals.html
@@ -9,16 +9,43 @@
 {% load crispy_forms_tags %}
 {% load utility_tags %}
 
+{% comment %}
+  Searching is done by the server so it covers the whole tab, not just the submissions on
+  this page. Submitting drops any ?page=, so a new search starts at its own first page.
+{% endcomment %}
+<form class="form-inline list-search-form" method="get" action="">
+  <div class="form-group">
+    <label class="sr-only" for="approvals-search-{{ tab.name|slugify }}">Search submissions</label>
+    <div class="input-group">
+      <input type="search" class="form-control" id="approvals-search-{{ tab.name|slugify }}" name="q"
+             value="{{ submission_search_term }}" placeholder="Search by quest or student">
+      <span class="input-group-btn">
+        <button class="btn btn-default" type="submit" title="Search every submission in this tab">
+          <i class="fa fa-fw fa-search"></i>
+        </button>
+        {% if submission_search_term %}
+          <a class="btn btn-default" href="{% querystring q=None page=None %}" role="button" title="Clear this search">
+            <i class="fa fa-fw fa-times"></i>
+          </a>
+        {% endif %}
+      </span>
+    </div>
+  </div>
+</form>
+
+{% if submission_search_term %}
+  <p class="text-muted">
+    {{ num_matching_submissions }} submission{{ num_matching_submissions|pluralize }} match{{ num_matching_submissions|pluralize:"es," }} "{{ submission_search_term }}".
+  </p>
+{% endif %}
+
 {% if tab.submissions %}
   {% include 'snippets/table_loading.html' %}
   <table id="accordion-available"
          class="accordian-table"
          data-classes="table table-hover"
          data-toggle="table"
-         data-detail-view="true"
-         data-search="true"
-         data-trim-on-search="false"
-         data-custom-search="multiKeywordSearch">
+         data-detail-view="true">
     <thead>
       <tr class="panel-heading">
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
@@ -120,6 +147,8 @@
     {% include "quest_manager/pagination_controls.html" %}
   {% endwith %}
 
+{% elif submission_search_term %}
+  <p>No submissions in this tab match "{{ submission_search_term }}".</p>
 {% elif user.block_set.count == 0 %}
   <p>You are not assigned as the teacher for any {{ config.custom_name_for_group|lower }}s yet.</p>
   <a class="btn btn-info" href="{% url 'courses:block_list' %}">Join a {{ config.custom_name_for_group|lower }}</a>

--- a/src/quest_manager/templates/quest_manager/tab_quests_available.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_available.html
@@ -35,7 +35,7 @@
 </form>
 
 {% if search_term %}
-  <p class="text-muted">{{ num_matching_quests }} quest{{ num_matching_quests|pluralize }} match "{{ search_term }}".</p>
+  <p class="text-muted">{{ num_matching_quests }} quest{{ num_matching_quests|pluralize }} match{{ num_matching_quests|pluralize:"es," }} "{{ search_term }}".</p>
 {% endif %}
 
 {% if bulk_edit_mode %}

--- a/src/quest_manager/templates/quest_manager/tab_quests_submission.html
+++ b/src/quest_manager/templates/quest_manager/tab_quests_submission.html
@@ -6,6 +6,36 @@
     > PAST COURSES (tab_quests_submission.html)
 -->
 {% load crispy_forms_tags %}
+{% comment %}
+  Searching is done by the server so it covers the whole tab, not just the submissions on
+  this page. Submitting drops any ?page=, so a new search starts at its own first page.
+{% endcomment %}
+<form class="form-inline list-search-form" method="get" action="">
+  <div class="form-group">
+    <label class="sr-only" for="submissions-search-{% if completed %}completed{% elif past %}past{% else %}inprogress{% endif %}">Search submissions</label>
+    <div class="input-group">
+      <input type="search" class="form-control" id="submissions-search-{% if completed %}completed{% elif past %}past{% else %}inprogress{% endif %}" name="q"
+             value="{{ submission_search_term }}" placeholder="Search quests, campaigns and {{ config.custom_name_for_tag|lower }}s">
+      <span class="input-group-btn">
+        <button class="btn btn-default" type="submit" title="Search every submission in this tab">
+          <i class="fa fa-fw fa-search"></i>
+        </button>
+        {% if submission_search_term %}
+          <a class="btn btn-default" href="{% querystring q=None page=None %}" role="button" title="Clear this search">
+            <i class="fa fa-fw fa-times"></i>
+          </a>
+        {% endif %}
+      </span>
+    </div>
+  </div>
+</form>
+
+{% if submission_search_term %}
+  <p class="text-muted">
+    {{ num_matching_submissions }} submission{{ num_matching_submissions|pluralize }} match{{ num_matching_submissions|pluralize:"es," }} "{{ submission_search_term }}".
+  </p>
+{% endif %}
+
 {% if submissions %}
 
   {% include 'snippets/table_loading.html' %}
@@ -13,10 +43,7 @@
     class="accordian-table"
     data-classes="table table-hover"
     data-toggle="table"
-    data-detail-view="true"
-    data-search="true"
-    data-trim-on-search="false"
-    data-custom-search="multiKeywordSearch">
+    data-detail-view="true">
     <thead>
       <tr class="panel-heading">
         <th class="col-sm-1 col-xs-2 col-icon" data-field="icon"></th>
@@ -107,6 +134,8 @@
     {% include "quest_manager/pagination_controls.html" %}
   {% endwith %}
 
+{% elif submission_search_term %}
+  <p>No submissions in this tab match "{{ submission_search_term }}".</p>
 {% else %}
   <p>None.</p>
 {% endif %}

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -5352,6 +5352,9 @@ class SubmissionTabSortTests(ByteDeckTenantTestCase):
 
         cls.campaign_a = baker.make('quest_manager.Category', title='Aardvark Campaign')
         cls.campaign_z = baker.make('quest_manager.Category', title='Zebra Campaign')
+        # all_completed() reads the student's own registration, so their completed tab is
+        # empty without one however many submissions they have
+        baker.make('courses.CourseStudent', user=cls.student, semester=semester)
 
         cls.submissions = []
         for i in range(cls.SUBMISSION_COUNT):
@@ -5517,6 +5520,8 @@ class SubmissionTabSortTests(ByteDeckTenantTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['sort_column'], 'campaign')
         campaigns = [s.quest.campaign.title for s in response.context['completed_submissions']]
+        # Asserted non-empty: an ordering check passes vacuously on an empty tab
+        self.assertGreater(len(campaigns), 1)
         self.assertEqual(campaigns, sorted(campaigns))
 
     def test_quest_list__a_tab_that_is_not_paginated_offers_no_sort(self):
@@ -5530,6 +5535,169 @@ class SubmissionTabSortTests(ByteDeckTenantTestCase):
 
         self.assertEqual(response.context['sortable_columns'], {})
         self.assertEqual(response.context['sort_column'], '')
+
+
+class SubmissionTabSearchTests(ByteDeckTenantTestCase):
+    """The approvals and submissions tabs search the whole tab, not the page on screen.
+
+    Each searches what its own columns show: the approvals tabs name the student, and the
+    submissions tabs name the campaign and tags. A match the reader cannot see in any
+    column would look like the list ignoring what they typed (#2597).
+    """
+
+    #: More submissions than `paginate`'s default page, so a match can sit on page two.
+    SUBMISSION_COUNT = 35
+
+    @classmethod
+    def setUpTestData(cls):
+        """Fill a queue with submissions, and put one distinctive student at the end of it.
+
+        The queue runs newest first, so the student handed in longest ago is on page two:
+        a search confined to the rendered rows could not reach them.
+        """
+        cls.teacher = User.objects.create_user('search_tab_teacher', is_staff=True)
+        cls.filler_student = User.objects.create_user('search_tab_filler')
+        semester = SiteConfig.get().active_semester
+        now = timezone.now()
+
+        cls.campaign = baker.make('quest_manager.Category', title='Cartography Campaign')
+
+        # Quest.name is unique, so these can't be made in one _quantity call
+        for i in range(cls.SUBMISSION_COUNT):
+            quest = baker.make(Quest, name=f'Zfiller quest {i:02d}', campaign=cls.campaign)
+            baker.make(
+                QuestSubmission, quest=quest, user=cls.filler_student, semester=semester,
+                is_completed=True, is_approved=False, time_completed=now - timedelta(minutes=i),
+            )
+
+        # Last in, so oldest, so on the far side of the first page
+        cls.needle_student = User.objects.create_user(
+            'zzoldest', first_name='Ignatius', last_name='Featherstonehaugh',
+        )
+        cls.needle_student.profile.preferred_name = 'Iggy'
+        cls.needle_student.profile.save()
+        # all_completed() reads the student's own registration, so the completed tab is
+        # empty without one however many submissions they have
+        baker.make('courses.CourseStudent', user=cls.needle_student, semester=semester)
+        cls.needle_quest = baker.make(Quest, name='Astrolabe Assembly', campaign=cls.campaign)
+        cls.needle_quest.tags.add('navigation')
+        cls.needle = baker.make(
+            QuestSubmission, quest=cls.needle_quest, user=cls.needle_student, semester=semester,
+            is_completed=True, is_approved=False, time_completed=now - timedelta(days=2),
+        )
+        # A second submission of theirs that matches none of the search terms, so the
+        # student's own tab has something for the search to leave out
+        cls.decoy_quest = baker.make(Quest, name='Sundial Basics', campaign=None)
+        cls.decoy = baker.make(
+            QuestSubmission, quest=cls.decoy_quest, user=cls.needle_student, semester=semester,
+            is_completed=True, is_approved=False, time_completed=now - timedelta(days=3),
+        )
+
+    def setUp(self):
+        """Sign the teacher in, since the approvals tabs are staff only."""
+        super().setUp()
+        self.client.force_login(self.teacher)
+
+    def _names(self, url_name='quests:submitted_all', **params):
+        """The quest names on a tab's current page, in the order rendered.
+
+        Args:
+            url_name (str): the tab's url name.
+            **params: query parameters for the request.
+
+        Returns:
+            list[str]: the quest names on that page, in order.
+        """
+        response = self.client.get(reverse(url_name), params)
+        tab = next(t for t in response.context['tab_list'] if t['active'])
+        return [submission.quest.name for submission in tab['submissions']]
+
+    def test_approvals__searching_finds_a_submission_that_is_not_on_this_page(self):
+        """The search covers the queue, so it reaches a submission on a later page."""
+        self.assertNotIn('Astrolabe Assembly', self._names())
+
+        self.assertEqual(self._names(q='Astrolabe'), ['Astrolabe Assembly'])
+
+    def test_approvals__searching_matches_every_name_the_user_column_shows(self):
+        """The username and the preferred full name under it are all searchable.
+
+        A teacher types whichever of them they know, so a surname has to find the student
+        whether or not they set a preferred name.
+        """
+        # Searching a student turns up everything of theirs in the queue, not one row
+        for term in ('zzoldest', 'Iggy', 'Featherstonehaugh'):
+            with self.subTest(term=term):
+                self.assertEqual(sorted(self._names(q=term)), ['Astrolabe Assembly', 'Sundial Basics'])
+
+    def test_approvals__searching_matches_the_account_first_name_behind_a_preferred_one(self):
+        """A student's account first name still matches when a preferred name is set.
+
+        `Ignatius` is not on screen, `Iggy` is, but a teacher who only knows the roll can
+        reasonably type either.
+        """
+        self.assertEqual(sorted(self._names(q='Ignatius')), ['Astrolabe Assembly', 'Sundial Basics'])
+
+    def test_approvals__several_words_narrow_the_queue(self):
+        """Every word has to match something, so adding a word cannot widen the results."""
+        self.assertEqual(self._names(q='Astrolabe Iggy'), ['Astrolabe Assembly'])
+        self.assertEqual(self._names(q='Astrolabe Nobody'), [])
+
+    def test_approvals__a_column_this_tab_does_not_show_is_not_searched(self):
+        """The approvals tabs have no campaign or tag column, so neither is searched.
+
+        Matching on something the reader cannot see in any column reads as the list
+        returning rows at random.
+        """
+        self.assertEqual(self._names(q='Cartography'), [])
+        self.assertEqual(self._names(q='navigation'), [])
+
+    def test_quest_list__the_submissions_tab_searches_its_campaign_and_tag_columns(self):
+        """The student's own tabs show campaign and tags, so those are searchable there."""
+        self.client.force_login(self.needle_student)
+        QuestSubmission.objects.filter(pk__in=[self.needle.pk, self.decoy.pk]).update(is_approved=True)
+
+        unsearched = self.client.get(reverse('quests:completed'))
+        self.assertEqual(len(unsearched.context['completed_submissions']), 2)
+
+        for term in ('Astrolabe', 'Cartography', 'navigation'):
+            with self.subTest(term=term):
+                response = self.client.get(reverse('quests:completed'), {'q': term})
+                names = [s.quest.name for s in response.context['completed_submissions']]
+                self.assertEqual(names, ['Astrolabe Assembly'])
+
+    def test_approvals__a_search_that_matches_nothing_says_so_and_keeps_the_box(self):
+        """An empty result explains itself, and the box keeps what was typed to clear it."""
+        response = self.client.get(reverse('quests:submitted_all'), {'q': 'Nothingmatchesthis'})
+
+        self.assertContains(response, 'No submissions in this tab match')
+        self.assertContains(response, 'Nothingmatchesthis')
+        self.assertEqual(response.context['num_matching_submissions'], 0)
+
+    def test_approvals__the_match_count_agrees_with_its_number(self):
+        """One result reads "1 submission matches", not "1 submission match"."""
+        response = self.client.get(reverse('quests:submitted_all'), {'q': 'Astrolabe'})
+
+        self.assertContains(response, '1 submission matches')
+
+    def test_approvals__the_table_carries_no_client_side_search(self):
+        """The tab's searching is the server's, so the table asks bootstrap-table for none.
+
+        bootstrap-table would filter the rows it holds, which is one page, and report
+        nothing found for a student sitting on the next one.
+        """
+        response = self.client.get(reverse('quests:submitted_all'))
+
+        self.assertNotContains(response, 'data-custom-search="multiKeywordSearch"')
+        self.assertNotContains(response, 'data-search="true"')
+        self.assertContains(response, 'name="q"')
+
+    def test_approvals__a_search_and_a_sort_apply_together(self):
+        """Ordering a search reorders its results rather than dropping the search."""
+        names = self._names(q='Zfiller', sort='name')
+
+        self.assertEqual(names[0], 'Zfiller quest 00')
+        for name in names:
+            self.assertTrue(name.startswith('Zfiller quest'), f'{name} is not one of the searched-for quests')
 
 
 class QuestSubmissionSummaryTest(ByteDeckTenantTestCase):
@@ -5618,7 +5786,7 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
         A student in a course (StudentCourse) in the teacher's block (Block) should have their submissions
         appear here
         """
-        with patch('quest_manager.views.QuestSubmission.objects.all_awaiting_approval', return_value=[self.sub]):
+        with patch('quest_manager.views.QuestSubmission.objects.all_awaiting_approval', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:submitted'))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, str(self.sub))
@@ -5632,7 +5800,7 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
     def test_approvals__submitted_all_tab(self):
         """ All completed quests awaiting approvel, even for students with another teacher (teachers are connected by Block)
         """
-        with patch('quest_manager.views.QuestSubmission.objects.all_awaiting_approval', return_value=[self.sub]):
+        with patch('quest_manager.views.QuestSubmission.objects.all_awaiting_approval', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:submitted_all'))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, str(self.sub))
@@ -5657,7 +5825,7 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
     def test_approvals__approved_tab(self):
         """ Completed quests (submissions) that have been approved by a teacher """
 
-        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=[self.sub]):
+        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:approved'))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, str(self.sub))
@@ -5725,7 +5893,7 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
 
     def test_approvals__flagged_tab(self):
         """The flagged tab lists flagged submissions and activates the Flagged tab."""
-        with patch('quest_manager.views.QuestSubmission.objects.flagged', return_value=[self.sub]):
+        with patch('quest_manager.views.QuestSubmission.objects.flagged', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:flagged'))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, str(self.sub))
@@ -5738,7 +5906,7 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
     def test_approvals__approved_for_quest(self):
         """ Approved submissions of only this specific quest, regardless of teacher """
 
-        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=[self.sub]):
+        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:approved_for_quest', args=[self.quest.id]))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, str(self.sub))
@@ -5750,7 +5918,7 @@ class ApprovalsViewTest(ByteDeckTenantTestCase):
 
     def test_approvals__approved_for_quest_all(self):
         """The 'all' variant shows approvals of this quest across all semesters (past_approvals_all=True)."""
-        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=[self.sub]):
+        with patch('quest_manager.views.QuestSubmission.objects.all_approved', return_value=QuestSubmission.objects.filter(id=self.sub.id)):
             response = self.client.get(reverse('quests:approved_for_quest_all', args=[self.quest.id]))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['quest'], self.quest)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2,6 +2,7 @@ import json
 import posixpath
 import re
 import uuid
+from collections import namedtuple
 from datetime import datetime, timezone as dt_timezone
 
 from django.utils.html import format_html
@@ -42,7 +43,7 @@ from questions.utils import discard_draft_question_submissions, save_draft_file_
 from courses.models import Block, CourseStudent
 from utilities.sorting import apply_sort, resolve_sort
 
-from .listing import QUEST_SORT_COLUMNS, search_quests
+from .listing import QUEST_SORT_COLUMNS, search_quests, search_submissions
 from library.utils import is_library_schema_requested, library_schema_if_requested
 from notifications.signals import notify
 from notifications.models import notify_rank_up
@@ -901,29 +902,24 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
 
     # The quest tabs show the campaign, and are the student's own submissions, so there is
     # no user column. The in-progress tab's Status cell carries no time, so it offers no
-    # sort by it. The tabs that are not paginated offer nothing: their headings stay plain
-    # until they are paginated too.
-    sortable_columns = {}
-    sort_column, sort_descending = '', False
+    # sort by it. A quest tab leaves this empty: it has its own search and ordering below.
+    submission_tab = SubmissionTab(
+        page=None, sortable_columns={}, sort_column='', sort_descending=False,
+        search_term='', num_matching=0,
+    )
 
     if view_type == QuestListViewTabTypes.IN_PROGRESS:
-        sortable_columns = submission_sort_columns(campaign=True, status=False)
-        in_progress_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, in_progress_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, in_progress_submissions, page, campaign=True, status=False)
+        in_progress_submissions = submission_tab.page
         # available_quests = []
     elif view_type == QuestListViewTabTypes.COMPLETED:
         # completed_submissions_count = completed_submissions.count()
-        sortable_columns = submission_sort_columns(campaign=True)
-        completed_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, completed_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, completed_submissions, page, campaign=True)
+        completed_submissions = submission_tab.page
         # available_quests = []
     elif view_type == QuestListViewTabTypes.PAST:
-        sortable_columns = submission_sort_columns(campaign=True)
-        past_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, past_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, past_submissions, page, campaign=True)
+        past_submissions = submission_tab.page
         # available_quests = []
 
     if view_type == QuestListViewTabTypes.DRAFT:
@@ -972,10 +968,12 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
         "VIEW_TYPES": QuestListViewTabTypes,
         "view_type": view_type,
         "bulk_edit_mode": request.user.is_staff and 'bulk_edit' in request.GET,
-        # Read by snippets/sortable_column_heading.html in the submission tabs' table
-        "sortable_columns": sortable_columns,
-        "sort_column": sort_column,
-        "sort_descending": sort_descending,
+        # Read by the submission tabs' table and its search box
+        "sortable_columns": submission_tab.sortable_columns,
+        "sort_column": submission_tab.sort_column,
+        "sort_descending": submission_tab.sort_descending,
+        "submission_search_term": submission_tab.search_term,
+        "num_matching_submissions": submission_tab.num_matching,
         # The quest tabs (available, drafts, archived) carry their own search and order,
         # since they list quests rather than submissions
         "search_term": search_term,
@@ -1668,27 +1666,50 @@ def submission_sort_columns(*, campaign=False, user=False, status=True):
     return columns
 
 
-def sorted_submission_page(request, submissions, sort_columns, page):
-    """Order a tab's submissions by the chosen column, then cut the requested page out.
+#: What a submission tab needs to render itself once its page has been cut: the page, the
+#: columns it offers, the ordering applied, and the search it was narrowed by.
+SubmissionTab = namedtuple(
+    'SubmissionTab',
+    'page sortable_columns sort_column sort_descending search_term num_matching',
+)
 
-    Ordering before paginating is the whole point: the browser only ever holds one page,
-    so a sort applied there answers a question about the page rather than about the tab
-    (#2582). `id` settles submissions that tie, so paging through shows each exactly once.
+
+def submission_tab_page(request, submissions, page, *, campaign=False, user=False, status=True):
+    """Narrow, order and cut a page from one tab's submissions.
+
+    All three happen here, before the page is taken, because the browser only ever holds
+    one page: a search or a sort applied there answers a question about that page rather
+    than about the tab (#2582, #2597). `id` settles submissions that tie on the chosen
+    column, so paging through a sorted tab shows each of them exactly once.
 
     Args:
-        request (HttpRequest): the current request, for the `sort` parameter.
+        request (HttpRequest): the current request, for the `q` and `sort` parameters.
         submissions (QuerySet[QuestSubmission]): the tab's submissions.
-        sort_columns (dict): the columns this tab offers.
         page: the requested page.
+        campaign (bool): whether this tab shows the quest's campaign and tags.
+        user (bool): whether this tab shows whose submission it is.
+        status (bool): whether the Status column carries a time to order by.
 
     Returns:
-        tuple[Page, str, bool]: the page, the column key applied ('' for none), and
-        whether it was reversed.
+        SubmissionTab: the page and everything the template reads beside it.
     """
-    column, descending = resolve_sort(request, sort_columns)
-    submissions = apply_sort(submissions, sort_columns, column, descending, tie_break='id')
+    sortable_columns = submission_sort_columns(campaign=campaign, user=user, status=status)
 
-    return paginate(submissions, page), column, descending
+    search_term = request.GET.get('q', '').strip()
+    submissions = search_submissions(submissions, search_term, campaign=campaign, user=user)
+    num_matching = submissions.count()
+
+    column, descending = resolve_sort(request, sortable_columns)
+    submissions = apply_sort(submissions, sortable_columns, column, descending, tie_break='id')
+
+    return SubmissionTab(
+        page=paginate(submissions, page),
+        sortable_columns=sortable_columns,
+        sort_column=column,
+        sort_descending=descending,
+        search_term=search_term,
+        num_matching=num_matching,
+    )
 
 
 def paginate(object_list, page, per_page=30):
@@ -1760,32 +1781,27 @@ def approvals(request, quest_id=None, template="quest_manager/quest_approval.htm
     view_type = ApprovalsViewTabTypes.SUBMITTED
 
     page = request.GET.get("page")
-    # The approvals tabs show whose submission it is, and no campaign column. The
-    # in-progress tab's Status cell carries no time, so it offers no sort by it.
-    sortable_columns = submission_sort_columns(user=True)
+    # The approvals tabs show whose submission it is, and no campaign column, so that is
+    # what they search and order by. The in-progress tab's Status cell carries no time.
     # if '/submitted/' in request.path_info:
     #     approval_submissions = QuestSubmission.objects.all_awaiting_approval()
     if "/in-progress/" in request.path_info:
         view_type = ApprovalsViewTabTypes.INPROGRESS
-        sortable_columns = submission_sort_columns(user=True, status=False)
         in_progress_submissions = QuestSubmission.objects.all_not_completed().order_by(F("time_completed").desc(nulls_last=True))
-        in_progress_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, in_progress_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, in_progress_submissions, page, user=True, status=False)
+        in_progress_submissions = submission_tab.page
     elif "/approved/" in request.path_info:
         view_type = ApprovalsViewTabTypes.APPROVED
         approved_submissions = QuestSubmission.objects.all_approved(
             quest=quest, active_semester_only=active_sem_only
         )
-        approved_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, approved_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, approved_submissions, page, user=True)
+        approved_submissions = submission_tab.page
     elif "/flagged/" in request.path_info:
         view_type = ApprovalsViewTabTypes.FLAGGED
         flagged_submissions = QuestSubmission.objects.flagged(user=request.user)
-        flagged_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, flagged_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, flagged_submissions, page, user=True)
+        flagged_submissions = submission_tab.page
     else:  # default is /submitted/ (awaiting approval)
         view_type = ApprovalsViewTabTypes.SUBMITTED
         if current_teacher_only:
@@ -1795,9 +1811,8 @@ def approvals(request, quest_id=None, template="quest_manager/quest_approval.htm
         submitted_submissions = QuestSubmission.objects.all_awaiting_approval(
             teacher=teacher
         )
-        submitted_submissions, sort_column, sort_descending = sorted_submission_page(
-            request, submitted_submissions, sortable_columns, page,
-        )
+        submission_tab = submission_tab_page(request, submitted_submissions, page, user=True)
+        submitted_submissions = submission_tab.page
 
     tab_list = [
         {
@@ -1852,10 +1867,12 @@ def approvals(request, quest_id=None, template="quest_manager/quest_approval.htm
         "quest": quest,
         "quick_reply_text": SiteConfig.get().submission_quick_text,
         "show_all_blocks_button": show_all_blocks_button,
-        # Read by snippets/sortable_column_heading.html in the tab's table
-        "sortable_columns": sortable_columns,
-        "sort_column": sort_column,
-        "sort_descending": sort_descending,
+        # Read by the tab's table and its search box
+        "sortable_columns": submission_tab.sortable_columns,
+        "sort_column": submission_tab.sort_column,
+        "sort_descending": submission_tab.sort_descending,
+        "submission_search_term": submission_tab.search_term,
+        "num_matching_submissions": submission_tab.num_matching,
     }
     return render(request, template, context)
 


### PR DESCRIPTION
### What?

The quest approvals tabs (In Progress, Submitted, Approved, Flagged) and the quest submission tabs (In Progress, Completed, Past) now search on the server, over the whole tab rather than the page on screen.

Closes #2597

### Why?

These tabs are paginated and kept bootstrap-table's client-side search, which filters the row data the browser holds. On a queue of two hundred submissions that is the thirty rendered, so typing a student's name reported nothing found while their submission sat on page four.

That is worse than the sorting version of the same bug, which #2582 fixed: a sort confined to one page at least still shows you rows. A search that finds nothing reads as *this student has nothing waiting*, and there is no cue that the answer is on another page.

### How?

**Each tab searches what its own columns show.** The two flags on the helper exist for that reason: matching on a column a tab does not display would return rows whose match the reader cannot see anywhere, which reads as the list ignoring what they typed.

* The **approvals** tabs name the student, so they match the username and the preferred full name under it. That means four fields: `username`, `profile.preferred_name`, the account `first_name` behind it, and `last_name`. A teacher types whichever of them they know, and a surname finds the student whether or not they set a preferred name.
* The **submissions** tabs name the campaign and the tags instead, so those are matched there alongside the quest name.

Both keep the multi-word rule the quest lists use: every word has to match something, so adding a word narrows.

**`search_submissions()` sits beside `search_quests()`** in `quest_manager/listing.py`, so the two searches are read together.

**`sorted_submission_page` becomes `submission_tab_page`**, which narrows, orders and cuts the page in one place and hands back a `SubmissionTab`. The seven call sites each pass the flags for the columns their tab shows, which is one line per tab instead of three.

### Testing?

Ten tests in `SubmissionTabSearchTests`. The fixture puts one distinctive student at the far end of a 35-submission queue, so a search that only reached the rendered rows could not find them: searching reaches them; every name the User column shows matches, including the account first name behind a preferred one; several words narrow; the campaign and tag columns are searched only on the tab that displays them; the student's own Completed tab searches its campaign and tags; an empty result explains itself and keeps the box filled; the table no longer asks bootstrap-table to search; and a search and a sort apply together.

**Verified in both directions.** Reverting the four changed source files to the previous head fails all ten.

Full suite: `Ran 2752 tests ... OK`. `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean. `src/quest_manager/listing.py` stays at 100% coverage (19 statements, 12 branches, 0 misses, 0 partial branches).

### Screenshots (if front end is affected)

Captured from a running dev deck (`hackerspace.localhost:8000`, signed in as the deck owner) with 40 submissions awaiting approval, so the queue spans two pages.

**Before**: no search box; bootstrap-table's own field searched the rendered page.

![before: the approvals queue with no server-side search](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2597/before-approvals-search-tab.png)

**After**: the same `?q=` box the quest tabs and the Library use.

![after: the approvals queue with a search box](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2597/after-approvals-search-tab.png)

**After**, searching `shari`. That student is on page two of the default queue, which is exactly the submission the old search reported as not found.

![after: searching the approvals queue for a student on page two](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2597/after-approvals-search-student.png)

### Anything Else?

Two things turned up on the way, both small and both fixed here:

**Six tests patched a manager method to return a plain list.** No manager method returns a list, and a seventh test in the same class already patched with a queryset. The list form worked only because nothing had ever called `.count()` or `.filter()` on the result; it broke the moment the tab counted its matches. They now use the queryset form the class already established. Worth noting that the sorting added in #2582 would have hit the same thing had those tests passed a `?sort=`.

**The match count read "1 submission match".** The verb agrees with the number now, here and on the quest tabs, with a test pinning it.

`multiKeywordSearch` stays in `bootstrap-table-accordion.js`: several unpaginated tables still use it.

This finishes the set: #2410 (PR #2593), #2582 (PR #2594), the quest tabs (PR #2598) and now the submission tabs. Every paginated quest list searches and orders on the server.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side search for submissions across approvals and submissions tabs.
  * Search supports quest names, campaigns, tags, and submitter details where applicable.
  * Added clear-search controls, matching-result counts, and no-results messages.
  * Search applies across all matching submissions, not only the current page.

* **Bug Fixes**
  * Improved pluralization for quest search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->