### PR TITLE
fix: recognise an empty comment box however the editor spells it (#2609)

### DIFF
--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1715,6 +1715,27 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
         notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
         self.assertEqual(notifications.count(), 0)
 
+    def test_complete__no_notification_for_an_empty_looking_comment(self):
+        """No teacher notification for a comment box the student typed nothing into (#2609).
+
+        On an auto-approved quest a comment is the only reason to notify a teacher, since the
+        quest never reaches the approvals tab. The editor posts markup rather than an empty
+        string, so each of these looked like a comment and sent the teacher to read one that
+        renders as blank space. Every payload here got through, the exact `<p><br></p>`
+        included: the POST path builds SubmissionQuickReplyFormStudent, whose comment_text is
+        a plain Textarea, so summernote's own empty-string handling never runs.
+        """
+        self.sub.quest.verification_required = False
+        self.sub.quest.save()
+
+        for empty in ("<p><br></p>", "<p></p>", "<p> </p>", "<p>&nbsp;</p>", "<p><br></p><p><br></p>"):
+            with self.subTest(comment=empty):
+                Notification.objects.all().delete()
+                self.post_complete(submission_comment=empty)
+
+                notifications = Notification.objects.all_for_user_target(self.test_teacher, self.sub)
+                self.assertEqual(notifications.count(), 0)
+
     def test_complete__specific_teacher_is_own_teacher_no_notification(self):
         """
         If a quest has a specific teacher set to notify and that teacher is also the student's current teacher,

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -1594,6 +1594,43 @@ class SubmissionCompleteViewTest(ByteDeckTenantTestCase):
 
         self.assertErrorMessage(response)
 
+    def test_complete__empty_looking_comment_but_verification_required(self):
+        """An editor nobody typed in does not satisfy the attach-or-comment rule (#2609).
+
+        The summernote editor never posts an empty string. It posts markup, and markup is
+        truthy, so each of these reads as a real comment unless the check asks what the
+        markup renders as. On a verification-required quest that means the student completes
+        with nothing for the teacher to verify, and the teacher gets a submission whose
+        comment renders as blank space.
+        """
+        self.sub.quest.verification_required = True
+        self.sub.quest.save()
+
+        for empty in ("<p><br></p>", "<p></p>", "<p> </p>", "<p>&nbsp;</p>", "<p><br></p><p><br></p>"):
+            with self.subTest(comment=empty):
+                response = self.post_complete(submission_comment=empty)
+
+                self.assertRedirects(response, expected_url=self.sub.get_absolute_url())
+                self.sub.refresh_from_db()
+                self.assertFalse(self.sub.is_completed)
+                self.assertErrorMessage(response)
+
+    def test_complete__comment_that_is_only_an_image_satisfies_verification(self):
+        """A comment made entirely of a pasted image is a real comment and completes.
+
+        Stripping the tags out of it leaves nothing, so an emptiness test judging on text
+        alone would bounce a student who answered "show me your work" the way the quest
+        invites. Refusing a real comment is worse for them than accepting a blank one.
+        """
+        self.sub.quest.verification_required = True
+        self.sub.quest.save()
+
+        response = self.post_complete(submission_comment='<p><img src="/media/screenshot.png"></p>')
+
+        self.assertRedirects(response, expected_url=reverse('quests:quests'))
+        self.sub.refresh_from_db()
+        self.assertTrue(self.sub.is_completed)
+
     def test_quest_not_available__unpublished(self):
         """ If a quest is unpublished (moved to drafts) while a student's submission is
         in progress, they should not be able to complete it by entering the completion
@@ -5091,6 +5128,48 @@ class ApproveViewTest(ByteDeckTenantTestCase):
         comments = Comment.objects.all_with_target_object(self.sub)
         self.assertEqual(comments.count(), 1)
         self.assertEqual(comments.first().text, f"<p>{SiteConfig.get().blank_approval_text}</p>")
+
+    def test_approve__empty_looking_comment_uses_default_text(self):
+        """An editor the teacher typed nothing into gets the default text too (#2609).
+
+        The editor posts markup rather than an empty string, so without asking what that
+        markup renders as, a teacher who clicked into the box and pressed space or enter
+        stores that markup as their approval comment. The student then sees an approval
+        whose comment is blank space instead of the deck's configured wording.
+        """
+        from comments.models import Comment
+
+        for empty in ("<p><br></p>", "<p></p>", "<p> </p>", "<p>&nbsp;</p>", "<p><br></p><p><br></p>"):
+            with self.subTest(comment=empty):
+                # a fresh quest each time: only one in-progress submission per quest per
+                # student is allowed, so reusing one would trip that unique constraint
+                sub = baker.make(QuestSubmission, quest=baker.make(Quest), user=self.test_student)
+                self.client.post(
+                    reverse('quests:approve', args=[sub.id]),
+                    data={'comment_text': empty, 'approve_button': True},
+                )
+
+                comments = Comment.objects.all_with_target_object(sub)
+                self.assertEqual(comments.count(), 1)
+                self.assertEqual(comments.first().text, f"<p>{SiteConfig.get().blank_approval_text}</p>")
+
+    def test_approve__comment_that_is_only_an_image_is_kept(self):
+        """An approval comment made entirely of a pasted image is kept, not replaced.
+
+        Stripping its tags leaves nothing, so an emptiness test judging on text alone would
+        throw away a teacher's screenshot and substitute the default wording.
+        """
+        from comments.models import Comment
+
+        image_comment = '<p><img src="/media/marked-up-work.png"></p>'
+        self.client.post(
+            reverse('quests:approve', args=[self.sub.id]),
+            data={'comment_text': image_comment, 'approve_button': True},
+        )
+
+        comments = Comment.objects.all_with_target_object(self.sub)
+        self.assertEqual(comments.count(), 1)
+        self.assertIn("marked-up-work.png", comments.first().text)
 
     def test_approve__with_multiple_badges_staff_form(self):
         """ Test that multiple badges can be granted from the SubmissionFormStaff form"""

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -1538,6 +1538,23 @@ class ApproveView(NonPublicOnlyViewMixin, View):
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request, submission_id, *args, **kwargs):
+        """Act on a teacher's decision about one submission, and tell the student.
+
+        Which decision it is comes from the button the form carries (approve, return, comment,
+        skip), which `handle_form_button` reads; that also supplies the wording to store when
+        the teacher wrote no comment of their own. Any badge granted alongside is appended to
+        the comment, uploaded files are attached to it, and the student is notified.
+
+        Args:
+            request: the POST carrying the teacher's comment, any files, any badge, and which
+                button was pressed.
+            submission_id: pk of the submission being acted on.
+
+        Returns:
+            HttpResponse: `form_valid`'s redirect to the approvals tab, or a JsonResponse when
+            the request was made by ajax. An invalid form returns `form_invalid` instead,
+            which re-renders the submission page (or a 400 for ajax).
+        """
         self.submission = self.get_submission(submission_id)
         self.form = self.get_form()
 
@@ -2093,8 +2110,12 @@ def complete(request, submission_id):
 
     # Whether the student left a comment at all. The editor posts markup rather than an empty
     # string for a box nobody typed in, so this asks what that markup renders as (#2609); a
-    # comment that is only a pasted image counts as content and takes the other branch.
-    if is_empty_html(comment_text):
+    # comment that is only a pasted image counts as content. Answered once, here, because the
+    # branches below overwrite comment_text with placeholder text, and the teacher
+    # notification further down still needs to know whether there was ever a real comment.
+    has_comment = not is_empty_html(comment_text)
+
+    if not has_comment:
 
         # If the student answered at least one question, those answers are the submission's
         # content, so don't demand an additional comment or attachment on top of them.
@@ -2192,10 +2213,10 @@ def complete(request, submission_id):
 
         # Send notification to current teachers when a comment is left on an auto-approved quest
         # since these quests don't appear in the approvals tab, teacher would never know about the comment.
-        if (
-            form.cleaned_data.get("comment_text")
-            and not submission.quest.verification_required
-        ):
+        # has_comment rather than the posted value: an editor nobody typed in posts markup, and
+        # notifying a teacher to come and read a comment that renders as blank space wastes the
+        # trip (#2609).
+        if has_comment and not submission.quest.verification_required:
             affected_users.extend(request.user.profile.current_teachers())
 
         # Record which course the student said this counts toward, before the XP is granted so

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -41,6 +41,7 @@ from questions.forms import QuestionSubmissionFormsetFactory
 from questions.models import QuestionSubmission, QuestionType
 from questions.utils import discard_draft_question_submissions, save_draft_file_answers, sync_draft_question_submissions
 from courses.models import Block, CourseStudent
+from utilities.html import is_empty_html
 from utilities.sorting import apply_sort, resolve_sort
 
 from .listing import QUEST_SORT_COLUMNS, search_quests, search_submissions
@@ -1550,7 +1551,11 @@ class ApproveView(NonPublicOnlyViewMixin, View):
             # handle comment text
             # if staff didnt write any text for comment use blank_comment_text
             comment_text = self.form.cleaned_data.get("comment_text")
-            if not comment_text or comment_text == "<p><br></p>":
+            # An editor the teacher typed nothing into posts markup, not an empty string, so
+            # what counts as "no comment" is a question about what that markup renders as
+            # rather than about the string (#2609). An image on its own is a real comment and
+            # is kept: is_empty_html treats embedded media as content.
+            if is_empty_html(comment_text):
                 comment_text = blank_comment_text
 
             comment_new = Comment.objects.create_comment(
@@ -2086,9 +2091,10 @@ def complete(request, submission_id):
     # editor posts markup rather than an empty string (#2560).
     answered_a_question = bool(question_formset) and any(f.has_answer() for f in question_formset.forms)
 
-    # If the student didn't leave a comment (or the default html from summernote <p><br></p>)
-    # then need to check if we should bother handling this form submission
-    if not comment_text or comment_text == "<p><br></p>":
+    # Whether the student left a comment at all. The editor posts markup rather than an empty
+    # string for a box nobody typed in, so this asks what that markup renders as (#2609); a
+    # comment that is only a pasted image counts as content and takes the other branch.
+    if is_empty_html(comment_text):
 
         # If the student answered at least one question, those answers are the submission's
         # content, so don't demand an additional comment or attachment on top of them.


### PR DESCRIPTION
### What?

An empty comment box is now recognised as empty however the editor spells it, in all three places that ask. A student can no longer complete a verification-required quest by clicking into the comment box and pressing enter, a teacher's blank-looking approval gets the deck's configured wording instead of being stored as blank markup, and no teacher is sent a notification about a comment that renders as blank space.

Closes #2609

### Why?

Three places asked "is there a comment?" and none of them could answer it. Two compared against one exact string:

```python
if not comment_text or comment_text == "<p><br></p>":
```

`views.py:1553` (the teacher's approve/return form) and `views.py:2092` (the complete view). The summernote editor produces that exact markup only sometimes:

| what the user did | posted | passed the old check? |
| --- | --- | --- |
| clicked in, left | `<p><br></p>` | caught |
| pressed enter twice | `<p><br></p><p><br></p>` | **got through** |
| typed a space | `<p>&nbsp;</p>` | **got through** |
| typed and deleted | `<p></p>` | **got through** |

The multi-paragraph one is measured, not guessed: driving the real editor in a browser and pressing enter twice posts `<p><br></p><p><br></p><p><br></p>`.

**In the complete view this is the one that matters.** When `comment_text` looks like content, the entire attach-or-comment block is skipped:

```python
if not comment_text or comment_text == "<p><br></p>":
    ...
    elif submission.quest.verification_required and not request.FILES:
        messages.error(request, "Please read the Submission Instructions more carefully. ...")
        return redirect(origin_path)
```

So a student finished a verification-required quest with nothing in it, and the teacher received a submission to verify whose comment renders as blank space.

**The third place had no sentinel at all**, and is the strictest case. On an auto-approved quest, a comment is the only reason to notify a teacher, since the quest never reaches the approvals tab:

```python
if (
    form.cleaned_data.get("comment_text")
    and not submission.quest.verification_required
):
    affected_users.extend(request.user.profile.current_teachers())
```

That reads the raw posted value, so it fires for **every** empty payload including the exact `<p><br></p>`, sending a teacher to read blank space. Found by CodeRabbit on this PR; it predates it.

Worth noting *why* hand-written checks exist here at all, since django-summernote has its own empty-string handling: `SummernoteWidgetBase.value_from_datadict` maps `<p><br></p>` to `None`, but the POST path builds `SubmissionQuickReplyFormStudent`, whose `comment_text` is a plain `forms.Textarea` (`quest_manager/forms.py:396`). No widget normalisation runs on that path. That is why the sentinel was written by hand, why it was incomplete, and why the notification check was wrong even for the string the sentinel did catch.

In the teacher's form the consequence is milder: an approval that looks blank is stored as blank markup instead of the deck's `blank_approval_text` ("(Approved without comment)" and similar).

### How?

All three now go through `utilities.html.is_empty_html`, which landed with #2560 and was put in `utilities/` with this second caller in mind. It strips tags, decodes entities, and asks whether any non-whitespace character is left.

In the complete view the answer is computed once, before the branches below overwrite `comment_text` with placeholder text, so the notification further down can still tell whether there was ever a real comment:

```python
has_comment = not is_empty_html(comment_text)
```

`is_empty_html` also treats embedded media as content, which matters at every call site: a comment that is nothing but a pasted screenshot is a real comment. Without that, the complete view would bounce a student who answered with an image, and the teacher's form would throw away their screenshot and substitute the default wording. There is a test at each call site pinning that.

### Testing?

Full suite `Ran 2848 tests ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

Five new tests:

* `test_complete__empty_looking_comment_but_verification_required` posts each payload from the table above and asserts the submission bounces rather than completing.
* `test_complete__no_notification_for_an_empty_looking_comment` asserts no teacher notification for any of them on an auto-approved quest.
* `test_approve__empty_looking_comment_uses_default_text` asserts the deck's configured approval wording is used for each payload.
* `test_complete__comment_that_is_only_an_image_satisfies_verification` and `test_approve__comment_that_is_only_an_image_is_kept` assert an image-only comment is treated as real at both call sites.

The first and third fail against the old sentinel for every payload except the exact `<p><br></p>` it already handled. The complete-view failure is the user-visible one:

```
AssertionError: '/quests/available/' != '/quests/submission/1/'
```

which is the quest completing when it should have bounced. The notification test is stricter still: it fails for all five payloads, `<p><br></p>` included, with `AssertionError: 1 != 0`. The two image tests pass either way by design: they exist to catch over-rejection, not the original bug.

Confirmed in a browser on a seeded `hackerspace` deck, on a verification-required quest with no questions, clicking into the comment box and pressing enter twice:

```
WITHOUT the fix   comment box posts '<p><br></p><p><br></p><p><br></p>'  ->  QUEST COMPLETED with an empty comment
WITH the fix      comment box posts '<p><br></p><p><br></p><p><br></p>'  ->  BOUNCED with the attach-or-comment message
```

### Screenshots (if front end is affected)

A student on a verification-required quest, clicking into the comment box, pressing enter twice, and submitting.

**Before** (the quest completes and goes off for approval with nothing in it):

![Before: "Quest completed, awaiting approval."](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2609/before.png)

**After** (the student is told what is missing):

![After: "Please read the Submission Instructions more carefully. You are expected to attach something or comment to complete this quest!"](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2609/after.png)

### Anything Else?

This is the third fix built on the same observation, after #2560 (question answers) and #2608 (the editors not loading on the re-render). `is_empty_html` now has all of its callers, so every check in this flow agrees about what "empty" means.

**This one changes what students can do**, unlike the other two, so it is worth a deliberate look: a student who could previously finish a verification-required quest with an empty comment box will now be bounced. That is the point of the fix, but it is a real behaviour change rather than a pure correctness one.

`ApproveView.post` gained a docstring, since it had none and this PR changes its body. `complete()`'s docstring is not expanded here even though it needs it: that is already done and awaiting review in PR #2612, and duplicating it would risk a pointless conflict between two open PRs.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)