### PR TITLE
fix: give a submission question its own identity across decks (#2566)

### DIFF
--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -34,6 +34,7 @@ from library.utils import library_schema_context
 from prerequisites.models import IsAPrereqMixin, Prereq
 from badges.models import Badge
 from courses.models import Block, Course, Grade, Rank
+from comments.models import Comment
 from quest_manager.models import Category, CommonData, Quest, QuestSubmission
 from questions.models import Question, QuestionSubmission, QuestionType
 
@@ -720,13 +721,13 @@ class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):
         self.assertEqual([question.ordinal for question in imported.question_set.all()], [1, 3])
 
     def test_re_import__keeps_a_reordered_question_on_its_own_row(self):
-        """Reordering a question upstream moves it here; it does not overwrite the question
-        that used to sit in its place.
+        """A question keeps its own row when the author reorders the quest upstream: it
+        changes ordinal here, it does not take over the row of the question it passed.
 
-        Reordering swaps ordinals (`QuestionMoveView._swap_ordinals`), so matching arriving
-        questions to existing rows by ordinal handed each row the other question's content.
-        Students' answers point at those rows, so the marking view showed answers under the
-        wrong prompts (#2566). Matching on import_id is what keeps a row one question.
+        A row is one question for as long as the quest exists, because the answers students
+        gave point at it. Ordinal cannot carry that identity: reordering swaps ordinals
+        (`QuestionMoveView._swap_ordinals`), so the row at a given ordinal here and the
+        question arriving at that ordinal are not the same question (#2566). import_id is.
         """
         quest = self._quest_with_questions()
         imported = self._push_and_pull(quest)
@@ -742,19 +743,24 @@ class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):
         self.assertEqual([first.ordinal, second.ordinal], [2, 1])
 
     def test_re_import__keeps_a_published_answer_with_the_question_it_answered(self):
-        """A student's answer still reads as an answer to the question they were asked.
+        """A published answer stays attached to the question whose text it answers, across
+        a reorder upstream and a re-import.
 
-        The end of the same bug: the marking view renders each answer's question live off
-        the FK, so a row repainted with another question's content silently re-labels work
-        the student already submitted (#2566).
+        The marking view renders each answer's question live off the FK, so what that row
+        holds is what the marker reads the student's work as answering. Keeping the row one
+        question is what keeps the pairing true (#2566).
         """
         quest = self._quest_with_questions()
         imported = self._push_and_pull(quest)
         answered = imported.question_set.get(ordinal=1)
         submission = baker.make(QuestSubmission, quest=imported)
-        answer = QuestionSubmission.objects.create(
-            quest_submission=submission, question=answered, response_text="Rocket Car",
+        comment = Comment.objects.create_comment(
+            user=submission.user, path=submission.get_absolute_url(), text="Done!", target=submission,
         )
+        answer = QuestionSubmission.objects.create(
+            quest_submission=submission, question=answered, response_text="Rocket Car", comment=comment,
+        )
+        self.assertTrue(answer.is_published)
 
         self._swap_library_ordinals(quest, 1, 2)
         import_quest_to(destination_schema=connection.schema_name, quest_import_id=quest.import_id)

--- a/src/library/tests/test_transfer_contract.py
+++ b/src/library/tests/test_transfer_contract.py
@@ -34,8 +34,8 @@ from library.utils import library_schema_context
 from prerequisites.models import IsAPrereqMixin, Prereq
 from badges.models import Badge
 from courses.models import Block, Course, Grade, Rank
-from quest_manager.models import Category, CommonData, Quest
-from questions.models import Question, QuestionType
+from quest_manager.models import Category, CommonData, Quest, QuestSubmission
+from questions.models import Question, QuestionSubmission, QuestionType
 
 # The fields a Quest carries into the Library and back, as of today. This is not a wish
 # list: it is what the transfer currently moves, verified by `test_quest_field_inventory__every_field_is_classified`.
@@ -71,7 +71,7 @@ CATEGORY_FIELDS_NOT_TRANSFERRED = {
 
 QUESTION_FIELDS_TRANSFERRED = frozenset({
     'type', 'ordinal', 'required', 'instructions', 'solution_text', 'solution_file',
-    'allowed_file_type', 'marker_notes',
+    'allowed_file_type', 'marker_notes', 'import_id',
 })
 
 QUESTION_FIELDS_NOT_TRANSFERRED = {
@@ -718,6 +718,69 @@ class LibraryTransferQuestionContractTests(LibraryTenantTestCaseMixin):
 
         imported = Quest.objects.all_including_archived().get(import_id=quest.import_id)
         self.assertEqual([question.ordinal for question in imported.question_set.all()], [1, 3])
+
+    def test_re_import__keeps_a_reordered_question_on_its_own_row(self):
+        """Reordering a question upstream moves it here; it does not overwrite the question
+        that used to sit in its place.
+
+        Reordering swaps ordinals (`QuestionMoveView._swap_ordinals`), so matching arriving
+        questions to existing rows by ordinal handed each row the other question's content.
+        Students' answers point at those rows, so the marking view showed answers under the
+        wrong prompts (#2566). Matching on import_id is what keeps a row one question.
+        """
+        quest = self._quest_with_questions()
+        imported = self._push_and_pull(quest)
+        first, second = imported.question_set.get(ordinal=1), imported.question_set.get(ordinal=2)
+
+        self._swap_library_ordinals(quest, 1, 2)
+        import_quest_to(destination_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.instructions, "<p>What is the title of your project?</p>")
+        self.assertEqual(second.instructions, "<p>Describe your process.</p>")
+        self.assertEqual([first.ordinal, second.ordinal], [2, 1])
+
+    def test_re_import__keeps_a_published_answer_with_the_question_it_answered(self):
+        """A student's answer still reads as an answer to the question they were asked.
+
+        The end of the same bug: the marking view renders each answer's question live off
+        the FK, so a row repainted with another question's content silently re-labels work
+        the student already submitted (#2566).
+        """
+        quest = self._quest_with_questions()
+        imported = self._push_and_pull(quest)
+        answered = imported.question_set.get(ordinal=1)
+        submission = baker.make(QuestSubmission, quest=imported)
+        answer = QuestionSubmission.objects.create(
+            quest_submission=submission, question=answered, response_text="Rocket Car",
+        )
+
+        self._swap_library_ordinals(quest, 1, 2)
+        import_quest_to(destination_schema=connection.schema_name, quest_import_id=quest.import_id)
+
+        answer.refresh_from_db()
+        self.assertEqual(answer.response_text, "Rocket Car")
+        self.assertEqual(answer.question.instructions, "<p>What is the title of your project?</p>")
+
+    def _swap_library_ordinals(self, quest, one, other):
+        """Swap two of the Library copy's question ordinals, as reordering upstream would.
+
+        Written straight to the database, via a parking ordinal so the (quest, ordinal)
+        unique constraint holds at every statement, which is what the reorder view does too.
+
+        Args:
+            quest (Quest): the local quest, named by import_id.
+            one (int): one ordinal to swap.
+            other (int): the ordinal to swap it with.
+        """
+        with library_schema_context():
+            questions = Question.objects.filter(quest__import_id=quest.import_id)
+            first, second = questions.get(ordinal=one), questions.get(ordinal=other)
+            parking = questions.order_by("-ordinal").first().ordinal + 1
+            Question.objects.filter(pk=first.pk).update(ordinal=parking)
+            Question.objects.filter(pk=second.pk).update(ordinal=one)
+            Question.objects.filter(pk=first.pk).update(ordinal=other)
 
     def test_export_campaign_and_copy_quests__carries_questions_on_the_conflict_copy(self):
         """A quest copied in beside the Library's existing version brings its questions.

--- a/src/library/transfer.py
+++ b/src/library/transfer.py
@@ -226,8 +226,9 @@ def _snapshot_questions(quest):
 
     A question is part of the quest's content, not of the deck it was written on: a quest
     whose instructions say "answer the questions below" is a different quest without them,
-    so they travel with it (#2162). They have no identity of their own to travel under, so
-    they ride inside the quest's snapshot and are matched on the far side by ordinal.
+    so they travel with it (#2162). They ride inside the quest's snapshot rather than
+    travelling on their own, and each carries its `import_id`, which is what pairs it with
+    the right row on the far side (`_write_questions`).
 
     Must be called from within the source schema context.
 
@@ -470,13 +471,19 @@ def _find_prereq_target(import_id):
 def _write_questions(quest, questions):
     """Make this deck's copy of a quest ask exactly the questions it travelled with.
 
-    Matched by ordinal, which is the only identity a question has across schemas: it
-    carries no import_id, and the model already holds one question per ordinal per quest.
-    A question at an ordinal the quest already uses is updated in place rather than
+    Matched by `import_id`, the identity a question keeps across schemas and across a
+    reorder. A question the destination already has is updated in place rather than
     replaced, so answers students gave stay attached to the question they answered.
 
-    Ordinals the arriving quest does not use are deleted, which is what makes re-sharing a
-    quest whose author removed a question actually remove it here. Answers to a deleted
+    Ordinal cannot serve as that identity, because reordering is implemented as swapping
+    ordinals (`QuestionMoveView._swap_ordinals`): after the author reorders a shared quest,
+    the row sitting at a given ordinal here is a different question than the one arriving
+    with it, and updating it in place would leave every answer already published against it
+    displayed under another question's text (#2566). Ordinal now only decides the order
+    students answer in.
+
+    Questions the arriving quest no longer asks are deleted, which is what makes re-sharing
+    a quest whose author removed a question actually remove it here. Answers to a deleted
     question survive it (`QuestionSubmission.question` is SET_NULL) and show in the marking
     view as answers to a question that is gone.
 
@@ -494,10 +501,29 @@ def _write_questions(quest, questions):
     Raises:
         LibraryTransferError: if a question cannot be written.
     """
-    superseded = {question.ordinal: question for question in Question.objects.filter(quest=quest)}
+    existing = {question.import_id: question for question in Question.objects.filter(quest=quest)}
+    arriving = {fields['import_id'] for fields in questions}
+
+    Question.objects.filter(
+        pk__in=[question.pk for import_id, question in existing.items() if import_id not in arriving]
+    ).delete()
+
+    # Every ordinal is about to be reassigned, and (quest, ordinal) is unique, so a question
+    # that keeps its row but changes place would collide with whichever row is still standing
+    # there. Parking the rows being kept above every ordinal in play empties the range first.
+    # A plain UPDATE, not a validated save: this is bookkeeping between two writes of the same
+    # field, and the value is deliberately outside the range the quest ends up using.
+    kept = [question for import_id, question in existing.items() if import_id in arriving]
+    if kept:
+        parking = max(
+            [question.ordinal for question in existing.values()]
+            + [fields['ordinal'] for fields in questions]
+        ) + 1
+        for offset, question in enumerate(kept):
+            Question.objects.filter(pk=question.pk).update(ordinal=parking + offset)
 
     for fields in questions:
-        question = superseded.pop(fields['ordinal'], None) or Question(quest=quest)
+        question = existing.get(fields['import_id']) or Question(quest=quest)
         for name, value in fields.items():
             setattr(question, name, value)
 
@@ -513,8 +539,6 @@ def _write_questions(quest, questions):
             raise LibraryTransferError(
                 f"'{quest.name}' could not be copied: question {fields['ordinal']}: {error}"
             ) from error
-
-    Question.objects.filter(pk__in=[question.pk for question in superseded.values()]).delete()
 
 
 def write_quests(writes, *, with_campaign, refresh_matched_prereqs=False):

--- a/src/questions/migrations/0002_question_import_id_1.py
+++ b/src/questions/migrations/0002_question_import_id_1.py
@@ -1,0 +1,26 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # Adding a unique, non-nullable field over the next three migrations, per
+    # https://docs.djangoproject.com/en/5.2/howto/writing-migrations/#migrations-that-add-unique-fields
+    # (the same three-step badges/0006-0008 used for Badge.import_id). A single AddField
+    # would give every existing row the one value the default was called for.
+
+    dependencies = [
+        ("questions", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="question",
+            name="import_id",
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                null=True,
+                help_text="Identifies this question within its quest wherever the quest is shared, so re-importing the quest updates this question rather than a different one. Only change this if you want to disconnect it from the shared version.",
+            ),
+        ),
+    ]

--- a/src/questions/migrations/0003_question_import_id_2.py
+++ b/src/questions/migrations/0003_question_import_id_2.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.db import migrations
+
+
+def give_each_question_its_own_import_id(apps, schema_editor):
+    """Stamp every existing question with an import_id of its own.
+
+    0002 added the column with one value shared by every row, which is what Django's
+    schema-level default does; the constraint added in 0004 needs them distinct within
+    each quest.
+    """
+    Question = apps.get_model("questions", "Question")
+    for question in Question.objects.using(schema_editor.connection.alias).all():
+        question.import_id = uuid.uuid4()
+        question.save(update_fields=["import_id"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("questions", "0002_question_import_id_1"),
+    ]
+
+    operations = [
+        # No reverse: the ids are the questions' identities from here on, and there is
+        # nothing to restore them to. Unapplying leaves them in place for 0002 to drop.
+        migrations.RunPython(give_each_question_its_own_import_id, migrations.RunPython.noop),
+    ]

--- a/src/questions/migrations/0003_question_import_id_2.py
+++ b/src/questions/migrations/0003_question_import_id_2.py
@@ -9,11 +9,25 @@ def give_each_question_its_own_import_id(apps, schema_editor):
     0002 added the column with one value shared by every row, which is what Django's
     schema-level default does; the constraint added in 0004 needs them distinct within
     each quest.
+
+    Written with a queryset update per row rather than a model save, so nothing but the
+    new id is touched: a save would put the rest of a historic row through the model's
+    own machinery, and this migration has no business rejecting or rewriting a value it
+    is not here to change.
+
+    Args:
+        apps (StateApps): the historical model registry, which gives back Question as it
+            stands at this point in the migration graph.
+        schema_editor (BaseDatabaseSchemaEditor): the editor for the schema being
+            migrated, read for the database alias so the rows written are that tenant's.
+
+    Returns:
+        None: the rows are updated in place.
     """
     Question = apps.get_model("questions", "Question")
-    for question in Question.objects.using(schema_editor.connection.alias).all():
-        question.import_id = uuid.uuid4()
-        question.save(update_fields=["import_id"])
+    questions = Question.objects.using(schema_editor.connection.alias)
+    for pk in questions.values_list("pk", flat=True):
+        questions.filter(pk=pk).update(import_id=uuid.uuid4())
 
 
 class Migration(migrations.Migration):

--- a/src/questions/migrations/0004_question_import_id_3.py
+++ b/src/questions/migrations/0004_question_import_id_3.py
@@ -1,0 +1,27 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("questions", "0003_question_import_id_2"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="question",
+            name="import_id",
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                help_text="Identifies this question within its quest wherever the quest is shared, so re-importing the quest updates this question rather than a different one. Only change this if you want to disconnect it from the shared version.",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="question",
+            constraint=models.UniqueConstraint(
+                fields=("quest", "import_id"), name="unique_question_import_ids"
+            ),
+        ),
+    ]

--- a/src/questions/models.py
+++ b/src/questions/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 from django.urls import reverse
 
@@ -105,12 +107,24 @@ class Question(models.Model):
     type = models.CharField(
         max_length=20, choices=QuestionType.choices, default=QuestionType.SHORT_ANSWER
     )
+    import_id = models.UUIDField(
+        default=uuid.uuid4,
+        help_text=(
+            "Identifies this question within its quest wherever the quest is shared, so "
+            "re-importing the quest updates this question rather than a different one. "
+            "Only change this if you want to disconnect it from the shared version."
+        ),
+    )
 
     class Meta:
         ordering = ["ordinal"]
         constraints = [
             # ensure two questions in the same quest cannot have the same ordinal
             models.UniqueConstraint(fields=["quest", "ordinal"], name="unique_ordinals"),
+            # A question's import_id identifies it within its quest, not across the whole
+            # deck: two copies of a quest are two quests, and their questions legitimately
+            # share the identity they were copied from.
+            models.UniqueConstraint(fields=["quest", "import_id"], name="unique_question_import_ids"),
         ]
 
     def __str__(self):


### PR DESCRIPTION
### What?

`Question` gains an `import_id`, and the Shared Library matches arriving questions to existing rows by it instead of by `ordinal`.

Closes #2566.

### Why?

`_write_questions` paired an arriving question with whatever row held the same `ordinal`, then `setattr`'d every transferred field onto it. But reordering a question is implemented as **swapping ordinals** (`QuestionMoveView._swap_ordinals`), so once the author of a shared quest reorders it, the row at a given ordinal in an importing deck is a different question than the one arriving at that ordinal. The re-import overwrote that row's instructions, solution, marker notes and even its `type`.

Student answers point at those rows, and the marking view renders each answer's question live off the FK (`comment_answers.html:24`), so every answer already published silently re-labelled itself.

Reproduced on unmodified `develop`, with a student answer published against the first question and the two questions then swapped upstream:

```
BEFORE the author reorders upstream:
   student answered : <p>What is the title of your project?</p>
AFTER the deck re-imports:
   same answer text : Rocket Car
   now displayed as : <p>Describe your process.</p>
   MISATTRIBUTED    : True
```

"Rocket Car" is now a student's answer to "Describe your process.", and the marker sees the wrong solution and marker notes beside it. If the swap crosses types, a stored text answer ends up under a file-upload question, a state nothing else in the app can produce.

### How?

- `Question.import_id`, a `UUIDField` defaulting to `uuid4`, with `UniqueConstraint(fields=["quest", "import_id"])`.
- `_write_questions` builds its map from `import_id`, so a row is only ever updated by the question it actually is. `ordinal` is left to do only what it says: decide the order students answer in.
- Because a re-import can now reassign every ordinal at once, the rows being kept are parked above the whole range in play before the writes, so `(quest, ordinal)` holds at every statement. That is the same problem, and the same answer, as the reorder view's own swap.
- Questions the arriving quest no longer asks are deleted first, which frees their ordinals for the ones that remain.

**Unique per quest, not per deck**, which is where this differs from the `import_id` on Quest, Category and Badge. A question is only ever addressed through its quest, and two copies of a quest are two quests whose questions legitimately share the identity they were copied from. Scoping it that way is what lets both copy paths keep working untouched: the Library's conflict-copy path (which writes a second quest under a fresh `import_id`) and the local "- COPY" quest action both produce a new quest, so there is no collision to resolve and no fresh id to mint.

**Three migrations** (`0002`/`0003`/`0004`), as `badges/0006-0008` did for `Badge.import_id`: a single `AddField` would hand every existing row the one value the default was called for.

### Testing?

- Full suite: `Ran 2818 tests ... OK`; `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean.
- Two new tests in `LibraryTransferQuestionContractTests`: one pins that a reordered question keeps its own row (rather than overwriting the row that used to sit in its place), the other that a student's existing answer still reads as an answer to the question they were actually asked. `import_id` is added to `QUESTION_FIELDS_TRANSFERRED`, so the field-inventory contract test covers it too.
- **Confirmed the tests fail without the fix**: reverting `_write_questions` to ordinal matching turns both red, and the terminal reproduction above was run against unmodified `develop`.
- **Migrations applied for real.** Two question rows were inserted into the seeded `hackerspace` deck by raw SQL first, so they existed before the column did, exactly as a live deck's rows do. After `migrate_schemas`:

```
  ordinal=101  import_id=fdad8f9b-f251-4d8f-86ac-37ab0d86bb40
  ordinal=102  import_id=435b7493-c67d-4450-8224-7a4be7f9052b
  all distinct: True
  none null   : True
```

### Screenshots (if front end is affected)

No front end: this changes a model, three migrations and the Library's write path, and no template, view or form. What a user sees does change, but only in that the marking view goes back to showing each answer under the question it was written for, which is what the reproduction above and the two new tests pin.

### Anything Else?

- The id is deliberately kept out of `QuestionForm`, so a teacher never sees it on the question editor; it is visible and editable in the Django admin, like the quest's own, with help text saying what changing it does.
- `_snapshot_questions`'s docstring said questions "have no identity of their own to travel under", which this makes untrue, so it now names the `import_id` instead.
- Not addressed here: a re-import still deletes a question the author removed upstream, leaving its answers with `question=None` (rendered as "question was deleted"). That is existing, deliberate behaviour, tested, and unrelated to the misattribution.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Re-imported and reordered quest questions now retain their correct question records.
  - Students’ published answers remain attached to the questions they answered.
  - Removed questions are correctly deleted during synchronization.

- **Improvements**
  - Questions now have stable identifiers, improving consistency when sharing and updating quests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->