### PR TITLE
fix: load the answer editors when a submission bounces back (#2608)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -5,8 +5,8 @@
 {% load comment_tags %}
 
 {% block head %}
-    {# the comment box is a summernote editor too, so its media covers the answer editors #}
-    {{ submission_form.media }}
+    {# the comment form's assets combined with the answer editors', de-duplicated in the view #}
+    {{ form_media }}
     <link rel="stylesheet" href="{% static 'css/select2-bootstrap-0.1.0-beta.10.min.css' %}">
 {% endblock %}
 

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1352,6 +1352,7 @@ class ApproveView(NonPublicOnlyViewMixin, View):
             "submission": self.submission,
             # "comments": comments,
             "submission_form": self.form,
+            "form_media": _submission_page_media(self.form),
             "anchor": "submission-form-" + str(self.submission.quest.id),
             # "reply_comment_form": reply_comment_form,
         }
@@ -1922,6 +1923,39 @@ def unarchive(request, quest_id):
 #   QUEST SUBMISSION - STUDENT VIEWS
 #
 #########################################
+def _submission_page_media(form, question_formset=None):
+    """The assets the submission page's head needs, combined into one ``Media``.
+
+    The page carries editors from two different forms: the comment box on ``form``, and one
+    per long-answer question on ``question_formset``. Both need the summernote library, and
+    only a single ``Media`` object de-duplicates the shared files: two separate renders in
+    the template would emit the whole asset set twice (#2169). The answer forms set crispy's
+    ``include_media = False`` for that reason and depend on this being emitted for them.
+
+    Every form in the formset is asked, not the formset itself. ``BaseFormSet.media`` reads
+    only ``forms[0]`` on the assumption that a formset's forms are alike, which is not true
+    here: each answer form builds a widget for its own question type, so a quest whose first
+    question is a short answer would otherwise report no editor assets at all.
+
+    The comment form does not always carry them either. The POST path builds
+    ``SubmissionQuickReplyFormStudent``, whose ``comment_text`` is a plain textarea, so
+    without the formset's half a submission bounced back for a validation error loads no
+    summernote and every editor on the page degrades to a raw textarea (#2608).
+
+    Args:
+        form: the page's comment form.
+        question_formset: the answer formset, or None when the quest has no questions (or
+            the page is not showing them).
+
+    Returns:
+        Media: the combined assets, ready to render in the template's head.
+    """
+    media = form.media
+    for answer_form in question_formset.forms if question_formset else ():
+        media = media + answer_form.media
+    return media
+
+
 def _keep_posted_uploads(request, form, question_formset, submission, followup=""):
     """Save the POST's uploads that pass their own validation, and tell the student.
 
@@ -2071,6 +2105,7 @@ def complete(request, submission_id):
             "q": submission.quest,  # allows for common data to be displayed on sidebar more easily...
             "submission_form": form,
             "question_formset": question_formset,
+            "form_media": _submission_page_media(form, question_formset),
             "anchor": "submission-form-" + str(submission.quest.id),
         }
         return render(request, "quest_manager/submission.html", context)
@@ -2687,6 +2722,7 @@ def submission(request, submission_id=None, quest_id=None):
         "q": sub.quest,  # allows for common data to be displayed on sidebar more easily...
         "submission_form": main_comment_form,
         "question_formset": question_formset,
+        "form_media": _submission_page_media(main_comment_form, question_formset),
         # "reply_comment_form": reply_comment_form,
         "quick_reply_text": SiteConfig.get().submission_quick_text,
         # A quest can become unpublished (drafted) after a student has already submitted it.

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2004,6 +2004,19 @@ def complete(request, submission_id):
     When a student has completed a quest, or is commenting on an already completed quest, this view is called
     - The submission is marked as completed (by the student)
     - If the quest is automatically approved, then the submission is also marked as approved
+
+    Args:
+        request: the POST carrying the comment, any files, the answer formset, and which
+            button was pressed ("complete" or "comment").
+        submission_id: pk of the submission being completed or commented on.
+
+    Returns:
+        HttpResponse: a redirect once the submission is accepted, or the re-rendered
+        submission page (status 200) when the form or the answer formset has errors to show.
+
+    Raises:
+        Http404: on a GET, an unrecognized submit button, or a submission with no draft
+            comment that is not already completed.
     """
     submission = get_object_or_404(QuestSubmission, pk=submission_id)
     origin_path = submission.get_absolute_url()
@@ -2664,6 +2677,31 @@ def drop(request, submission_id):
 @non_public_only_view
 @login_required
 def submission(request, submission_id=None, quest_id=None):
+    """Show one submission: the student's work on a quest, and the form to add to it.
+
+    Serves both roles. A student sees their own in-progress submission with the comment box,
+    the answer formset for the quest's questions, and their draft comment (created here on
+    first visit, since the draft-save endpoint needs one to write to). Staff see the same
+    submission with the approval form instead, which carries the extra fields for granting
+    badges. Anyone who is neither the owner nor staff is redirected away.
+
+    The answer formset is only built while the submission can still be worked on. Once it is
+    completed or approved the answers are published and shown with their comment instead.
+
+    Args:
+        request: the HTTP request; ``request.user`` decides which form and whose submission.
+        submission_id: pk of the submission to show. A submission whose quest has since
+            become unavailable is still found, through the user's completed submissions.
+        quest_id: unused. No URL pattern routes to this view with it, and nothing in the
+            body reads it; kept so existing callers passing it do not break.
+
+    Returns:
+        HttpResponse: the rendered submission page, or a redirect to the quest list when the
+        requesting user may not see this submission.
+
+    Raises:
+        Http404: if no submission with this pk is visible to the requesting user.
+    """
     try:
         sub = QuestSubmission.objects.get(pk=submission_id)
     except QuestSubmission.DoesNotExist:

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -134,12 +134,15 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
         gets its editor (#2608).
         """
         Question.objects.filter(quest=self.quest).delete()
-        baker.make(Question, quest=self.quest, ordinal=1, type="short_answer", required=False)
+        short_first = baker.make(Question, quest=self.quest, ordinal=1, type="short_answer", required=False)
         baker.make(Question, quest=self.quest, ordinal=2, type="long_answer", required=False)
 
-        content = self.assert200("quests:submission", args=[self.submission.id]).content.decode()
+        response = self.assert200("quests:submission", args=[self.submission.id])
 
-        self.assertEqual(content.count("summernote.min.js"), 1)
+        # the assertion below only means anything while the first form is the short answer,
+        # since that is the one `BaseFormSet.media` would have reported on by itself
+        self.assertEqual(response.context["question_formset"].forms[0].question, short_first)
+        self.assertEqual(response.content.decode().count("summernote.min.js"), 1)
 
     def test_complete__failed_submit_rerenders_with_the_editor_assets(self):
         """A submission bounced back for a validation error still loads the editors (#2608).

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -125,6 +125,40 @@ class SubmissionPageFormsetTest(QuestionSubmissionFlowTestBase):
 
         self.assertEqual(content.count("summernote.min.js"), 1)
 
+    def test_submission_page__summernote_assets_load_when_a_short_answer_comes_first(self):
+        """The editor assets are found however the quest orders its questions.
+
+        `BaseFormSet.media` reads only `forms[0]`, on the assumption that a formset's forms
+        are alike. These are not: each answer form builds a widget for its own question type.
+        The page therefore asks every form, so a long answer sitting behind a short one still
+        gets its editor (#2608).
+        """
+        Question.objects.filter(quest=self.quest).delete()
+        baker.make(Question, quest=self.quest, ordinal=1, type="short_answer", required=False)
+        baker.make(Question, quest=self.quest, ordinal=2, type="long_answer", required=False)
+
+        content = self.assert200("quests:submission", args=[self.submission.id]).content.decode()
+
+        self.assertEqual(content.count("summernote.min.js"), 1)
+
+    def test_complete__failed_submit_rerenders_with_the_editor_assets(self):
+        """A submission bounced back for a validation error still loads the editors (#2608).
+
+        The POST path builds `SubmissionQuickReplyFormStudent`, whose `comment_text` is a
+        plain textarea carrying no summernote assets. The answer editors are summernote
+        widgets, and crispy is told not to emit their media inline, so the page's head is the
+        only place those assets can come from: without them every editor on the re-rendered
+        page falls back to a raw textarea showing the student their own answer as markup.
+        """
+        response = self.client.post(
+            reverse("quests:complete", args=[self.submission.id]),
+            data={"complete": True, "comment_text": "", **self.formset_data(short_text="")})
+
+        self.assertEqual(response.status_code, 200, "expected the validation-error re-render")
+        content = response.content.decode()
+        self.assertContains(response, "You must provide a text response")
+        self.assertEqual(content.count("summernote.min.js"), 1)
+
     def test_submission_page__no_formset_without_questions(self):
         """A quest with no questions renders no formset."""
         plain_quest = baker.make(Quest)


### PR DESCRIPTION
### What?

When a quest submission is bounced back for a validation error, the rich-text answer editors come back with it. They were disappearing entirely: the page re-rendered with the summernote library never loaded, so every editor became a raw textarea.

Closes #2608

### Why?

`submission.html` pulled the library in through the comment form's media:

```django
{# the comment box is a summernote editor too, so its media covers the answer editors #}
{{ submission_form.media }}
```

That comment holds on the GET path, where `submission()` builds the full `SubmissionForm` (its `comment_text` uses `ByteDeckSummernoteSafeInplaceWidget`). It does not hold on the POST path: with no files and no custom XP, `complete()` builds `SubmissionQuickReplyFormStudent`, whose `comment_text` is a plain `forms.Textarea` (`quest_manager/forms.py:396`). No summernote media, so nothing loaded.

The answer editors are summernote widgets of their own, but they deliberately set crispy's `include_media = False` so a long-answer question does not repeat the whole asset set mid-page (#2169). The head was their only source.

Measured in the browser on a seeded deck, same page, before and after the bounce:

| | fresh GET | error re-render |
| --- | --- | --- |
| `.note-editable` elements | 2 | **0** |
| `typeof jQuery.fn.summernote` | `function` | **`undefined`** |
| page errors | none | **`$sn.summernote is not a function`** |

So the student was bounced onto a page with no formatting tools, no way to paste an image, and their previous answer shown back to them as literal markup, at exactly the moment they were being asked to fix something.

### How?

Combine the two forms' media in the view and render the result:

```python
media = form.media
for answer_form in question_formset.forms if question_formset else ():
    media = media + answer_form.media
return media
```

Combining matters. A single `Media` object de-duplicates the shared files on addition, so the GET path still emits summernote exactly once (which `test_submission_page__summernote_assets_load_once` pins). Two separate `{{ ... .media }}` renders in the template cannot do that, and would double the asset set on every GET.

**Every form is asked, not the formset.** `BaseFormSet.media` reads only `forms[0]`, on the documented assumption that a formset's forms are alike. These are not: each answer form builds a widget for its own question type. Measured directly on a quest with a short answer first and a long answer second:

```
formset.media has summernote:            False
combined per-form media has summernote:  True
per-form:                                [False, True]
```

So the tempting one-liner (`form.media + question_formset.media`) fixes this only for quests whose *first* question happens to be a long answer. Both regression tests use the short-answer-first ordering deliberately, and fail against that narrower fix as well as against the original bug.

**Deliberately not changed: which form class the POST path builds.** Swapping `SubmissionQuickReplyFormStudent` for the full `SubmissionForm` would make the re-rendered page identical to the one the student was just looking at, but it changes what every comment validates and stores, which is far wider than this bug warrants. So the comment box on a bounced page stays a plain textarea, by that form's own design. What comes back is the answer editors, which are the ones that declare assets and were not getting them. If the form-class asymmetry is worth closing, it deserves its own change; the option is recorded on the issue.

### Testing?

Full suite `Ran 2845 tests ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

Two new tests in `questions/tests/test_integration.py`:

* `test_complete__failed_submit_rerenders_with_the_editor_assets` submits with the required answer blank and asserts the re-rendered response carries the summernote assets. It fails on unpatched code, **and** fails against the naive `question_formset.media` version, because the fixture's first question is a short answer.
* `test_submission_page__summernote_assets_load_when_a_short_answer_comes_first` pins the ordering independence on the GET path, and that the count stays at exactly one. It asserts `forms[0]` really is the short answer first, so a fixture change cannot leave it passing while it stops covering the ordering it exists for.

Browser measurement on the seeded `hackerspace` deck, driving the real bounce (submit with the required short answer blank):

```
WITHOUT the fix   re-render editors: 0   summernote fn: undefined   errors: ['$sn.summernote is not a function']
WITH the fix      re-render editors: 1   summernote fn: function    errors: []
```

(1 rather than 2 is the comment box being a plain textarea on that path, as described above.)

### Screenshots (if front end is affected)

Question 2's long-answer field on the re-rendered page, after submitting with the required Question 1 left blank.

**Before** (a bare textarea, no toolbar):

![Before: the long-answer field is a plain empty textarea](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2608/before.png)

**After** (the editor is back):

![After: the long-answer field has its summernote toolbar](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2608/after.png)

### Anything Else?

Found while capturing screenshots for #2560, whose "after" shot showed the raw markup this causes. That fix routes many more students onto this page, since a blank required long answer now bounces where it previously completed, which is why this followed straight after it.

Review round: CodeRabbit asked for the formset-ordering assertion above, and for docstrings on the views this touches. `submission()` had none at all and now has one (including that `quest_id` is a parameter no URL routes to and nothing reads); `complete()` gained Args/Returns/Raises, which is worth having since its two successful outcomes are a redirect and the 200 re-render this PR fixes. I declined the same request for `ApproveView.form_invalid`, which already documents its purpose and both return values in the repo's existing informal style: there was no missing information, only a reformatting, and it would leave the file in two docstring styles. A repo-wide pass on that is fine, just not riding along with a media fix.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)