### PR TITLE
feat: fail a deploy that leaves the site down (#2633)

### DIFF
--- a/.github/workflows/production_config.yml
+++ b/.github/workflows/production_config.yml
@@ -18,6 +18,7 @@ on:
       - 'docker-compose*.yml'
       - 'nginx/**'
       - 'production/tests/**'
+      - 'production/wait-for-healthy.sh'
       - '.env.example*'
       - '.github/workflows/production_config.yml'
   push:
@@ -27,6 +28,7 @@ on:
       - 'docker-compose*.yml'
       - 'nginx/**'
       - 'production/tests/**'
+      - 'production/wait-for-healthy.sh'
       - '.env.example*'
       - '.github/workflows/production_config.yml'
 
@@ -56,6 +58,18 @@ jobs:
         run: pip install pyyaml
       - name: Assert the production compose contract
         run: python production/tests/check_prod_compose.py
+
+  deploy-health-gate:
+    name: Deploy health gate
+    runs-on: ubuntu-22.04
+    # Deliberately no `needs`: this stubs `docker` rather than using it, so it
+    # depends on nothing the other jobs establish and finishes in seconds.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Assert the deploy fails when the app does not come back
+        run: bash production/tests/check_deploy_health_gate.sh
 
   image:
     name: Application image

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -104,11 +104,14 @@ application image and asserts it runs as the unprivileged `app` user with no
 compiler left in it. Both scripts are runnable by hand from the repo root:
 
 ```bash
-python production/tests/check_prod_compose.py   # renders the prod config, asserts its invariants
-bash production/tests/check_prod_topology.sh    # boots the stack, asserts who can reach whom
+python production/tests/check_prod_compose.py        # renders the prod config, asserts its invariants
+bash production/tests/check_prod_topology.sh         # boots the stack, asserts who can reach whom
+bash production/tests/check_deploy_health_gate.sh    # asserts the deploy goes red when the app stays down
 ```
 
-The first needs no Docker daemon and takes seconds. The second boots the real
+The first and the third need no Docker daemon and take seconds (the third
+replaces `docker` on PATH with a stub, so it can drive container states a real
+deploy only reaches by accident). The second boots the real
 production overlay against throwaway certificates, substituting a trivial server
 for the application image, so it tests the topology rather than the app. Between
 them they assert that nothing but nginx is published to the host, that the app
@@ -169,7 +172,14 @@ git pull                      # master (prod) or staging (staging host)
    second. That is a connection error rather than the maintenance page, so a
    deploy is not strictly seamless. It is bounded and rare (only when the
    base image moved), against the `down` always doing it on every deploy.
-7. Tail the compose logs when run interactively; print a recent snapshot and
+7. `./production/wait-for-healthy.sh web` to confirm the app actually came
+   back, failing the deploy if it did not. Step 6 returns once the containers
+   are *created*, which is a much weaker claim than "the deploy worked": a bad
+   setting, a missing env var, or an import error in the deployed commit leaves
+   uwsgi refusing to bind (`need-app = true`) and nginx serving the maintenance
+   page. Without this the script would print its logs and exit 0, so the
+   **Deploy** job would go green over a site that is down.
+8. Tail the compose logs when run interactively; print a recent snapshot and
    exit when run non-interactively (e.g. from the deploy runner).
 
 > **Why not `systemctl restart bytedeck.com`?** The unit's `ExecStop` is

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -12,7 +12,10 @@ set -e
 # Always operate from the repo root, regardless of the caller's CWD.
 cd "$(dirname "$0")/.."
 
+# Exported so wait-for-healthy.sh below acts on the same stack rather than
+# falling back to its own default.
 COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"
+export COMPOSE
 
 # Reclaim disk before building so image layers and BuildKit cache left by earlier
 # deploys can't fill the host and fail the build mid-`pip install` ([Errno 28] No
@@ -112,6 +115,25 @@ $COMPOSE run --rm --no-deps web python src/manage.py collectstatic --noinput
 # owns the stack and still brings it back after a host reboot.
 sudo systemctl start bytedeck.com
 $COMPOSE up -d --remove-orphans
+
+# Assert the app actually came back, and fail the deploy if it did not. `up -d`
+# above returns once the containers are *created*, which is a much weaker claim
+# than "the deploy worked": a bad setting, a missing env var or an import error
+# in the deployed commit leaves uwsgi refusing to bind (`need-app = true`) and
+# nginx serving the maintenance page, and without this the script would go on
+# to print its logs and exit 0, so the Deploy job would go green over a site
+# that is down.
+#
+# Failing here does not roll anything back. It makes the failure loud, and
+# wait-for-healthy.sh puts the web log in the job output so the red run is
+# worth opening. Rolling back is issue #2346: a rollback means rebuilding from
+# an older commit, which is not something to do automatically.
+#
+# Invoked via the interpreter, not ./, for the reason deploy.yml gives for
+# invoking this script the same way: a lost exec bit in git would otherwise
+# fail the deploy with "Permission denied" for a reason that has nothing to do
+# with the deploy.
+sh production/wait-for-healthy.sh web
 
 # Show logs. Follow them when run interactively; in an automated deploy (no TTY,
 # e.g. the CI runner) print a recent snapshot and exit so the job can finish.

--- a/production/tests/check_deploy_health_gate.sh
+++ b/production/tests/check_deploy_health_gate.sh
@@ -27,7 +27,17 @@ cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
 for arg in "$@"; do
     case $arg in
-        ps)      echo "${CONTAINER_ID-}"; exit 0 ;;
+        ps)
+            # Real `docker compose ps` lists only RUNNING containers unless --all is
+            # passed, so this has to as well. A stub that always answers cannot tell
+            # whether the caller remembered the flag, and the fail-fast path for an
+            # exited container is exactly the one that needs it.
+            stub_state=$(head -n 1 "$STATE_SEQUENCE" | cut -d' ' -f1)
+            case " $* " in
+                *" --all "*|*" -a "*)                  echo "${CONTAINER_ID-}" ;;
+                *) [ "$stub_state" = "running" ] &&    echo "${CONTAINER_ID-}" ;;
+            esac
+            exit 0 ;;
         logs)    echo "(stub log line)"; exit 0 ;;
         inspect) 
             line=$(head -n 1 "$STATE_SEQUENCE")

--- a/production/tests/check_deploy_health_gate.sh
+++ b/production/tests/check_deploy_health_gate.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Assert production/wait-for-healthy.sh passes and fails when it should.
+#
+# The deploy gate is only worth having if it goes red on a broken deploy and
+# green on a working one, and both of those are states a live container reaches
+# by accident at best. So `docker` is replaced on PATH with a stub that reports
+# a scripted sequence of container states, which drives every branch of the
+# wait loop directly: healthy, slow-then-healthy, unhealthy, exited, a missing
+# container, and never becoming healthy at all.
+#
+# No Docker daemon and no images are needed, so this runs anywhere the rest of
+# the checks do.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+STUB_DIR="$WORKDIR/bin"
+mkdir -p "$STUB_DIR"
+
+# The stub answers the two calls the gate makes. `compose ... ps -q` returns
+# whatever CONTAINER_ID holds (empty stands in for "no such container"), and
+# `inspect` pops the next line of STATE_SEQUENCE, repeating the last line once
+# the sequence runs out so a poll loop can keep asking.
+cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+    case $arg in
+        ps)      echo "${CONTAINER_ID-}"; exit 0 ;;
+        logs)    echo "(stub log line)"; exit 0 ;;
+        inspect) 
+            line=$(head -n 1 "$STATE_SEQUENCE")
+            if [ "$(wc -l < "$STATE_SEQUENCE")" -gt 1 ]; then
+                tail -n +2 "$STATE_SEQUENCE" > "$STATE_SEQUENCE.next"
+                mv "$STATE_SEQUENCE.next" "$STATE_SEQUENCE"
+            fi
+            echo "$line"
+            exit 0 ;;
+    esac
+done
+exit 0
+STUB
+chmod +x "$STUB_DIR/docker"
+
+export PATH="$STUB_DIR:$PATH"
+export HEALTH_POLL_INTERVAL=1
+
+failures=0
+
+# check <expected-exit: pass|fail> <description> <container-id> <state lines...>
+check() {
+    local expectation=$1 description=$2 container=$3
+    shift 3
+    export STATE_SEQUENCE="$WORKDIR/states"
+    printf '%s\n' "$@" > "$STATE_SEQUENCE"
+    export CONTAINER_ID="$container"
+
+    local started elapsed status
+    started=$(date +%s)
+    if output=$(./production/wait-for-healthy.sh web 3 2>&1); then status=pass; else status=fail; fi
+    elapsed=$(( $(date +%s) - started ))
+
+    if [ "$status" = "$expectation" ]; then
+        echo "  PASS  $description (exit $status in ${elapsed}s)"
+    else
+        echo "  FAIL  $description (expected $expectation, got $status)"
+        echo "        output: $output"
+        failures=$((failures + 1))
+    fi
+    LAST_ELAPSED=$elapsed
+    LAST_OUTPUT=$output
+}
+
+echo "Driving the deploy health gate through its states..."
+
+check pass "a container already healthy is accepted" abc123 "running healthy"
+
+check pass "a container that starts slowly is waited for" abc123 \
+    "running starting" "running starting" "running healthy"
+if [ "$LAST_ELAPSED" -lt 1 ]; then
+    echo "  FAIL  the slow-start case did not actually wait (${LAST_ELAPSED}s)"
+    failures=$((failures + 1))
+else
+    echo "  PASS  the slow-start case actually waited (${LAST_ELAPSED}s)"
+fi
+
+check fail "an unhealthy container fails the deploy" abc123 "running unhealthy"
+# The point of failing fast: an unhealthy verdict already survived the
+# healthcheck's retries, so burning the remaining timeout tells nobody anything.
+if [ "$LAST_ELAPSED" -lt 3 ]; then
+    echo "  PASS  unhealthy fails fast rather than waiting out the timeout (${LAST_ELAPSED}s)"
+else
+    echo "  FAIL  unhealthy burned the whole timeout (${LAST_ELAPSED}s)"
+    failures=$((failures + 1))
+fi
+
+check fail "an exited container fails the deploy" abc123 "exited none"
+if [ "$LAST_ELAPSED" -lt 3 ]; then
+    echo "  PASS  exited fails fast rather than waiting out the timeout (${LAST_ELAPSED}s)"
+else
+    echo "  FAIL  exited burned the whole timeout (${LAST_ELAPSED}s)"
+    failures=$((failures + 1))
+fi
+
+check fail "a container that never becomes healthy fails the deploy" abc123 "running starting"
+check fail "no container at all fails the deploy" "" "running healthy"
+
+# A red deploy is only actionable if the job carries the reason and the log.
+case "$LAST_OUTPUT" in
+    *"FAIL:"*) echo "  PASS  failure output says why" ;;
+    *) echo "  FAIL  failure output does not say why"; failures=$((failures + 1)) ;;
+esac
+case "$LAST_OUTPUT" in
+    *"stub log line"*) echo "  PASS  failure output carries the service log" ;;
+    *) echo "  FAIL  failure output carries no service log"; failures=$((failures + 1)) ;;
+esac
+
+# A container with no healthcheck declared: running is all there is to go on.
+check pass "a running container with no healthcheck is accepted" abc123 "running none"
+
+echo
+echo "$failures failure(s)"
+exit $(( failures > 0 ? 1 : 0 ))

--- a/production/wait-for-healthy.sh
+++ b/production/wait-for-healthy.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Wait for a compose service to report healthy, and fail if it never does.
+#
+# Usage: production/wait-for-healthy.sh <service> [timeout_seconds]
+#
+# Called by server-update.sh after the containers are swapped, so a deploy that
+# leaves the site on the maintenance page exits non-zero instead of reporting
+# success. `docker compose up -d` returns once the containers are *created*,
+# which says nothing about whether uwsgi ever bound :8000.
+#
+# Also useful by hand on the host to answer "is the app actually up?":
+#
+#   ./production/wait-for-healthy.sh web 60
+#
+# The signal is the service's own healthcheck from docker-compose.yml, rather
+# than a probe repeated here, so there is one definition of what healthy means.
+# For `web` that healthcheck is a TCP connect to :8000, which is exactly the
+# thing that silently fails: uwsgi runs with `need-app = true`, so it refuses to
+# bind at all when the Django app cannot be imported.
+#
+# Waiting costs deploy wall-clock, not user-visible downtime: the site is
+# serving from the moment uwsgi binds, and this only delays the job reporting
+# done. Docker evaluates a healthcheck on its `interval` (30s for web), so even
+# a container that came up instantly can take that long to be *reported*
+# healthy.
+set -e
+
+service=${1:?usage: wait-for-healthy.sh <service> [timeout_seconds]}
+timeout=${2:-600}
+
+# How often to ask. Overridable so the tests can drive the loop quickly.
+interval=${HEALTH_POLL_INTERVAL:-5}
+
+# Always operate from the repo root, regardless of the caller's CWD.
+cd "$(dirname "$0")/.."
+
+# Inherited from server-update.sh when called from a deploy; the default is the
+# same production file pair, so this also runs standalone on the host.
+COMPOSE=${COMPOSE:-"docker compose -f docker-compose.yml -f docker-compose.prod.aws.yml"}
+
+# Report why the wait failed, then show what the service said about itself. A
+# deploy that goes red is only useful if the log that explains it is in the job.
+give_up() {
+    echo "FAIL: $service $1 after ${waited}s" >&2
+    echo "--- last 50 log lines from $service ---" >&2
+    $COMPOSE logs --tail=50 --no-color "$service" >&2 2>/dev/null || true
+    exit 1
+}
+
+waited=0
+while :; do
+    # One inspect for both facts, so a poll is a single round trip. `none` for
+    # health covers a service with no healthcheck declared, where the container
+    # running is the strongest signal available.
+    container=$($COMPOSE ps -q "$service" 2>/dev/null | head -n 1)
+    if [ -n "$container" ]; then
+        report=$(docker inspect \
+            -f '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+            "$container" 2>/dev/null || echo "unknown unknown")
+        state=${report% *}
+        health=${report#* }
+
+        case "$state $health" in
+            *" healthy")
+                echo "OK: $service is healthy after ${waited}s"
+                exit 0
+                ;;
+            "running none")
+                echo "OK: $service is running after ${waited}s (no healthcheck declared)"
+                exit 0
+                ;;
+            *" unhealthy")
+                # Docker reports `starting`, not `unhealthy`, for the whole
+                # start_period, so reaching unhealthy means the check has
+                # really failed its retries. Nothing is gained by waiting out
+                # the rest of the timeout.
+                give_up "is unhealthy"
+                ;;
+            "exited "*|"dead "*)
+                # `restart: unless-stopped` means a crash normally shows up as
+                # `restarting`, which is worth waiting on. A container that has
+                # settled into exited or dead is not coming back by itself.
+                give_up "has $state"
+                ;;
+        esac
+    fi
+
+    if [ "$waited" -ge "$timeout" ]; then
+        give_up "never became healthy"
+    fi
+    sleep "$interval"
+    waited=$((waited + interval))
+done

--- a/production/wait-for-healthy.sh
+++ b/production/wait-for-healthy.sh
@@ -52,7 +52,12 @@ while :; do
     # One inspect for both facts, so a poll is a single round trip. `none` for
     # health covers a service with no healthcheck declared, where the container
     # running is the strongest signal available.
-    container=$($COMPOSE ps -q "$service" 2>/dev/null | head -n 1)
+    # --all because `docker compose ps` lists only running containers by default,
+    # and a container that has exited is precisely the case worth catching early:
+    # without it the lookup comes back empty and the fail-fast below never sees
+    # the exited state, so a dead container costs the whole timeout instead of
+    # one poll.
+    container=$($COMPOSE ps --all -q "$service" 2>/dev/null | head -n 1)
     if [ -n "$container" ]; then
         report=$(docker inspect \
             -f '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \


### PR DESCRIPTION
### What?

A deploy that leaves the site on the maintenance page now exits non-zero and turns the **Deploy** job red, instead of reporting success.

Closes #2633

### Why?

`production/server-update.sh` ended by printing logs and exiting. Nothing asserted that anything was serving, and `docker compose up -d` returns as soon as the containers are **created**, so the script's exit status claimed "the containers were created" while reading as "the deploy worked".

uwsgi runs with `need-app = true`, so a bad setting, a missing env var, or an import error in the deployed commit means it never binds `:8000` at all. nginx then serves the maintenance page indefinitely, the Deploy job goes **green**, and whoever merged gets no signal. The reason was in the 100 log lines the script printed, which is exactly where nobody looks on a green job.

### How?

The swap is followed by `sh production/wait-for-healthy.sh web`.

**The signal is the service's own healthcheck** from `docker-compose.yml`, polled rather than re-implemented, so there is one definition of what healthy means. For `web` that is a TCP connect to `:8000`, which is precisely the thing that silently fails.

**It fails fast where waiting cannot help.** A container reporting `unhealthy` has already exhausted the healthcheck's retries (Docker reports `starting` for the whole `start_period`), and one that has settled into `exited` or `dead` is not coming back on its own. `restarting` **is** still waited on, since `restart: unless-stopped` makes that the normal shape of a crash that may yet recover. The lookup passes `--all`, because `docker compose ps` lists only running containers by default and an exited container is exactly the case the fail-fast path exists for.

**A red run carries what you need.** On failure it prints the reason and the last 50 log lines from the service, so the job is worth opening.

**Waiting costs deploy wall-clock, not user-visible downtime.** The site serves from the moment uwsgi binds; this only delays the job reporting done. Docker evaluates a healthcheck on its `interval` (30s for `web`), so a container that came up instantly can still take that long to be *reported* healthy. That is the price of reusing the declared healthcheck instead of duplicating the probe, and it is paid by the runner rather than by a student.

**Failing does not roll back.** It makes the failure loud. A rollback here means rebuilding from an older commit, which is issue #2346 and not something to do automatically.

Two smaller decisions:

* **A separate script, not inline.** It can then be tested, and the maintainer can run it by hand on the host to ask whether the app is up (`./production/wait-for-healthy.sh web 60`). `COMPOSE` is exported from `server-update.sh` so the helper acts on the same stack, with the same production file pair as its standalone default.
* **Invoked as `sh production/wait-for-healthy.sh`, not `./`.** Same reason `deploy.yml` gives for invoking `server-update.sh` that way: a lost exec bit in git would otherwise fail the deploy with "Permission denied" for a reason that has nothing to do with the deploy.

### Testing?

The gate is only worth having if it goes red on a broken deploy and green on a working one, and both are states a live container reaches by accident at best. So `production/tests/check_deploy_health_gate.sh` **replaces `docker` on PATH with a stub** that reports a scripted sequence of container states, which drives every branch of the wait loop directly. No Docker daemon and no images, so it runs anywhere the other checks do (and in its own CI job with no `needs`, finishing in seconds).

Twelve assertions, all passing, covering: already healthy, slow-then-healthy (and that it *actually waited*), unhealthy, exited, no container at all, never healthy, a service with no healthcheck declared, plus that the failure output says why and carries the service log.

**Every one was confirmed discriminating by mutation**, not just observed green:

| Mutation | Result |
| --- | --- |
| Make the gate always `exit 0` (the exact bug in #2633) | **7 assertions fail** |
| Drop the `unhealthy` fail-fast branch | exactly the fail-fast assertion fails (burns the full timeout) |
| Drop the log dump from the failure output | exactly the log assertion fails |
| Drop `--all` from the container lookup | exactly the `exited` fail-fast assertion fails |
| Restored | `0 failure(s)` |

Also run: `sh -n` on both shell scripts and `bash -n` on the test, `check_prod_compose.py` still `0 failure(s)`, and the workflow YAML re-parsed to confirm the new job and both path filters (the file's own comment says the two path lists must be kept in step, so both were updated).

### Screenshots (if front end is affected)

N/A: deploy tooling, nothing a user sees renders differently.

### Review round

CodeRabbit raised two.

**One real, and the more useful half was why the test missed it.** `docker compose ps -q` lists only running containers, so an exited `web` came back as no container id and the fail-fast branch never saw it: the deploy still went red, but after the full timeout rather than one poll. Fixed in `9b5c6d39`. The test had not caught it because the `docker` stub answered every `ps` with an id regardless of state, which is more permissive than the real command; the stub now models the real semantics, and that change alone turns the `exited` assertion red against the unfixed script.

**One declined**, and the maintainer settled it on the thread: renaming the script and CI job off "gate" to "prerequisite". That convention is about the project's `Prerequisite` model, not deployment health checks. CodeRabbit withdrew the finding.

### Anything Else?

**The HTTP smoke test I first reached for is deliberately not here.** Asserting the app *responds*, rather than that its socket is bound, would catch the narrower case of uwsgi binding while every request 500s. Doing it properly is awkward in this app and I would rather not do it badly: nginx terminates TLS with a real certificate and enforces a `server_name` check, and django-tenants resolves the tenant from the Host header, so a request needs a valid deck hostname and matching SNI rather than a plain `curl localhost`. The bound-socket check covers the failure mode #2633 actually described, since `need-app = true` means uwsgi refuses to bind when Django cannot be imported. If the response-level check is wanted, it deserves its own issue and its own thought about which hostname a health probe should use.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)