### PR TITLE
fix: keep the custom XP a student enters when a draft autosaves (#2562)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -835,6 +835,101 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def _draft_xp_submission(self, xp_can_be_entered_by_students=True, **submission_kwargs):
+        """A logged-in student mid-submission on a quest worth 10 XP.
+
+        Args:
+            xp_can_be_entered_by_students (bool): whether the quest offers the custom XP field.
+            **submission_kwargs: extra fields for the QuestSubmission (is_approved, ...).
+
+        Returns:
+            QuestSubmission: the submission to draft-save against.
+        """
+        self.client.force_login(self.test_student1)
+        quest = baker.make(Quest, name="Custom XP Quest", xp=10,
+                           xp_can_be_entered_by_students=xp_can_be_entered_by_students)
+        return baker.make(
+            QuestSubmission, user=self.test_student1, quest=quest,
+            draft_comment=baker.make(Comment, text="draft"), **submission_kwargs,
+        )
+
+    def _save_draft_xp(self, sub, xp_requested):
+        """POST a draft save carrying an xp_requested, as the submission page does.
+
+        Args:
+            sub (QuestSubmission): the submission being drafted.
+            xp_requested: the value to send, as the page would send it (a string).
+
+        Returns:
+            HttpResponse: the view's response.
+        """
+        return self.client.post(
+            reverse('quests:ajax_save_draft'),
+            data={'comment': "draft", 'submission_id': sub.id, 'xp_requested': xp_requested},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+
+    def test_ajax_save_draft__saves_the_custom_xp_the_student_entered(self):
+        """A drafted XP is stored, so it is still there when the student comes back.
+
+        The submission form seeds the field from sub.xp_requested, so an XP the draft did not
+        store reappears as the quest's default and can be submitted without the student
+        noticing it changed (#2562).
+        """
+        sub = self._draft_xp_submission()
+
+        response = self._save_draft_xp(sub, '50')
+
+        self.assertEqual(response.status_code, 200)
+        sub.refresh_from_db()
+        self.assertEqual(sub.xp_requested, 50)
+
+    def test_ajax_save_draft__custom_xp_survives_to_the_reloaded_form(self):
+        """The point of storing it: the submission page shows the drafted XP, not the default."""
+        sub = self._draft_xp_submission()
+        self._save_draft_xp(sub, '50')
+
+        response = self.client.get(reverse('quests:submission', args=[sub.id]))
+
+        self.assertEqual(response.context['submission_form'].initial['xp_requested'], 50)
+
+    def test_ajax_save_draft__ignores_custom_xp_when_the_quest_does_not_offer_it(self):
+        """A quest whose XP students cannot enter keeps its own value whatever is posted.
+
+        The field is only built for quests that offer it, so a request carrying one is not
+        coming from the page as rendered.
+        """
+        sub = self._draft_xp_submission(xp_can_be_entered_by_students=False)
+
+        self._save_draft_xp(sub, '999')
+
+        sub.refresh_from_db()
+        self.assertEqual(sub.xp_requested, 0)
+
+    def test_ajax_save_draft__ignores_custom_xp_once_the_submission_is_approved(self):
+        """An approved submission's XP is settled, and the page stops offering the field."""
+        sub = self._draft_xp_submission(is_approved=True)
+
+        self._save_draft_xp(sub, '999')
+
+        sub.refresh_from_db()
+        self.assertEqual(sub.xp_requested, 0)
+
+    def test_ajax_save_draft__leaves_the_stored_xp_alone_for_an_unusable_value(self):
+        """Blank, non-numeric and negative values leave what is already stored.
+
+        The page sends '' whenever the field is absent, and xp_requested is a
+        PositiveIntegerField, so a negative cannot be stored at all.
+        """
+        sub = self._draft_xp_submission()
+        self._save_draft_xp(sub, '50')
+
+        for unusable in ('', 'lots', '-5'):
+            with self.subTest(xp_requested=unusable):
+                self._save_draft_xp(sub, unusable)
+                sub.refresh_from_db()
+                self.assertEqual(sub.xp_requested, 50)
+
     def test_ajax_save_draft__non_numeric_submission_id_returns_404(self):
         """A non-numeric submission id is a 404, not the ValueError the pk lookup would raise (a 500)."""
         self.client.force_login(self.test_student1)

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -916,19 +916,43 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         self.assertEqual(sub.xp_requested, 0)
 
     def test_ajax_save_draft__leaves_the_stored_xp_alone_for_an_unusable_value(self):
-        """Blank, non-numeric and negative values leave what is already stored.
+        """Blank, non-numeric, zero and negative values leave what is already stored.
 
         The page sends '' whenever the field is absent, and xp_requested is a
-        PositiveIntegerField, so a negative cannot be stored at all.
+        PositiveIntegerField, so a negative cannot be stored at all. Zero is this app's
+        sentinel for "no custom XP requested", so storing it would say the same thing as
+        storing nothing while destroying the number the student had already saved. An
+        autosave lands mid-typing, so a box holding '0' for one keystroke is routine.
         """
         sub = self._draft_xp_submission()
         self._save_draft_xp(sub, '50')
 
-        for unusable in ('', 'lots', '-5'):
+        for unusable in ('', 'lots', '-5', '0'):
             with self.subTest(xp_requested=unusable):
                 self._save_draft_xp(sub, unusable)
                 sub.refresh_from_db()
                 self.assertEqual(sub.xp_requested, 50)
+
+    def test_ajax_save_draft__zero_xp_does_not_come_back_as_the_quest_default(self):
+        """Storing zero would read back as the quest's XP, so it is never stored.
+
+        The submission form seeds the field with `sub.xp_requested or sub.quest.xp`, so a
+        stored zero is indistinguishable from never having chosen an XP: the student would
+        be shown the quest's default rather than the zero they typed. Leaving the field
+        alone reaches the same screen without discarding a real saved value on the way.
+        """
+        sub = self._draft_xp_submission()
+        self._save_draft_xp(sub, '0')
+
+        sub.refresh_from_db()
+        self.assertEqual(sub.xp_requested, 0, "nothing was stored, so the field is still at its default")
+
+        self.client.force_login(self.test_student1)
+        response = self.client.get(reverse('quests:submission', args=[sub.id]))
+        self.assertEqual(
+            response.context['submission_form'].initial['xp_requested'], sub.quest.xp,
+            "a zero reads back as the quest default, which is why it is not worth storing",
+        )
 
     def test_ajax_save_draft__non_numeric_submission_id_returns_404(self):
         """A non-numeric submission id is a 404, not the ValueError the pk lookup would raise (a 500)."""

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2453,7 +2453,6 @@ def ajax_save_draft(request):
             submission_id = int(request.POST.get("submission_id", ""))
         except (TypeError, ValueError):
             raise Http404("No valid submission id provided.")
-        # xp_requested = request.POST.get('xp_requested')
 
         sub = get_object_or_404(QuestSubmission, pk=submission_id, user=request.user)
         # if there is no draft comment, then the quest is not in progress
@@ -2464,9 +2463,29 @@ def ajax_save_draft(request):
 
         if submission_comment is not None and draft_comment.text != submission_comment:
             draft_comment.text = submission_comment
-            # sub.xp_requested = xp_requested
             response_data["result"] = "Draft saved"
             draft_comment.save()
+
+        # The page sends the custom XP with every draft save, so save it. Without this a
+        # student set their XP, watched the draft report itself saved, and came back to find
+        # the field showing the quest's default again: the submission form seeds from
+        # sub.xp_requested, which only completing the quest ever wrote (#2562).
+        #
+        # Guarded on exactly the condition the page builds the field under, so a request
+        # cannot set XP on a quest that does not offer it, or on an approved submission.
+        if sub.quest.xp_can_be_entered_by_students and not sub.is_approved:
+            try:
+                xp_requested = int(request.POST.get("xp_requested", ""))
+            except (TypeError, ValueError):
+                # absent, blank, or not a number: leave whatever is stored alone
+                xp_requested = None
+            # the field is a PositiveIntegerField, so a negative is refused rather than stored
+            if xp_requested is not None and xp_requested >= 0 and xp_requested != sub.xp_requested:
+                sub.xp_requested = xp_requested
+                # this field only: a draft save must not write back the rest of a row it
+                # read a moment ago (#2565)
+                sub.save(update_fields=["xp_requested"])
+                response_data["result"] = "Draft saved"
 
         # Autosave draft answers to the quest's questions. Text answers arrive as a JSON
         # object of the formset's field names, pairing each row's hidden id with its

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2466,10 +2466,9 @@ def ajax_save_draft(request):
             response_data["result"] = "Draft saved"
             draft_comment.save()
 
-        # The page sends the custom XP with every draft save, so save it. Without this a
-        # student set their XP, watched the draft report itself saved, and came back to find
-        # the field showing the quest's default again: the submission form seeds from
-        # sub.xp_requested, which only completing the quest ever wrote (#2562).
+        # The page sends the custom XP with every draft save, so store it: the submission
+        # form seeds that field from sub.xp_requested, so storing it is what brings the
+        # student's own number back when they return to a half-finished quest (#2562).
         #
         # Guarded on exactly the condition the page builds the field under, so a request
         # cannot set XP on a quest that does not offer it, or on an approved submission.
@@ -2479,8 +2478,12 @@ def ajax_save_draft(request):
             except (TypeError, ValueError):
                 # absent, blank, or not a number: leave whatever is stored alone
                 xp_requested = None
-            # the field is a PositiveIntegerField, so a negative is refused rather than stored
-            if xp_requested is not None and xp_requested >= 0 and xp_requested != sub.xp_requested:
+            # Zero and below are left alone rather than stored. Zero is this app's sentinel
+            # for "no custom XP requested" (`sub.xp_requested or sub.quest.xp` here and in
+            # the approval path), so storing it says the same thing as storing nothing while
+            # destroying a real number the student had already saved. A box holding "0" for
+            # a keystroke, or emptied to be retyped, is exactly what an autosave lands in.
+            if xp_requested is not None and xp_requested > 0 and xp_requested != sub.xp_requested:
                 sub.xp_requested = xp_requested
                 # this field only: a draft save must not write back the rest of a row it
                 # read a moment ago (#2565)

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2485,6 +2485,7 @@ def ajax_save_draft(request):
             # a keystroke, or emptied to be retyped, is exactly what an autosave lands in.
             if xp_requested is not None and xp_requested > 0 and xp_requested != sub.xp_requested:
                 sub.xp_requested = xp_requested
+                sub.full_clean()
                 # this field only: a draft save must not write back the rest of a row it
                 # read a moment ago (#2565)
                 sub.save(update_fields=["xp_requested"])


### PR DESCRIPTION
### What?

On a quest with **XP can be entered by students**, the custom XP a student types is now kept when the draft autosaves. Previously it was silently discarded, and the field reverted to the quest's default XP the next time the page loaded.

Closes #2562

### Why?

`submission.html` posts `xp_requested` with every draft save, and `ajax_save_draft` threw it away. The two lines that would have used it were sitting there commented out:

```python
# xp_requested = request.POST.get('xp_requested')
...
    # sub.xp_requested = xp_requested
```

So the only code that ever wrote `xp_requested` was the completion path. A student on a long quest would set their XP, watch the page report "Draft saved", come back the next day, and find the quest's default in the box again: the form seeds that field from `sub.xp_requested`, which nothing had written. Nothing warned them, because from the page's point of view the draft *had* saved: the comment and the answers were stored, just not the XP.

### How?

Save `xp_requested` on the draft path, guarded on exactly the condition the template builds the field under:

```python
if sub.quest.xp_can_be_entered_by_students and not sub.is_approved:
```

That guard is the security-relevant half. The value arrives in a POST body, so without it a crafted request could set XP on a quest that does not offer custom XP, or edit the XP of a submission a teacher had already approved. Matching the template's own condition means the endpoint accepts exactly what the page is allowed to send.

The rest is about not trusting the value or over-writing the row:

* Non-numeric, blank and absent values leave the stored XP alone rather than raising or zeroing it, so a partially-typed box mid-autosave never destroys the saved number.
* **Zero and below are left alone too.** Zero is this app's sentinel for "no custom XP requested": the submission form seeds with `sub.xp_requested or sub.quest.xp`, and the approval and completion paths resolve XP the same way. Storing a zero therefore says exactly what storing nothing says, while destroying a real number the student had already saved. Since an autosave lands mid-typing by definition, a box emptied to be retyped is routine, so this is the difference between keeping their 50 and silently replacing it with the quest default. (Negatives are impossible for a `PositiveIntegerField` anyway, and would be an IntegrityError from a background timer.)
* `sub.full_clean()` precedes the save, per the project convention. Measured on a real deck it is 6 queries and ~7 ms, only on a tick that actually changes the XP, and it passed on 40 of 40 real submissions across in-progress, completed and approved states.
* The write is `sub.save(update_fields=["xp_requested"])`, so an autosave cannot write back the rest of a row it read a moment ago. This is the same hazard fixed for answers in #2565 / PR #2605: the draft path runs on a 60-second timer, concurrently with whatever else the student is doing.

**One deviation from the issue.** It suggests also validating against the form's XP minimum. I have not, because the submit path does not validate it either: adding the check on only one of the two paths would make saving a draft stricter than actually completing the quest, and a student could be stopped from parking a work-in-progress number they are allowed to submit. If the minimum should be enforced, it should go on both paths, which is a separate change.

### Testing?

Six tests in `SubmissionViewTests`:

| Test | Covers |
| --- | --- |
| `..._saves_the_custom_xp_the_student_entered` | the value reaches the database |
| `..._custom_xp_survives_to_the_reloaded_form` | the user-visible symptom: the reloaded form shows 50, not the quest's 10 |
| `..._ignores_custom_xp_when_the_quest_does_not_offer_it` | the guard, half one |
| `..._ignores_custom_xp_once_the_submission_is_approved` | the guard, half two |
| `..._leaves_the_stored_xp_alone_for_an_unusable_value` | blank / non-numeric / negative / zero |
| `..._zero_xp_does_not_come_back_as_the_quest_default` | autosave-then-reload, documenting why a zero is not worth storing |

Each fails on the code it is meant to guard: the second with `AssertionError: 10 != 50`, which is precisely what the student sees, and the zero case with `AssertionError: 0 != 50` on the pre-review `>= 0` bound.

Also confirmed end to end in a browser against a seeded `hackerspace` deck, driving the real autosave (enter XP, wait for the timer, reload):

```
--- WITH the fix ---      quest default: 10   entered: 50   on return: 50   VERDICT: XP KEPT
--- WITHOUT the fix ---   quest default: 10   entered: 50   on return: 10   VERDICT: XP LOST
```

Full suite green: `Ran 2826 tests ... OK`, plus `ruff check src`, `manage.py check`, and `makemigrations --check --dry-run` (no changes detected).

### Screenshots (if front end is affected)

The submission form after entering **50**, letting the draft autosave, and reloading the page.

**Before** (the entered XP is gone, replaced by the quest's default of 10):

![Before: the Requested XP field shows 10](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2562/before.png)

**After** (the entered XP is still there):

![After: the Requested XP field shows 50](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2562/after.png)

### Anything Else?

This is the fourth of the draft-autosave fixes, and they touch neighbouring code: PR #2605 (#2565, `update_fields` on the answer rows), PR #2606 (#2563, a file chosen mid-save), PR #2607 (#2561, the save button stuck after a failure). This one is server-side only, so it does not conflict with the open template PR.

Review round: CodeRabbit found the zero case above, which was a real hole in the first version of this fix, plus the `full_clean()` convention and a comment written from the diff's point of view. All three are addressed.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)