### PR TITLE
feat: warn before leaving a submission or question form with unsaved text (#2572)

### DIFF
--- a/src/quest_manager/templates/quest_manager/submission.html
+++ b/src/quest_manager/templates/quest_manager/submission.html
@@ -95,10 +95,14 @@
       <h3 class="panel-title">Quest Submission Form</h3>
     </div>
     <div class="panel-body panel-summernote">
+      {% comment %} data-warn-unsaved opts both forms into warn-unsaved-changes.js, so leaving the
+         page with answer, comment or marking text that has not reached the server draws the
+         browser's "Leave site?" prompt (#2572). The comment box is a div, not a nested form, so
+         the attribute here covers it and every answer editor. {% endcomment %}
       {% if request.user.is_staff %}
-        <form method="POST" enctype="multipart/form-data" action="{% url 'quests:approve' submission.id%}">
+        <form method="POST" enctype="multipart/form-data" action="{% url 'quests:approve' submission.id%}" data-warn-unsaved>
       {% else %}
-        <form id="submission-main-form" method="POST" enctype="multipart/form-data" action="{% url 'quests:complete' submission.id%}">
+        <form id="submission-main-form" method="POST" enctype="multipart/form-data" action="{% url 'quests:complete' submission.id%}" data-warn-unsaved>
       {% endif %}
 
         {% csrf_token %}
@@ -333,6 +337,7 @@
                 // the file that went out, so it is only allowed to touch an input still
                 // holding it (#2563).
                 var sentFiles = chosen_files_by_input();
+                var sentEdits = edits_so_far();
                 formData.set('csrfmiddlewaretoken', '{{ csrf_token }}');
                 formData.set('comment', draftComment);
                 formData.set('submission_id', '{{ submission.id }}');
@@ -350,6 +355,7 @@
                     success : function(json) {
                       $('#draft-error').hide();
                       show_saved_files(json, sentFiles);
+                      mark_draft_saved(sentEdits);
                       hide_check_show_text();
                     },
 
@@ -374,6 +380,28 @@
                 });
             }
 
+        }
+
+        function unsaved_guard() {
+            // The guard warn-unsaved-changes.js attaches to a form carrying data-warn-unsaved.
+            // Absent if that script has not run, which must leave saving working regardless.
+            var form = document.getElementById('submission-main-form');
+            return form && form.warnUnsaved;
+        }
+
+        function edits_so_far() {
+            // How many edits the guard has counted, read before a draft save leaves. Snapshotted
+            // for the same reason chosen_files_by_input() is: what comes back can only be said to
+            // have saved the edits that were there when it was sent.
+            var guard = unsaved_guard();
+            return guard ? guard.edits() : 0;
+        }
+
+        function mark_draft_saved(sentEdits) {
+            // The server has the draft as it stood at sentEdits, so stop warning about those
+            // edits. Anything typed while the request was in flight keeps the guard armed.
+            var guard = unsaved_guard();
+            if (guard) guard.saved(sentEdits);
         }
 
         function chosen_files(input) {

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -458,6 +458,27 @@ class SubmissionViewTests(ByteDeckTenantTestCase):
         response = self.client.get(reverse('quests:submission', args=[self.sub1.pk]))
         self.assertNotContains(response, status_url)
 
+    def test_submission_view__both_forms_warn_about_unsaved_changes(self):
+        """The student's form and the marker's form opt into the unsaved-changes guard (#2572).
+
+        Answers, the comment box and marking feedback all sit in a form that only reaches the
+        server on a submit or the 60-second autosave, so leaving the page in between loses
+        whatever was typed since. `data-warn-unsaved` is the attribute the site-wide
+        warn-unsaved-changes.js binds to.
+
+        Matched inside a form tag, not anywhere on the page: base.html names the attribute in
+        the HTML comment above the script, so a plain substring assertion passes on every page
+        in the site whether or not any form opted in.
+        """
+        guarded_form = r"<form[^>]*\sdata-warn-unsaved"
+        url = reverse('quests:submission', args=[self.sub1.pk])
+
+        self.client.force_login(self.test_student1)
+        self.assertRegex(self.client.get(url).content.decode(), guarded_form)
+
+        self.client.force_login(self.test_teacher)
+        self.assertRegex(self.client.get(url).content.decode(), guarded_form)
+
     def test_submission_view__quest_quick_reply_button_shown_when_set(self):
         """When a quest has quick_reply text, staff reviewing a submission of it get a quest-specific quick-reply button (#161)."""
         self.quest1.quick_reply = "Reminder: attach a screenshot of your working code."

--- a/src/questions/templates/questions/question_form.html
+++ b/src/questions/templates/questions/question_form.html
@@ -6,7 +6,8 @@
 {% block heading_inner %}{{ heading }} <small>for <a href="{% url 'quests:quest_detail' quest.id %}">{{ quest.name }}</a></small>{% endblock %}
 
 {% block content %}
-<form method='post' enctype="multipart/form-data">{% csrf_token %}
+{# data-warn-unsaved: leaving with a half-written question draws the browser's "Leave site?" prompt (#2572). #}
+<form method='post' enctype="multipart/form-data" data-warn-unsaved>{% csrf_token %}
     {% crispy form %}
     <a href="{% url 'questions:list' quest.id %}" role="button" class="btn btn-danger">Cancel</a>
     <input type="submit" value="{{ submit_btn_value }}" class="btn btn-success">

--- a/src/questions/tests/test_views.py
+++ b/src/questions/tests/test_views.py
@@ -11,6 +11,12 @@ from questions.models import Question
 User = get_user_model()
 
 
+# A <form> that opted into warn-unsaved-changes.js. Matching the tag rather than the bare
+# attribute name matters: base.html mentions `data-warn-unsaved` in the comment above the
+# script tag, so a plain substring is present on every page in the site (#2572).
+GUARDED_FORM = r"<form[^>]*\sdata-warn-unsaved"
+
+
 class QuestionCRUDViewTest(ByteDeckTenantTestCase):
     """Tests for the staff-only question CRUD views (list/create/update/delete)."""
 
@@ -159,6 +165,27 @@ class QuestionCRUDViewTest(ByteDeckTenantTestCase):
         self.client.force_login(self.test_teacher)
         self.assert200(
             "questions:create", kwargs={"quest_id": self.quest.id, "question_type": "short_answer"})
+
+    def test_create__form_warns_about_unsaved_changes(self):
+        """Creating or editing a question opts into the unsaved-changes guard (#2572).
+
+        A teacher part way through writing a question's instructions, solution and marker
+        notes loses all of it to a stray click on the navbar, with nothing saved anywhere
+        until they submit. `data-warn-unsaved` is the attribute warn-unsaved-changes.js binds.
+
+        Matched inside a form tag, not anywhere on the page: base.html names the attribute in
+        the HTML comment above the script, so a plain substring assertion passes on every page
+        in the site whether or not any form opted in.
+        """
+        self.client.force_login(self.test_teacher)
+
+        created = self.assert200(
+            "questions:create", kwargs={"quest_id": self.quest.id, "question_type": "short_answer"})
+        updated = self.assert200(
+            "questions:update", kwargs={"quest_id": self.quest.id, "pk": self.question1.id})
+
+        self.assertRegex(created.content.decode(), GUARDED_FORM)
+        self.assertRegex(updated.content.decode(), GUARDED_FORM)
 
     def test_create__invalid_type_404(self):
         """Creating a question with an unsupported type in the URL is a 404 (not a crash)."""

--- a/src/static/js/warn-unsaved-changes.js
+++ b/src/static/js/warn-unsaved-changes.js
@@ -7,36 +7,60 @@
   native "Leave site? Changes you made may not be saved." confirmation.
 
   Submitting the form is a deliberate save, so it clears the guard and never warns.
+
+  A form that is also saved without submitting (the submission page autosaves a
+  draft over Ajax) reports those saves through the small API the guard hangs on the
+  form element (#2572):
+
+      var sent = form.warnUnsaved.edits();   // before the request leaves
+      form.warnUnsaved.saved(sent);          // once the server confirms it
+
+  Passing the count captured before the request is what makes it safe: an edit made
+  while the request was in flight leaves the guard armed, because that edit was not
+  part of what the server stored. Without the round trip, an autosaved form would
+  warn on every exit and students would learn to click straight through it.
 */
 (function () {
   "use strict";
 
   function guardForm(form) {
-    var dirty = false;
+    // Edits are counted rather than flagged so a save can say which edits it covered.
+    var edits = 0;
+    var saved = 0;
     var submitting = false;
 
     function markDirty() {
-      dirty = true;
+      edits += 1;
     }
+
+    form.warnUnsaved = {
+      edits: function () {
+        return edits;
+      },
+      saved: function (upTo) {
+        // Math.max, because two saves can be in flight and land out of order.
+        if (typeof upTo === "number") saved = Math.max(saved, upTo);
+      }
+    };
 
     // Native controls: text inputs, textareas, selects, checkboxes, radios, etc.
     form.addEventListener("input", markDirty);
     form.addEventListener("change", markDirty);
 
     // Summernote WYSIWYG editors (used for quest/announcement content) sync to a
-    // hidden textarea and emit a bubbling `summernote.change` jQuery event — catch
+    // hidden textarea and emit a bubbling `summernote.change` jQuery event, so catch
     // those edits too, since they don't fire a native input/change on the form.
     if (window.jQuery) {
       window.jQuery(form).on("summernote.change", markDirty);
     }
 
-    // A submit is an intentional save — don't warn about it.
+    // A submit is an intentional save, so don't warn about it.
     form.addEventListener("submit", function () {
       submitting = true;
     });
 
     window.addEventListener("beforeunload", function (e) {
-      if (dirty && !submitting) {
+      if (edits > saved && !submitting) {
         // Setting returnValue is what triggers the native confirmation dialog;
         // modern browsers ignore any custom message and show their own text.
         e.preventDefault();


### PR DESCRIPTION
### What?

The student submission form, the marker's approve form and the teacher's question editor now warn before you leave them with text that has not reached the server.

Closes #2572

### Why?

The guard has existed since #192. `warn-unsaved-changes.js` is loaded site-wide from `base.html` and opts a form in on `data-warn-unsaved`; `quest_form.html` and `announcements/form.html` use it. The three forms where the most typing happens never did.

A student's answers and comment reach the server on a submit or the 60-second autosave, and nothing else: no keystroke handler, no `change` handler, no `beforeunload`. Click the navbar in between and up to a minute of typing is gone, silently. A teacher half way through marking feedback, or through a question's instructions, solution and marker notes, loses all of it the same way, with nothing saved anywhere until they submit.

### How?

`data-warn-unsaved` on all three forms. On the submission page the comment box is a `<div id="main-comment-form">`, not a nested form, so the one attribute covers the comment editor and every answer editor at once.

**Arming it unconditionally would have been worse than not doing this.** The common exit is: student types, the autosave saves everything, student clicks away. A guard that cannot see the autosave says "Changes you made may not be saved" there every single time, and a warning that is usually wrong is exactly the one people learn to click straight through.

So the guard counts edits instead of setting a flag, and offers a two-call API on the form element for saves that are not submits:

```js
var sent = form.warnUnsaved.edits();   // before the request leaves
form.warnUnsaved.saved(sent);          // once the server confirms it
```

`save_draft` reports every successful save that way. **Passing the count captured before the request is the whole point:** an edit typed while the request was in flight leaves the guard armed, because the server did not store it. Clearing unconditionally on success would trade a noisy false positive for a silent false negative, which is the failure this issue is about.

That is not a new idea in this file. `save_draft` already snapshots `chosen_files_by_input()` before the POST and compares with `same_files(current, sent)` afterward, for the same reason and against the same race. The dirty count now gets the same treatment.

### Testing?

Full suite `Ran 2857 tests in 491.871s ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

Two new tests, both failing on unpatched templates, covering all three forms.

**They nearly did not.** `assertContains(response, "data-warn-unsaved")` passes on *every page in the site*, because `base.html` names the attribute in the HTML comment above the script tag. Both tests initially passed against `develop`, which is how I found it. They now match `<form[^>]*\sdata-warn-unsaved` instead, and the constant carries a comment saying why:

```
FAIL: test_create__form_warns_about_unsaved_changes
FAIL: test_submission_view__both_forms_warn_about_unsaved_changes
Ran 2 tests ... FAILED (failures=2)
```

The guard's behaviour is JavaScript, so it is driven in a real browser on a seeded `hackerspace` deck instead. Each line dispatches a cancelable `beforeunload` and reports whether the handler cancelled it, which is precisely the condition Chrome uses to decide whether to prompt:

```
form has data-warn-unsaved: true
guard API attached: true
1. untouched page armed?           false (expect false)
2. after typing a short answer     true (expect true)
3. after a successful Save Draft   false (expect false)
4. after editing again             true (expect true)
5. edit made while save in flight  true (expect true)
6. saved again, clean              false (expect false)
7. after typing in the editor      true (expect true)
```

Line 5 is the race, with a real 200 from `/quests/submission/save/`: the save succeeds and the guard stays armed, because the keystroke landed after the request left.

Then the real prompt, by actually closing the tab:

```
native dialogs seen on close with unsaved text: ["beforeunload: \"\""]
native dialogs seen on close after Save Draft:  []
```

And the marker's side, including that submitting is still silent:

```
staff form guarded: /quests/submission/60/approve/
1. untouched                  false (expect false)
2. after typing feedback      true (expect true)
3. submitted, dialogs seen:   []      (expect [])
   landed on: /quests/approvals/
```

### Screenshots (if front end is affected)

**This change renders no new pixels, and the thing it produces cannot be screenshotted.** The visible outcome is Chrome's own "Leave site? Changes you made may not be saved." prompt, which is browser UI drawn outside the page, so no page-level screenshot tool reaches it; and any automation able to trigger it (CDP, and therefore Playwright and devtools) also intercepts it before the browser draws it, which is why the transcripts above report the dialog rather than picture it.

It is not a new dialog in any case: it is character for character the prompt this repo has shown on the quest form and the announcement form since #192. Editing a quest, typing into it and clicking the navbar shows exactly what a student will now see.

### Anything Else?

**Drop Quest draws the prompt too**, because it is a plain link. A student who has typed something and then decides to drop the quest gets "Leave site?" and then the drop page's own confirmation: two dialogs for one intent, and the first is arguably a false alarm since dropping discards the draft anyway. I have left it rather than widening this PR, since the same is already true of the Cancel button on the quest form (a link inside a guarded form, since #192). Say the word and I will exempt that link.

The two em dashes in `warn-unsaved-changes.js`'s comments are replaced, per the convention about cleaning them from files you touch. It is not in the directories #2569's checker scans yet.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unsaved-change warnings to submission and question forms.
  - Warnings now account for edits made while drafts are being saved, preventing newer changes from being marked as saved incorrectly.
  - Navigation warnings are suppressed while a form is being submitted.

- **Bug Fixes**
  - Improved draft-saving behavior so unsaved edits are reliably preserved and tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->