### PR TITLE
fix: give long-answer and file answers a per-question accessible name (#2570)

### DIFF
--- a/src/bytedeck_summernote/templates/bytedeck_summernote/widget_common.html
+++ b/src/bytedeck_summernote/templates/bytedeck_summernote/widget_common.html
@@ -80,6 +80,20 @@ Changes because: fix django-summernote/issues/465 issue, make it possible to use
                          {% for k, v in attrs.items %}
                          $wrap.attr('{{ k }}', '{{ v }}');
                          {% endfor %}
+{% comment %} Start changes from source at https://github.com/summernote/django-summernote/blob/main/django_summernote/templates/django_summernote/widget_common.html
+
+Changes because: bytedeck/issues/2570, put a widget's accessible name on the element that takes
+focus. The loop above writes every attr onto the wrapper div, and a name on a generic div is
+ignored by screen readers, so aria-label set on a summernote widget announced nothing at all.
+.note-editable is the element summernote gives role="textbox", so the name belongs there.
+Widgets that set no aria-label are untouched.
+{% endcomment %}
+                         var ariaLabel = $wrap.attr('aria-label');
+                         if (ariaLabel) {
+                             $nEditor.find('.note-editable').attr('aria-label', ariaLabel);
+                             $wrap.removeAttr('aria-label');
+                         }
+{% comment %} End changes {% endcomment %}
 {% endif %}
 
                          // Move dropdown dialog when it exceeds the bound of the editor

--- a/src/questions/forms.py
+++ b/src/questions/forms.py
@@ -216,8 +216,15 @@ class QuestionSubmissionForm(forms.ModelForm):
             )
         elif self.question.type == QuestionType.LONG_ANSWER:
             del self.fields["response_file"]
+            # No visible label (the question's instructions directly above serve as one), so
+            # without an aria-label the editor announces nothing at all, while the short answer
+            # beside it announces "Response to question N". The widget's attrs are applied to a
+            # wrapper div; bytedeck_summernote's template forwards aria-label from there onto
+            # .note-editable, which is the element that takes focus (#2570).
             self.fields["response_text"] = forms.CharField(
-                label="", required=self.question.required, widget=AnswerSummernoteWidget()
+                label="",
+                required=self.question.required,
+                widget=AnswerSummernoteWidget(attrs={"aria-label": self._response_aria_label()}),
             )
         elif self.question.type == QuestionType.FILE_UPLOAD:
             del self.fields["response_text"]
@@ -243,7 +250,11 @@ class QuestionSubmissionForm(forms.ModelForm):
                 required=self.question.required,
                 content_types=mime_types,
                 max_upload_size=MAX_RESPONSE_FILE_SIZE,
-                widget=forms.ClearableFileInput(attrs={"multiple": False}),
+                # The visible label is the same on every file question, so several of them on
+                # one page are indistinguishable by name. The aria-label adds the question number
+                # while keeping the label's own words, which is what WCAG 2.5.3 (Label in Name)
+                # requires of a control whose visible label is text (#2570).
+                widget=forms.ClearableFileInput(attrs={"multiple": False, "aria-label": self._file_aria_label()}),
                 label="Attach files",
                 help_text=help_text,
             )
@@ -263,23 +274,49 @@ class QuestionSubmissionForm(forms.ModelForm):
             form_fields,
         )
 
-    def _response_aria_label(self):
-        """Return a per-question aria-label for the short-answer input.
+    def _question_position(self):
+        """Return this question's 1-based position on the submission page, or None.
 
-        Several short-answer inputs on one page would otherwise all announce the identical
-        "Response", so screen-reader users couldn't tell them apart. The form's formset prefix
-        is "question_submissions-<i>" (0-based); i + 1 matches the visible "Question N:" heading
-        rendered just above the input in submission.html. Falls back to "Response" if the form
-        isn't in a formset (no numeric prefix, e.g. the formset's empty_form placeholder).
+        The form's formset prefix is "question_submissions-<i>" (0-based); i + 1 matches the
+        visible "Question N:" heading rendered just above the answer field in submission.html.
 
         Returns:
-            str: the aria-label for this input, e.g. "Response to question 2".
+            int | None: the question number, or None if the form isn't in a formset (no numeric
+            prefix, e.g. the formset's empty_form placeholder).
         """
         try:
-            position = int(self.prefix.rsplit("-", 1)[-1]) + 1
+            return int(self.prefix.rsplit("-", 1)[-1]) + 1
         except (AttributeError, ValueError):
+            return None
+
+    def _response_aria_label(self):
+        """Return a per-question aria-label for the short-answer input or long-answer editor.
+
+        Several answer fields on one page would otherwise all announce the identical "Response"
+        (or, for the editor, nothing at all), so screen-reader users couldn't tell them apart.
+
+        Returns:
+            str: the aria-label for this field, e.g. "Response to question 2".
+        """
+        position = self._question_position()
+        if position is None:
             return "Response"
         return f"Response to question {position}"
+
+    def _file_aria_label(self):
+        """Return a per-question aria-label for the file input.
+
+        Keeps the visible label's own words and adds the question number: WCAG 2.5.3 (Label in
+        Name) asks that a control's accessible name contain its visible label text, so that
+        someone driving the page by voice can still say "attach files" to reach it.
+
+        Returns:
+            str: the aria-label for this input, e.g. "Attach files for question 3".
+        """
+        position = self._question_position()
+        if position is None:
+            return "Attach files"
+        return f"Attach files for question {position}"
 
     def clean_response_text(self):
         """Sanitize the answer text with the comments allow-list (issue #1343 / #2113).

--- a/src/questions/tests/test_forms.py
+++ b/src/questions/tests/test_forms.py
@@ -201,6 +201,70 @@ class QuestionSubmissionFormTest(ByteDeckTenantTestCase):
         form = QuestionSubmissionForm(instance=self.short_answer)
         self.assertEqual(form.fields["response_text"].widget.attrs["aria-label"], "Response")
 
+    def test_init__every_answer_field_gets_a_distinct_aria_label(self):
+        """All three answer types announce their question number, not just the short answer.
+
+        A quest with several questions renders several answer fields with no visible labels of
+        their own (or, for file uploads, the identical one), so without this a screen-reader
+        student hears "Attach files" twice over and an unnamed editor between them (#2570).
+        """
+        queryset = QuestionSubmission.objects.filter(
+            quest_submission=self.submission,
+        ).order_by("question__ordinal")
+        formset = QuestionSubmissionFormsetFactory(instance=self.submission, queryset=queryset)
+
+        labels = [
+            form.fields["response_text" if "response_text" in form.fields else "response_file"]
+            .widget.attrs["aria-label"]
+            for form in formset.forms
+        ]
+        self.assertEqual(
+            labels,
+            ["Response to question 1", "Response to question 2", "Attach files for question 3"],
+        )
+
+    def test_init__file_aria_label_contains_its_visible_label(self):
+        """The file input's accessible name keeps the words of its visible label.
+
+        WCAG 2.5.3 (Label in Name) asks that a control's accessible name contain its visible
+        label text, so someone driving the page by voice can still say "attach files" to reach
+        it. An aria-label of "File for question 3" would read well but break that.
+        """
+        queryset = QuestionSubmission.objects.filter(
+            quest_submission=self.submission, question__type="file_upload",
+        )
+        formset = QuestionSubmissionFormsetFactory(instance=self.submission, queryset=queryset)
+        field = formset.forms[0].fields["response_file"]
+
+        self.assertIn(field.label.lower(), field.widget.attrs["aria-label"].lower())
+
+    def test_init__long_answer_and_file_aria_label_fallback_without_formset(self):
+        """Standalone forms (no numeric prefix, as for the formset's empty_form) fall back to a
+        generic name rather than erroring on the missing position."""
+        long_form = QuestionSubmissionForm(instance=self.long_answer)
+        file_form = QuestionSubmissionForm(instance=self.file_answer)
+
+        self.assertEqual(long_form.fields["response_text"].widget.attrs["aria-label"], "Response")
+        self.assertEqual(file_form.fields["response_file"].widget.attrs["aria-label"], "Attach files")
+
+    def test_init__answer_fields_render_their_aria_label(self):
+        """The aria-label survives rendering, on the editor's wrapper and on the file input.
+
+        The long-answer editor's attributes are handed to summernote's init script rather than
+        written onto a tag, so this asserts on the call that applies them; the widget template
+        forwards aria-label from that wrapper onto the .note-editable the student focuses.
+        """
+        queryset = QuestionSubmission.objects.filter(
+            quest_submission=self.submission,
+        ).order_by("question__ordinal")
+        formset = QuestionSubmissionFormsetFactory(instance=self.submission, queryset=queryset)
+        long_html = str(formset.forms[1]["response_text"])
+        file_html = str(formset.forms[2]["response_file"])
+
+        self.assertIn("$wrap.attr('aria-label', 'Response to question 2');", long_html)
+        self.assertIn(".note-editable').attr('aria-label', ariaLabel)", long_html)
+        self.assertIn('aria-label="Attach files for question 3"', file_html)
+
     def test_clean__required_text_missing_is_invalid(self):
         """A required text question rejects an empty response with a friendly error, and
         accepts a filled one."""


### PR DESCRIPTION
### What?

The long-answer editor and the file-upload input now announce which question they belong to, the way the short-answer input already does.

Closes #2570

### Why?

`_response_aria_label` was added so that "screen-reader users could tell [inputs] apart when a page has several", but only the `SHORT_ANSWER` branch used it. On a quest with one question of each type, this is what the accessibility tree of the real submission page contained:

```
BEFORE                                       AFTER
textbox  "Response to question 1"            textbox  "Response to question 1"
textbox  ""                                  textbox  "Response to question 2"
button   "Attach files"                      button   "Attach files for question 3"
button   "Attach files"                      button   "Attach files for question 4"
textbox  ""              <- comment editor   textbox  ""              <- comment editor
button   "Attach files"  <- comment files    button   "Attach files"  <- comment files
```

Both columns are read out of Chromium's accessibility tree on a running `hackerspace` deck, on the same page, by the same script. A student on that quest heard "Attach files, button" three times with nothing distinguishing them, and reached an editor that announced no name at all.

### How?

`_response_aria_label`'s position lookup is split out into `_question_position`, and two namers sit on top of it, so all three answer types derive their number the same way:

| field | accessible name |
| --- | --- |
| short answer (unchanged) | `Response to question N` |
| long answer | `Response to question N` |
| file upload | `Attach files for question N` |

**Why the file input is not `File for question N`,** as the issue suggested. `aria-label` replaces the `<label>` in the accessible name, and here that label is *visible text*. Dropping its words breaks [WCAG 2.5.3 Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html): someone driving the browser by voice says "click attach files", and the control would no longer match. Keeping the label's own words and appending the number satisfies both, and `test_init__file_aria_label_contains_its_visible_label` asserts the containment rather than the literal string, so it stays true if the visible label is ever reworded.

**The long answer needed a change in the summernote widget template to work at all.** `bytedeck_summernote/widget_common.html` applies widget attrs to a wrapper div:

```js
var $wrap = $($nEditor).wrap('<div class="summernote-div"></div>').parent();
{% for k, v in attrs.items %}
$wrap.attr('{{ k }}', '{{ v }}');
{% endfor %}
```

An `aria-label` there names a generic `div`, which screen readers ignore, so passing one to the widget would have looked correct in the form code and announced nothing. `.note-editable` is the element summernote gives `role="textbox"` and the one that takes focus, so the template now forwards `aria-label` from the wrapper onto it. Verified live: with the fix `.note-editable` for question 2 carries `aria-label="Response to question 2"`, and the comment editor on the same page, whose widget sets none, is untouched.

That change is in the shared widget template, so it applies to every summernote editor in the app: any widget that sets an `aria-label` now gets it announced instead of silently dropped. Widgets that set none render exactly as before.

### Testing?

Full suite `Ran 2859 tests in 642.606s ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

Four new tests in `questions/tests/test_forms.py`, **all four failing on unpatched code** (three `KeyError: 'aria-label'`, one assertion on the rendered widget):

* `test_init__every_answer_field_gets_a_distinct_aria_label` walks a formset over all three question types and asserts the three names.
* `test_init__file_aria_label_contains_its_visible_label` is the WCAG 2.5.3 guard described above.
* `test_init__long_answer_and_file_aria_label_fallback_without_formset` covers the no-numeric-prefix path (the formset's `empty_form`), which would otherwise `ValueError`.
* `test_init__answer_fields_render_their_aria_label` asserts the name survives rendering: `aria-label="Attach files for question 3"` on the file input, and `$wrap.attr('aria-label', 'Response to question 2');` in the editor's init script together with the forwarding onto `.note-editable`.

Driven in a real browser on a seeded `hackerspace` deck, as a student with a submission open, reading Chromium's accessibility tree. That is the before/after table above.

### Screenshots (if front end is affected)

The page in question, four questions on one submission, exactly as it renders on the `hackerspace` deck:

![Four questions on a submission page: a short answer, a long-answer editor, and two file uploads, the last two both labelled Attach files](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2570/submission-questions.png)

**Before and after are pixel-identical, so there is no pair.** An accessible name is not drawn: the only place this change is observable is the accessibility tree, which is the before/after table under **Why?**. The screenshot is here to show the two "Attach files" labels that a sighted student tells apart by the "Question 3" / "Question 4" heading above them, and a screen-reader student could not.

### Anything Else?

Two controls on that same page are still unnamed, and are left alone here because they are not question fields: the submission's own comment editor (`textbox ""`) and its attachments input (the third `Attach files`). The comment editor's silence is not specific to this page: every summernote editor in the app is unnamed today. The template change above is what makes naming them a one-line change per widget, and I have asked @tylerecouture whether to open an issue for that sweep.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added distinct, question-specific labels to long-answer, short-answer, and file-upload fields.
  * Preserved accessible labels when rendering rich-text editors and file-upload controls.
  * Added fallback labels for standalone forms and controls without question numbering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->