### PR TITLE
fix: say how often a draft actually saves in the question-list help (#2571)

### DIFF
--- a/src/questions/templates/questions/question_list.html
+++ b/src/questions/templates/questions/question_list.html
@@ -22,8 +22,9 @@
         (image, video, audio, image or video, or any file).</li>
     </ul>
     <p>Questions marked <strong>Required</strong> must be answered before the quest can be submitted;
-    optional questions can be left blank. Answers are saved with the student's draft as they work:
-    text as they type, and any chosen files too. Once submitted, answers appear with the
+    optional questions can be left blank. Answers are saved with the student's draft as they work,
+    chosen files included: the draft autosaves about every minute, and the
+    <strong>Save Draft</strong> button saves it right away. Once submitted, answers appear with the
     submission for marking, right beside each question's <strong>Solution</strong> and
     <strong>Marker Notes</strong>, which only staff ever see.
     Deleting a question keeps any answers students have already submitted.</p>

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -126,9 +126,10 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
         """The page's copy matches how often a draft actually saves (#2571).
 
         A draft is written by a 60-second timer and by the Save Draft button, and by nothing
-        else: there is no keystroke, change or unload handler. Copy promising that text saves
-        as the student types has a teacher telling students their typing is safe when up to a
-        minute of it is not, so the sentence names the interval and the button instead.
+        else: there is no keystroke, change or unload handler. So the sentence names the
+        interval and the button, and must not say answers save "as they type", which the third
+        assertion guards: a teacher reading that tells students their typing is safe when up to
+        a minute of it is not.
         """
         self.client.force_login(self.test_teacher)
 

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -119,8 +119,24 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
 
         response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
 
-        self.assertContains(response, "any chosen files too")
+        self.assertContains(response, "chosen files included")
         self.assertNotContains(response, "upload when the quest is submitted")
+
+    def test_list__help_text_says_how_often_a_draft_saves(self):
+        """The page's copy matches how often a draft actually saves (#2571).
+
+        A draft is written by a 60-second timer and by the Save Draft button, and by nothing
+        else: there is no keystroke, change or unload handler. Copy promising that text saves
+        as the student types has a teacher telling students their typing is safe when up to a
+        minute of it is not, so the sentence names the interval and the button instead.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self.assert200("questions:list", kwargs={"quest_id": self.quest.id})
+
+        self.assertContains(response, "autosaves about every minute")
+        self.assertContains(response, "Save Draft")
+        self.assertNotContains(response, "as they type")
 
     def test_list__an_image_solution_shows_as_a_thumbnail(self):
         """A picture used as a solution is shown in the table, not just named (#2172).


### PR DESCRIPTION
### What?

The help text above a quest's question table now says how often a draft actually saves, instead of promising that answers save as the student types.

Closes #2571

### Why?

The sentence read:

> Answers are saved with the student's draft as they work: **text as they type**, and any chosen files too.

A submission page saves a draft in exactly two ways, and I checked for the others rather than assuming:

| trigger | in `submission.html` |
| --- | --- |
| the 60-second timer | `setInterval(function() { save_draft(); }, 60000);` |
| the Save Draft button | `save_draft(true);` on click |
| a keystroke handler | none |
| a `change` handler | none |
| a `beforeunload` save | none |

So nothing is written per keystroke. A student whose browser or connection dies just before the next tick loses up to a minute of typing that the page told their teacher was already saved. The **Save Draft** button, three panels down the same feature, has always been honest about this: its tooltip says "Your draft autosaves about every minute".

(One correction to the issue: the `setInterval` is at `submission.html:282`, not 276. The claim itself holds.)

### How?

One sentence, worded to match that button's tooltip so the two do not drift apart again:

> Answers are saved with the student's draft as they work, chosen files included: the draft autosaves about every minute, and the **Save Draft** button saves it right away.

"chosen files included" is deliberate rather than incidental. Files really do ride along with the draft (#1459), and `test_list__help_text_says_files_save_with_the_draft` exists to stop this sentence sliding back to claiming they wait for the submit. That test pinned the literal words `any chosen files too`, which this rewording drops, so the assertion moves to the new phrase rather than being deleted. Its negative assertion is untouched.

### Testing?

Full suite `Ran 2856 tests in 535.267s ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

One new test, `test_list__help_text_says_how_often_a_draft_saves`, asserting the copy names the interval and the button and no longer says "as they type".

**Both it and the updated `..._files_save_with_the_draft` fail on unpatched copy**, which is the point of moving the assertion instead of deleting it:

```
FAIL: test_list__help_text_says_how_often_a_draft_saves
  Couldn't find 'autosaves about every minute' in the following response
FAIL: test_list__help_text_says_files_save_with_the_draft
Ran 2 tests ... FAILED (failures=2)
```

`test_list__help_text_uses_no_em_dashes` is untouched and still passes: the new wording uses a colon.

### Screenshots (if front end is affected)

The help block on the question list for a quest with four questions, as the deck owner sees it on a seeded `hackerspace` deck.

**Before:**

![Before: the help text reads 'Answers are saved with the student's draft as they work: text as they type, and any chosen files too'](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2571/before.png)

**After:**

![After: the help text reads 'Answers are saved with the student's draft as they work, chosen files included: the draft autosaves about every minute, and the Save Draft button saves it right away'](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2571/after.png)

### Anything Else?

The equivalent popover on the quest detail page (added in #2617) says nothing about saving, so there is no second copy of this claim to fix. `as they type` appears nowhere else in `src/`.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that drafts autosave approximately every minute rather than continuously while typing.
  * Explained that **Save Draft** saves immediately, including selected files.
  * Clarified when uploaded files are saved and that they are included when the draft is saved, rather than waiting until question submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->