### PR TITLE
fix: let draft saving recover after one failed save (#2561)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -180,6 +180,11 @@
               <span id="draft-spin" style="display:none"><i class="fa fa-spinner fa-spin fa-fw"></i><span class="sr-only">Saving draft...</span></span>
               <span id="draft-check" style="display:none" class="text-success"><i class="fa fa-check fa-fw"></i><span class="sr-only">Draft saved successfully</span></span>
             </a>
+            {# Shown when a draft save fails, and cleared by the next one that works. The autosave #}
+            {# keeps trying, so this says so rather than interrupting the student every minute. #}
+            <span id="draft-error" class="text-danger" style="display:none" role="status">
+              <i class="fa fa-exclamation-triangle fa-fw"></i> Draft not saved. It will try again shortly.
+            </span>
             {% if submission.is_approved %}
               <input type='submit' name='comment' class='btn btn-primary' value='Add Comment' />
             {% else %}
@@ -269,16 +274,17 @@
             // Save drafts via Ajax when button pressed
             $('#save-draft-btn').on('click', function(event){
                 event.preventDefault(); // prevent browser from reloading
-                console.log("Draft saved!")  // sanity check
-                save_draft();
+                save_draft(true);  // pressed, so a failure is worth interrupting for
             });
 
-            setInterval(save_draft, 60000); // autosave every 60 seconds
+            // autosave every 60 seconds, unattended: a failure here reports itself in the
+            // page instead of in a modal the student did not ask for
+            setInterval(function() { save_draft(); }, 60000);
 
 
         });
 
-        function save_draft() {
+        function save_draft(pressed) {
             // scoped to the main comment form: question answers add their own summernote editors
             $summernoteEditor = $('#main-comment-form div.note-editable')
             draftComment = $summernoteEditor.html()
@@ -335,16 +341,28 @@
 
                     // handle a successful response
                     success : function(json) {
+                      $('#draft-error').hide();
                       show_saved_files(json);
                       hide_check_show_text();
                     },
 
                     // handle a non-successful response
                     error : function(xhr,errmsg,err) {
-                        $('#results').html("<div class='alert-box alert radius' data-alert>Oops! We have encountered an error: "+errmsg+
-                            " <a href='#' class='close'>&times;</a></div>"); // add the error to the dom
+                        // Put the button back first. save_draft() only runs while #draft-text is
+                        // visible, so leaving the spinner up after a failure stops every later
+                        // autosave tick and every click from saving at all, for the rest of the
+                        // page's life, with no sign of why (#2561).
+                        $('#draft-spin').hide();
+                        $('#draft-check').hide();
+                        $('#draft-text').show();
+                        $('#draft-error').show();
                         console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
-                        alert("ERROR!\n\nSorry, something went wrong and the draft wasn't saved.  \n\nSee the browser console for error details.");
+                        if (pressed) {
+                            // The student asked for this save, so tell them it did not happen.
+                            // The timer's own failures stay in #draft-error: now that they retry,
+                            // a modal would interrupt a whole lesson, once a minute.
+                            alert("ERROR!\n\nSorry, something went wrong and the draft wasn't saved.  \n\nSee the browser console for error details.");
+                        }
                     }
                 });
             }

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -348,10 +348,10 @@
 
                     // handle a non-successful response
                     error : function(xhr,errmsg,err) {
-                        // Put the button back first. save_draft() only runs while #draft-text is
-                        // visible, so leaving the spinner up after a failure stops every later
-                        // autosave tick and every click from saving at all, for the rest of the
-                        // page's life, with no sign of why (#2561).
+                        // Put the button back first: save_draft() only runs while #draft-text is
+                        // visible, so restoring it is what lets the next autosave tick, or a
+                        // click, attempt the save again. #draft-error stays up alongside it
+                        // until a save succeeds, so the failure is visible meanwhile (#2561).
                         $('#draft-spin').hide();
                         $('#draft-check').hide();
                         $('#draft-text').show();
@@ -359,8 +359,8 @@
                         console.log(xhr.status + ": " + xhr.responseText); // provide a bit more info about the error to the console
                         if (pressed) {
                             // The student asked for this save, so tell them it did not happen.
-                            // The timer's own failures stay in #draft-error: now that they retry,
-                            // a modal would interrupt a whole lesson, once a minute.
+                            // A timer's failure is reported only in #draft-error: it retries by
+                            // itself, and a modal once a minute would interrupt a whole lesson.
                             alert("ERROR!\n\nSorry, something went wrong and the draft wasn't saved.  \n\nSee the browser console for error details.");
                         }
                     }


### PR DESCRIPTION
### What?

A failed draft save puts the Save Draft button back, so the next autosave tick tries again.

Closes #2561.

### Why?

`save_draft()` only runs while `#draft-text` is visible, and it hides that span before sending. Only the success handler put it back:

```js
if ($draftText.is(':visible')) {
    $draftText.hide(0);
    $draftSpin.show();
    $.ajax({ ... success: function(json) { ... hide_check_show_text(); }, ... });
}
```

So any failure left the spinner up for good. Every later 60-second tick and every click on Save Draft returned immediately without saving, silently, with nothing on the page to say why. One brief wifi drop, expired session or server error cost a student every keystroke after it unless they thought to reload.

The error handler did try to say something, but it wrote to `$('#results')`, and no template in the repo contains an element with that id, so jQuery was writing into an empty set. The only visible sign was one `alert()`.

### How?

The error handler restores the button, which is what lets the next tick retry. Two things follow from retrying:

- **Somewhere to report a failure that is not a modal.** The dead `$('#results')` write is replaced by a `#draft-error` notice beside the button, cleared by the next save that works.
- **The `alert()` now fires only when the student pressed Save Draft themselves.** Before this, a permanent failure alerted once and then everything went quiet. Now that saves retry, keeping the alert unconditional would interrupt a student once a minute for as long as their connection was bad. A press is a question that deserves an answer; the timer's failures are unattended and belong in the notice.

### Testing?

- Full suite: `Ran 2820 tests ... OK`; `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` all clean.
- **There is no unit test for this, and there is nowhere to put one**: the repo has no JavaScript test setup at all (no `package.json`, no runner in CI; `Analyze (javascript-typescript)` is CodeQL). Rather than imply coverage that does not exist, this was verified as a real reproduction in a browser.
- **The reproduction**, driven with Playwright against the seeded `hackerspace` dev deck: abort one draft-save request, then press Save Draft again with the network restored.

```
                          develop                    this PR
button after the failure  text hidden, spinner on    text shown, spinner off
requests made on retry    0                          1
succeeded                 0                          1
VERDICT                   draft saving DEAD          draft saving RECOVERS
```

Alerts shown: 1 in both runs, the manual save's. The fix adds no modals.

### Screenshots (if front end is affected)

The button at the moment of failure. Before, a spinner that never stops and no explanation; after, the button is usable again and says what happened.

| Before | After |
| --- | --- |
| ![Stuck spinner after a failed save](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2561/before_at_failure.png) | ![Button restored with a failure notice](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2561/after_at_failure.png) |

### Anything Else?

- **Will need a small manual merge with #2606** (for #2563): both touch `submission.html` in the same `success`/`error` handler region. Whichever lands second needs it, and I will do that merge as soon as either merges.
- Standing up a JS test harness would make this and the other autosave issues properly testable. That is new tooling in CI rather than a bug fix, so it is not being smuggled in here; happy to open an issue proposing it.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic draft saving every 60 seconds.
  - Added clear feedback for successful and failed draft saves.
  - Autosave failures now retry automatically without interrupting the user.
  - Manual save failures display an alert, while save controls are restored for another attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->