### PR TITLE
style: replace em dashes in submission-questions copy and comments (#2569)

### DIFF
--- a/src/hackerspace_online/tests/test_conventions.py
+++ b/src/hackerspace_online/tests/test_conventions.py
@@ -40,7 +40,11 @@ _EM_DASHES = ("\u2014", "&mdash;")
 _EM_DASH_SUFFIXES = (".py", ".html", ".css", ".js", ".md", ".txt")
 
 # A line asserting an em dash is absent has to contain one to say so.
-_ASSERTS_ABSENCE = ("assertNotContains", "assertNotIn")
+#: Written on a line that has to carry an em dash to do its job, which in practice means a
+#: test asserting the character is absent from a page. The marker is what exempts the line,
+#: rather than the name of the assertion on it: a line can assert an absence and still carry
+#: an em dash of its own somewhere else, and that one is a violation like any other.
+_EM_DASH_ALLOWED_MARKER = "em-dash-ok"
 
 # src/ directory (this file is src/hackerspace_online/tests/test_conventions.py).
 _SRC_ROOT = Path(__file__).resolve().parents[2]
@@ -82,7 +86,7 @@ def _em_dash_violations(path):
     """
     problems = []
     for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        if any(marker in line for marker in _ASSERTS_ABSENCE):
+        if _EM_DASH_ALLOWED_MARKER in line:
             continue
         if any(dash in line for dash in _EM_DASHES):
             problems.append(f"{number}: {line.strip()}")
@@ -107,8 +111,9 @@ class TestNoEmDashes(SimpleTestCase):
         """No source file in EM_DASH_CHECKED_DIRS contains an em dash, in either spelling.
 
         The rule covers comments and docstrings as much as anything a user reads, so this
-        scans lines rather than only rendered strings. A line asserting an em dash is absent
-        is skipped, since it has to name one to do that.
+        scans lines rather than only rendered strings. A line that genuinely has to carry the
+        character, such as one asserting a page does not contain it, says so with an
+        ``em-dash-ok`` marker and is skipped.
         """
         failures = {}
         for rel, path in _iter_em_dash_sources():

--- a/src/hackerspace_online/tests/test_conventions.py
+++ b/src/hackerspace_online/tests/test_conventions.py
@@ -26,10 +26,9 @@ LEGACY_UNCONVENTIONAL = set()
 
 _SETUP_METHODS = {"setUp", "setUpTestData", "tearDown"}
 
-# Directories under src/ scanned for em dashes. CLAUDE.md bans them project-wide, but the
-# rest of the tree still carries a backlog (102 more, across 35 files, when #2569 was written), so
-# this starts at the app that has been cleared and grows as others are. Adding a name here
-# is the last step of cleaning a directory, not the first.
+# Directories under src/ scanned for em dashes. CLAUDE.md bans them project-wide, but only
+# the directories named here are clear of them, so only these can be enforced. The list grows
+# as others are cleared: adding a name is the last step of cleaning a directory, not the first.
 EM_DASH_CHECKED_DIRS = ("questions",)
 
 # The two spellings CLAUDE.md names. The entity is the one that hides from a plain search

--- a/src/hackerspace_online/tests/test_conventions.py
+++ b/src/hackerspace_online/tests/test_conventions.py
@@ -1,17 +1,18 @@
 """Meta-tests that enforce this project's test-writing conventions.
 
 Two conventions from ``CLAUDE.md`` are checked by scanning every ``test_*.py``
-module's AST:
+module's AST, and a third (no em dashes) by scanning the source of the
+directories listed in ``EM_DASH_CHECKED_DIRS``:
 
-* **Naming** — each ``test_*`` method name follows
+* **Naming**: each ``test_*`` method name follows
   ``test_method_or_class_name__specific_case_being_tested`` (i.e. contains a
   ``__`` separating the subject from the specific case).
-* **Docstrings** — each ``test_*`` method, and each ``setUp`` /
+* **Docstrings**: each ``test_*`` method, and each ``setUp`` /
   ``setUpTestData`` / ``tearDown``, has a docstring.
 
 The whole suite has been brought into conformance, so ``LEGACY_UNCONVENTIONAL``
 is empty and every ``test_*.py`` is enforced. It remains as an escape hatch only:
-never add entries — write conforming tests instead.
+never add entries: write conforming tests instead.
 """
 
 import ast
@@ -19,11 +20,27 @@ from pathlib import Path
 
 from django.test import SimpleTestCase
 
-# Empty: the whole suite conforms. Keep it empty — never add entries; fix the
+# Empty: the whole suite conforms. Keep it empty, never add entries; fix the
 # test to follow the naming/docstring conventions instead.
 LEGACY_UNCONVENTIONAL = set()
 
 _SETUP_METHODS = {"setUp", "setUpTestData", "tearDown"}
+
+# Directories under src/ scanned for em dashes. CLAUDE.md bans them project-wide, but the
+# rest of the tree still carries a backlog (102 more, across 35 files, when #2569 was written), so
+# this starts at the app that has been cleared and grows as others are. Adding a name here
+# is the last step of cleaning a directory, not the first.
+EM_DASH_CHECKED_DIRS = ("questions",)
+
+# The two spellings CLAUDE.md names. The entity is the one that hides from a plain search
+# for the character, which is how three copies of one tooltip kept theirs (#2569).
+_EM_DASHES = ("\u2014", "&mdash;")
+
+# Source a check like this can read; everything else under a directory is data or binary.
+_EM_DASH_SUFFIXES = (".py", ".html", ".css", ".js", ".md", ".txt")
+
+# A line asserting an em dash is absent has to contain one to say so.
+_ASSERTS_ABSENCE = ("assertNotContains", "assertNotIn")
 
 # src/ directory (this file is src/hackerspace_online/tests/test_conventions.py).
 _SRC_ROOT = Path(__file__).resolve().parents[2]
@@ -54,6 +71,58 @@ def _violations(path):
     return problems
 
 
+def _em_dash_violations(path):
+    """Return ``["<line no>: <line>"]`` for each line of ``path`` carrying an em dash.
+
+    Args:
+        path (Path): the source file to scan.
+
+    Returns:
+        list[str]: one entry per offending line, empty when the file is clean.
+    """
+    problems = []
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if any(marker in line for marker in _ASSERTS_ABSENCE):
+            continue
+        if any(dash in line for dash in _EM_DASHES):
+            problems.append(f"{number}: {line.strip()}")
+    return problems
+
+
+def _iter_em_dash_sources():
+    """Yield (repo-relative-str, Path) for every source file under ``EM_DASH_CHECKED_DIRS``."""
+    for directory in EM_DASH_CHECKED_DIRS:
+        for path in sorted((_SRC_ROOT / directory).rglob("*")):
+            if not path.is_file() or path.suffix not in _EM_DASH_SUFFIXES:
+                continue
+            if "__pycache__" in path.parts or "migrations" in path.parts:
+                continue
+            yield path.relative_to(_SRC_ROOT).as_posix(), path
+
+
+class TestNoEmDashes(SimpleTestCase):
+    """Guard for CLAUDE.md's ban on em dashes, over the directories cleared of them."""
+
+    def test_conventions__checked_directories_have_no_em_dashes(self):
+        """No source file in EM_DASH_CHECKED_DIRS contains an em dash, in either spelling.
+
+        The rule covers comments and docstrings as much as anything a user reads, so this
+        scans lines rather than only rendered strings. A line asserting an em dash is absent
+        is skipped, since it has to name one to do that.
+        """
+        failures = {}
+        for rel, path in _iter_em_dash_sources():
+            problems = _em_dash_violations(path)
+            if problems:
+                failures[rel] = problems
+        self.assertEqual(
+            failures, {},
+            "Em dashes found (CLAUDE.md: use a colon for a substatement, or brackets for a "
+            "parenthetical aside):\n"
+            + "\n".join(f"{f}:\n  " + "\n  ".join(v) for f, v in failures.items()),
+        )
+
+
 class TestNamingAndDocstringConventions(SimpleTestCase):
     """Guard that enforces test naming + docstring conventions on non-legacy modules."""
 
@@ -81,5 +150,5 @@ class TestNamingAndDocstringConventions(SimpleTestCase):
             if not path.exists():
                 stale.append(f"{rel}: file no longer exists")
             elif not _violations(path):
-                stale.append(f"{rel}: now conforms — remove it from LEGACY_UNCONVENTIONAL")
+                stale.append(f"{rel}: now conforms, remove it from LEGACY_UNCONVENTIONAL")
         self.assertEqual(stale, [], "Stale LEGACY_UNCONVENTIONAL entries:\n  " + "\n  ".join(stale))

--- a/src/quest_manager/templates/quest_manager/buttons.html
+++ b/src/quest_manager/templates/quest_manager/buttons.html
@@ -105,7 +105,7 @@
         {% endif %}
 
         {% if request.user.profile.is_TA %}
-          <a title="Copy Quest &mdash; available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
+          <a title="Copy Quest, available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
              class="btn btn-default" role="button" href="{% url 'quests:quest_copy' q.id %}" >
             <i class="fa fa-copy"></i>
           </a>

--- a/src/quest_manager/templates/quest_manager/preview_content_submissions.html
+++ b/src/quest_manager/templates/quest_manager/preview_content_submissions.html
@@ -46,7 +46,7 @@
        The copy view (quests:quest_copy) already allows TAs; this exposes it from the submission tabs,
        where a started quest lives once it leaves the Available list. {% endcomment %}
     {% if request.user.profile.is_TA %}
-      <a title="Copy Quest &mdash; available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
+      <a title="Copy Quest, available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
          class="btn btn-default" role="button" href="{% url 'quests:quest_copy' s.quest.id %}">
         <i class="fa fa-fw fa-copy"></i>
       </a>

--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -198,7 +198,7 @@
              In Progress/Completed tab preview (#141). Shown regardless of the quest's published
              state so a TA can always template off a quest they've started. {% endcomment %}
           {% if request.user.profile.is_TA %}
-            <a title="Copy Quest &mdash; available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
+            <a title="Copy Quest, available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default."
                class="btn btn-default" role="button" href="{% url 'quests:quest_copy' submission.quest.id %}">
               <i class="fa fa-fw fa-copy"></i> Copy Quest
             </a>

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -203,7 +203,7 @@ class CategoryCreate(NonPublicOnlyViewMixin, CreateView):
 
         Returns:
             dict: template context including the form heading, submit button label,
-            and `cancel_url` — the campaigns list, since a new campaign has no
+            and `cancel_url`: the campaigns list, since a new campaign has no
             detail view to return to yet.
         """
         kwargs["heading"] = "Create New Campaign"
@@ -228,7 +228,7 @@ class CategoryUpdate(NonPublicOnlyViewMixin, UpdateView):
 
         Returns:
             dict: template context including the form heading, submit button label,
-            and `cancel_url` — the campaign's detail view, so cancelling returns
+            and `cancel_url`: the campaign's detail view, so cancelling returns
             to the page the edit was started from (issue #1931).
         """
         kwargs["heading"] = "Update Campaign"
@@ -440,7 +440,7 @@ class QuestCopy(QuestCreate):
         duplication all run inside a single transaction, so a failure duplicating a question rolls
         back the whole copy rather than leaving an orphaned quest with no (or partial) questions.
 
-        Student answers are not copied — those belong to submissions, not to the quest. The
+        Student answers are not copied: those belong to submissions, not to the quest. The
         solution_file reference is shared with the source question, matching how the copied
         quest already shares its icon file.
         """
@@ -1186,9 +1186,9 @@ def quest_user_status(request, quest_id):
     quest = get_object_or_404(Quest.objects.all(), pk=quest_id)
 
     # Three student groups the page can show, as sets of user ids (issue #1973):
-    #   active    — all active students (in a course or not); the superset
-    #   current   — students registered in a course in a semester that is open
-    #   my_blocks — students in a course block the current teacher teaches in one of those
+    #   active    : all active students (in a course or not); the superset
+    #   current   : students registered in a course in a semester that is open
+    #   my_blocks : students in a course block the current teacher teaches in one of those
     # The last two span every open semester, since a deck can run more than one at a time
     # (issue #2157 Phase 3): scoping them to the deck's default would count a student as
     # current and then leave them out of their own teacher's group.
@@ -2105,7 +2105,7 @@ def complete(request, submission_id):
         # stale page from before the quest's questions changed) can present fewer answer forms
         # than the quest has questions. Without this guard those omitted questions are never
         # validated yet still published (the blanket publish below), so required questions
-        # could be bypassed — completing/auto-approving a quest with nothing answered. Require
+        # could be bypassed, completing or auto-approving a quest with nothing answered. Require
         # the POST to cover exactly the quest's current questions; otherwise bounce back to a
         # freshly-built page that shows them all.
         expected_ids = set(draft_rows.values_list("pk", flat=True))

--- a/src/questions/forms.py
+++ b/src/questions/forms.py
@@ -79,7 +79,7 @@ class QuestionForm(forms.ModelForm):
 
         Raises:
             ValueError: If ``question_type`` is not one of the supported types. Callers
-                (views) must validate user-supplied types first — by the time the form is
+                (views) must validate user-supplied types first: by the time the form is
                 constructed an unknown type is a programming error.
         """
         question_type = kwargs.pop('question_type', None)

--- a/src/questions/templatetags/question_tags.py
+++ b/src/questions/templatetags/question_tags.py
@@ -80,8 +80,9 @@ def unwrap_p(value):
     The Summernote editor wraps even one line of text in a ``<p>``; nesting that block inside an
     inline context (``<small>``, ``<span>``) makes the browser reparent it onto a new line, so
     removing the wrapper is what actually keeps it inline. Multi-paragraph content (an inner
-    ``<p>``) is returned unchanged. The value is assumed already sanitized (these fields are
-    teacher-authored and were previously rendered with ``|safe``), so the result is marked safe.
+    ``<p>``) is returned unchanged. The values this runs on (a question's instructions and its
+    marker notes) are staff-authored, through the teacher's own question form, so their HTML is
+    trusted the way the rest of a quest's rich text is and the result is marked safe.
     """
     if not value:
         return value

--- a/src/questions/templatetags/question_tags.py
+++ b/src/questions/templatetags/question_tags.py
@@ -80,8 +80,8 @@ def unwrap_p(value):
     The Summernote editor wraps even one line of text in a ``<p>``; nesting that block inside an
     inline context (``<small>``, ``<span>``) makes the browser reparent it onto a new line, so
     removing the wrapper is what actually keeps it inline. Multi-paragraph content (an inner
-    ``<p>``) is returned unchanged. The value is assumed already sanitized — these fields are
-    teacher-authored and were previously rendered with ``|safe`` — so the result is marked safe.
+    ``<p>``) is returned unchanged. The value is assumed already sanitized (these fields are
+    teacher-authored and were previously rendered with ``|safe``), so the result is marked safe.
     """
     if not value:
         return value

--- a/src/questions/tests/test_integration.py
+++ b/src/questions/tests/test_integration.py
@@ -1166,7 +1166,7 @@ class CompleteSecurityTest(QuestionSubmissionFlowTestBase):
         )
 
     def test_autosave__sanitizes_script_on_write(self):
-        """A hostile draft answer is neutralized as it is stored, not just on the form path —
+        """A hostile draft answer is neutralized as it is stored, not just on the form path:
         the raw value would otherwise be published verbatim and rendered with |safe."""
         row = sync_draft_question_submissions(self.submission).get(question=self.short_question)
         self.autosave({

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -105,8 +105,9 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
 
         response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
 
-        self.assertNotContains(response, "—")
-        self.assertNotContains(response, "&mdash;")
+        # each of these names the character it is asserting is absent, hence the markers
+        self.assertNotContains(response, "—")  # em-dash-ok
+        self.assertNotContains(response, "&mdash;")  # em-dash-ok
 
     def test_list__help_text_says_files_save_with_the_draft(self):
         """The page's copy matches how draft saving works (#2551).


### PR DESCRIPTION
### What?

Removes the em dashes from the Submission Questions feature's copy, docstrings and comments, and adds a conventions test that keeps them out.

Closes #2569

### Why?

CLAUDE.md bans em dashes in anything written for this project: user-facing copy, docs, code comments, commit messages. The one that actually reaches a user here is the TA **Copy Quest** tooltip, which renders in three places.

**Four corrections to the issue**, all posted on it:

| the issue says | what is actually there |
| --- | --- |
| 1 occurrence in the Copy Quest tooltip | 3, one per template that renders the button |
| the tooltips use the `—` character | they use `&mdash;`, the HTML entity |
| `is_empty_html` in `utilities/html.py` has one | it does not; that file is clean |
| `questions/utils.py:93`, and `questions/tests/test_integration.py:830` and `:948` | `utils.py` has none at all, in either spelling; `test_integration.py` has exactly one, at line 1169, which this PR fixes |

The second correction is the interesting one, and it is why this needs a test rather than a one-off sweep. `&mdash;` renders as an em dash but does not match a search for one, so all three tooltips read clean to `grep -r '—' src/` while shipping the character to every TA who hovers the button.

### How?

Each occurrence becomes a colon where it introduced a substatement, or brackets where it was a parenthetical aside, which is what CLAUDE.md asks for.

| file | fixed |
| --- | --- |
| `quest_manager/views.py` | 7 (docstrings and the `quest_user_status` group comment) |
| `quest_manager/templates/.../buttons.html` | 1 (Copy Quest tooltip) |
| `quest_manager/templates/.../preview_content_submissions.html` | 1 (same tooltip) |
| `quest_manager/templates/.../submission.html` | 1 (same tooltip) |
| `questions/templatetags/question_tags.py` | 2 |
| `questions/forms.py` | 1 |
| `questions/tests/test_integration.py` | 1 |

The three-line comment in `quest_user_status` used em dashes as a column separator in an aligned list, so that one became `:` in each row rather than a rewrite.

**Two lines are deliberately left alone.** `questions/tests/test_views.py` asserts that a rendered page contains no em dash, in either spelling, so those two lines have to name both to do it. Each carries an `em-dash-ok` marker, and that marker is the only thing that exempts a line. Skipping on the *name* of the assertion instead was too wide: a line can assert an absence and still carry an em dash of its own, in a trailing comment or another argument, and that one is a violation like any other.

**`TestNoEmDashes`, in `hackerspace_online/tests/test_conventions.py`**, scans the directories named in `EM_DASH_CHECKED_DIRS` for both spellings and fails with the file and line of each hit:

```
AssertionError: {'questions/forms.py': ['82: (views) must validate user-supplied types first — ']} != {}
AssertionError: {'questions/utils.py': ['86: """Ensure — exactly one draft answer row ']} != {}
```

That is a real run against each spelling reintroduced into `src/questions/`, one at a time, to confirm it catches what it claims to.

`EM_DASH_CHECKED_DIRS` starts at `("questions",)` and is meant to grow. The rest of the tree still carries a backlog (102 more, on 90 lines across 35 files, as of this branch), so a repo-wide scan would fail on day one and get deleted. Adding a directory to the tuple is the last step of clearing it, not the first, and the comment on the constant says so.

The checker names both spellings itself, on the line that defines them. It cannot not: it scans `questions/` and lives in `hackerspace_online/`, so it never scans itself.

### Testing?

Full suite `Ran 2856 tests in 446.602s ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run`.

The conventions test was verified against both spellings as shown above; it is a `SimpleTestCase`, so it needs no database or tenant.

The marker rule was measured against the blind spot it replaces, by putting a stray em dash in the trailing comment of an unrelated `assertNotContains` line:

```
marker rule:  FAILED
              questions/tests/test_views.py:
                150: self.assertNotContains(response, "``&lt;video")  # stray — in a trailing comment·old rule:     OK·'''``

Read back from the running app on a seeded `hackerspace` deck, logged in as a TA in a course, in all three places the tooltip renders. The `title` attribute read out of the live DOM:

```
                                                     before                     after
available tab preview   (buttons.html)               Copy Quest — available…    Copy Quest, available…
in progress preview     (preview_content_subs.html)  Copy Quest — available…    Copy Quest, available…
submission page         (submission.html)            Copy Quest — available…    Copy Quest, available…
```

Full string after: `Copy Quest, available to you because you're a TA: creates a new draft quest using this one as a template, with this quest set as a prerequisite for the new one by default.`

The before column is a real reading too, taken by checking the three templates back out of `develop` in the running dev deck and re-reading the same three pages.

### Screenshots (if front end is affected)

The button whose tooltip this changes, on a real submission page on the `hackerspace` deck, as a TA sees it:

![The Copy Quest button beside Save Draft, Submit Quest for Approval and Drop Quest on a submission page](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2569/copy-quest-button.png)

**There is no before/after image pair, and no picture of the tooltip itself.** The tooltip is a native `title`, which the browser draws outside the page, so no screenshot tool can capture it: Playwright, devtools and a manual screen grab all photograph the page underneath it. The page's own pixels are byte-identical before and after, so a labelled pair of them would show a difference that is not there. The live DOM readings in **Testing?** are the evidence for the change; this image is here to show where the tooltip lives.

### Anything Else?

The other 102 are out of scope. They are spread over 35 files in apps this issue does not name (`djcytoscape` and `courses` are the worst of it), mostly in comments and docstrings, and sweeping them here would bury an eight-file change under a few hundred lines of unrelated churn. `EM_DASH_CHECKED_DIRS` is the mechanism for retiring them a directory at a time: clear one, add its name, and it can never come back. Whether to open an issue tracking that backlog is a question for @tylerecouture, because some of the 102 are a judgement call rather than a cleanup: `profile_manager/profile_detail.html:142` and `quest_manager/templates/quest_manager/quest_user_status.html:146` use `—` as a *table placeholder for "no value"*, which is a typographic convention rather than punctuation in a sentence, and may well be meant to stay.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation, comments, tooltips, and interface text for consistent punctuation.
  * Clarified guidance across quest-copy controls and question-related content.

* **Tests**
  * Added automated checks for prohibited punctuation in configured source directories.
  * Reports identify affected files and lines to simplify corrections.

* **Bug Fixes**
  * Corrected inconsistent punctuation in staff-facing quest-copy labels and submission previews.
  * No functional behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->