### PR TITLE
fix: stop creating draft answer rows that nothing can ever reach (#2567)

### DIFF
--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2630,7 +2630,7 @@ def ajax_save_draft(request):
             saved_attachments = []
             file_errors = {}
 
-            # Same state gate as the page GET and complete(): building the formset calls
+            # Same submission-state condition as the page GET and complete(): building the formset calls
             # sync_draft_question_submissions, which creates a draft row per question when
             # none exists. On a submission that is finished those rows can never be
             # published or rendered, so they would be invisible and permanent, and on a

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -2555,7 +2555,15 @@ def ajax_save_draft(request):
             saved_attachments = []
             file_errors = {}
 
-            if sub.quest.question_set.exists():
+            # Same state gate as the page GET and complete(): building the formset calls
+            # sync_draft_question_submissions, which creates a draft row per question when
+            # none exists. On a submission that is finished those rows can never be
+            # published or rendered, so they would be invisible and permanent, and on a
+            # skipped quest they would undo the discard the skip flow just performed
+            # (#2164, #2567). The page still offers Save Draft on a completed submission,
+            # and the draft comment the GET creates is enough to reach this, so the guard
+            # has to be here rather than relying on the button being hidden.
+            if not sub.is_completed and not sub.is_approved and sub.quest.question_set.exists():
                 question_formset = QuestionSubmissionFormsetFactory(
                     request.POST, request.FILES,
                     instance=sub, queryset=sync_draft_question_submissions(sub),

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
+from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -584,7 +585,7 @@ class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
         )
 
     def test_save_draft__comment_attachment_still_saves_on_a_completed_submission(self):
-        """The state gate is on the answer formset only: a comment attachment still saves.
+        """The submission-state condition covers the answer formset only: an attachment still saves.
 
         A student commenting on a quest they already finished is a normal thing to do, and
         the file they attach belongs to that comment rather than to any answer row.
@@ -1055,7 +1056,7 @@ class QuestDetailEntryPointTest(QuestionSubmissionFlowTestBase):
 class DraftRowHealingTest(QuestionSubmissionFlowTestBase):
     """sync_draft_question_submissions heals duplicate draft rows for the same question."""
 
-    def test_sync__duplicate_draft_rows_healed_keeping_content(self):
+    def test_sync_draft_question_submissions__duplicate_draft_rows_healed_keeping_content(self):
         """When duplicate draft rows exist for one question (concurrency race, or a deleted
         published comment reverting answers into an active cycle), sync keeps the row with
         content and deletes the empty duplicates."""
@@ -1070,7 +1071,7 @@ class DraftRowHealingTest(QuestionSubmissionFlowTestBase):
         self.assertEqual(short_rows.count(), 1)
         self.assertEqual(short_rows.first().response_text, "keep me")
 
-    def test_sync__duplicate_dropped_when_keeper_has_content(self):
+    def test_sync_draft_question_submissions__duplicate_dropped_when_keeper_has_content(self):
         """When the most recently edited duplicate is the contentful one, the older empty
         duplicate is simply dropped."""
         # older empty duplicate first, then the contentful row (edited last = the keeper)
@@ -1084,7 +1085,7 @@ class DraftRowHealingTest(QuestionSubmissionFlowTestBase):
         self.assertEqual(short_rows.first().id, contentful.id)
 
 
-    def test_sync__unpublished_answer_to_a_deleted_question_is_removed(self):
+    def test_sync_draft_question_submissions__unpublished_answer_to_a_deleted_question_is_removed(self):
         """A draft answer whose question was deleted is cleaned up rather than left forever.
 
         `question` is SET_NULL, so deleting a question leaves the row behind with no way for
@@ -1104,7 +1105,34 @@ class DraftRowHealingTest(QuestionSubmissionFlowTestBase):
 
         self.assertFalse(QuestionSubmission.objects.filter(id=row.id).exists())
 
-    def test_sync__published_answer_to_a_deleted_question_is_kept(self):
+    def test_sync_draft_question_submissions__deleted_orphan_takes_its_uploaded_file_with_it(self):
+        """The uploaded file goes when its orphaned row does, rather than being stranded.
+
+        Django has not deleted a FileField's storage on row delete since 1.3, so removing
+        the row alone would leave the file on disk with nothing in the database naming it:
+        worse than the orphan this cleans up, since the row at least pointed at the file a
+        sweep could have found (#2567).
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="all",
+        )
+        row = sync_draft_question_submissions(self.submission).get(question=file_question)
+        row.response_file = SimpleUploadedFile("orphaned.png", b"file_content", content_type="image/png")
+        row.save()
+        stored_name = row.response_file.name
+        self.assertTrue(row.response_file.storage.exists(stored_name))
+        file_question.delete()
+
+        sync_draft_question_submissions(self.submission)
+
+        self.assertFalse(QuestionSubmission.objects.filter(id=row.id).exists())
+        self.assertFalse(
+            default_storage.exists(stored_name),
+            "the uploaded file should not outlive the row that named it",
+        )
+
+    def test_sync_draft_question_submissions__published_answer_to_a_deleted_question_is_kept(self):
         """A published answer survives its question being deleted: it is part of the record.
 
         It still renders with the comment it was published against, so unlike the draft above

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -509,6 +509,69 @@ class DraftFileSaveTest(QuestionSubmissionFlowTestBase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
 
+    def test_save_draft__no_draft_rows_created_on_a_completed_submission(self):
+        """Draft-saving a file on a finished submission does not spawn answer rows (#2567).
+
+        The page still offers Save Draft on a completed submission, and `submission()` creates
+        a draft comment for any owner view, so the endpoint is reachable. Building the answer
+        formset there would call sync and create a row per question that can never be
+        published or rendered: invisible and permanent. Comment attachments still save, which
+        the test below covers.
+        """
+        file_question = baker.make(
+            Question, quest=self.quest, ordinal=3, type="file_upload",
+            required=False, allowed_file_type="all",
+        )
+        # Build the payload while the submission is still in progress: the helpers call sync
+        # themselves, so capturing the POST first is what keeps this test measuring the view.
+        field_name = self.file_field_name(file_question)
+        payload = {
+            "comment": "<p>draft words</p>",
+            "submission_id": self.submission.id,
+            **self.formset_data(short_text="draft title"),
+            field_name: SimpleUploadedFile("late.png", b"file_content", content_type="image/png"),
+        }
+        # clear the drafts and finish the submission, as completing the quest does
+        QuestionSubmission.objects.filter(quest_submission=self.submission).delete()
+        self.submission.is_completed = True
+        self.submission.save()
+
+        self.client.post(
+            reverse("quests:ajax_save_draft"), data=payload,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(
+            QuestionSubmission.objects.filter(quest_submission=self.submission).count(), 0,
+            "a finished submission must not gain draft answer rows",
+        )
+
+    def test_save_draft__comment_attachment_still_saves_on_a_completed_submission(self):
+        """The state gate is on the answer formset only: a comment attachment still saves.
+
+        A student commenting on a quest they already finished is a normal thing to do, and
+        the file they attach belongs to that comment rather than to any answer row.
+        """
+        payload = {
+            "comment": "<p>draft words</p>",
+            "submission_id": self.submission.id,
+            **self.formset_data(short_text="draft title"),
+            "attachments": SimpleUploadedFile("receipt.png", b"file_content", content_type="image/png"),
+        }
+        self.submission.is_completed = True
+        self.submission.save()
+
+        response = self.client.post(
+            reverse("quests:ajax_save_draft"), data=payload,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        payload = json.loads(response.content)
+        self.assertTrue(
+            any("receipt" in name for name in payload["saved_attachments"]),
+            f"the comment attachment should still be saved, got {payload['saved_attachments']}",
+        )
+
     def test_save_draft__stores_a_file_answer(self):
         """A file chosen on a file-upload question is stored on its draft row by Save Draft,
         unpublished, and the response names it so the page can show it was kept."""
@@ -982,6 +1045,47 @@ class DraftRowHealingTest(QuestionSubmissionFlowTestBase):
         short_rows = rows.filter(question=self.short_question)
         self.assertEqual(short_rows.count(), 1)
         self.assertEqual(short_rows.first().id, contentful.id)
+
+
+    def test_sync__unpublished_answer_to_a_deleted_question_is_removed(self):
+        """A draft answer whose question was deleted is cleaned up rather than left forever.
+
+        `question` is SET_NULL, so deleting a question leaves the row behind with no way for
+        anything to reach it: answers render only through `comment.question_submissions`,
+        which a NULL comment excludes, and this function's own queryset filters on
+        `question__isnull=False`. Kept, it would sit in the schema indefinitely along with an
+        uploaded file of up to 16 MiB (#2567).
+        """
+        row = sync_draft_question_submissions(self.submission).get(question=self.short_question)
+        row.response_text = "answered before the question was deleted"
+        row.save()
+        self.short_question.delete()
+        row.refresh_from_db()
+        self.assertIsNone(row.question_id, "SET_NULL should have orphaned the row")
+
+        sync_draft_question_submissions(self.submission)
+
+        self.assertFalse(QuestionSubmission.objects.filter(id=row.id).exists())
+
+    def test_sync__published_answer_to_a_deleted_question_is_kept(self):
+        """A published answer survives its question being deleted: it is part of the record.
+
+        It still renders with the comment it was published against, so unlike the draft above
+        it is neither invisible nor unreachable, and deleting it would remove work a student
+        actually submitted.
+        """
+        comment = baker.make("comments.Comment", target_object_id=self.submission.id)
+        row = sync_draft_question_submissions(self.submission).get(question=self.short_question)
+        row.response_text = "submitted work"
+        row.comment = comment
+        row.save()
+        self.short_question.delete()
+
+        sync_draft_question_submissions(self.submission)
+
+        row.refresh_from_db()
+        self.assertIsNone(row.question_id)
+        self.assertEqual(row.response_text, "submitted work")
 
 
 class CompleteSecurityTest(QuestionSubmissionFlowTestBase):

--- a/src/questions/utils.py
+++ b/src/questions/utils.py
@@ -90,9 +90,13 @@ def sync_draft_question_submissions(quest_submission):
     so the formset always matches the quest's *current* question set:
 
     * A question added after the student started gets a fresh draft row here.
-    * A deleted question's rows have question=None (SET_NULL) and are excluded from the
-      returned queryset, so they can't block or crash the formset; the rows themselves are
-      kept (any content may still interest a marker).
+    * A deleted question's rows have question=None (SET_NULL). A *published* one is kept:
+      it renders with its comment as part of the student's record, and is excluded from the
+      returned queryset so it can't block or crash the formset. An unpublished one is
+      deleted, because nothing can ever reach it again: answers display only through
+      ``comment.question_submissions``, which a NULL comment excludes, and the publish step
+      filters on ``question__isnull=False``. Left alone it would sit in the schema forever,
+      along with an uploaded file of up to 16 MiB (#2567).
     * Published rows (comment set) belong to an earlier submission cycle and are ignored,
       so a returned-and-resubmitted quest starts a fresh set of drafts.
     * Duplicate draft rows for the same question are healed by keeping one and deleting the
@@ -100,9 +104,16 @@ def sync_draft_question_submissions(quest_submission):
       arise from two concurrent first renders racing this function, or from a published
       comment being deleted (its answers revert to draft via SET_NULL) while a new cycle's
       draft for the same question already exists. A DB uniqueness constraint can't be used
-      here precisely because of that revert path — it would turn the comment deletion into
+      here precisely because of that revert path: it would turn the comment deletion into
       an IntegrityError.
     """
+    # Unpublished answers to a question that has since been deleted: invisible to every
+    # code path and reachable by none, so this is their only chance to be cleaned up
+    # (#2567). Published ones are untouched: those still render with their comment.
+    QuestionSubmission.objects.filter(
+        quest_submission=quest_submission, comment__isnull=True, question__isnull=True
+    ).delete()
+
     drafts = QuestionSubmission.objects.filter(
         quest_submission=quest_submission, comment__isnull=True, question__isnull=False
     )

--- a/src/questions/utils.py
+++ b/src/questions/utils.py
@@ -110,9 +110,20 @@ def sync_draft_question_submissions(quest_submission):
     # Unpublished answers to a question that has since been deleted: invisible to every
     # code path and reachable by none, so this is their only chance to be cleaned up
     # (#2567). Published ones are untouched: those still render with their comment.
-    QuestionSubmission.objects.filter(
+    #
+    # The uploaded file goes first, and has to. Django has not deleted a FileField's
+    # storage on row delete since 1.3, so dropping the row alone would leave the file on
+    # disk with nothing left in the database pointing at it: worse than the orphan being
+    # fixed, because the row at least named the file a sweep could find. Deleted one row at
+    # a time rather than through the queryset, since QuerySet.delete() never opens the
+    # files. save=False because the row is about to be deleted anyway.
+    orphans = QuestionSubmission.objects.filter(
         quest_submission=quest_submission, comment__isnull=True, question__isnull=True
-    ).delete()
+    )
+    for orphan in orphans:
+        if orphan.response_file:
+            orphan.response_file.delete(save=False)
+    orphans.delete()
 
     drafts = QuestionSubmission.objects.filter(
         quest_submission=quest_submission, comment__isnull=True, question__isnull=False


### PR DESCRIPTION
### What?

Closes the two remaining sources of invisible, permanent draft `QuestionSubmission` rows: the file leg of `ajax_save_draft` creating them on finished submissions, and a deleted question leaving its unpublished answers behind forever. The uploaded file goes with the row.

Closes #2567

### Why?

**1. The file leg had no state check.** It built the answer formset under `if sub.quest.question_set.exists():` alone, while the other two call sites both look at the submission's state:

| call site | condition |
| --- | --- |
| page GET (`views.py:2706`) | `not sub.is_completed and not sub.is_approved and ...` |
| `complete()` (`views.py:2050`) | `not submission.is_completed and ...` |
| `ajax_save_draft` file leg | **none** |

Building the formset calls `sync_draft_question_submissions`, which `bulk_create`s a draft row per question when none exists. So a student who opened a finished submission and chose a file got one empty row per question, which can never be published or rendered. On a skipped quest it undoes the `discard_draft_question_submissions` cleanup the skip flow just performed, which is the exact thing #2164 set out to prevent.

The path is genuinely reachable, not theoretical: the only entry guard is `if not sub.draft_comment: raise Http404`, and `submission()` creates a `draft_comment` for any non-staff owner view with no state check of its own. Opening a completed submission is enough to arm it, and the template still shows Save Draft there.

**2. A deleted question orphans its unpublished answers.** `QuestionSubmission.question` is `SET_NULL`, and the rows were deliberately kept, with this rationale in `sync_draft_question_submissions`:

> the rows themselves are kept (any content may still interest a marker)

That is not true, and the code says so in two places. Answers reach a marker only through `comment.question_submissions.all` (`comments/templates/comments/comments.html:68`), which a NULL comment excludes; and the function's own returned queryset filters on `question__isnull=False`, so the formset never sees them either. A row that is NULL on both is unreachable by every path, and sat in the tenant schema indefinitely along with an uploaded file of up to 16 MiB.

### How?

The file leg gets the same condition the page GET uses. The comment-attachment branch is deliberately left outside it: commenting on a quest you already finished is normal, and that file belongs to the comment, not to any answer row.

`sync_draft_question_submissions` deletes rows that are NULL on **both** `question` and `comment`, alongside the duplicate-healing it already does there. Putting it in a function that runs on a GET is not something I would normally do, but that is where the existing cleanup lives, so a second cleanup path would have been worse; the docstring now says as much.

**The uploaded file is deleted first, and has to be.** Django has not deleted a `FileField`'s storage on row delete since 1.3, so dropping the row alone would leave the file on disk with nothing in the database naming it. That is worse than the orphan being fixed rather than merely incomplete: the row at least pointed at the file, so a row-based sweep could find it, and afterwards nothing could. Deleted one row at a time, since `QuerySet.delete()` never opens the files. (Caught in review; the first version of this PR had exactly that regression.)

**A published answer to a deleted question is untouched.** It still renders with the comment it was published against, so it is neither invisible nor unreachable, and deleting it would destroy work a student actually submitted. There is a test pinning that.

The docstring that justified keeping the rows is rewritten rather than left standing, since it is the reason this looked deliberate: it now names which rows are kept, which are deleted, and why the deleted ones cannot be reached.

### Testing?

Full suite `Ran 2855 tests ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

Five new tests, each fix paired with a guard against over-deleting:

* `test_save_draft__no_draft_rows_created_on_a_completed_submission` fails on unpatched code with `AssertionError: 3 != 0`.
* `test_save_draft__comment_attachment_still_saves_on_a_completed_submission` pins that the condition covers the answer formset only.
* `test_sync_draft_question_submissions__unpublished_answer_to_a_deleted_question_is_removed` fails on unpatched code with `AssertionError: True is not false`.
* `test_sync_draft_question_submissions__deleted_orphan_takes_its_uploaded_file_with_it` asserts against storage, not the field, and fails without the file delete with `AssertionError: True is not false: the uploaded file should not outlive the row that named it`.
* `test_sync_draft_question_submissions__published_answer_to_a_deleted_question_is_kept` pins that a published answer survives.

The two pre-existing `test_sync__` tests were renamed alongside the new ones to name the callable they exercise, matching what #2591 and #2592 just did for the tenant and library apps.

One note on the first test, since it is easy to get wrong: `save_draft()` and `file_field_name()` both call `sync_draft_question_submissions` themselves, so building the payload after finishing the submission recreates the very rows under test. It builds the POST while the submission is still in progress, then finishes it, then posts. Written the obvious way it reported `3 != 0` against the *fixed* code too.

### Screenshots (if front end is affected)

None, and not as a shortcut: this changes only which rows and files exist, and every row it stops creating or deletes is one that no template can render. A before/after of any page would be two identical pictures. The student-facing behaviour that *is* observable, comment attachments still saving on a finished submission, is covered by a test above.

### Anything Else?

Scope boundary on the file deletion, since the issue mentions a separately-filed follow-up for orphaned files: this removes files that **this cleanup would otherwise strand itself**. Files already stranded on disk before this ships still need that sweep, and this PR does not attempt it.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)