### PR TITLE
fix: sort the quest and campaign lists by name again (#2623, #2624)

### DIFF
--- a/src/library/tests/test_views.py
+++ b/src/library/tests/test_views.py
@@ -2957,10 +2957,11 @@ class LibraryQuestSortTests(LibraryTenantTestCaseMixin):
             self.assertTrue(name.startswith('Zsort quest'), f'{name} is not one of the searched-for quests')
 
     def test_LibraryQuestListView__a_column_this_tab_does_not_offer_is_ignored(self):
-        """A stale or hand-made `?sort=` falls back to the Library's own order, not an error.
+        """A stale or hand-made `?sort=` falls back to the tab's default column, not an error.
 
         Tags are the live case: the column is rendered but deliberately not sortable, so a
-        link someone kept from elsewhere names a column this tab will not order by.
+        link someone kept from elsewhere names a column this tab will not order by. The
+        fallback is the quest name, the same column an unsorted visit lands on (#2623).
         """
         default_order = self._sorted_names()
 
@@ -2970,7 +2971,7 @@ class LibraryQuestSortTests(LibraryTenantTestCaseMixin):
 
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual([quest.name for quest in response.context['library_quests']], default_order)
-                self.assertEqual(response.context['sort_column'], '')
+                self.assertEqual(response.context['sort_column'], 'name')
                 self.assertFalse(response.context['sort_descending'])
 
     def test_LibraryQuestListView__quests_with_no_campaign_sort_last_in_both_directions(self):

--- a/src/library/views.py
+++ b/src/library/views.py
@@ -606,11 +606,14 @@ class LibraryQuestListView(NonPublicOnlyViewMixin, TemplateView):
     def get_sort(self):
         """The column the list is ordered by and its direction, from the `sort` parameter.
 
+        Falls back to the quest name, so the Library's quests tab comes up in the order a
+        reader browsing it expects, and matches the deck's own quest tabs (#2623).
+
         Returns:
-            tuple[str, bool]: the column key, '' when none applies, and whether it was
+            tuple[str, bool]: the column key, 'name' when none applies, and whether it was
             asked for in reverse.
         """
-        return resolve_sort(self.request, self.SORT_COLUMNS)
+        return resolve_sort(self.request, self.SORT_COLUMNS, default='name')
 
     def sort_library_quests(self, quests, column, descending):
         """Order the quests by the chosen column, before the page is cut from them.

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -80,7 +80,7 @@ class CategoryManager(models.Manager):
     def all_published_with_importable_quests(self):
         """
         Returns a queryset of published campaigns (categories) in the library schema
-        that have at least one importable quest — meaning a quest that is published and not archived.
+        that have at least one importable quest: one that is published and not archived.
 
         Each returned campaign is annotated with:
         - quest_count: the number of importable quests in the campaign
@@ -112,7 +112,10 @@ class CategoryManager(models.Manager):
         # Exclude campaigns without any qualifying quests
         qs = qs.filter(quest_count__gt=0)
 
-        return qs
+        # The aggregate annotation above groups the query, and Django emits no ORDER BY at all
+        # for a grouped query, so Category.Meta.ordering is lost and the Library's campaigns
+        # tab comes up in whatever order Postgres finds them. Ask for the title back (#2624).
+        return qs.order_by('title')
 
 
 class Category(IsAPrereqMixin, IsLibraryContentMixin, models.Model):

--- a/src/quest_manager/models.py
+++ b/src/quest_manager/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db import models
-from django.db.models import Count, DateTimeField, Exists, ExpressionWrapper, F, Max, OuterRef, Q, Sum
+from django.db.models import BooleanField, Count, DateTimeField, Exists, ExpressionWrapper, F, Max, OuterRef, Q, Sum
 from django.db.models.functions import Greatest
 from django.urls import reverse
 from django.utils import timezone
@@ -412,6 +412,23 @@ class QuestQuerySet(models.QuerySet):
 
         # Remove quests with no expiry date AND past expiry time (i.e. daily expiration at set time)
         return qs_date.exclude(Q(date_expired=None) & Q(time_expired__lt=now_local.time()))
+
+    def with_is_expired(self):
+        """Annotate each quest with ``is_expired``, so a page can read it without a query each.
+
+        ``Quest.expired()`` reads this annotation when it is present, and falls back to a query
+        per quest when it is not, which a list of thirty pays thirty times over. The value comes
+        from ``not_expired()`` rather than from a second copy of the date and time rules, so the
+        two can never disagree about what expired means.
+
+        Returns:
+            QuerySet[Quest]: the same quests, each carrying a boolean ``is_expired``.
+        """
+        not_expired = self.model.objects.filter(id=OuterRef("id")).not_expired().values("id")
+
+        return self.annotate(
+            is_expired=ExpressionWrapper(~Exists(not_expired), output_field=BooleanField()),
+        )
 
     def published(self):
         """

--- a/src/quest_manager/templates/quest_manager/category_list.html
+++ b/src/quest_manager/templates/quest_manager/category_list.html
@@ -1,6 +1,7 @@
 {% extends "quest_manager/base.html" %}
 {% block head_title %}Campaigns |{% endblock %}
-{% block head %}{% endblock %}
+{% comment %} `head` is left to quest_manager/base.html: it loads bootstrap-table's stylesheet,
+   without which this page's table has no sort indicators and no layout of its own (#2624). {% endcomment %}
 {% block content_first %}{% endblock %}
 {% block heading %}
   <i class="fa fa-compass pull-right"></i>

--- a/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
+++ b/src/quest_manager/templates/quest_manager/tab_campaigns_list.html
@@ -9,19 +9,26 @@
   </p>
 {% endif %}
 {% include 'snippets/table_loading.html' %}
+{% comment %} The whole list is in the page, so bootstrap-table's own sorting covers all of it
+   rather than one page of it, and data-sort-name gives the table a column to come up sorted by:
+   the Title heading then carries the arrow saying so. The rows arrive in that order from the
+   view as well, so the pre-JavaScript paint is not a different list (#2624). {% endcomment %}
 <table data-toggle='table'
        data-search='true'
        data-classes="table"
        data-pagination='true'
        data-page-size="15"
-       data-page-list="[15, 50, 100, all]">
+       data-page-list="[15, 50, 100, all]"
+       data-sort-name='title'
+       data-sort-order='asc'>
   <thead>
+    {# fixed column widths, so sorting a column cannot resize it and shove the rest along #}
     <tr>
-      <th data-sortable='true' data-field='title'>Title</th>
-      <th>Icon</th>
-      <th data-sortable='true' data-field='count'># of Quests</th>
-      <th data-sortable='true' data-field='xp'>XP Available</th>
-      <th>Action</th>
+      <th class="col-sm-5" data-sortable='true' data-field='title'>Title</th>
+      <th class="col-sm-1">Icon</th>
+      <th class="col-sm-2" data-sortable='true' data-field='count'># of Quests</th>
+      <th class="col-sm-2" data-sortable='true' data-field='xp'>XP Available</th>
+      <th class="col-sm-2">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/src/quest_manager/tests/test_managers.py
+++ b/src/quest_manager/tests/test_managers.py
@@ -68,6 +68,26 @@ class CategoryManagerTests(LibraryTenantTestCaseMixin):
             self.assertEqual(category.quest_count, 1)
             self.assertEqual(category.xp_sum, 100)
 
+    def test_all_published_with_importable_quests__ordered_by_title(self):
+        """The Library's campaigns arrive in alphabetical order (#2624).
+
+        The aggregate annotations group the query, and Django emits no ORDER BY at all for a
+        grouped query, so `Category.Meta.ordering` is dropped and the database is free to
+        return the rows however it finds them. The campaigns are created here in an order
+        that is not alphabetical, so a queryset that lost its ordering fails this.
+        """
+        with library_schema_context():
+            Quest.objects.all().delete()
+            Category.objects.all().delete()
+
+            for title in ("Zebra Robotics", "Intro to Python", "Animation", "Music Production"):
+                campaign = baker.make(Category, title=title, published=True)
+                baker.make(Quest, campaign=campaign, published=True, archived=False, xp=10)
+
+            titles = list(Category.objects.all_published_with_importable_quests().values_list('title', flat=True))
+
+        self.assertEqual(titles, sorted(titles))
+
     def test_all_published_with_importable_quests__excludes_categories_without_importable_quests(self):
         """
         Ensures that published campaigns with no importable quests are excluded

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -3654,25 +3654,32 @@ class QuestListViewTest(ByteDeckTenantTestCase):
         # should now see the quest
         self.assertContains(response, f'id="heading-quest-{self.quest1.id}')
 
-    def test_quest_list__available_tab_is_sorted_by_name(self):
-        """The quest tabs come up in alphabetical order (#2623).
+    def test_quest_list__default_order_is_sort_order_then_expired_then_name(self):
+        """A quest tab comes up in the teacher's manual order, expired first, then by name (#2623).
 
-        `Quest.Meta.ordering` leads with `sort_order` and the expiry date, none of which the
-        table shows, so a deck where some quests carry either gets an order the reader cannot
-        account for. These three are created so that the model's own ordering would put them
-        in exactly the opposite order to their names.
+        Each key earns its place: `sort_order` is the manual ordering a teacher sets on the
+        quest form, so nothing may override it; expired quests are the ones needing attention,
+        so they group ahead of the rest; and the name settles everything else, which is what
+        makes the bulk of a deck read alphabetically since almost every quest is `sort_order` 0.
+
+        Two of the names cut against the key that decides their place, so dropping that key
+        reorders the list: "Aardvark" would lead on name alone, and its `sort_order` sends it
+        last; "Zulu" would trail on name alone, and being expired brings it first. "Alpha" and
+        "Bravo" tie on both of those, so the name is the only thing separating them.
         """
         Quest.objects.all().delete()
-        baker.make(Quest, name="Alpha", sort_order=9)
-        baker.make(Quest, name="Bravo", date_expired=date(2030, 1, 2))
-        baker.make(Quest, name="Charlie", date_expired=date(2030, 1, 1))
+        baker.make(Quest, name="Aardvark", sort_order=9)
+        baker.make(Quest, name="Zulu", date_expired=date(2020, 1, 1))  # in the past: expired
+        baker.make(Quest, name="Bravo", date_expired=date(2030, 1, 1))  # in the future: not yet
+        baker.make(Quest, name="Alpha")
         self.client.force_login(self.test_teacher)
 
         response = self.client.get(reverse('quests:quests'))
 
-        self.assertEqual([quest.name for quest in response.context['quests']], ["Alpha", "Bravo", "Charlie"])
-        # and the heading says so, rather than leaving the reader to work the order out
-        self.assertEqual(response.context['quest_sort_column'], 'name')
+        self.assertEqual(
+            [quest.name for quest in response.context['quests']], ["Zulu", "Alpha", "Bravo", "Aardvark"])
+        # no single heading owns this order, so none of them claims to
+        self.assertEqual(response.context['quest_sort_column'], '')
         self.assertFalse(response.context['quest_sort_descending'])
 
     def test_quest_list__a_chosen_sort_still_wins_over_the_default(self):
@@ -5585,11 +5592,7 @@ class QuestTabListingTests(ByteDeckTenantTestCase):
             self.assertTrue(name.startswith('Zsort quest'), f'{name} is not one of the searched-for quests')
 
     def test_quest_list__a_column_this_tab_does_not_offer_is_ignored(self):
-        """A stale or hand-made `?sort=` falls back to the tab's default column, not an error.
-
-        The fallback is the name, the same column an unsorted visit lands on, so the heading
-        still says what the list is ordered by rather than showing no column at all (#2623).
-        """
+        """A stale or hand-made `?sort=` falls back to the tab's own order, not an error."""
         default_order = self._names()
 
         for unknown in ('tags', 'nonsense', 'name; drop table', '-'):
@@ -5598,7 +5601,7 @@ class QuestTabListingTests(ByteDeckTenantTestCase):
 
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual([q.name for q in response.context['quests']], default_order)
-                self.assertEqual(response.context['quest_sort_column'], 'name')
+                self.assertEqual(response.context['quest_sort_column'], '')
 
     def test_quest_list__the_table_carries_no_client_side_search_or_sort(self):
         """The tab's searching and ordering are the server's, so the table asks for neither.

--- a/src/quest_manager/tests/test_views.py
+++ b/src/quest_manager/tests/test_views.py
@@ -40,7 +40,7 @@ from profile_manager.models import Profile
 from djcytoscape.models import CytoScape
 from library.utils import library_schema_context
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 
 User = get_user_model()
@@ -3654,6 +3654,40 @@ class QuestListViewTest(ByteDeckTenantTestCase):
         # should now see the quest
         self.assertContains(response, f'id="heading-quest-{self.quest1.id}')
 
+    def test_quest_list__available_tab_is_sorted_by_name(self):
+        """The quest tabs come up in alphabetical order (#2623).
+
+        `Quest.Meta.ordering` leads with `sort_order` and the expiry date, none of which the
+        table shows, so a deck where some quests carry either gets an order the reader cannot
+        account for. These three are created so that the model's own ordering would put them
+        in exactly the opposite order to their names.
+        """
+        Quest.objects.all().delete()
+        baker.make(Quest, name="Alpha", sort_order=9)
+        baker.make(Quest, name="Bravo", date_expired=date(2030, 1, 2))
+        baker.make(Quest, name="Charlie", date_expired=date(2030, 1, 1))
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:quests'))
+
+        self.assertEqual([quest.name for quest in response.context['quests']], ["Alpha", "Bravo", "Charlie"])
+        # and the heading says so, rather than leaving the reader to work the order out
+        self.assertEqual(response.context['quest_sort_column'], 'name')
+        self.assertFalse(response.context['quest_sort_descending'])
+
+    def test_quest_list__a_chosen_sort_still_wins_over_the_default(self):
+        """Clicking a column heading orders by it, so the default is only a starting point."""
+        Quest.objects.all().delete()
+        baker.make(Quest, name="Alpha", xp=30)
+        baker.make(Quest, name="Bravo", xp=10)
+        baker.make(Quest, name="Charlie", xp=20)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:quests'), {'sort': 'xp'})
+
+        self.assertEqual([quest.name for quest in response.context['quests']], ["Bravo", "Charlie", "Alpha"])
+        self.assertEqual(response.context['quest_sort_column'], 'xp')
+
     def test_quest_list__student_sees_quests_available_outside_course(self):
         """A quest flagged available_outside_course appears for a student not in a course."""
         self.client.force_login(self.test_student)
@@ -4207,6 +4241,46 @@ class CategoryViewTests(ByteDeckTenantTestCase):
 
         response = self.client.get(reverse('quests:categories'))
         self.assertNotContains(response, reverse('quests:category_publish', args=[published_campaign.id]))
+
+    def test_CategoryList_view__lists_campaigns_in_alphabetical_order(self):
+        """The campaign list comes up sorted by title (#2624).
+
+        The list annotates a quest count and an XP sum, and an aggregate annotation groups the
+        query, for which Django emits no ORDER BY at all: `Category.Meta.ordering` is dropped
+        and the database returns the rows however it finds them. These are created in an order
+        that is not alphabetical, so a queryset that lost its ordering fails this.
+        """
+        for title in ("Zebra Robotics", "Intro to Python", "Animation", "Music Production"):
+            baker.make(Category, title=title, published=True)
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:categories'))
+
+        titles = [campaign.title for campaign in response.context['object_list']]
+        self.assertEqual(titles, sorted(titles))
+
+    def test_CategoryList_view__loads_the_bootstrap_table_stylesheet(self):
+        """The campaigns page keeps the stylesheet its table is styled by (#2624).
+
+        The page used to blank the `head` block it inherits, which is where
+        `quest_manager/base.html` loads bootstrap-table's CSS. Without it the headings carry
+        the sortable classes but nothing draws the arrow or reserves room for it, so the table
+        offered a sort with no way to see which column it was on.
+        """
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:categories'))
+
+        self.assertContains(response, 'bootstrap-table-1.20.2.min.css')
+
+    def test_CategoryList_view__table_names_the_column_it_is_sorted_by(self):
+        """The campaigns table declares its default sort, so a heading shows the arrow (#2624)."""
+        self.client.force_login(self.test_teacher)
+
+        response = self.client.get(reverse('quests:categories'))
+
+        self.assertContains(response, "data-sort-name='title'")
+        self.assertContains(response, "data-sort-order='asc'")
 
     def test_CategoryList_view__shows_the_decks_own_campaign_actions(self):
         """The deck's campaign list offers the local actions (details, edit, delete), not the
@@ -5511,7 +5585,11 @@ class QuestTabListingTests(ByteDeckTenantTestCase):
             self.assertTrue(name.startswith('Zsort quest'), f'{name} is not one of the searched-for quests')
 
     def test_quest_list__a_column_this_tab_does_not_offer_is_ignored(self):
-        """A stale or hand-made `?sort=` falls back to the tab's own order, not an error."""
+        """A stale or hand-made `?sort=` falls back to the tab's default column, not an error.
+
+        The fallback is the name, the same column an unsorted visit lands on, so the heading
+        still says what the list is ordered by rather than showing no column at all (#2623).
+        """
         default_order = self._names()
 
         for unknown in ('tags', 'nonsense', 'name; drop table', '-'):
@@ -5520,7 +5598,7 @@ class QuestTabListingTests(ByteDeckTenantTestCase):
 
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual([q.name for q in response.context['quests']], default_order)
-                self.assertEqual(response.context['quest_sort_column'], '')
+                self.assertEqual(response.context['quest_sort_column'], 'name')
 
     def test_quest_list__the_table_carries_no_client_side_search_or_sort(self):
         """The tab's searching and ordering are the server's, so the table asks for neither.

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -97,6 +97,16 @@ class CategoryList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
         return self.request.path in [reverse('quest_manager:categories'), reverse('quest_manager:categories_available')]
 
     def get_queryset(self):
+        """The campaigns for the tab being viewed, counted, summed and ordered by title.
+
+        Which tab is showing decides whether the published or the unpublished campaigns are
+        listed, and the two annotations give the template its per-campaign figures without a
+        query each.
+
+        Returns:
+            QuerySet[Category]: the tab's campaigns, alphabetical by title, each carrying
+            `quest_count_annotated` and `xp_sum_annotated` for its current quests.
+        """
         queryset = super().get_queryset()
 
         if self.inactive_tab_active:
@@ -819,6 +829,25 @@ class QuestListViewTabTypes:
 @non_public_only_view
 @login_required
 def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
+    """Render the quest tabs: available, in progress, completed, past, drafts and archived.
+
+    Which tab is shown comes from the path, or from `quest_id`, which opens the Available tab
+    with that quest expanded. Every tab is counted in full for its badge, then searched,
+    ordered and cut to a page in the database, so each of those three answers a question about
+    the whole tab rather than about the page the browser is holding (#2379, #2410, #2582).
+
+    A staff member sees every published quest; a student sees the ones available to them, plus
+    the repeatable ones still inside their cooldown window, shown as available again soon.
+
+    Args:
+        request (HttpRequest): the request, whose path picks the tab and whose query string
+            carries the page, the search term and the sort.
+        quest_id (int): a quest to open on the Available tab, or None for the tab alone.
+        template (str): the template to render.
+
+    Returns:
+        HttpResponse: the rendered quest list.
+    """
     available_quests = []
     in_progress_submissions = []
     completed_submissions = []

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -20,7 +20,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import transaction
 from django.db.models import (
-    Case, DateTimeField, F, ExpressionWrapper, fields, BooleanField, Count, Exists, IntegerField, OuterRef, Q, Sum, Value, When,
+    Case, DateTimeField, F, ExpressionWrapper, fields, Count, IntegerField, Q, Sum, Value, When,
 )
 from django.db.models.functions import Coalesce, Now
 from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
@@ -45,6 +45,7 @@ from utilities.html import is_empty_html
 from utilities.sorting import apply_sort, resolve_sort
 
 from .listing import QUEST_SORT_COLUMNS, search_quests, search_submissions
+
 from library.utils import is_library_schema_requested, library_schema_if_requested
 from notifications.signals import notify
 from notifications.models import notify_rank_up
@@ -69,6 +70,12 @@ from .models import Quest, QuestSubmission, Category, CommonData
 from djcytoscape.models import CytoScape
 
 User = get_user_model()
+
+#: How a quest tab is ordered until a heading is clicked. `sort_order` is the teacher's own
+#: manual ordering (#1179), so it comes first and nothing else may override it; expired quests
+#: are grouped ahead of the rest, since they are the ones needing attention; and the name
+#: settles everything else, which is the column the reader is looking at (#2623).
+DEFAULT_QUEST_ORDERING = ('sort_order', '-is_expired', 'name')
 
 
 def is_staff_or_TA(user):
@@ -188,14 +195,7 @@ class CategoryDetail(NonPublicOnlyViewMixin, LoginRequiredMixin, DetailView):
         # icon), tags, and calls quest.expired() (twice), so select_related the
         # campaign, prefetch tags and annotate is_expired to avoid a handful of
         # queries per quest. This mirrors the quest list view (see quest_list()).
-        quests = quests.select_related("campaign").prefetch_related("tags")
-        not_expired_subquery = quests.not_expired().values("id")
-        quests = quests.annotate(
-            is_expired=ExpressionWrapper(
-                ~Exists(not_expired_subquery.filter(id=OuterRef("id"))),
-                output_field=BooleanField(),
-            )
-        )
+        quests = quests.select_related("campaign").prefetch_related("tags").with_is_expired()
 
         kwargs['category_displayed_quests'] = quests
 
@@ -891,14 +891,6 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
             .select_related("campaign", "editor__profile")
             .prefetch_related("tags")
         )
-        # There was a looping call to quest.expired() which was causing a lot of queries.  Instead, annotate the value here
-        not_expired_subquery = available_quests.not_expired().values("id")
-        available_quests = available_quests.annotate(
-            is_expired=ExpressionWrapper(
-                ~Exists(not_expired_subquery.filter(id=OuterRef("id"))),
-                output_field=BooleanField(),
-            )
-        )
     else:
         if request.user.profile.has_current_course:
             available_quests = Quest.objects.get_available(request.user, remove_hidden)
@@ -970,12 +962,16 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
     quests = search_quests(quests, search_term)
     num_matching_quests = quests.count()
 
-    # Sorted by name unless a heading was clicked. Quest.Meta.ordering leads with sort_order
-    # and the expiry date, none of which this table shows, so a deck where some quests carry
-    # an expiry gets those first and the rest alphabetically after them, which reads as no
-    # order at all (#2623). The name is the column the reader is looking at.
-    quest_sort_column, quest_sort_descending = resolve_sort(request, QUEST_SORT_COLUMNS, default='name')
-    quests = apply_sort(quests, QUEST_SORT_COLUMNS, quest_sort_column, quest_sort_descending, tie_break='name')
+    # `is_expired` is read by the table (it colours an expired row) and by the ordering below,
+    # so every tab carries it, not only the staff Available one. Annotating beats the looping
+    # `quest.expired()` call it replaces, which cost a query per row.
+    quests = quests.with_is_expired()
+
+    quest_sort_column, quest_sort_descending = resolve_sort(request, QUEST_SORT_COLUMNS)
+    if quest_sort_column:
+        quests = apply_sort(quests, QUEST_SORT_COLUMNS, quest_sort_column, quest_sort_descending, tie_break='name')
+    else:
+        quests = quests.order_by(*DEFAULT_QUEST_ORDERING)
     quests = paginate(quests, page)
 
     # Used to explain why the "Available" tab is empty, if it is

--- a/src/quest_manager/views.py
+++ b/src/quest_manager/views.py
@@ -113,7 +113,10 @@ class CategoryList(NonPublicOnlyViewMixin, LoginRequiredMixin, ListView):
             xp_sum_annotated=Sum('quest__xp', filter=current_quest_filter),
         )
 
-        return queryset
+        # An aggregate annotation groups the query, and Django emits no ORDER BY at all for a
+        # grouped query, so Category.Meta.ordering is lost and Postgres returns the campaigns
+        # in whatever order it finds them. Ask for the title back explicitly (#2624).
+        return queryset.order_by('title')
 
     def get_context_data(self, *args, **kwargs):
         """Add the tab state and the campaign table's flags to the deck's campaign list.
@@ -938,7 +941,11 @@ def quest_list(request, quest_id=None, template="quest_manager/quests.html"):
     quests = search_quests(quests, search_term)
     num_matching_quests = quests.count()
 
-    quest_sort_column, quest_sort_descending = resolve_sort(request, QUEST_SORT_COLUMNS)
+    # Sorted by name unless a heading was clicked. Quest.Meta.ordering leads with sort_order
+    # and the expiry date, none of which this table shows, so a deck where some quests carry
+    # an expiry gets those first and the rest alphabetically after them, which reads as no
+    # order at all (#2623). The name is the column the reader is looking at.
+    quest_sort_column, quest_sort_descending = resolve_sort(request, QUEST_SORT_COLUMNS, default='name')
     quests = apply_sort(quests, QUEST_SORT_COLUMNS, quest_sort_column, quest_sort_descending, tie_break='name')
     quests = paginate(quests, page)
 

--- a/src/utilities/sorting.py
+++ b/src/utilities/sorting.py
@@ -9,29 +9,36 @@ them.
 from django.db.models import F
 
 
-def resolve_sort(request, sort_columns):
+def resolve_sort(request, sort_columns, default=''):
     """The column a list is ordered by and its direction, from the `sort` query parameter.
 
     A leading '-' asks for the reverse, which is Django's own `order_by` spelling and what
     the column headings put in their links. A column the list does not offer is ignored
-    rather than refused, so a stale link, or one somebody typed, falls back to the list's
-    own order instead of erroring.
+    rather than refused, so a stale link, or one somebody typed, falls back to `default`
+    instead of erroring.
+
+    `default` is the column the list comes up sorted by before anyone clicks a heading. A
+    list that names one is sorted by something the reader can see and can be told about,
+    since the heading for the returned column draws its arrow (#2623, #2624). Leaving it
+    empty keeps the model's own `Meta.ordering` instead, for a list whose natural order is
+    the useful one.
 
     Args:
         request (HttpRequest): the current request.
         sort_columns (dict): the columns this list offers, keyed by the key its headings
             use, valued by what `apply_sort` should order on.
+        default (str): the column key to fall back on, or '' to keep the list's own order.
 
     Returns:
-        tuple[str, bool]: the column key, '' when none applies, and whether it was asked
-        for in reverse.
+        tuple[str, bool]: the column key, `default` when none applies, and whether it was
+        asked for in reverse.
     """
     requested = request.GET.get('sort', '')
     descending = requested.startswith('-')
     column = requested[1:] if descending else requested
 
     if column not in sort_columns:
-        return '', False
+        return default, False
 
     return column, descending
 

--- a/src/utilities/tests/test_sorting.py
+++ b/src/utilities/tests/test_sorting.py
@@ -1,0 +1,51 @@
+from django.test import RequestFactory, SimpleTestCase
+
+from utilities.sorting import resolve_sort
+
+
+SORT_COLUMNS = {'name': 'name', 'xp': 'xp', 'campaign': 'campaign__title'}
+
+
+class ResolveSortTest(SimpleTestCase):
+    """What `resolve_sort` reads out of the `sort` query parameter, and what it falls back to."""
+
+    def sort_for(self, query=''):
+        """Resolve the sort for a request carrying `query`, against SORT_COLUMNS.
+
+        Args:
+            query (str): the query string, without the leading '?'.
+
+        Returns:
+            tuple[str, bool]: what `resolve_sort` returned.
+        """
+        return resolve_sort(RequestFactory().get(f'/?{query}'), SORT_COLUMNS)
+
+    def test_resolve_sort__reads_the_column_and_its_direction(self):
+        """A column the list offers is used, and a leading '-' asks for the reverse."""
+        self.assertEqual(self.sort_for('sort=xp'), ('xp', False))
+        self.assertEqual(self.sort_for('sort=-xp'), ('xp', True))
+
+    def test_resolve_sort__no_default_means_the_lists_own_order(self):
+        """Asked for nothing, or for a column that does not exist, and given no default,
+        it reports no column, which leaves the queryset's own ordering alone."""
+        self.assertEqual(self.sort_for(''), ('', False))
+        self.assertEqual(self.sort_for('sort=colour'), ('', False))
+        self.assertEqual(self.sort_for('sort=-colour'), ('', False))
+
+    def test_resolve_sort__falls_back_to_the_default_column(self):
+        """A list that names a default comes up sorted by it (#2623, #2624).
+
+        The fallback covers a stale link and a typed one as well as an absent parameter,
+        so a column that does not exist lands on the default rather than on the model's
+        `Meta.ordering`, which is what the reader was not seeing an order in.
+        """
+        request = RequestFactory().get('/')
+        self.assertEqual(resolve_sort(request, SORT_COLUMNS, default='name'), ('name', False))
+
+        stale = RequestFactory().get('/?sort=colour')
+        self.assertEqual(resolve_sort(stale, SORT_COLUMNS, default='name'), ('name', False))
+
+    def test_resolve_sort__a_chosen_column_wins_over_the_default(self):
+        """Clicking a heading still decides the order, in either direction."""
+        chosen = RequestFactory().get('/?sort=-campaign')
+        self.assertEqual(resolve_sort(chosen, SORT_COLUMNS, default='name'), ('campaign', True))


### PR DESCRIPTION
### What?

Quest tabs come up in the teacher's manual order, expired quests first, then alphabetically. Campaign lists come up sorted by title, and the campaigns page gets its sort indicators and stops resizing its columns when you sort.

Closes #2623
Closes #2624

### Why?

Two separate causes, and **no test ever asserted the order of either list**, which answers the question on #2623: nothing was removed or changed to allow this.

**Quest lists have never been ordered by anything the reader can see.** `XPItem.Meta.ordering` is `["sort_order", "date_expired", "time_expired", "name"]`, so name is the *fourth* key. `sort_order` leading is correct and deliberate (see below), but the two expiry keys sort the dated quests *among themselves by date*, and Postgres puts NULLs last, so a deck where a handful of quests carry an expiry gets those first in date order and everything else alphabetically behind them. Reproduced on a dev deck by setting an expiry on six quests and a `sort_order` on one:

```
sort_order  date_expired  name
   0        2026-09-01    brave-prairie-520
   0        2026-09-02    brave-prairie-8112
   ... (four more dated quests)
   0        None          Accessibility check: three answer types
   0        None          ByteDeck Class Contract
   ...
   5        None          Create an Avatar        <- sort_order pushes it to the bottom
```

That order was always there. Server-side sorting and pagination (#2598) only made it visible, since `apply_sort` leaves the queryset alone when no `?sort=` is given and the browser no longer holds the whole tab.

**Campaign lists are a straightforward regression.** Both of them annotate a quest count and an XP sum. An aggregate annotation groups the query, and Django emits no `ORDER BY` at all for a grouped query, so `Category.Meta.ordering = ["title"]` is dropped and the database returns the rows however it finds them:

```
PLAIN  ... WHERE "quest_manager_category"."published" ORDER BY "quest_manager_category"."title" ASC
ANNOT  ... WHERE "quest_manager_category"."published" GROUP BY "quest_manager_category"."id"
```

**The campaigns page had no sort indicators, and its columns resized when sorted, both from one cause.** `category_list.html` blanked the `head` block it inherits, which is where `quest_manager/base.html` loads bootstrap-table's stylesheet. The headings carried bootstrap-table's `sortable both` classes, but the rules that draw the arrow and reserve room for it were not on the page:

```
{ "text": "Title", "cls": "th-inner sortable both", "bgImage": "none", "padRight": "0px" }
```

Nothing constrained the layout either, so the columns were sized from whatever content landed in them. Sorting Title the other way moved the longest title off page 1 and the widths went from `[334, 62, 90, 97, 137]` to `[279, 71, 102, 109, 160]`.

### How?

**Quest tabs default to `sort_order`, then expired, then name.** Each key earns its place:

* `sort_order` leads, and nothing may override it. It is the manual ordering a teacher sets on the quest form's Advanced panel, added deliberately in #1179; honouring it is the whole point of the field.
* Expired quests group ahead of the rest, since they are the ones needing attention. This is the *state* the table already colours, not the date the reader cannot see, which is the difference that stops a deck with a few expiry dates looking unordered.
* The name settles everything else, which is what makes the bulk of a deck read alphabetically: almost every quest sits at `sort_order` 0 with no expiry.

No column heading claims this order, because no single column is it, so `resolve_sort` reports no active column until a heading is clicked. Clicking one still orders by that column alone, and a stale `?sort=` naming a column the tab does not offer falls back to the default rather than erroring.

* `is_expired` moves onto `QuestQuerySet` as `with_is_expired()`, derived from `not_expired()` so the two cannot disagree about what expired means. The two copies of that annotation in `views.py` now call it, and every quest tab carries it rather than only the staff Available one, so the drafts and archived tabs colour an expired row too.
* `resolve_sort` gained a `default` column, used by the Library's quests tab. That one stays alphabetical: it is a shared catalogue, where another deck's `sort_order` carries no meaning and a deck's expiry dates do not apply.
* `CategoryList.get_queryset()` and `CategoryManager.all_published_with_importable_quests()` each ask for `order_by('title')` back after their annotations.
* `category_list.html` leaves the `head` block alone, so the stylesheet loads. The campaigns table declares `data-sort-name='title'` (the rows arrive in that order from the view too, so the pre-JavaScript paint is not a different list) and its headings carry bootstrap `col-*` widths.

### Testing

Full suite green (2878 tests) plus `check` and `makemigrations --check`. Every new test was run against unmodified `develop` first and fails there:

```
ERROR: test_resolve_sort__a_chosen_column_wins_over_the_default
ERROR: test_resolve_sort__falls_back_to_the_default_column
FAIL:  test_all_published_with_importable_quests__ordered_by_title
FAIL:  test_quest_list__default_order_is_sort_order_then_expired_then_name
FAIL:  test_CategoryList_view__lists_campaigns_in_alphabetical_order
FAIL:  test_CategoryList_view__loads_the_bootstrap_table_stylesheet
FAIL:  test_CategoryList_view__table_names_the_column_it_is_sorted_by
```

The ordering test's fixture is built so two of the three keys are individually load-bearing, measured by dropping each from `DEFAULT_QUEST_ORDERING` in turn:

```
without 'sort_order'   -> FAILED     "Aardvark" would lead on name alone
without '-is_expired'  -> FAILED     "Zulu" would trail on name alone
```

`name` is what separates the remaining pair, which tie on both other keys.

### Screenshots (if front end is affected)

From a real `hackerspace` dev deck, signed in as a teacher.

**Campaigns.** Before: unsorted, no arrows on the sortable headings, the loading line and search box unstyled.

![The campaigns table listing Campaign-hidden-harbor-6287, Zebra Robotics, Animation Fundamentals and Storyboarding Workshop, Web Design, with no sort arrows in any heading](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2624/campaigns-before.png)

After: alphabetical, a blue arrow on Title saying so, the neutral sort control on the other two sortable columns, and fixed column widths.

![The same table listing 3D Printing, AI Ethics, Animation Fundamentals and Storyboarding, with an upward arrow beside Title and sort controls beside # of Quests and XP Available](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2624/campaigns-after.png)

**Available quests.** Before: the six quests carrying an expiry date come first, ordered by a date the table does not show, then the list restarts alphabetically.

![The available quests tab listing brave-prairie-520, brave-prairie-8112, clever-glacier-667 and three more, then Accessibility check: three answer types and ByteDeck Class Contract](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2623/quests-before.png)

After, on a deck where nothing is expired and every quest sits at `sort_order` 0, which is the ordinary case: alphabetical from the top.

![The same tab listing Accessibility check: three answer types, ByteDeck Class Contract, Create an Avatar, Screenshots](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2623/quests-after.png)

The "after" shot was taken before the default gained its `sort_order` and expiry keys, so the arrow beside **Quest** is no longer drawn: no single heading owns the order now. The rows are the ones that matter and they are unchanged, since that deck has nothing expired and no manual ordering set.

### Anything Else?

**Found on the way, not fixed here:** a campaign with no quests shows `None` under XP Available rather than 0, because `Sum` over no rows is NULL. Visible in both campaign screenshots above. Filed as #2626.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)