### PR TITLE
fix: stop the quest map drawing campaign columns on top of each other (#2627)

### DIFF
--- a/src/djcytoscape/static/djcytoscape/js/maps.js
+++ b/src/djcytoscape/static/djcytoscape/js/maps.js
@@ -183,15 +183,24 @@ addedCampaignLayoutEdges.remove();
  * order the elements were fed in, so campaign order has to be imposed on the finished layout.
  *
  * Rather than repack every column left-to-right (which spreads the map out whenever campaign-less
- * "bridge" nodes — e.g. a shared badge, or the intro quest — sit between campaigns, and which merged
- * two campaigns into one un-orderable column when one branches off the other), we PERMUTE the
- * campaigns among the x-slots dagre already gave them: sort the campaigns by (map_order, smallest
- * quest id) and drop the i-th into the i-th slot from the left. The set of x positions is unchanged,
- * so the map stays exactly as compact as dagre made it and campaign-less nodes don't move — only the
- * campaigns swap places. Each campaign's quests shift together as a rigid block, so their internal
- * shape and every node's vertical position (the #1787 vertical stacking) are untouched. Because both
- * the sorted slots and the desired order are deterministic, the result no longer toggles between
- * generations even though dagre's raw order does (the original #1977 complaint).
+ * "bridge" nodes: a shared badge, or the intro quest, sit between campaigns, and which merged two
+ * campaigns into one un-orderable column when one branches off the other), we PERMUTE the campaigns
+ * among the x-slots dagre already gave them: sort the campaigns by (map_order, smallest quest id)
+ * and drop the i-th into the i-th slot from the left. The set of x positions is unchanged, so the
+ * map stays exactly as compact as dagre made it and campaign-less nodes don't move.
+ *
+ * Campaigns only trade places with the campaigns they stand BESIDE, though: those whose quests share
+ * vertical space (#2627). An x-slot is only wide enough for the campaign dagre put in it, and dagre
+ * sizes a slot from what competes for that x at the same ranks. A campaign that sits above the
+ * others gets its x for free, with room on either side, so handing that slot to one of a row of
+ * side-by-side campaigns squeezes it against its neighbour and the two are drawn on top of each
+ * other. Grouping by shared vertical space keeps every swap inside one row of slots, which dagre
+ * did space to fit them.
+ *
+ * Each campaign's quests shift together as a rigid block, so their internal shape and every node's
+ * vertical position (the #1787 vertical stacking) are untouched. Because both the sorted slots and
+ * the desired order are deterministic, the result no longer toggles between generations even though
+ * dagre's raw order does (the original #1977 complaint).
  ***************************************/
 (function orderCampaignColumns() {
     // Only campaigns (compound parents) are reordered; campaign-less quests stay where dagre put them.
@@ -207,31 +216,55 @@ addedCampaignLayoutEdges.remove();
             var idNum = parseInt(k.id(), 10);
             if (!isNaN(idNum) && idNum < minId) { minId = idNum; }
         });
+        // The quests' own extent, not the campaign box's: the box adds padding that makes campaigns
+        // in different bands appear to touch, which would merge two rows of slots into one.
+        var bb = kids.boundingBox();
         // A campaign's column x is its compound node's centre (which follows its children).
-        return { kids: kids, x: camp.position('x'), order: order, minId: minId };
+        return { kids: kids, x: camp.position('x'), order: order, minId: minId, y1: bb.y1, y2: bb.y2 };
     });
 
-    // The x-slots the campaigns currently occupy, left to right.
-    var slots = info.map(function (i) { return i.x; }).sort(function (a, b) { return a - b; });
+    // Rows of campaigns that stand side by side: sweep by vertical extent and start a new row
+    // wherever a campaign begins below everything before it. Only campaigns within one row compete
+    // for the same x positions, so only they may trade slots.
+    var rows = [];
+    var current = null;
+    var reach = -Infinity;
+    info.slice().sort(function (a, b) { return a.y1 - b.y1; }).forEach(function (item) {
+        if (current === null || item.y1 >= reach) {
+            current = [];
+            rows.push(current);
+            reach = item.y2;
+        } else if (item.y2 > reach) {
+            reach = item.y2;
+        }
+        current.push(item);
+    });
 
-    // Desired left-to-right order: campaign map_order, then smallest quest id (the deterministic
-    // #2012 order) so ties — and every campaign at the default map_order 0 — stay stable.
-    var desired = info.slice().sort(function (a, b) { return (a.order - b.order) || (a.minId - b.minId); });
-
-    // Drop the i-th campaign (desired order) into the i-th slot, shifting its quests horizontally as
-    // a rigid block. Positions were all read before any shift, so swaps don't interfere.
     var moved = false;
-    desired.forEach(function (item, idx) {
-        var dx = slots[idx] - item.x;
-        if (dx !== 0) { item.kids.shift({ x: dx, y: 0 }); moved = true; }
+    rows.forEach(function (row) {
+        if (row.length < 2) { return; }
+
+        // The x-slots this row's campaigns currently occupy, left to right.
+        var slots = row.map(function (i) { return i.x; }).sort(function (a, b) { return a - b; });
+
+        // Desired left-to-right order: campaign map_order, then smallest quest id (the deterministic
+        // #2012 order) so ties, and every campaign at the default map_order 0, stay stable.
+        var desired = row.slice().sort(function (a, b) { return (a.order - b.order) || (a.minId - b.minId); });
+
+        // Drop the i-th campaign (desired order) into the i-th slot, shifting its quests horizontally
+        // as a rigid block. Positions were all read before any shift, so swaps don't interfere.
+        desired.forEach(function (item, idx) {
+            var dx = slots[idx] - item.x;
+            if (dx !== 0) { item.kids.shift({ x: dx, y: 0 }); moved = true; }
+        });
     });
 
-    // Reordering a campaign can strand a campaign-less "connector" node — the intro quest that leads
-    // into a campaign, a shared badge, etc. — over the campaign's OLD position (e.g. an intro quest
-    // left sitting above where a campaign used to be instead of above the one it points to). Re-centre
-    // each campaign-less node over the mean x of its neighbours so it follows the campaign(s) it
-    // connects to. Skip this entirely when nothing moved (every campaign at the default map_order) so
-    // those maps stay byte-for-byte unchanged; read all neighbour positions before moving anything.
+    // Reordering a campaign can strand a campaign-less "connector" node: the intro quest that leads
+    // into a campaign, a shared badge, and so on, over the campaign's OLD position (e.g. an intro
+    // quest left sitting above where a campaign used to be instead of above the one it points to).
+    // Re-centre each campaign-less node over the mean x of its neighbours so it follows the
+    // campaign(s) it connects to. Skip this entirely when nothing moved so those maps stay
+    // byte-for-byte unchanged; read all neighbour positions before moving anything.
     if (!moved) { return; }
     var recentre = [];
     cy.nodes().forEach(function (node) {

--- a/src/djcytoscape/templates/djcytoscape/quest_map.html
+++ b/src/djcytoscape/templates/djcytoscape/quest_map.html
@@ -100,10 +100,10 @@
   name-wrap fix (#1289 / PR #1937) never reached users who had already cached the old maps.js.
   Bump this version whenever maps.js / maps-dark.js changes.
 {% endcomment %}
-<script src="{% static 'djcytoscape/js/maps.js' %}?v=1.1"></script>
+<script src="{% static 'djcytoscape/js/maps.js' %}?v=1.2"></script>
 
 {% if request.user.profile.dark_theme %}
- <script src="{% static 'djcytoscape/js/maps-dark.js' %}?v=1.1"></script>
+ <script src="{% static 'djcytoscape/js/maps-dark.js' %}?v=1.2"></script>
 {% endif %}
 
 

--- a/src/djcytoscape/tests/test_map_order_render.py
+++ b/src/djcytoscape/tests/test_map_order_render.py
@@ -207,3 +207,154 @@ class CampaignMapOrderRenderTest(SimpleTestCase):
             abs(p["intro"] - p["a"]), abs(p["intro"] - p["b"]),
             "intro node should still sit over campaign A after swapping the order",
         )
+
+
+# A campaign of two quests feeding two campaigns of three, which is the shape of a map whose intro
+# campaign leads into parallel paths. The intro campaign sits in its own vertical band above the
+# other two, so its x-slot has room on either side that a side-by-side campaign's slot does not.
+_STACKED_PAGE_TEMPLATE = """<!doctype html><html><head>
+<style>#cy {{ width: 1400px; height: 1200px; position: absolute; top: 0; left: 0; }}</style>
+</head><body><div id="cy"></div>
+<script>{jquery_stub}</script>
+<script src="file://{js_dir}/cytoscape.min.js"></script>
+<script src="file://{js_dir}/dagre.min.js"></script>
+<script src="file://{js_dir}/cytoscape-dagre.js"></script>
+<script>
+var elements = {{
+  nodes: [
+    {{ data: {{ id: '10', label: 'Intro Campaign', campaignOrder: {order_i} }} }},
+    {{ data: {{ id: '100', parent: '10', label: 'I0', campaignOrder: {order_i} }} }},
+    {{ data: {{ id: '101', parent: '10', label: 'I1', campaignOrder: {order_i} }} }},
+    {{ data: {{ id: '20', label: 'Path A', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '200', parent: '20', label: 'A0', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '201', parent: '20', label: 'A1', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '202', parent: '20', label: 'A2', campaignOrder: {order_a} }} }},
+    {{ data: {{ id: '30', label: 'Path B', campaignOrder: {order_b} }} }},
+    {{ data: {{ id: '300', parent: '30', label: 'B0', campaignOrder: {order_b} }} }},
+    {{ data: {{ id: '301', parent: '30', label: 'B1', campaignOrder: {order_b} }} }},
+    {{ data: {{ id: '302', parent: '30', label: 'B2', campaignOrder: {order_b} }} }}
+  ],
+  edges: [
+    {{ data: {{ id: 'i1', source: '100', target: '101' }} }},
+    {{ data: {{ id: 'a1', source: '200', target: '201' }} }},
+    {{ data: {{ id: 'a2', source: '201', target: '202' }} }},
+    {{ data: {{ id: 'b1', source: '300', target: '301' }} }},
+    {{ data: {{ id: 'b2', source: '301', target: '302' }} }},
+    {{ data: {{ id: 'ia', source: '101', target: '200' }} }},
+    {{ data: {{ id: 'ib', source: '101', target: '300' }} }}
+  ]
+}};
+var cy = cytoscape({{ container: document.getElementById('cy'), elements: elements, style: [] }});
+</script>
+<script src="file://{js_dir}/maps.js"></script>
+</body></html>"""
+
+
+@skipUnless(HAS_PLAYWRIGHT and _CHROMIUM, "Playwright and a Chromium build are required")
+class CampaignColumnOverlapRenderTest(SimpleTestCase):
+    """Campaign columns never sit on top of each other, whatever their map_order (#2627).
+
+    An x-slot is only as wide as dagre made it, and dagre widens a slot for whatever competes with
+    it at the same ranks. A campaign in a vertical band of its own has room on either side that a
+    campaign standing beside another does not, so the two kinds of slot are not interchangeable:
+    moving a side-by-side campaign into a solitary campaign's slot puts it closer to its neighbour
+    than a node is wide, and the two campaigns are drawn over each other for their whole height.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Start one headless browser and locate the vendored cytoscape assets for the class."""
+        super().setUpClass()
+        cls.js_dir = os.path.join(apps.get_app_config("djcytoscape").path, "static", "djcytoscape", "js")
+        cls._pw = sync_playwright().start()
+        cls._browser = cls._pw.chromium.launch(executable_path=_CHROMIUM)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Close the browser and stop Playwright."""
+        cls._browser.close()
+        cls._pw.stop()
+        super().tearDownClass()
+
+    def _campaign_boxes(self, order_i=0, order_a=0, order_b=0):
+        """Render the stacked map and return each campaign's rendered box.
+
+        Args:
+            order_i (int): map_order of the intro campaign, which sits above the other two.
+            order_a (int): map_order of the left-hand path.
+            order_b (int): map_order of the right-hand path.
+
+        Returns:
+            list[dict]: one ``{'label', 'x1', 'x2', 'y1', 'y2'}`` per campaign.
+        """
+        html = _STACKED_PAGE_TEMPLATE.format(
+            jquery_stub=_JQUERY_STUB, js_dir=self.js_dir,
+            order_i=order_i, order_a=order_a, order_b=order_b,
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as fh:
+            fh.write(html)
+            html_path = fh.name
+        page = self._browser.new_page()
+        try:
+            page.goto("file://" + html_path)
+            page.wait_for_timeout(300)
+            return page.evaluate(
+                "() => cy.nodes().filter(n => n.isParent()).map(function (c) {"
+                "  var b = c.boundingBox();"
+                "  return { label: c.data('label'), x1: b.x1, x2: b.x2, y1: b.y1, y2: b.y2 }; })"
+            )
+        finally:
+            page.close()
+            os.unlink(html_path)
+
+    def _overlaps(self, boxes):
+        """Return a readable description of each pair of campaign boxes that intersect.
+
+        Args:
+            boxes (list[dict]): campaign boxes from `_campaign_boxes`.
+
+        Returns:
+            list[str]: one entry per overlapping pair, empty when the columns are clear of
+            each other. Touching edges do not count; only a positive area in both axes does.
+        """
+        found = []
+        for i, first in enumerate(boxes):
+            for second in boxes[i + 1:]:
+                across = min(first["x2"], second["x2"]) - max(first["x1"], second["x1"])
+                down = min(first["y2"], second["y2"]) - max(first["y1"], second["y1"])
+                if across > 0 and down > 0:
+                    found.append(
+                        f"{first['label']} and {second['label']} overlap by "
+                        f"{round(across)}x{round(down)} px"
+                    )
+        return found
+
+    def test_campaign_columns__do_not_overlap_at_the_default_map_order(self):
+        """The default map_order still reorders campaigns, and must not stack them on each other.
+
+        Every campaign at map_order 0 falls back to the smallest quest id, and the intro campaign
+        holds the smallest of all, so it is sorted to the leftmost slot. The slot it vacates is the
+        middle one, between the two paths, which is only wide enough for a campaign standing alone
+        above them.
+        """
+        overlaps = self._overlaps(self._campaign_boxes())
+        self.assertEqual(overlaps, [], "campaign columns overlap: " + "; ".join(overlaps))
+
+    def test_campaign_columns__do_not_overlap_when_map_order_reorders_them(self):
+        """Setting a map_order on each campaign must not stack them either, in either direction."""
+        for orders in ((1, 2, 3), (3, 2, 1), (2, 3, 1), (1, 3, 2)):
+            with self.subTest(orders=orders):
+                overlaps = self._overlaps(self._campaign_boxes(*orders))
+                self.assertEqual(overlaps, [], "campaign columns overlap: " + "; ".join(overlaps))
+
+    def test_campaign_columns__map_order_still_swaps_the_two_side_by_side_paths(self):
+        """The two paths still obey map_order between themselves, which is what #1977 asked for.
+
+        Only campaigns that stand beside each other trade places now, so this is the swap that has
+        to keep working: the intro campaign above them is not part of their row.
+        """
+        by_label = {b["label"]: b for b in self._campaign_boxes(order_i=0, order_a=1, order_b=2)}
+        self.assertLess(by_label["Path A"]["x1"], by_label["Path B"]["x1"])
+
+        by_label = {b["label"]: b for b in self._campaign_boxes(order_i=0, order_a=2, order_b=1)}
+        self.assertLess(by_label["Path B"]["x1"], by_label["Path A"]["x1"])

--- a/src/djcytoscape/tests/test_map_order_render.py
+++ b/src/djcytoscape/tests/test_map_order_render.py
@@ -281,8 +281,8 @@ class CampaignColumnOverlapRenderTest(SimpleTestCase):
 
         Args:
             order_i (int): map_order of the intro campaign, which sits above the other two.
-            order_a (int): map_order of the left-hand path.
-            order_b (int): map_order of the right-hand path.
+            order_a (int): map_order of Path A.
+            order_b (int): map_order of Path B.
 
         Returns:
             list[dict]: one ``{'label', 'x1', 'x2', 'y1', 'y2'}`` per campaign.
@@ -330,12 +330,12 @@ class CampaignColumnOverlapRenderTest(SimpleTestCase):
         return found
 
     def test_campaign_columns__do_not_overlap_at_the_default_map_order(self):
-        """The default map_order still reorders campaigns, and must not stack them on each other.
+        """A map nobody has ordered comes out with its columns clear of each other.
 
-        Every campaign at map_order 0 falls back to the smallest quest id, and the intro campaign
-        holds the smallest of all, so it is sorted to the leftmost slot. The slot it vacates is the
-        middle one, between the two paths, which is only wide enough for a campaign standing alone
-        above them.
+        Every campaign at map_order 0 falls back to the smallest quest id, so a default map is
+        reordered too rather than left alone: this is what a deck that has never touched campaign
+        ordering gets. The intro campaign is a row of one, so it keeps the x dagre gave it, and
+        the two paths share a row and may trade places within it.
         """
         overlaps = self._overlaps(self._campaign_boxes())
         self.assertEqual(overlaps, [], "campaign columns overlap: " + "; ".join(overlaps))


### PR DESCRIPTION
### What?

Campaigns only trade places with the campaigns they stand beside, so a map whose intro campaign leads into parallel paths stops drawing those paths on top of each other.

Closes #2627

### Why?

`orderCampaignColumns()` in `maps.js` (added for #1977) permutes campaigns among the x positions dagre gave them, sorted by `(map_order, smallest quest id)`. It treats those positions as interchangeable slots. They are not.

dagre widens a slot for whatever competes with it **at the same ranks**. Two campaigns standing side by side get slots spaced to fit them both; a campaign in a vertical band of its own gets its x for free, with room on either side that nothing else needs. Handing that solitary slot to one of a side-by-side pair puts it closer to its neighbour than a node is wide, and the two are drawn over each other for their whole height.

Measured on a map shaped like the reported one, an intro campaign of four quests feeding two campaigns of eleven. Campaign boxes are 222 px wide:

| | Side Scroller | Top Down | overlap |
| --- | --- | --- | --- |
| with the reorder | x[148, 369] | x[286, 507] | **83 x 550 px** |
| with the reorder removed | x[9, 231] | x[286, 507] | none |

It happens at the **default** `map_order` too. Ties fall back to the smallest quest id, the intro campaign holds the smallest of all, so it sorts into the leftmost slot and displaces a path into the middle slot, which only existed because the intro campaign sat above the others.

**The #1787 duplicate intra-campaign edges are not involved.** Rendering with those removed, with `orderCampaignColumns` removed, and with both removed gives identical geometry; only removing the reorder clears the overlap. So this is not a case for reverting both recent changes.

### How?

Campaigns are grouped into rows whose quests share vertical space, by sweeping their extents, and only campaigns within a row trade places. Every swap then stays inside a set of slots dagre did size to fit those campaigns, and `map_order` keeps working between the campaigns that actually stand beside each other, which is what #1977 asked for.

Grouping reads the **quests'** own extent rather than the campaign box's: the box adds padding that dips into the band below, which would merge two rows of slots into one and reintroduce the bug.

Everything else is unchanged. The set of x positions, each campaign's internal shape, every node's vertical position (the #1787 stacking) and the re-centring of campaign-less connector nodes all behave as before.

### Testing

Full suite green (2898 tests), plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run`.

Three new tests in `djcytoscape/tests/test_map_order_render.py`, which drives the real vendored cytoscape/dagre and the real `maps.js` in headless Chromium. They render an intro campaign feeding two paths and assert no two campaign boxes intersect, at the default `map_order` and at four different orderings, plus one asserting the two paths still swap by `map_order` between themselves.

Measured against the code with only the row grouping removed, so they fail for the reason they name:

```
FAIL: test_campaign_columns__do_not_overlap_at_the_default_map_order
AssertionError: Lists differ: ['Path A and Path B overlap by 84x150 px'] != []
FAIL: test_campaign_columns__do_not_overlap_when_map_order_reorders_them (orders=(1, 2, 3))
AssertionError: Lists differ: ['Path A and Path B overlap by 84x150 px'] != []
```

The five existing `map_order` render tests still pass, and they really run here rather than skipping (`Ran 8 tests ... OK`), so the #1977 behaviour is intact.

### Screenshots (if front end is affected)

Rendered through the real `maps.js` and the vendored cytoscape/dagre, on a map shaped like the reported one.

**Before:** the two paths are drawn over each other, each column's quest names clipped by the other column's boxes, and "2D Top Down Path" rotated and buried between the columns.

![Quest map with the 2D Side Scroller and 2D Top Down columns overlapping, quest names clipped mid-word](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2627/before.png)

**After:** the two paths sit in their own columns, every quest name readable and each campaign name legible down its left edge.

![The same map with the two paths cleanly separated side by side](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2627/after.png)

`maps.js`'s cache-buster in `quest_map.html` goes to `?v=1.2`, so people who have the old file cached get this.

### Anything Else?

**Visible in both screenshots, not fixed here.** A campaign box's padding dips about 34 px into the vertical band below it, so a campaign sitting above another clips the top of it slightly (the "Game Analysis and Design" label crossing the first path node). It is independent of this bug, present with the reorder removed as well, and comes from `rankSep: 15` being smaller than the compound node's padding. Raising `rankSep` would fix it and would also re-space every map vertically, so it wants its own change and its own look. Happy to open an issue if you want it tracked.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign layout to prevent overlap between vertically separated campaigns.
  * Preserved deterministic ordering while supporting valid side-by-side reordering.
  * Kept connector nodes correctly positioned after campaigns move.

* **Tests**
  * Added browser-based coverage for campaign overlap prevention and map-order behavior.

* **Chores**
  * Updated asset versioning so the latest map layout changes load correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->