### PR TITLE
tweak: copy the other semesters' excluded dates into this one (#2648) …

### DIFF
--- a/src/courses/models.py
+++ b/src/courses/models.py
@@ -785,6 +785,38 @@ class ExcludedDate(models.Model):
     def __str__(self):
         return self.date.strftime("%d-%b-%Y")
 
+    @classmethod
+    def from_other_semesters(cls, semester):
+        """The excluded dates every other semester holds, one entry per calendar date.
+
+        What the semester form offers to copy in, so a deck running two semesters at once does
+        not type the same holidays twice (#2648). Each semester holds its own row for a day it
+        skips, and the teacher wants that day offered once, so rows are collapsed by date: a
+        labelled row wins over an unlabelled one, since the label is the part worth carrying
+        over, and between two labelled rows the lower semester id wins, which is arbitrary but
+        stable from one page load to the next.
+
+        Args:
+            semester (Semester): the semester being edited. Its own dates are left out, since
+                it already lists them. An unsaved one (the create form) has none to leave out.
+
+        Returns:
+            list[dict]: ``{'date': 'YYYY-MM-DD', 'label': str}`` entries ordered by date. The
+            date is a string because this is read by the page's JavaScript, which compares
+            those directly: ISO dates sort as text exactly as they do as dates.
+        """
+        rows = cls.objects.order_by('date', 'semester_id')
+        if semester.pk is not None:
+            rows = rows.exclude(semester_id=semester.pk)
+
+        label_for_date = {}
+        for row in rows:
+            label = row.label or ''
+            if row.date not in label_for_date or (label and not label_for_date[row.date]):
+                label_for_date[row.date] = label
+
+        return [{'date': date.isoformat(), 'label': label} for date, label in label_for_date.items()]
+
 
 class Course(IsAPrereqMixin, models.Model):
     title = models.CharField(max_length=50, unique=True)

--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -24,6 +24,22 @@
     <h3>Excluded Dates</h3>
     <p>Weekends are automatically excluded in mark calculations. To exclude additional dates, add them here:</p>
 
+    {% if other_excluded_dates %}
+      {% comment %} Only shown when another semester actually has dates to bring over, so a deck
+         running one semester does not carry a button that can never do anything (#2648).
+         The title sits on the span, not the button: a disabled button receives no mouse
+         events, so a title on it would never appear, which is the state that most needs
+         explaining. The span is not disabled, so it gets the hover either way. {% endcomment %}
+      <p>
+        <span id="copy-excluded-dates-tooltip">
+          <button type="button" id="copy-excluded-dates" class="btn btn-default btn-sm" disabled>
+            <i class="fa fa-copy"></i> Copy dates from your other semesters
+          </button>
+        </span>
+      </p>
+      {{ other_excluded_dates|json_script:"other-excluded-dates" }}
+    {% endif %}
+
     <div id="form-management"> {{ formset.management_form }} </div>
     <div id="form-container">
         <div class="row">
@@ -79,7 +95,7 @@
         return d;
     }
 
-    function AddForm() {
+    function AddForm(date, label) {
         // management form change data
         var totalForms = parseInt(formTotalForms.getAttribute("value"));
 
@@ -115,6 +131,14 @@
             copiedLabel = lastLabelInput.value;
         }
 
+        // A caller can name the row's values instead (the copy button below), in which case
+        // they stand in for the guesses above, a blank label included: a date arriving with
+        // none of its own should not inherit the label of the row above it.
+        if (date !== undefined) {
+            nextDateStr = date;
+            copiedLabel = label || '';
+        }
+
         // increment form count
         formTotalForms.setAttribute("value", totalForms + 1);
 
@@ -138,8 +162,10 @@
         if (newDateInput && nextDateStr) {
             newDateInput.value = nextDateStr;
         }
+        // Assigned even when blank, so a caller-supplied blank clears the label carried
+        // forward above. On a row nobody supplied values for, the field is empty either way.
         const newLabelInput = document.querySelector(`#id_form-${newIndex}-label`);
-        if (newLabelInput && copiedLabel) {
+        if (newLabelInput) {
             newLabelInput.value = copiedLabel;
         }
 
@@ -153,14 +179,21 @@
         // get the datepicker options from newly added form field
         // initialize the datepicker widget using the options from its class
         var $datepicker = $(`#id_form-${newIndex}-date`)
-        var config = JSON.parse($datepicker.attr("data-dbdp-config"));
 
-        // have to sub in `backend_date_format` if options.format does not exist
-        // Null-coalescing operator
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
-        config.options.format ??= config.backend_date_format;
+        // The picker is an enhancement on a text input the teacher can type a date into, so
+        // the row works without it. Its plugin is fetched from a CDN, and on a network that
+        // cannot reach that CDN this would otherwise throw and take the caller down with it,
+        // which for the copy button below means the rest of its dates never arrive.
+        if (typeof $datepicker.datetimepicker === "function") {
+            var config = JSON.parse($datepicker.attr("data-dbdp-config"));
 
-        $datepicker.datetimepicker(config.options);
+            // have to sub in `backend_date_format` if options.format does not exist
+            // Null-coalescing operator
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
+            config.options.format ??= config.backend_date_format;
+
+            $datepicker.datetimepicker(config.options);
+        }
     }
 
     function RemoveForm(index) {
@@ -172,6 +205,80 @@
         // add delete input for POST DATA
         var deleteInput = document.getElementById(`id_form-${index}-DELETE`);
         deleteInput.setAttribute("value", "on");
+    }
+
+    // Copy the excluded dates the deck's other semesters hold into this one (#2648). Only wired
+    // up when the view found some to offer; otherwise the button is not on the page at all.
+    const copyButton = document.getElementById("copy-excluded-dates");
+    if (copyButton) {
+        const copyTooltip = document.getElementById("copy-excluded-dates-tooltip");
+        const otherDates = JSON.parse(document.getElementById("other-excluded-dates").textContent);
+        const firstDayInput = document.getElementById("id_first_day");
+        const lastDayInput = document.getElementById("id_last_day");
+
+        const NO_RANGE_TITLE = "Set this semester's first and last day first, so its dates can be picked out.";
+        const READY_TITLE = "Add the dates your other semesters exclude that fall inside this one.";
+
+        // Every date here is ISO (YYYY-MM-DD), which sorts and compares as text exactly as it
+        // does as a date, so the range test needs no parsing and no timezone handling.
+        function semesterRange() {
+            const first = firstDayInput.value, last = lastDayInput.value;
+            return (first && last && first <= last) ? {first: first, last: last} : null;
+        }
+
+        function refreshCopyButton() {
+            const range = semesterRange();
+            copyButton.disabled = range === null;
+            copyTooltip.setAttribute("title", range === null ? NO_RANGE_TITLE : READY_TITLE);
+        }
+
+        // The date input of every row still on screen, in form order. A removed row is hidden
+        // rather than deleted, and its date is going away with it, so it is not one of these.
+        function visibleDateInputs() {
+            const inputs = [];
+            const totalForms = parseInt(formTotalForms.getAttribute("value"));
+            for (let i = 0; i < totalForms; i++) {
+                const dateInput = document.querySelector(`#id_form-${i}-date`);
+                const row = document.getElementById(`form-${i}-container`);
+                if (dateInput && row && row.style.display !== "none") {
+                    inputs.push(dateInput);
+                }
+            }
+            return inputs;
+        }
+
+        copyButton.addEventListener("click", function () {
+            const range = semesterRange();
+            if (range === null) {
+                return;
+            }
+
+            // A date already on the form is left alone rather than added again: a second row for
+            // it would only fail validation, and the teacher may have edited the one that is there.
+            const listed = new Set(visibleDateInputs().map(input => input.value).filter(Boolean));
+            const arriving = otherDates.filter(
+                entry => entry.date >= range.first && entry.date <= range.last && !listed.has(entry.date)
+            );
+
+            for (const entry of arriving) {
+                // Fill the blank row the formset always ends with before adding another, so
+                // copying into an empty semester does not leave a stray empty row behind.
+                const blank = visibleDateInputs().find(input => !input.value);
+                if (blank) {
+                    blank.value = entry.date;
+                    document.getElementById(blank.id.replace(/-date$/, "-label")).value = entry.label;
+                } else {
+                    AddForm(entry.date, entry.label);
+                }
+            }
+        });
+
+        // The dates are typed on this same page, so the button follows them as they are filled in.
+        for (const input of [firstDayInput, lastDayInput]) {
+            input.addEventListener("change", refreshCopyButton);
+            input.addEventListener("input", refreshCopyButton);
+        }
+        refreshCopyButton();
     }
 
 </script>

--- a/src/courses/tests/test_models.py
+++ b/src/courses/tests/test_models.py
@@ -1988,3 +1988,63 @@ class ExcludedDateModelTest(ByteDeckTenantTestCase):
 
         with self.assertRaises(IntegrityError):
             ExcludedDate.objects.create(semester=semester, date=date(2019, 11, 11))
+
+    def test_from_other_semesters__returns_the_other_semesters_dates_in_date_order(self):
+        """Every excluded date the deck holds outside this semester, oldest first."""
+        semester = baker.make(Semester)
+        other = baker.make(Semester)
+        baker.make(ExcludedDate, semester=other, date=date(2019, 12, 25), label='Christmas')
+        baker.make(ExcludedDate, semester=other, date=date(2019, 11, 11), label='Remembrance Day')
+
+        self.assertEqual(
+            ExcludedDate.from_other_semesters(semester),
+            [{'date': '2019-11-11', 'label': 'Remembrance Day'},
+             {'date': '2019-12-25', 'label': 'Christmas'}],
+        )
+
+    def test_from_other_semesters__leaves_out_this_semesters_own_dates(self):
+        """A date this semester already excludes is not offered back to it."""
+        semester = baker.make(Semester)
+        other = baker.make(Semester)
+        baker.make(ExcludedDate, semester=semester, date=date(2019, 11, 11), label='mine')
+        baker.make(ExcludedDate, semester=other, date=date(2019, 12, 25), label='theirs')
+
+        self.assertEqual(
+            ExcludedDate.from_other_semesters(semester),
+            [{'date': '2019-12-25', 'label': 'theirs'}],
+        )
+
+    def test_from_other_semesters__offers_a_date_two_semesters_both_hold_once(self):
+        """Two semesters skipping the same holiday is one day to copy, not two rows."""
+        semester = baker.make(Semester)
+        for _ in range(2):
+            baker.make(ExcludedDate, semester=baker.make(Semester), date=date(2019, 11, 11), label='Remembrance Day')
+
+        self.assertEqual(
+            ExcludedDate.from_other_semesters(semester),
+            [{'date': '2019-11-11', 'label': 'Remembrance Day'}],
+        )
+
+    def test_from_other_semesters__prefers_a_labelled_row_over_an_unlabelled_one(self):
+        """Collapsing two rows for a date keeps the label, which is the part worth copying."""
+        semester = baker.make(Semester)
+        baker.make(ExcludedDate, semester=baker.make(Semester), date=date(2019, 11, 11), label='')
+        baker.make(ExcludedDate, semester=baker.make(Semester), date=date(2019, 11, 11), label='Remembrance Day')
+
+        self.assertEqual(
+            ExcludedDate.from_other_semesters(semester),
+            [{'date': '2019-11-11', 'label': 'Remembrance Day'}],
+        )
+
+    def test_from_other_semesters__an_unsaved_semester_has_none_of_its_own_to_leave_out(self):
+        """The create form is offered every excluded date on the deck.
+
+        `SemesterCreate.get_object` hands the form an unsaved Semester, which cannot be the
+        owner of any row, so there is nothing to exclude from the offer.
+        """
+        baker.make(ExcludedDate, semester=baker.make(Semester), date=date(2019, 11, 11), label='Remembrance Day')
+
+        self.assertEqual(
+            ExcludedDate.from_other_semesters(Semester()),
+            [{'date': '2019-11-11', 'label': 'Remembrance Day'}],
+        )

--- a/src/courses/tests/test_views.py
+++ b/src/courses/tests/test_views.py
@@ -1701,6 +1701,52 @@ class SemesterViewTests(ByteDeckTenantTestCase):
 
         self.assertFalse(ExcludedDate.objects.exists())
 
+    def test_SemesterUpdate__offers_the_other_semesters_excluded_dates_to_copy(self):
+        """The form carries the deck's other excluded dates, and the button that copies them in.
+
+        The dates are read by the page's JavaScript, which decides which of them fall inside
+        this semester, so they are rendered to the page rather than filtered here (#2648).
+        """
+        self.client.force_login(self.test_teacher)
+        night_school = baker.make(Semester)
+        baker.make(ExcludedDate, semester=night_school, date=datetime.date(2019, 11, 11), label='Remembrance Day')
+
+        semester = SiteConfig.get().active_semester
+        response = self.assert200('courses:semester_update', args=[semester.pk])
+
+        self.assertEqual(
+            response.context['other_excluded_dates'],
+            [{'date': '2019-11-11', 'label': 'Remembrance Day'}],
+        )
+        self.assertContains(response, 'id="copy-excluded-dates"')
+        self.assertContains(response, '2019-11-11')
+
+    def test_SemesterUpdate__no_copy_button_when_the_other_semesters_exclude_nothing(self):
+        """A deck with nothing to copy is not shown a button that could never do anything."""
+        self.client.force_login(self.test_teacher)
+        baker.make(Semester)
+
+        semester = SiteConfig.get().active_semester
+        baker.make(ExcludedDate, semester=semester, date=datetime.date(2019, 11, 11))
+        response = self.assert200('courses:semester_update', args=[semester.pk])
+
+        self.assertEqual(response.context['other_excluded_dates'], [])
+        self.assertNotContains(response, 'id="copy-excluded-dates"')
+
+    def test_SemesterCreate__offers_every_excluded_date_on_the_deck_to_copy(self):
+        """A semester being created is offered all of them: it owns none of them yet."""
+        self.client.force_login(self.test_teacher)
+        baker.make(ExcludedDate, semester=SiteConfig.get().active_semester,
+                   date=datetime.date(2019, 11, 11), label='Remembrance Day')
+
+        response = self.assert200('courses:semester_create')
+
+        self.assertEqual(
+            response.context['other_excluded_dates'],
+            [{'date': '2019-11-11', 'label': 'Remembrance Day'}],
+        )
+        self.assertContains(response, 'id="copy-excluded-dates"')
+
     def test_SemesterUpdate__a_date_another_semester_already_excludes_is_accepted(self):
         """A holiday another semester excludes can be excluded from this one too.
 

--- a/src/courses/views.py
+++ b/src/courses/views.py
@@ -34,7 +34,7 @@ from .forms import (
     BlockForm, CourseStudentForm, CourseStudentStaffForm, MarkRangeForm, RankForm, SemesterForm,
     ExcludedDateFormset, ExcludedDateFormsetHelper,
 )
-from .models import Block, Course, CourseStudent, Rank, Semester, MarkRange, semester_for
+from .models import Block, Course, CourseStudent, ExcludedDate, Rank, Semester, MarkRange, semester_for
 
 from django.db import transaction
 from django.db.models import ProtectedError, Q
@@ -806,6 +806,14 @@ class SemesterCreateUpdateFormsetMixin:
         ctx = super().get_context_data(**kwargs).copy()
         ctx['formset'] = kwargs.get('formset', self.get_formset())
         ctx['helper'] = ExcludedDateFormsetHelper()
+        # What the page's Copy button offers to bring in, so the same holidays are not typed
+        # again for every semester running alongside this one (#2648). Empty on a deck whose
+        # other semesters exclude nothing, and the template then leaves the button out.
+        #
+        # From get_object() rather than self.object, like get_formset_queryset above: on a
+        # create GET, CreateView.get sets self.object back to None after this mixin's own get
+        # has set it, so the semester is only reliably reachable by asking for it again.
+        ctx['other_excluded_dates'] = ExcludedDate.from_other_semesters(self.get_object())
         return ctx
 
     # formsets


### PR DESCRIPTION
…(#2650)

* fix: make an excluded date unique per semester, not deck-wide (#2647)

`ExcludedDate.date` was `unique=True`, so one row per date across the whole deck. Every excluded date already belongs to a semester through its own FK, and a semester counts its class days off only its own `excludeddate_set`, so the constraint was answering a question nobody asked: it let one semester's holiday block another semester from recording the same day.

Now that a deck can run more than one semester at a time, that is a wall. A teacher entering Remembrance Day for the second semester is told "Excluded date with this Date already exists" and cannot record it at all, so the semester's class-day count is wrong by however many holidays the other semester claimed first.

Replace it with a UniqueConstraint on (semester, date), which is what the model meant. A semester still gets one row per day; two semesters get one each.

`semester` is not a field on `ExcludedDateForm` (the view attaches it in `save`), and Django's formset uniqueness check only covers a constraint whose every field is on the form, so it no longer sees this one: two rows naming the same day would reach the database as an IntegrityError and a 500. The formset now compares its rows against each other, which is the whole check, because the view hands it the semester's entire `excludeddate_set`. Rows marked for deletion are skipped, so retyping a date on a fresh row while removing the one that held it still saves.

The migration drops the old unique index before adding the constraint and touches no column, so it is safe in the deploy window: the outgoing version reads the same rows and its own extra uniqueness check simply finds nothing.

Closes #2647


Claude-Session: https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox

* feat: copy the other semesters' excluded dates into this one (#2648)

A deck running two semesters at once skips the same public holidays in both, and since #2647 that means entering each of them twice by hand. The semester form now offers a button that brings the dates the deck's other semesters exclude into this one, and the teacher edits or removes any of them before saving, since nothing is written until they press Update.

Only the dates falling between this semester's first and last day arrive, so a semester copying from a longer one does not inherit days it never runs on. That range is typed on the same page, so the button is disabled until both ends are filled in, and its hover text says so. The title sits on a wrapping span rather than the button, because a disabled button receives no mouse events and a title on it would never be seen in exactly the state that needs explaining.

`ExcludedDate.from_other_semesters` gathers what is on offer. Two semesters that both skip a holiday hold a row each and the teacher wants that day once, so the rows are collapsed by date, keeping the label where one of them has it. The create form is offered every excluded date on the deck: its semester does not exist yet, so none of the rows can be its own.

The button is only rendered when there is something to copy, so a deck running a single semester does not carry a control that could never do anything. The dates are handed to the page rather than filtered here, because the range they are matched against is being typed rather than stored.

`AddForm` grows optional date and label arguments, so a caller can say what the new row holds instead of overwriting the guess it makes from the row above. Its date-picker set-up is now conditional on the plugin having loaded: the picker is an enhancement on a text input, its script comes from a CDN, and a network that cannot reach that CDN would otherwise throw there and abandon the caller, which for the copy button means the rest of the dates never arrive.

Closes #2648


Claude-Session: https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox

* fix: delete excluded dates before saving the rows that changed (#2647)

Moving a date onto a day that a row further down the form is giving up raised IntegrityError, so the teacher who retyped a mistyped holiday onto the right day and deleted the leftover row got a 500.

Django walks the rows the formset already had in form order, deleting or writing each as it comes, and the view hands them over sorted by date. The edited row is therefore written while the row being deleted still holds the day, and a date is unique within its semester.

This is a regression from the constraint change, not something it inherited. Before it, the same edit came back as a validation error: `date` was unique on its own, so Django's per-form uniqueness check covered it. The new constraint names `semester`, which is not a field on these forms, so that check no longer runs and the collision reaches the database instead.

Sort the rows so the deletions go first, which frees the day before anything moves onto it, and put the order back afterwards, since it is the order the rows were validated and would be rendered in.

Reported by CodeRabbit on PR #2649.


Claude-Session: https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox

---------
