### PR TITLE
fix: keep a file chosen while the previous draft save is in flight (#2563)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -326,7 +326,7 @@
                 // have chosen a different file in the same input. The response speaks about
                 // the file that went out, so it is only allowed to touch an input still
                 // holding it (#2563).
-                var sentFiles = chosen_file_names_by_input();
+                var sentFiles = chosen_files_by_input();
                 formData.set('csrfmiddlewaretoken', '{{ csrf_token }}');
                 formData.set('comment', draftComment);
                 formData.set('submission_id', '{{ submission.id }}');
@@ -358,22 +358,28 @@
 
         }
 
-        function chosen_file_names(input) {
-            // The file names an input currently holds, as one string, so a selection can be
-            // compared with the one a request went out with. Several names can be selected at
-            // once in the comment's Attach files field, so all of them count.
-            return Array.prototype.map.call((input && input.files) || [], function(file) {
-                return file.name;
-            }).join('\n');
+        function chosen_files(input) {
+            // The File objects an input currently holds. Identity is what is compared later,
+            // not the names: choosing a file always produces new File objects, so this notices
+            // a replacement even when the student picked another file of the same name. The
+            // comment's Attach files field takes several at once, so the whole list counts.
+            return Array.prototype.slice.call((input && input.files) || []);
         }
 
-        function chosen_file_names_by_input() {
+        function chosen_files_by_input() {
             // Every file input on the form, keyed by name, ready to compare against later.
-            var names = {};
+            var chosen = {};
             $('#submission-main-form input[type="file"]').each(function() {
-                names[this.name] = chosen_file_names(this);
+                chosen[this.name] = chosen_files(this);
             });
-            return names;
+            return chosen;
+        }
+
+        function same_files(current, sent) {
+            // Whether an input still holds exactly what it sent. An untracked input (no
+            // snapshot) counts as changed, which is the safe answer: it means leave it alone.
+            if (!sent || current.length !== sent.length) return false;
+            return current.every(function(file, index) { return file === sent[index]; });
         }
 
         function show_saved_files(json, sentFiles) {
@@ -405,7 +411,7 @@
             // clearing it would throw that newer file away, and the note would name one they
             // have moved on from (or blame it for the older file's error). Leave both alone;
             // the next save reports the new file in the ordinary way (#2563).
-            if (chosen_file_names(input[0]) !== ((sentFiles || {})[input.attr('name')] || '')) return;
+            if (!same_files(chosen_files(input[0]), (sentFiles || {})[input.attr('name')])) return;
             input.val('');
             var note = input.closest('.form-group').find('.draft-file-note');
             if (!note.length) {

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -320,6 +320,13 @@
                 // management form, row ids and files) come from the form itself.
                 var mainForm = document.getElementById('submission-main-form');
                 var formData = mainForm ? new FormData(mainForm) : new FormData();
+                // What each file input is sending, captured with the snapshot above. The
+                // response arrives later (a file answer may be 16 MiB, and the 60s autosave
+                // starts these uploads with no action from the student), and by then they may
+                // have chosen a different file in the same input. The response speaks about
+                // the file that went out, so it is only allowed to touch an input still
+                // holding it (#2563).
+                var sentFiles = chosen_file_names_by_input();
                 formData.set('csrfmiddlewaretoken', '{{ csrf_token }}');
                 formData.set('comment', draftComment);
                 formData.set('submission_id', '{{ submission.id }}');
@@ -335,7 +342,7 @@
 
                     // handle a successful response
                     success : function(json) {
-                      show_saved_files(json);
+                      show_saved_files(json, sentFiles);
                       hide_check_show_text();
                     },
 
@@ -351,7 +358,25 @@
 
         }
 
-        function show_saved_files(json) {
+        function chosen_file_names(input) {
+            // The file names an input currently holds, as one string, so a selection can be
+            // compared with the one a request went out with. Several names can be selected at
+            // once in the comment's Attach files field, so all of them count.
+            return Array.prototype.map.call((input && input.files) || [], function(file) {
+                return file.name;
+            }).join('\n');
+        }
+
+        function chosen_file_names_by_input() {
+            // Every file input on the form, keyed by name, ready to compare against later.
+            var names = {};
+            $('#submission-main-form input[type="file"]').each(function() {
+                names[this.name] = chosen_file_names(this);
+            });
+            return names;
+        }
+
+        function show_saved_files(json, sentFiles) {
             // A saved file is stored with the draft, so its input is cleared: the file no
             // longer needs re-choosing, and the next autosave must not upload it again. A
             // note under the input says where it went. A rejected file is cleared too, with
@@ -359,22 +384,28 @@
             $.each(json.saved_answer_files || {}, function(field_name, file_name) {
                 file_note($('[name="' + field_name + '"]'),
                     '<i class="fa fa-paperclip fa-fw"></i> Attached: ' + $('<i>').text(file_name).html() +
-                    ' <small>(saved with your draft)</small>');
+                    ' <small>(saved with your draft)</small>', sentFiles);
             });
             if ((json.saved_attachments || []).length) {
                 var names = json.saved_attachments.map(function(name) { return $('<i>').text(name).html(); });
                 file_note($('#submission-main-form input[name="attachments"]'),
                     '<i class="fa fa-paperclip fa-fw"></i> Attached: ' + names.join(', ') +
-                    ' <small>(saved with your draft)</small>');
+                    ' <small>(saved with your draft)</small>', sentFiles);
             }
             $.each(json.file_errors || {}, function(field_name, error_text) {
                 file_note($('[name="' + field_name + '"]'),
-                    '<span class="text-danger">' + $('<i>').text(error_text).html() + '</span>');
+                    '<span class="text-danger">' + $('<i>').text(error_text).html() + '</span>', sentFiles);
             });
         }
 
-        function file_note(input, html) {
+        function file_note(input, html, sentFiles) {
             if (!input.length) return;
+            // The response describes the file this input sent. If the input now holds a
+            // different choice, the student replaced it while the request was in flight:
+            // clearing it would throw that newer file away, and the note would name one they
+            // have moved on from (or blame it for the older file's error). Leave both alone;
+            // the next save reports the new file in the ordinary way (#2563).
+            if (chosen_file_names(input[0]) !== ((sentFiles || {})[input.attr('name')] || '')) return;
             input.val('');
             var note = input.closest('.form-group').find('.draft-file-note');
             if (!note.length) {


### PR DESCRIPTION
### What?

A draft-save response now only touches a file input that still holds the file that response is about.

Closes #2563.

### Why?

The autosave snapshots its FormData when it sends, but the success handler cleared every file input it had news about, with nothing checking whether the input still held the file the news was about:

```js
function file_note(input, html) {
    if (!input.length) return;
    input.val('');          // unconditional
```

A file answer may be 16 MiB, and the autosave fires on a 60-second timer with no action from the student, so a request is easily still in flight at the moment they notice they picked the wrong file and choose the right one. The response then wiped their correct selection and labelled the input with the file they had just moved on from. If they do not notice, the wrong file is what publishes on submit. The `file_errors` leg goes through the same clear, so a valid replacement was thrown away and blamed for the older file's validation error.

### How?

Each file input's chosen `File` objects are captured alongside the FormData, and `file_note` returns early when the input no longer holds them:

```js
var sentFiles = chosen_files_by_input();
...
if (!same_files(chosen_files(input[0]), (sentFiles || {})[input.attr('name')])) return;
input.val('');
```

The comparison is by object identity, not by name. Choosing a file always produces new `File` objects, so this notices a replacement even when the student picked another file of the same name, which comparing names would read as no change at all. An input with no snapshot counts as changed, so the fallback is to leave it alone rather than clear it. The comment's Attach files field is a `RestrictedMultiFileFormField`, so the whole list is compared, not just the first.

When the selection changed, both the input and its note are left alone. The note describes a file the student has moved on from, so it has nothing useful left to say about that input, and the next save reports the new file in the ordinary way.

### Testing?

- Full suite on the current head, with develop merged in: `Ran 2820 tests ... OK`; `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean.
- **There is no unit test for this, and there is nowhere to put one**: the repo has no JavaScript test setup at all (no `package.json`, no runner in CI; `Analyze (javascript-typescript)` is CodeQL). Rather than imply coverage that does not exist, this was verified as a real reproduction in a browser.
- **The reproduction**, driven with Playwright against the seeded `hackerspace` dev deck: hold the draft-save response, choose `wrong-file.txt`, click Save Draft, choose `correct-file.txt` while the request is still held, then release it.

```
                develop            this PR
input holds     (none)             correct-file.txt
note says       Attached:          (no note)
                wrong-file_....txt
VERDICT         selection LOST     selection KEPT
```

- The same run with the replacement **sharing the older file's name**, which is the case CodeRabbit raised on this PR: two different `draft.txt` files, 3 bytes and 20 bytes, so which one survives is unambiguous.

```
                          comparing names        comparing the files
input holds               (none)                 draft.txt (20 bytes)
VERDICT                   replacement LOST       replacement KEPT
```

### Screenshots (if front end is affected)

The file-upload question on the submission page, at the end of that run. Before, the student's `correct-file.txt` is gone ("No file chosen") and the input is captioned with the file they abandoned; after, their choice is still there.

| Before | After |
| --- | --- |
| ![File input after the race, before the fix](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2563/before_file_race.png) | ![File input after the race, with the fix](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2563/after_file_race.png) |

### Anything Else?

- Standing up a JS test harness would make this and the other autosave issues testable, but it is new tooling in CI rather than a bug fix, so it is not being smuggled in here. Happy to open an issue proposing it if that is wanted.
- The same `file_note` guard covers the `saved_attachments` and `file_errors` legs, so all three paths that clear an input are protected by one check rather than three copies of it.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft autosave reliability for file uploads.
  * Prevented in-progress autosaves from replacing newer file selections.
  * Ensured saved-file and validation messages remain associated with the correct uploaded file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->