### PR TITLE
perf: keep the slow half of a deploy out of the downtime window

### DIFF
--- a/docker-compose.prod.aws.yml
+++ b/docker-compose.prod.aws.yml
@@ -37,10 +37,20 @@ services:
   # user, so none of them run as root.
   web:
     <<: *prod-service
+    # migrate_schemas runs here so a cold start reaches a migrated database on
+    # its own: a host reboot brings this stack up straight from systemd, with
+    # no deploy script involved. A deploy has already applied them from
+    # production/server-update.sh, so by the time a deploy reaches this it is a
+    # check that finds nothing to do.
+    #
+    # collectstatic is deliberately NOT here. Only a deploy produces new static
+    # files, and publishing them is hundreds of round trips to S3; every one of
+    # them would land between nginx losing its backend and uwsgi binding :8000,
+    # where a visitor is looking at the maintenance page. server-update.sh does
+    # it against the new image while the previous one is still serving.
     command: bash -c "cd /app/src/ &&
                       python manage.py migrate_schemas --shared &&
                       python manage.py migrate_schemas --executor=multiprocessing &&
-                      python manage.py collectstatic --noinput &&
                       uwsgi --ini uwsgi.aws.ini ${UWSGI_EXTRA_ARGS:-}"
 
   celery:
@@ -106,12 +116,14 @@ services:
       - "443:8088"
       - "80:8080"
     # Start ordering only. nginx must come up straight away, without waiting
-    # for web to pass its healthcheck: web spends minutes running
-    # migrate_schemas over every tenant schema and then collectstatic before
-    # uwsgi binds :8000, and nginx serves the maintenance page for that whole
-    # window. Gating on service_healthy would leave 443 unbound until the
-    # migrations finished, so visitors would get a connection error instead of
-    # the "ByteDeck is updating" page. nginx re-resolves `web` at request time
+    # for web to pass its healthcheck: web runs migrate_schemas over every
+    # tenant schema before uwsgi binds :8000, and on a cold start with
+    # migrations still to apply that takes minutes. nginx serves the
+    # maintenance page for that window. Gating on service_healthy would leave
+    # 443 unbound until the migrations finished, so visitors would get a
+    # connection error instead of the "ByteDeck is updating" page. (A deploy
+    # does not reach that: production/server-update.sh migrates before it
+    # swaps the containers.) nginx re-resolves `web` at request time
     # (see the resolver directive in nginx/bytedeck.conf.template), so it does
     # not need the upstream to exist when it starts.
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,9 @@ services:
       - frontend-network
     # Liveness: something is listening on :8000 (uwsgi in prod, runserver in
     # dev; TCP connect covers both). The long start_period covers the
-    # migrate_schemas (+ collectstatic in prod) run before the server binds --
-    # failures during start_period don't count against the container. Shown as
+    # migrate_schemas run before the server binds, which on a cold start with
+    # migrations to apply walks every tenant schema -- failures during
+    # start_period don't count against the container. Shown as
     # (healthy)/(unhealthy) in `docker compose ps`.
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; socket.create_connection(('127.0.0.1', 8000), timeout=5).close()"]

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -148,10 +148,36 @@ git pull                      # master (prod) or staging (staging host)
 3. Install the certbot-renew override (see [TLS](#tls--certificates)) and the
    `redis-host-setup.service` host tuning (disables THP, sets
    `vm.overcommit_memory=1` — the settings the dockerized Redis warns about).
-4. `systemctl daemon-reload`, enable + run `redis-host-setup`, then enable and
-   **restart** `bytedeck.com.service` (which runs `docker compose ... up -d`).
-5. Tail the compose logs when run interactively; print a recent snapshot and
+4. `systemctl daemon-reload`, then enable + run `redis-host-setup` and enable
+   `bytedeck.com.service`.
+5. Run `migrate_schemas` (shared, then every tenant schema) and `collectstatic`
+   from the **newly built image**, in one-off `docker compose run --rm
+   --no-deps web` containers, while the **previous** containers are still
+   serving. This is the slow part of a deploy, and doing it here is what keeps
+   it out of the window when nginx has no backend. A migration that fails stops
+   the deploy here, with the previous version still up.
+6. `docker compose ... up -d --remove-orphans` to swap the containers. Compose
+   recreates only what changed, so `redis` and `nginx` keep running and only
+   the app services are replaced; the outage a visitor sees is the few seconds
+   between the old `web` stopping and the new one binding `:8000`.
+7. Tail the compose logs when run interactively; print a recent snapshot and
    exit when run non-interactively (e.g. from the deploy runner).
+
+> **Why not `systemctl restart bytedeck.com`?** The unit's `ExecStop` is
+> `docker compose ... down`, which removes *every* container. That takes nginx
+> with it, so for part of the window nothing is listening on 443 and a visitor
+> gets a connection error rather than the maintenance page, and it takes redis
+> with it, which runs with persistence disabled, so any queued Celery task is
+> lost. `up -d` reaches the same end state without either. The script still
+> calls `systemctl start` (a no-op while the unit is active) so systemd keeps
+> owning the stack and still brings it back after a reboot.
+
+**Migrations are applied before the new code runs**, so each one has to be
+readable by the code it replaces for the seconds between step 5 and step 6.
+That is the ordinary expand-then-contract discipline for an online schema
+change: add and backfill in one release, stop reading the old shape in the
+next, drop it in a third. A migration that renames or drops in a single step
+will break the outgoing version during that window.
 
 The app is managed by the **`bytedeck.com.service`** systemd unit
 (`Type=oneshot`, `RemainAfterExit=yes`) so it comes back up automatically on
@@ -313,13 +339,15 @@ request, so it redirects every request forever).
 
 ## Troubleshooting
 
-- **502 right after a restart:** expected while `web` is still starting, and it
-  lasts as long as startup does rather than any fixed time: the `web` container
-  runs `migrate_schemas` over every tenant schema and then `collectstatic`
-  before uwsgi binds :8000 (the more tenants, the longer it takes; the
-  container healthcheck allows up to 10 minutes), and nginx has nothing to talk
-  to until it does. The 502s clear once `spawned uWSGI master process` appears
-  in the web logs:
+- **Maintenance page right after a restart:** expected while `web` is still
+  starting, and it lasts as long as startup does rather than any fixed time:
+  the `web` container runs `migrate_schemas` over every tenant schema before
+  uwsgi binds :8000, and nginx has nothing to talk to until it does. After a
+  deploy that is a check that finds nothing to do (`server-update.sh` migrated
+  before it swapped the containers) and clears in seconds; after a **cold
+  start** with migrations still to apply it is as long as those take, and the
+  more tenants the longer (the container healthcheck allows up to 10 minutes).
+  It clears once `spawned uWSGI master process` appears in the web logs:
   ```bash
   cd ~/bytedeck
   C="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -56,7 +56,7 @@ Services started in production:
 
 | Service       | What it does                                                                 |
 | ------------- | --------------------------------------------------------------------------- |
-| `web`         | Django served by **uwsgi** (`uwsgi --ini uwsgi.aws.ini`), listening on `:8000`. On start it runs `migrate_schemas --shared`, `migrate_schemas --executor=multiprocessing`, and `collectstatic`. The port is **not** published to the host: nginx reaches it over the internal `frontend-network`, so TLS and the host check can't be bypassed. |
+| `web`         | Django served by **uwsgi** (`uwsgi --ini uwsgi.aws.ini`), listening on `:8000`. On start it runs `migrate_schemas --shared` and `migrate_schemas --executor=multiprocessing`, so a cold start reaches a migrated database on its own; `collectstatic` is a deploy step (`server-update.sh`), not a startup one. The port is **not** published to the host: nginx reaches it over the internal `frontend-network`, so TLS and the host check can't be bypassed. |
 | `celery`      | Celery worker (`-c 3 -Q default`) for background tasks.                      |
 | `celery-beat` | Celery beat scheduler (`DatabaseScheduler`) for periodic tasks.             |
 | `nginx`       | Reverse proxy / TLS terminator, built from `./nginx`. Mounts `/etc/letsencrypt`. Publishes host `443 -> 8088` and `80 -> 8080` (the container listens on high ports because it runs as a non-root user). |
@@ -87,7 +87,8 @@ visible, not quietly loop-restart. **Healthchecks** are shared (defined in
 `docker-compose.yml`, so development gets them too):
 
 - `web`: TCP connect to the uwsgi socket (`:8000`), with a long `start_period`
-  to cover the `migrate_schemas`/`collectstatic` startup run.
+  to cover the `migrate_schemas` startup run, which on a cold start with
+  migrations to apply walks every tenant schema.
 - `celery`: `celery inspect ping` against the worker over the broker — catches
   hung/disconnected workers, not just dead processes.
 - `celery-beat`: process check (`pgrep`) — beat has no ping command, and a dead
@@ -157,9 +158,17 @@ git pull                      # master (prod) or staging (staging host)
    it out of the window when nginx has no backend. A migration that fails stops
    the deploy here, with the previous version still up.
 6. `docker compose ... up -d --remove-orphans` to swap the containers. Compose
-   recreates only what changed, so `redis` and `nginx` keep running and only
-   the app services are replaced; the outage a visitor sees is the few seconds
-   between the old `web` stopping and the new one binding `:8000`.
+   recreates only the services whose image or configuration changed, which on
+   a typical deploy is the three app services; `redis` is untouched, so queued
+   Celery tasks survive. What a visitor sees is the few seconds between the
+   old `web` stopping and the new one binding `:8000`.
+
+   `nginx` usually keeps running too, but not always: step 1 builds it with
+   `--pull`, so when the upstream `nginx:stable` tag has moved its image
+   changes and Compose recreates it as well, unbinding 443 for about a
+   second. That is a connection error rather than the maintenance page, so a
+   deploy is not strictly seamless. It is bounded and rare (only when the
+   base image moved), against the `down` always doing it on every deploy.
 7. Tail the compose logs when run interactively; print a recent snapshot and
    exit when run non-interactively (e.g. from the deploy runner).
 

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
-# Build the images and (re)start the app via its systemd unit.
+# Build the images, migrate, and swap the running containers for the new ones.
 #
 # Run from anywhere, either manually on the host or automatically by the Deploy
 # workflow (.github/workflows/deploy.yml) on a self-hosted runner.
+#
+# Ordered so the slow work happens while the previous version is still serving:
+# build, then migrate and collect static from the new image, and only then
+# replace the containers. What a visitor can see is the last step.
 set -e
 
 # Always operate from the repo root, regardless of the caller's CWD.
@@ -55,11 +59,50 @@ sudo cp production/systemd/redis-host-setup.service /etc/systemd/system/redis-ho
 # Load the new systemd modules
 sudo systemctl daemon-reload
 
-# Ensure the services are enabled, apply the Redis host tuning, then restart the app
+# Ensure the services are enabled and apply the Redis host tuning
 sudo systemctl enable redis-host-setup.service
 sudo systemctl restart redis-host-setup.service
 sudo systemctl enable bytedeck.com.service
-sudo systemctl restart bytedeck.com
+
+# Migrate and publish static files from the NEW image while the OLD containers
+# are still serving. Both steps are slow -- migrate_schemas walks every tenant
+# schema, and collectstatic uploads to S3 over the network -- and doing them
+# here rather than inside the replacement web container is what keeps them out
+# of the window when nginx has no backend to talk to.
+#
+# `run --rm --no-deps` starts a one-off container from the image built above,
+# on the same networks, and leaves every running service alone: --no-deps so it
+# cannot recreate redis underneath the containers currently using it, --rm so
+# these do not pile up as exited containers. The database is RDS, reached over
+# the network, so a one-off container talks to exactly the database the running
+# app is using.
+#
+# A migration that fails now stops the deploy with the previous version still
+# serving, instead of replacing it and leaving nginx on the maintenance page.
+# The trade is that each migration has to be readable by the code it replaces
+# for the seconds between here and the switch below, which is the ordinary
+# expand-then-contract discipline for an online schema change: add and backfill
+# in one release, stop reading the old shape in the next, drop it in a third.
+$COMPOSE run --rm --no-deps web python src/manage.py migrate_schemas --shared
+$COMPOSE run --rm --no-deps web python src/manage.py migrate_schemas --executor=multiprocessing
+$COMPOSE run --rm --no-deps web python src/manage.py collectstatic --noinput
+
+# Swap the containers. `up -d` recreates only the services whose image or
+# configuration changed, so redis and nginx keep running and what a visitor
+# sees is the few seconds between the old web stopping and the new one binding
+# :8000, covered by nginx's maintenance page.
+#
+# Restarting the systemd unit instead would run its ExecStop, `docker compose
+# down`, which removes every container: nginx included, so for part of the
+# window nothing is listening on 443 at all and a visitor gets a connection
+# error rather than the "ByteDeck is updating" page; and redis included, which
+# runs with persistence disabled, so any Celery task still queued is lost.
+#
+# `systemctl start` is a no-op while the unit is active (it is, on every deploy
+# after the first) and runs this same `up -d` when it is not, so systemd still
+# owns the stack and still brings it back after a host reboot.
+sudo systemctl start bytedeck.com
+$COMPOSE up -d --remove-orphans
 
 # Show logs. Follow them when run interactively; in an automated deploy (no TTY,
 # e.g. the CI runner) print a recent snapshot and exit so the job can finish.

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -88,9 +88,18 @@ $COMPOSE run --rm --no-deps web python src/manage.py migrate_schemas --executor=
 $COMPOSE run --rm --no-deps web python src/manage.py collectstatic --noinput
 
 # Swap the containers. `up -d` recreates only the services whose image or
-# configuration changed, so redis and nginx keep running and what a visitor
-# sees is the few seconds between the old web stopping and the new one binding
+# configuration changed, which on a typical deploy is the three app services.
+# redis is untouched, so queued Celery tasks survive, and what a visitor sees
+# is the few seconds between the old web stopping and the new one binding
 # :8000, covered by nginx's maintenance page.
+#
+# nginx usually keeps running through that, but not always: the build above
+# passes --pull, so when the upstream nginx:stable tag has moved, nginx's image
+# changes too and it is recreated with the rest, unbinding 443 for about a
+# second. That second is a connection error rather than the maintenance page,
+# so this is not a seamless deploy; it is bounded, and it only happens when the
+# base image actually moved, where the unit restart described next unbinds 443
+# on every deploy.
 #
 # Restarting the systemd unit instead would run its ExecStop, `docker compose
 # down`, which removes every container: nginx included, so for part of the

--- a/production/tests/check_prod_compose.py
+++ b/production/tests/check_prod_compose.py
@@ -35,6 +35,21 @@ def runs_as_root(user):
     return str(user).split(":", 1)[0].strip().lower() in ("0", "root")
 
 
+def command_text(command):
+    """Return a rendered Compose `command` as one searchable string.
+
+    Compose accepts a command as a string or as an argv list, and renders it as
+    whichever the file used, so a caller looking for a word in it has to handle
+    both: joining a string would put a space between every character. None (no
+    command, the image's own CMD applies) reads as the empty string.
+    """
+    if command is None:
+        return ""
+    if isinstance(command, list):
+        return " ".join(str(part) for part in command)
+    return str(command)
+
+
 def log_size_is_bounded(size):
     """Return whether a json-file `max-size` option actually bounds the log.
 
@@ -110,6 +125,21 @@ def main():
     # Production runs the built image, not the host checkout.
     for name in APP_SERVICES:
         check(not services[name].get("volumes"), f"{name} mounts no source volume")
+
+    # What `web` does before uwsgi binds :8000 is what a visitor waits through
+    # on the maintenance page, so the split between start-up work and deploy
+    # work is a deployment invariant and not a style choice.
+    #   - migrate_schemas belongs here: a host reboot starts this stack from
+    #     systemd with no deploy script involved, and it has to reach a
+    #     migrated database on its own.
+    #   - collectstatic does not: only a deploy produces new static files, and
+    #     publishing them is hundreds of round trips to S3.
+    # production/server-update.sh runs both against the new image while the
+    # previous one is still serving, so on a deploy the migrate here finds
+    # nothing to do.
+    web_command = command_text(services["web"].get("command"))
+    check("migrate_schemas" in web_command, "web migrates on start (a cold start has no deploy script)")
+    check("collectstatic" not in web_command, "web does not collectstatic on start (a deploy step)")
 
     # Nothing may be pinned to root here. The rendered config cannot see the
     # image's own USER, so this only catches an explicit root override; that the


### PR DESCRIPTION
### What?

A deploy to `master` (or `staging`) no longer takes the site down for the length of its slowest step. Migrations and `collectstatic` now run from the newly built image **while the previous containers are still serving**, and the containers are swapped with `docker compose up -d` instead of a systemd unit restart.

What a visitor sees becomes the few seconds between the old `web` stopping and the new one binding `:8000`.

### Why?

`production/server-update.sh` ended with `systemctl restart bytedeck.com`. That unit is `Type=oneshot` with `ExecStop=docker compose ... down`, so a restart **removed every container** and started them again from nothing. On the way back up, `docker-compose.prod.aws.yml` had `web` run:

```
migrate_schemas --shared → migrate_schemas (every tenant schema) → collectstatic → uwsgi binds :8000
```

nginx had no backend for that entire window. The container healthcheck budgets **ten minutes** for it, and SERVER-README's own troubleshooting section said the wait scales with tenant count. `collectstatic` in production writes to S3 through `StaticStorage`, so it is hundreds of network round trips, all of them inside the outage.

Two things made that worse than it needed to be, both from the `down`:

* **nginx was removed too.** The compose file explains that nginx must start immediately so it can serve the "ByteDeck is updating" page while `web` is busy, but `down` took nginx away first, so for part of the window nothing was listening on 443 at all and a visitor got a connection error rather than the maintenance page.
* **redis was removed too**, and it runs with `--save "" --appendonly no`. Every deploy silently dropped whatever Celery tasks were queued.

This matters more the more often you deploy, which is the point of the continuous-delivery discussion this came out of: at three releases a week it is invisible, at several a day during class time it is not.

### How?

**Move the slow work ahead of the swap** (`production/server-update.sh`). Migrations and `collectstatic` run in one-off `docker compose run --rm --no-deps web` containers, from the image built moments earlier, on the same networks:

* `--no-deps` so the one-off cannot recreate `redis` underneath the containers currently using it.
* `--rm` so they do not accumulate as exited containers.
* The database is RDS, reached over the network, so a one-off container talks to exactly the database the running app is using. (There is no `db` service in production; it is dev-only.)

A **failed migration now stops the deploy with the previous version still serving**, rather than replacing it and leaving nginx on the maintenance page.

**Split start-up work from deploy work** (`docker-compose.prod.aws.yml`):

* `collectstatic` **leaves** the container command. Only a deploy produces new static files, and a cold start has nothing to publish.
* `migrate_schemas` **stays**. A host reboot brings the stack up straight from systemd with no deploy script involved, so it has to reach a migrated database on its own. After a deploy it is a check that finds nothing to do.

**Swap with `up -d --remove-orphans`** instead of restarting the unit. Compose recreates only the services whose image or configuration changed, which on a typical deploy is the three app services. `--remove-orphans` keeps the cleanup the `down` used to provide. `systemctl start` still runs first: it is a no-op while the unit is active, runs this same `up -d` when it is not, and keeps systemd owning the stack so a host reboot still brings it back.

**This is not a seamless deploy, and the comments say so.** `redis` is genuinely untouched, which is what makes queued Celery tasks survive. `nginx` usually is, but not always: the build step passes `--pull`, so whenever the upstream `nginx:stable` tag has moved, nginx's image changes too and Compose recreates it with the rest, unbinding 443 for about a second. That second is a connection error rather than the maintenance page. It is bounded, and only happens when the base image actually moved, against a unit restart unbinding 443 on every single deploy. Holding 443 across the swap means a blue/green cutover at the nginx layer, which is issue #2634.

**The other trade, stated plainly.** A migration is now applied *before* the code that needs it, so it has to be readable by the outgoing code for the seconds between the two steps. That is the ordinary expand-then-contract discipline for an online schema change: add and backfill in one release, stop reading the old shape in the next, drop it in a third. A migration that renames or drops a column in a single step will break the outgoing version during that window. This is now written down in SERVER-README.md; enforcing it is issue #2632.

### Testing?

**All 9 checks green, including `Production topology`**, which boots the real production overlay. That job is the meaningful one here and I could not run it locally: it needs `python:3.12-slim` and `nginx:stable` from Docker Hub, and this sandbox's IP was 429 rate-limited across four attempts with backoff. CI ran it and it passed.

**`production/tests/check_prod_compose.py` gains the two invariants this change rests on**, since the split between start-up work and deploy work is now a deployment property and not a style choice:

* `web migrates on start (a cold start has no deploy script)`
* `web does not collectstatic on start (a deploy step)`

**Both were proved discriminating**, not just green: re-adding `collectstatic` to the start command fails the second and leaves the first passing; deleting `migrate_schemas` fails the first and leaves the second passing; the restored file passes both with `0 failure(s)`.

Also run locally:

* `check_prod_compose.py` on the full tree: **0 failure(s)**, all 30 assertions.
* `command_text()` exercised over all three shapes Compose can render a command as (`None`, string, argv list) - the real file renders a list, so the other two branches are otherwise unexercised.
* `sh -n production/server-update.sh` (the file is `#!/bin/sh`, so the additions are POSIX, not bash).
* `docker compose ... config -q`: valid, and the rendered `web` command is now exactly `cd /app/src/ && python manage.py migrate_schemas --shared && python manage.py migrate_schemas --executor=multiprocessing && uwsgi --ini uwsgi.aws.ini`.
* `--remove-orphans`, `--no-deps` and `--rm` confirmed present in the installed Compose (5.1.1).
* `manage.py check` (no issues), `makemigrations --check --dry-run` (no changes), `ruff check src` (clean).

The full Django suite is not implicated: this changes no code under `src/`.

### Review round

CodeRabbit raised three. Two were real and are fixed in `04fbe41a`:

* **Stale startup documentation.** SERVER-README's services table and healthcheck bullet still said `web` runs `collectstatic` on start. I had updated the runbook and troubleshooting sections and stopped there.
* **The nginx claim was overstated.** Both the script comment and runbook step 6 said "redis and nginx keep running" flatly, when nginx is only unaffected while its image is unchanged. Now qualified in both places, as described under How.

One declined: replacing "Gating on `service_healthy`" with "prerequisite". CLAUDE.md's terminology rule is about the app's own domain language and carves this out in its own last line ("'Gate' is still fine for unrelated concepts"). That line is about a Compose `depends_on` condition, not a quest's or badge's prerequisite, and the substitution would read as if `service_healthy` were one.

### Screenshots (if front end is affected)

N/A: nothing a user sees renders differently. The change is to deploy sequencing, and the only user-visible effect is how long the existing nginx maintenance page is up for, which is not something a screenshot can show.

### Anything Else?

Three follow-ups, all filed rather than folded in here, so this PR stays one reviewable change:

* Issue #2632: adopt and enforce expand-then-contract migrations, which this PR's ordering now depends on.
* Issue #2633: assert the site actually came back after a deploy. `server-update.sh` currently ends by printing 100 log lines and never checks that anything is serving, so a deploy that leaves the site on the maintenance page still reports success.
* Issue #2634: uwsgi graceful reload / blue-green cutover, which would take the remaining seconds (and the nginx-recreate second above) to zero.

One correction to something I said in chat while investigating: I described the `down` as stopping Postgres. It does not. Production's database is RDS and there is no `db` service in the production overlay, so what `down` removed was nginx, redis and the three app services. The redis point above is the one that actually cost something.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)