### PR TITLE
fix: stop an in-flight draft save from unpublishing a submitted answer (#2565)

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2515,7 +2515,10 @@ def ajax_save_draft(request):
                 if row and row.response_text != text:
                     row.response_text = text
                     row.full_clean()
-                    row.save()
+                    # Only the answer, never the whole row: the filter above read `comment`
+                    # before this save, so a submit publishing in between would otherwise
+                    # have that stale NULL written back over it (#2565).
+                    row.save(update_fields=["response_text", "datetime_last_edit"])
                     response_data["result"] = "Draft saved"
 
         # Draft-save any files in the POST (#1459). The Save Draft button posts the whole

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -1,5 +1,6 @@
 import json
 import re
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
@@ -10,9 +11,9 @@ from model_bakery import baker
 
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from quest_manager.models import Quest, QuestSubmission
-from questions.forms import SHORT_ANSWER_MAX_LENGTH
+from questions.forms import QuestionSubmissionFormsetFactory, SHORT_ANSWER_MAX_LENGTH
 from questions.models import Question, QuestionSubmission
-from questions.utils import sync_draft_question_submissions
+from questions.utils import save_draft_file_answers, sync_draft_question_submissions
 
 User = get_user_model()
 
@@ -631,6 +632,89 @@ class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
         self.assertEqual(payload["saved_answer_files"], {})
         self.submission.draft_comment.refresh_from_db()
         self.assertEqual(self.submission.draft_comment.text, "<p>still saves</p>")
+
+
+class DraftSaveRacesSubmitTest(QuestionSubmissionFlowTestBase):
+    """A draft save that lands while the student's submit is publishing writes only the
+    answer it carries, so it cannot revert a published answer to a draft (#2565).
+
+    Both draft-save legs read their answer rows, then write them back a moment later. In
+    between, the submit request can publish those rows by setting `comment`. Whether the
+    page still shows the student's work therefore depends on the write touching only the
+    column it came to change.
+    """
+
+    def publish_answers(self):
+        """Publish this submission's draft answers, as completing the quest does.
+
+        Returns:
+            Comment: the comment the answers were published against.
+        """
+        comment = self.submission.draft_comment
+        QuestionSubmission.objects.filter(
+            quest_submission=self.submission, comment__isnull=True, question__isnull=False
+        ).update(comment=comment)
+        return comment
+
+    def test_save_draft_file_answers__keeps_an_answer_published_when_a_submit_beats_it(self):
+        """The file leg holds instances loaded before the submit, so its write is the one
+        that lands last: the answer stays published, and gains the file the student chose."""
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="all",
+        )
+        sync_draft_question_submissions(self.submission)
+        field_name = self.file_field_name(file_question)
+        upload = SimpleUploadedFile("sketch.png", b"file_content", content_type="image/png")
+
+        # The autosave request reaches the point where it has read the rows and validated
+        # the upload, which is where it takes its snapshot of `comment`.
+        formset = QuestionSubmissionFormsetFactory(
+            self.formset_data(), {field_name: upload},
+            instance=self.submission, queryset=sync_draft_question_submissions(self.submission),
+        )
+        formset.is_valid()
+
+        # The student's submit lands in that gap and publishes the answers.
+        comment = self.publish_answers()
+
+        save_draft_file_answers(formset, {field_name: upload})
+
+        row = QuestionSubmission.objects.get(quest_submission=self.submission, question=file_question)
+        self.assertEqual(row.comment_id, comment.id, "the published answer must stay published")
+        self.assertIn("sketch", row.response_file.name)
+
+    def test_ajax_save_draft__keeps_a_text_answer_published_when_a_submit_beats_it(self):
+        """The text leg re-reads `comment` when it selects the row, which leaves a smaller
+        gap before the write, not none: a submit publishing inside it must still stand.
+
+        `full_clean` runs between the read and the write, so publishing from there puts the
+        submit exactly in that gap without depending on real request timing.
+        """
+        row = sync_draft_question_submissions(self.submission).get(question=self.short_question)
+        comment = self.submission.draft_comment
+
+        def publish_between_the_read_and_the_write(instance, *args, **kwargs):
+            QuestionSubmission.objects.filter(pk=instance.pk).update(comment=comment)
+
+        with patch.object(QuestionSubmission, "full_clean", autospec=True,
+                          side_effect=publish_between_the_read_and_the_write):
+            self.client.post(
+                reverse("quests:ajax_save_draft"),
+                data={
+                    "submission_id": self.submission.id,
+                    "comment": "<p>draft words</p>",
+                    "answers": json.dumps({
+                        "question_submissions-0-id": str(row.id),
+                        "question_submissions-0-response_text": "my website",
+                    }),
+                },
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+        row.refresh_from_db()
+        self.assertEqual(row.comment_id, comment.id, "the published answer must stay published")
+        self.assertEqual(row.response_text, "my website")
 
 
 class AnswerDisplayTest(QuestionSubmissionFlowTestBase):

--- a/src/questions/utils.py
+++ b/src/questions/utils.py
@@ -17,6 +17,10 @@ def save_draft_file_answers(question_formset, uploaded_files):
     not upload to this time are skipped, so an earlier file is never overwritten by a
     re-submit that left the field alone.
 
+    Each write touches the file column and nothing else, so a save that lands after the
+    student's submit has published these answers adds the file they chose to the published
+    answer rather than reverting the row to a draft (#2565).
+
     Args:
         question_formset: the bound answer formset, with validation already run.
         uploaded_files: the request's ``FILES``, used to tell a fresh upload from an untouched
@@ -36,15 +40,21 @@ def save_draft_file_answers(question_formset, uploaded_files):
             continue
 
         row = form.instance
-        # Defensive: the formset is only ever built over this submission's own unpublished
-        # draft rows, so a saved-but-published row cannot reach here. Guarded anyway so that
-        # widening the caller's queryset can never overwrite a finished cycle's answer.
+        # This reads the snapshot the formset was built from, so it catches a row that was
+        # already published when this request started, not one published since: the formset
+        # is only ever built over this submission's own unpublished draft rows, so that
+        # cannot happen unless a caller widens the queryset. A row published in the meantime
+        # is what `update_fields` on the save below is for.
         if not row.pk or row.comment_id is not None:  # pragma: no cover
             continue
 
         row.response_file = upload
         row.full_clean()
-        row.save()
+        # Only the file, never the whole row. This instance was loaded before the request
+        # that is now publishing these answers ran, so its `comment` is a snapshot: a full
+        # save would write that stale NULL back over a `comment_id` the student's submit
+        # has just set, quietly unpublishing an answer they did submit (#2565).
+        row.save(update_fields=["response_file", "datetime_last_edit"])
         saved += 1
     return saved
 


### PR DESCRIPTION
### What?

Both draft-save legs now write only the answer column they came to write, instead of the whole answer row.

Closes #2565.

### Why?

A draft save reads a submission's answer rows, then writes them back a moment later. In between, the student's own submit can publish those same rows:

```python
QuestionSubmission.objects.filter(
    quest_submission=submission, comment__isnull=True, question__isnull=False
).update(comment=draft_comment)          # quest_manager/views.py
```

The draft save then wrote its whole snapshot back, `comment_id` included, putting the NULL it had read back over the comment the submit had just set. An answer the student did submit reverted to a draft:

- it disappears from the completion comment's answers table, so the marker sees the answer missing (on a single-question quest, no answers table at all) and may return work that was actually done;
- the orphaned row re-enters the draft set on any later resubmission.

The trigger needs no unusual behaviour from the student: the autosave fires on a 60-second timer with no action from them, so it only has to land while they are clicking Submit.

**One correction to the issue's analysis.** It says the text leg is immune because it re-filters `comment__isnull=True` at query time. That makes the window small, not absent: the filter decides whether to write, and the write that follows still carried the whole row. Both legs needed the same fix.

### How?

```python
row.save(update_fields=["response_file", "datetime_last_edit"])   # questions/utils.py
row.save(update_fields=["response_text", "datetime_last_edit"])   # quest_manager/views.py
```

`comment_id` is no longer part of either statement, so no draft save can unpublish an answer, whatever it read.

A save that lands after the publish now adds the file or text the student chose to the published answer, which is what they were trying to save in the first place. That is the desirable half of the race, and it is what the file-leg test asserts.

Also corrected a comment that had become misleading, on the guard just above the file write. It claimed a published row "cannot reach here"; it can, carrying a stale snapshot that still reads as unpublished. The guard catches rows that were already published when the request started, and `update_fields` is what covers the rest.

### Testing?

- Full suite on the current head, with develop merged in: `Ran 2820 tests ... OK`; `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean.
- New `DraftSaveRacesSubmitTest` in `questions/tests/test_integration.py`, one test per leg. The file-leg test builds and validates the formset (where that leg takes its snapshot), publishes the answers, and only then calls `save_draft_file_answers`. The text leg has no such seam, so its test patches `QuestionSubmission.full_clean`, which runs between that leg's read and its write, and publishes from there. That makes the race deterministic rather than dependent on real request timing.
- **Confirmed both fail without the fix**, each with the symptom itself:

```
FAIL: test_ajax_save_draft__keeps_a_text_answer_published_when_a_submit_beats_it
AssertionError: None != 1 : the published answer must stay published
FAIL: test_save_draft_file_answers__keeps_an_answer_published_when_a_submit_beats_it
AssertionError: None != 2 : the published answer must stay published
```

### Screenshots (if front end is affected)

No front end: the change is two save calls and their tests, with no template, view signature or form touched. The user-visible effect is the absence of a disappearance, so there is no "after" state to photograph that differs from a correct submission today. The two tests are what pin it.

### Anything Else?

- The remaining race is deliberate and benign: a save landing after the publish writes the student's chosen answer onto the published row. Closing that too would mean rejecting the student's own last edit, which is worse than accepting it.
- A filtered `.update(..., comment__isnull=True)` was considered instead. It would not close the window either (the check would still precede the write) and it cannot carry a file to storage, which the file leg needs. `update_fields` closes the unpublish completely, so a second, weaker guard would be noise.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented draft autosaves from overwriting answers that were published concurrently.
  * Preserved published answer status while saving updated text or file responses.
  * Limited draft file saves to file content and edit timestamps, preventing stale fields from replacing newer data.

* **Tests**
  * Added coverage for text and file draft saves racing with answer submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->