### PR TITLE
docs: add 1.34.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file chronologically records all notable changes to this website, including
 
 [Changelogs](http://keepachangelog.com/en/0.3.0/) | [Versioning](http://semver.org/) | [Branch model](https://nvie.com/posts/a-successful-git-branching-model/)
 
+### [1.34.1] 2026-08-28
+* Devops:
+  - **An update now interrupts the site for seconds rather than minutes.** Updating used to stop the site first and only then run the database migrations and re-upload every static file, so the "ByteDeck is updating" page stayed up for as long as all of that took: longer the more decks there are, and the update allowed itself ten minutes for it. That work now happens while the previous version is still serving, and only the app itself is swapped at the end. Two things that went wrong quietly on every single update are fixed with it: for part of the window the site refused connections outright instead of showing the updating page, and any background job still queued (a notification digest, say) was thrown away [#2631](https://github.com/bytedeck/bytedeck/issues/2631)
+  - **An update that leaves the site down now reports a failure.** Nothing checked that the site had come back, so a release that never actually started, because of a bad setting or an error in the new code, was recorded as a success while every deck sat on the "ByteDeck is updating" page indefinitely. The update now waits for the app to answer, and fails with the reason in its log if it never does [#2633](https://github.com/bytedeck/bytedeck/issues/2633)
+* Codebase:
+  - Migrations are now applied while the previous version is still serving, so one that drops or renames a column would break the running site for those seconds. A new migration doing that now fails the build, and CONTRIBUTING.md documents the two-release recipe for removing a column without that window [#2632](https://github.com/bytedeck/bytedeck/issues/2632)
+
+
 ### [1.34.0] 2026-08-27 Claude VI
 * New Features:
   - **You are warned before leaving a submission with unsaved text.** A student's draft saves on a timer, about once a minute, so clicking a navbar link, pressing back, or closing the tab in between silently threw away everything typed since the last save. The submission page now asks first, the same prompt a quest or announcement form already gives, and it stops asking once a draft save has gone through, so the ordinary autosave does not leave you arguing with a dialog. The staff question editor gets the same protection [#2572](https://github.com/bytedeck/bytedeck/issues/2572)


### PR DESCRIPTION
### What?

A `### [1.34.1] 2026-08-28` entry at the top of `CHANGELOG.md`, covering the three commits that landed on `develop` after 1.34.0 went out. No other file changes.

### Why?

1.34.0 reached `master` at 2026-08-27 07:35 and has been announced, so its section is published and must not be edited. Three commits have landed on `develop` since, and they are currently in no entry at all:

* #2631, the deploy sequencing change
* #2636, the deploy health check (issue #2633)
* #2637, the migration guard (issue #2632)

### How?

**Patch, not minor.** Nothing here is a feature or a bugfix a teacher or student asked for: two Devops items and one Codebase item, and no other categories. The only effect a deck notices is that an update interrupts the site for a shorter time, which is operational rather than a change to the app. If you would rather keep the every-release-is-`x.y.0` pattern, say so and I will make it 1.35.0.

**No codename**, matching the earlier patch entries: 1.25.2 and 1.25.1 carry none, while the Claude III to VI series runs across the minor releases.

**Written for a teacher, not for us.** #2631 and #2636 are both really about the "ByteDeck is updating" page, so each item leads with what changes about that rather than with `docker compose` mechanics. The two incidental fixes in #2631 are named plainly (the site could refuse connections outright rather than show the updating page, and queued background jobs were discarded on every update) since a deck owner who ever saw either deserves to know it is fixed.

#2637 goes under Codebase because it changes what a contributor may write, not what anyone using a deck sees.

### Testing?

No source change, so no suite run applies. What was verified is the machinery that consumes this file:

* **The announcement parser reads the new section, and only it.** `BEFORE_SHA=$(git rev-parse origin/develop) .github/scripts/changelog_new_sections.py` reports `New version(s) detected: 1.34.1`, title `Bytedeck App Updates (1.34.1)`, and writes a `discussion_body.md` holding exactly the new lines. 1.34.0 is not re-announced.
* **Format matches the file's conventions**: `### [x.y.z] YYYY-MM-DD` heading, documented category order with empty ones omitted, `[#NNNN](.../issues/NNNN)` links, and two blank lines before the 1.34.0 heading.
* **No em dashes** in the added lines.
* The three commits were enumerated from `git log origin/master..origin/develop --first-parent`, not from memory, and 1.34.0's presence on `master` was confirmed by reading `CHANGELOG.md` at `origin/master`.

### Screenshots (if front end is affected)

N/A: documentation only, nothing in the app renders this file.

### Anything Else?

**#2631 links to a pull request, not an issue.** It came from a direct request rather than a filed issue, so there is no issue number for it. The link uses the same `/issues/` form as every other entry, which GitHub redirects to the pull request.

**This entry ships whenever `develop` is next promoted.** It does not need to go out on its own: if more work lands before the next promotion, adding to this section is fine right up until it reaches `master`, since the announcement fires on the push there.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updates now apply database migrations and re-upload static files while the previous version continues serving, reducing interruption time.
  * Updates that leave the site unavailable are now reported as failures instead of successes.
  * Builds now fail when migrations attempt to drop or rename a database column, helping prevent accidental data loss.

* **Documentation**
  * Added guidance for safely removing database columns across two releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->