### PR TITLE
feat: fail the build on a migration that breaks the outgoing version (#2632)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Semi-isolated approach: one database, one schema per tenant. Tenants are identif
 * **Tests**: tests that use models must inherit from `TenantTestCase` and use `TenantClient`.
 * **SiteConfig**: each tenant has a `SiteConfig` singleton (per-deck settings); always fetch it with `SiteConfig.get()`.
 * **Migrations**: never use the standard `migrate` command: use `migrate_schemas`. To run a shell/management command against tenants, use `tenant_command` (e.g. `python src/manage.py tenant_command shell`).
+* **Deploy-safe migrations**: a deploy applies migrations from the new image while the previous containers still serve, so a migration that drops or renames a column breaks the outgoing version for those seconds. Adding a nullable column is fine; `RemoveField`, `DeleteModel`, `RenameField` and `RenameModel` are not, and `test_conventions.py` fails the build on a new one. Dropping a column takes two releases (`SeparateDatabaseAndState` first, the real drop second): the recipe is in CONTRIBUTING.md under "Migrations and the deploy window".
 
 ### Async tasks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,16 +158,27 @@ traffic, that is real requests failing during a lesson.
 
    After this ships, nothing running mentions the column, but it is still there.
 
-2. **Release two.** Actually drop it, once no deployed version knows about it:
+2. **Release two.** Actually drop the column, once no deployed version knows about it.
+   This one has to be `RunSQL`, **not** another `RemoveField`:
 
    ```python
    operations = [
-       migrations.SeparateDatabaseAndState(
-           database_operations=[migrations.RemoveField(model_name="quest", name="old_field")],
-           state_operations=[],  # already gone from state in release one
+       migrations.RunSQL(
+           sql='ALTER TABLE "quest_manager_quest" DROP COLUMN "old_field";',
+           reverse_sql='ALTER TABLE "quest_manager_quest" ADD COLUMN "old_field" integer NULL;',
        ),
    ]
    ```
+
+   `RemoveField` resolves the field from the migration's *from-state* to work out what to
+   drop, and release one already took it out of that state, so a `RemoveField` here raises
+   `KeyError: 'old_field'` before it reaches the database. `RunSQL` reads no state at all,
+   which is exactly why it is the right tool for the half that is only a column change.
+
+   The unqualified table name is correct here: `migrate_schemas` runs each migration once
+   per tenant schema with the search path already set, so the statement drops the column in
+   every deck rather than only the public one. Write `reverse_sql` too, so the migration is
+   still reversible in development.
 
 A **rename** is the same shape with more steps: add the new column, write both for a
 release, backfill, switch reads to the new one, then drop the old one by the two steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,76 @@ When contributing to this repo, you need to keep in mind its multi-tenant archit
 * **SiteConfig**: To get the SiteConfig singleton of a specific tenant, use the class method `SiteConfig.get()`
 * **Migrations**: Do NOT use the standard migrate command! If for some reason you need to manually migrate, use the `migrate_schemas` command instead (you can find docs for this and other management commands [here](https://django-tenants.readthedocs.io/en/latest/use.html?highlight=migrations#management-commands))
 
+### Migrations and the deploy window
+
+A deploy applies migrations from the **new** image while the **previous** containers are
+still serving, so that the slow part of a deploy happens with the site up rather than down
+(see `production/server-update.sh`). For the seconds between the two, the outgoing code is
+querying the new schema.
+
+Django `SELECT`s every concrete field of a model by default. So a column the outgoing
+version still declares on its model class, and no longer finds in the database, makes its
+ordinary reads raise `ProgrammingError` until it is replaced. With six uwsgi workers on live
+traffic, that is real requests failing during a lesson.
+
+**Safe in one release:**
+
+* Adding a nullable column, or one with a database default. The outgoing version does not
+  know about it and never mentions it.
+* Adding a model, an index, or a constraint that existing rows already satisfy.
+* Backfilling data with a `RunPython` that only writes columns the outgoing version can
+  already cope with.
+
+**Not safe in one release**, and caught by the guard in
+`src/hackerspace_online/tests/test_conventions.py`:
+
+* `RemoveField`, `DeleteModel`: the outgoing version still selects it.
+* `RenameField`, `RenameModel`: the same, and there is no ordering that avoids it. A rename
+  is a drop and an add.
+
+**How to drop a column safely**, over two releases:
+
+1. **Release one.** Remove the field from `models.py`, but keep the column. Write the
+   migration by hand so it changes Django's *state* without touching the database:
+
+   ```python
+   operations = [
+       migrations.SeparateDatabaseAndState(
+           database_operations=[],  # the column stays exactly as it is
+           state_operations=[migrations.RemoveField(model_name="quest", name="old_field")],
+       ),
+   ]
+   ```
+
+   After this ships, nothing running mentions the column, but it is still there.
+
+2. **Release two.** Actually drop it, once no deployed version knows about it:
+
+   ```python
+   operations = [
+       migrations.SeparateDatabaseAndState(
+           database_operations=[migrations.RemoveField(model_name="quest", name="old_field")],
+           state_operations=[],  # already gone from state in release one
+       ),
+   ]
+   ```
+
+A **rename** is the same shape with more steps: add the new column, write both for a
+release, backfill, switch reads to the new one, then drop the old one by the two steps
+above. If that sounds like a lot for a tidier name, it is: that is the argument for leaving
+the name alone.
+
+**Tightening a column** (`AlterField` to `null=False`, or a narrower type) is unsafe for the
+mirror reason: the outgoing version still writes the old shape. Add the constraint in a later
+release than the code that stops violating it. This one is *not* automated, because most
+`AlterField`s are harmless and a check that cries wolf on the common case only teaches people
+to skip it.
+
+**If a migration genuinely cannot hurt a deploy** (a table nothing has ever queried in
+production, say), put a `deploy-unsafe-ok` marker in the migration file with a comment saying
+which of those it is. Do not add entries to `LEGACY_DEPLOY_UNSAFE_MIGRATIONS`: that list is
+the migrations that predate the check.
+
 ### Use a Consistent Coding Style
 We use [ruff](https://docs.astral.sh/ruff/) (lint only) with a few exclusions -- see `[tool.ruff]` in [pyproject.toml](pyproject.toml).  These will be enforced by the pre-commit hook.
 

--- a/production/SERVER-README.md
+++ b/production/SERVER-README.md
@@ -182,11 +182,18 @@ git pull                      # master (prod) or staging (staging host)
 > owning the stack and still brings it back after a reboot.
 
 **Migrations are applied before the new code runs**, so each one has to be
-readable by the code it replaces for the seconds between step 5 and step 6.
-That is the ordinary expand-then-contract discipline for an online schema
-change: add and backfill in one release, stop reading the old shape in the
-next, drop it in a third. A migration that renames or drops in a single step
-will break the outgoing version during that window.
+readable by the code it replaces for the seconds between step 5 and step 6. A
+migration that renames or drops a column in a single step breaks the outgoing
+version during that window: Django selects every concrete field of a model, so
+a column it still declares and no longer finds raises `ProgrammingError` on
+ordinary reads.
+
+Dropping a column safely takes two releases, the first removing it from
+Django's state while leaving the column alone (`SeparateDatabaseAndState`) and
+the second dropping it once nothing deployed knows about it. The full recipe,
+and what is safe to do in one release, is in CONTRIBUTING.md under "Migrations
+and the deploy window"; `src/hackerspace_online/tests/test_conventions.py`
+fails the build on a new migration that skips it.
 
 The app is managed by the **`bytedeck.com.service`** systemd unit
 (`Type=oneshot`, `RemainAfterExit=yes`) so it comes back up automatically on

--- a/production/server-update.sh
+++ b/production/server-update.sh
@@ -80,9 +80,11 @@ sudo systemctl enable bytedeck.com.service
 # A migration that fails now stops the deploy with the previous version still
 # serving, instead of replacing it and leaving nginx on the maintenance page.
 # The trade is that each migration has to be readable by the code it replaces
-# for the seconds between here and the switch below, which is the ordinary
-# expand-then-contract discipline for an online schema change: add and backfill
-# in one release, stop reading the old shape in the next, drop it in a third.
+# for the seconds between here and the switch below: Django selects every
+# concrete field of a model, so a column the outgoing version still declares
+# and no longer finds raises ProgrammingError on ordinary reads. Dropping one
+# safely takes two releases; see CONTRIBUTING.md, "Migrations and the deploy
+# window".
 $COMPOSE run --rm --no-deps web python src/manage.py migrate_schemas --shared
 $COMPOSE run --rm --no-deps web python src/manage.py migrate_schemas --executor=multiprocessing
 $COMPOSE run --rm --no-deps web python src/manage.py collectstatic --noinput

--- a/src/hackerspace_online/tests/test_conventions.py
+++ b/src/hackerspace_online/tests/test_conventions.py
@@ -22,6 +22,7 @@ never add entries: write conforming tests instead.
 
 import ast
 import inspect
+import re
 from pathlib import Path
 
 from django.db.migrations.loader import MigrationLoader
@@ -117,10 +118,12 @@ LEGACY_DEPLOY_UNSAFE_MIGRATIONS = frozenset({
 })
 
 #: Written in a migration whose unsafe operation is deliberate and cannot hurt a deploy: a
-#: table nothing has ever queried in production, say. The marker exempts the file and must be
-#: accompanied by a comment saying which of those it is, since the whole point of the check is
-#: that "I am sure it is fine" is the reasoning that breaks a class mid-lesson.
-_DEPLOY_UNSAFE_ALLOWED_MARKER = "deploy-unsafe-ok"
+#: table nothing has ever queried in production, say. Spelled ``deploy-unsafe-ok: <reason>``,
+#: and the reason is required rather than conventional: the whole point of the check is that
+#: "I am sure it is fine" is the reasoning that breaks a class mid-lesson, so a bare marker
+#: exempts nothing. Matched anywhere in the file, since it belongs in a comment next to the
+#: operation it excuses.
+_DEPLOY_UNSAFE_ALLOWED_MARKER = re.compile(r"deploy-unsafe-ok:[ \t]*\S+")
 
 
 def _iter_project_migrations():
@@ -152,14 +155,40 @@ def _deploy_unsafe_operations(migration):
     """
     problems = []
     for operation in migration.operations:
-        name = type(operation).__name__
-        if name not in DEPLOY_UNSAFE_OPERATIONS:
-            continue
-        # Every one of these names a model, and all but DeleteModel name a field too.
-        target = getattr(operation, "model_name", None) or getattr(operation, "name", "?")
-        field = getattr(operation, "old_name", None) or getattr(operation, "name", None)
-        problems.append(f"{name} on {target}.{field}" if field and field != target else f"{name} on {target}")
+        problems.extend(_unsafe_within(operation))
     return problems
+
+
+def _unsafe_within(operation, prefix=""):
+    """Return the deploy-unsafe descriptions in ``operation``, looking inside wrappers.
+
+    ``SeparateDatabaseAndState`` is how CONTRIBUTING.md's two-release drop separates the
+    model change from the column change, so it needs opening rather than skipping. Only its
+    ``database_operations`` are examined: those touch real columns, while ``state_operations``
+    only tell Django the field is gone, which is the safe half and the whole point of release
+    one. A wrapper carrying a destructive operation in *both* halves is a plain destructive
+    migration wearing a hat, and is reported like one.
+
+    Args:
+        operation (Operation): the migration operation to inspect.
+        prefix (str): how to label a nested operation in the report.
+
+    Returns:
+        list[str]: one entry per offending operation, empty when there is nothing unsafe.
+    """
+    name = type(operation).__name__
+    if name == "SeparateDatabaseAndState":
+        problems = []
+        for inner in operation.database_operations:
+            problems.extend(_unsafe_within(inner, prefix="SeparateDatabaseAndState.database_operations -> "))
+        return problems
+    if name not in DEPLOY_UNSAFE_OPERATIONS:
+        return []
+    # Every one of these names a model, and all but DeleteModel name a field too.
+    target = getattr(operation, "model_name", None) or getattr(operation, "name", "?")
+    field = getattr(operation, "old_name", None) or getattr(operation, "name", None)
+    described = f"{name} on {target}.{field}" if field and field != target else f"{name} on {target}"
+    return [prefix + described]
 
 
 def _iter_test_modules():
@@ -257,7 +286,7 @@ class TestMigrationsSurviveTheDeployWindow(SimpleTestCase):
         for rel, migration, path in _iter_project_migrations():
             if rel in LEGACY_DEPLOY_UNSAFE_MIGRATIONS:
                 continue
-            if _DEPLOY_UNSAFE_ALLOWED_MARKER in path.read_text(encoding="utf-8"):
+            if _DEPLOY_UNSAFE_ALLOWED_MARKER.search(path.read_text(encoding="utf-8")):
                 continue
             problems = _deploy_unsafe_operations(migration)
             if problems:

--- a/src/hackerspace_online/tests/test_conventions.py
+++ b/src/hackerspace_online/tests/test_conventions.py
@@ -1,8 +1,9 @@
 """Meta-tests that enforce this project's test-writing conventions.
 
 Two conventions from ``CLAUDE.md`` are checked by scanning every ``test_*.py``
-module's AST, and a third (no em dashes) by scanning the source of the
-directories listed in ``EM_DASH_CHECKED_DIRS``:
+module's AST, a third (no em dashes) by scanning the source of the directories
+listed in ``EM_DASH_CHECKED_DIRS``, and a fourth (migrations survive the deploy
+window) by loading the migration graph from disk:
 
 * **Naming**: each ``test_*`` method name follows
   ``test_method_or_class_name__specific_case_being_tested`` (i.e. contains a
@@ -10,14 +11,20 @@ directories listed in ``EM_DASH_CHECKED_DIRS``:
 * **Docstrings**: each ``test_*`` method, and each ``setUp`` /
   ``setUpTestData`` / ``tearDown``, has a docstring.
 
+* **Deploy-safe migrations**: a migration adds no operation that breaks the
+  version it replaces while both are briefly live (see
+  ``DEPLOY_UNSAFE_OPERATIONS``).
+
 The whole suite has been brought into conformance, so ``LEGACY_UNCONVENTIONAL``
 is empty and every ``test_*.py`` is enforced. It remains as an escape hatch only:
 never add entries: write conforming tests instead.
 """
 
 import ast
+import inspect
 from pathlib import Path
 
+from django.db.migrations.loader import MigrationLoader
 from django.test import SimpleTestCase
 
 # Empty: the whole suite conforms. Keep it empty, never add entries; fix the
@@ -47,6 +54,112 @@ _EM_DASH_ALLOWED_MARKER = "em-dash-ok"
 
 # src/ directory (this file is src/hackerspace_online/tests/test_conventions.py).
 _SRC_ROOT = Path(__file__).resolve().parents[2]
+
+# Operations that break the version they replace, for the seconds a deploy runs both.
+#
+# production/server-update.sh applies migrations from the new image while the previous
+# containers are still serving, which is what keeps the slow part of a deploy out of the
+# downtime window (#2631). The cost is that the outgoing code meets the new schema. Django
+# SELECTs every concrete field of a model by default, so dropping or renaming a column the
+# outgoing version still has in its own model class makes its ordinary queries raise
+# ProgrammingError until it is replaced. With six uwsgi workers serving live traffic, that is
+# real requests failing, not a theoretical race.
+#
+# Only operations that are unsafe *whatever* the surrounding code does are listed. AddField
+# and AlterField can be unsafe too (a NOT NULL column with no default, or tightening an
+# existing column's nullability, both break the outgoing version's INSERTs), but they are
+# usually fine, and telling the two apart means diffing model state rather than reading a
+# list of operations. They are documented in CONTRIBUTING.md and deliberately not automated
+# here: a check that cries wolf on the common case would only teach people to skip it.
+DEPLOY_UNSAFE_OPERATIONS = frozenset({
+    "RemoveField",
+    "RenameField",
+    "RenameModel",
+    "DeleteModel",
+})
+
+# Migrations that predate the check, listed so it can be enforced from here on rather than
+# waiting for the history to be rewritten (which it cannot be: these are long applied).
+#
+# Never add entries. A new migration needing one of these operations goes through
+# CONTRIBUTING.md's two-release drop instead, or, where that genuinely does not apply, carries
+# a `deploy-unsafe-ok` marker saying why.
+LEGACY_DEPLOY_UNSAFE_MIGRATIONS = frozenset({
+    "badges/0010_auto_20200901_1505",
+    "badges/0015_rename_active_badge_published",
+    "courses/0004_remove_coursestudent_grade",
+    "courses/0008_auto_20190815_2253",
+    "courses/0011_remove_semester_number",
+    "courses/0017_remove_semester_active",
+    "courses/0022_auto_20220811_1743",
+    "courses/0026_delete_datetype_model",
+    "courses/0029_semester_status",
+    "djcytoscape/0008_auto_20200705_1904",
+    "djcytoscape/0009_auto_20200705_1906",
+    "djcytoscape/0010_remove_cytoscape_container_element_id",
+    "profile_manager/0011_remove_profile_student_number",
+    "profile_manager/0013_auto_20200818_1355",
+    "profile_manager/0018_auto_20240107_1115",
+    "profile_manager/0019_auto_20240807_1432",
+    "profile_manager/0021_remove_profile_intro_tour_completed",
+    "quest_manager/0009_auto_20190807_1525",
+    "quest_manager/0011_auto_20200105_2257",
+    "quest_manager/0018_auto_20200818_1356_squashed_0019_auto_20200818_1357",
+    "quest_manager/0038_remove_questsubmission_draft_text",
+    "quest_manager/0045_rename_visible_to_students_to_published",
+    "quest_manager/0047_rename_category_active_to_published",
+    "siteconfig/0002_auto_20200402_2201",
+    "siteconfig/0004_auto_20200402_2233",
+    "siteconfig/0017_auto_20220812_1554",
+    "siteconfig/0032_remove_siteconfig_enable_submission_questions",
+    "tenant/0007_django_tenants_migration",
+    "tenant/0025_remove_tenant_max_quests_remove_tenant_owner_email_and_more",
+})
+
+#: Written in a migration whose unsafe operation is deliberate and cannot hurt a deploy: a
+#: table nothing has ever queried in production, say. The marker exempts the file and must be
+#: accompanied by a comment saying which of those it is, since the whole point of the check is
+#: that "I am sure it is fine" is the reasoning that breaks a class mid-lesson.
+_DEPLOY_UNSAFE_ALLOWED_MARKER = "deploy-unsafe-ok"
+
+
+def _iter_project_migrations():
+    """Yield ``("<app>/<name>", Migration, Path)`` for every migration under src/.
+
+    Third-party migrations (Django's own, allauth's, django_celery_beat's) load into the same
+    graph and are excluded by path: their contents are not ours to change, so flagging them
+    would only mean listing them as legacy forever.
+    """
+    loader = MigrationLoader(connection=None, ignore_no_migrations=True)
+    for (app_label, name), migration in sorted(loader.disk_migrations.items()):
+        try:
+            path = Path(inspect.getfile(type(migration))).resolve()
+        except TypeError:  # pragma: no cover - a migration built in memory has no file
+            continue
+        if not path.is_relative_to(_SRC_ROOT):
+            continue
+        yield f"{app_label}/{name}", migration, path
+
+
+def _deploy_unsafe_operations(migration):
+    """Return ``["<Operation> on <target>"]`` for each deploy-unsafe operation in ``migration``.
+
+    Args:
+        migration (Migration): the loaded migration to inspect.
+
+    Returns:
+        list[str]: one entry per offending operation, empty when the migration is safe.
+    """
+    problems = []
+    for operation in migration.operations:
+        name = type(operation).__name__
+        if name not in DEPLOY_UNSAFE_OPERATIONS:
+            continue
+        # Every one of these names a model, and all but DeleteModel name a field too.
+        target = getattr(operation, "model_name", None) or getattr(operation, "name", "?")
+        field = getattr(operation, "old_name", None) or getattr(operation, "name", None)
+        problems.append(f"{name} on {target}.{field}" if field and field != target else f"{name} on {target}")
+    return problems
 
 
 def _iter_test_modules():
@@ -125,6 +238,53 @@ class TestNoEmDashes(SimpleTestCase):
             "parenthetical aside):\n"
             + "\n".join(f"{f}:\n  " + "\n  ".join(v) for f, v in failures.items()),
         )
+
+
+class TestMigrationsSurviveTheDeployWindow(SimpleTestCase):
+    """Guard that a new migration cannot break the version it replaces mid-deploy."""
+
+    def test_conventions__new_migrations_carry_no_deploy_unsafe_operation(self):
+        """No migration outside LEGACY_DEPLOY_UNSAFE_MIGRATIONS drops or renames a column.
+
+        A deploy applies migrations from the new image while the previous containers are
+        still serving (#2631), so for those seconds the outgoing code queries the new schema.
+        Django SELECTs every concrete field of a model, so a column it still knows about and
+        no longer finds raises ProgrammingError on ordinary reads. CONTRIBUTING.md's
+        two-release drop is how to remove one without that window; a migration that genuinely
+        cannot hurt a deploy says so with a ``deploy-unsafe-ok`` marker and a reason.
+        """
+        failures = {}
+        for rel, migration, path in _iter_project_migrations():
+            if rel in LEGACY_DEPLOY_UNSAFE_MIGRATIONS:
+                continue
+            if _DEPLOY_UNSAFE_ALLOWED_MARKER in path.read_text(encoding="utf-8"):
+                continue
+            problems = _deploy_unsafe_operations(migration)
+            if problems:
+                failures[rel] = problems
+        self.assertEqual(
+            failures, {},
+            "Migrations that would break the outgoing version during a deploy. Use the "
+            "two-release drop in CONTRIBUTING.md ('Migrations and the deploy window') rather "
+            "than adding to LEGACY_DEPLOY_UNSAFE_MIGRATIONS:\n"
+            + "\n".join(f"{f}:\n  " + "\n  ".join(v) for f, v in failures.items()),
+        )
+
+    def test_legacy_migration_list__has_no_stale_entries(self):
+        """Every LEGACY_DEPLOY_UNSAFE_MIGRATIONS entry still exists and is still unsafe.
+
+        Migrations are not edited once applied, so an entry going stale means one was renamed,
+        squashed away or deleted. Catching that keeps the list from quietly growing into a
+        place where a real violation could hide behind a name nothing checks any more.
+        """
+        known = {rel: migration for rel, migration, _ in _iter_project_migrations()}
+        stale = []
+        for rel in sorted(LEGACY_DEPLOY_UNSAFE_MIGRATIONS):
+            if rel not in known:
+                stale.append(f"{rel}: migration no longer exists")
+            elif not _deploy_unsafe_operations(known[rel]):
+                stale.append(f"{rel}: is now safe, remove it from LEGACY_DEPLOY_UNSAFE_MIGRATIONS")
+        self.assertEqual(stale, [], "Stale LEGACY_DEPLOY_UNSAFE_MIGRATIONS entries:\n  " + "\n  ".join(stale))
 
 
 class TestNamingAndDocstringConventions(SimpleTestCase):


### PR DESCRIPTION
### What?

A migration that would break the running site during a deploy now fails the build, and CONTRIBUTING.md explains how to write one that does not.

Closes #2632

### Why?

PR #2631 moved migrations ahead of the container swap, so a deploy applies them from the new image while the previous containers are still serving. That is what took the outage from minutes to seconds, and its cost is that **for those seconds the outgoing code queries the new schema**.

Django `SELECT`s every concrete field of a model by default. So a column the outgoing version still declares on its model class, and no longer finds in the database, makes its ordinary reads raise `ProgrammingError`. With six uwsgi workers on live traffic, that is real requests failing during a lesson, not a theoretical race.

#2631 introduced that trade and only wrote a paragraph about it. A paragraph in a server README is not going to stop the migration that breaks a class.

### How?

**The guard** lives in `src/hackerspace_online/tests/test_conventions.py`, alongside the naming, docstring and em-dash guards, and follows their shape exactly. It loads the migration graph from disk (`MigrationLoader(connection=None)`, so no database) and fails on any migration carrying `RemoveField`, `RenameField`, `RenameModel` or `DeleteModel`. The failure names the migration and the field.

* **It looks inside `SeparateDatabaseAndState`**, but only at `database_operations`. Those touch real columns; `state_operations` only tell Django the field is gone, which is the safe half and the entire point of release one below. A wrapper carrying a destructive operation in *both* halves is a plain destructive migration wearing a hat, and is reported like one.
* **29 pre-existing migrations** are listed in `LEGACY_DEPLOY_UNSAFE_MIGRATIONS`, so the rule can be enforced from here on rather than waiting for history that cannot be rewritten. Append-never, exactly like `LEGACY_UNCONVENTIONAL`, with a companion test that catches a stale entry.
* **Third-party migrations are excluded by path.** `contenttypes/0002_remove_content_type_name` and `django_celery_beat/0014_...` load into the same graph; their contents are not ours to change, so flagging them would only mean listing them as legacy forever.
* **`deploy-unsafe-ok: <reason>`** in a migration file is the escape hatch, for the case where the operation genuinely cannot hurt a deploy (a table nothing has ever queried in production). The reason is required, not conventional: a bare marker exempts nothing.

**`AddField` and `AlterField` are deliberately not checked.** They *can* be unsafe: a `NOT NULL` column with no default, or tightening an existing column's nullability, both break the outgoing version's INSERTs. But they are usually fine (`AlterField` appears 211 times in this repo), and telling the two apart means diffing model state rather than reading a list of operations. A check that cries wolf on the common case only teaches people to skip it, so those are documented instead.

**CONTRIBUTING.md gains "Migrations and the deploy window"**: what is safe to do in one release, what is not, and the two-release recipe for dropping a column. Release one removes the field from Django's *state* with `SeparateDatabaseAndState`, leaving the column alone. Release two drops the column with **`RunSQL`** once nothing deployed knows about it. CLAUDE.md points at it from its migrations bullet, since that is where a session will actually meet it.

**This corrects #2631.** What I wrote there, in both SERVER-README and `server-update.sh`, was *"add and backfill in one release, stop reading the old shape in the next, drop it in a third"*. That does not work in Django: the middle release still declares the field on the model, so its `SELECT`s still ask for the column. `SeparateDatabaseAndState` is what actually separates model state from the database, and both places now say so and point at the recipe.

### Testing?

**Every behaviour was confirmed by probe, not just observed green.** Each probe is a real migration file dropped into `src/siteconfig/migrations/` and removed afterwards.

| Probe | Expected | Result |
| --- | --- | --- |
| A new migration with `RemoveField` | flagged | fails, naming `RemoveField on siteconfig.site_name` |
| The same plus `deploy-unsafe-ok: <reason>` | exempt | passes |
| The same with a **bare** `deploy-unsafe-ok` | still flagged | fails |
| A new migration adding only a nullable column | not flagged | passes (no false positive on the common case) |
| **Release one** of the recipe (`state_operations` only) | not flagged | passes |
| **Release two** of the recipe (`RunSQL`) | not flagged | passes |
| A `SeparateDatabaseAndState` destructive in **both** halves | flagged | fails, naming the nested operation |
| A fabricated allowlist entry | reported stale | fails with `migration no longer exists` |

The two "not flagged" recipe rows matter as much as the failures: they pin that the guard cannot drift into rejecting the very recipe it documents.

Also run locally: `test_conventions` 5 tests OK; `src/hackerspace_online` 137 tests OK (standalone, per CLAUDE.md's note about the `library`-before-`hackerspace_online` ordering flake); `ruff check src` clean; `manage.py check` no issues; `makemigrations --check --dry-run` no changes.

The 29 legacy entries were generated from the graph itself rather than by grep, which is what caught the two third-party migrations a grep would have swept in.

### Screenshots (if front end is affected)

N/A: nothing a user sees renders differently. This is a build-time guard plus documentation.

### Review round

CodeRabbit raised three, all real, all fixed in `670901f8`.

**The documented recipe did not work.** Release two used `RemoveField` inside `database_operations`, but `RemoveField` resolves the field from the migration's from-state to work out what to drop, and release one has already taken it out of that state. I reproduced it rather than reasoning from the source: applying the documented pair raises `KeyError: 'old_field'` before it reaches the database. Release two is now `RunSQL`, which reads no state at all. Checking that also surfaced two things worth documenting: the unqualified table name is correct because `migrate_schemas` runs each migration once per tenant schema with the search path already set, and a `RunSQL` that appears to emit nothing outside a tenant schema is `TenantSyncRouter` declining `allow_migrate`, not the operation failing.

**The guard did not look inside `SeparateDatabaseAndState`**, so a wrapper carrying a destructive operation slipped past the check the recipe exists to satisfy. Now recursed, `database_operations` only.

**The marker was a bare substring match**, so it exempted a migration whether or not anyone had said why, while the docstring claimed a reason was required. Now `deploy-unsafe-ok: <reason>`.

### Anything Else?

**This adds real friction to removing a field**, and that is the point, but it is worth saying plainly: dropping a column is now a two-PR job. If that turns out to be heavier than the risk warrants at ByteDeck's deploy frequency, the honest alternative is to go back to stopping the app during migrations, which is what #2631 removed. The guard is the cheaper half of that trade.

**Two things deliberately left out.** Asserting the column is *physically* gone after the two-release sequence would need a throwaway app and a real `migrate_schemas` run across every tenant schema, which is a lot of machinery to prove something Postgres guarantees; the guard-level probes cover the part that can actually regress. And the marker is matched anywhere in the file rather than only in a comment, since pinning that means AST-parsing for comment tokens, and someone willing to smuggle the marker through a docstring to dodge a check they could have satisfied by writing a reason is not a threat model worth building for.

**Also not covered, and documented instead:** the `AddField`/`AlterField` cases above, and data migrations (`RunPython`) that rewrite rows the outgoing version is still reading. If either bites in practice, that is a follow-up with a real example behind it rather than a guess now.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)