### PR TITLE
fix: post the dates the copy button fills in (#2652)

### DIFF
--- a/src/courses/templates/courses/semester_form.html
+++ b/src/courses/templates/courses/semester_form.html
@@ -81,6 +81,21 @@
     const formInitialForms = document.getElementById("id_form-INITIAL_FORMS");
     const initialForms = parseInt(formInitialForms.getAttribute("value"))-1;
 
+    // Put a date into a row's field, updating both the box the teacher reads and the value the
+    // form posts. The date picker moves the field's name onto a hidden input beside it and
+    // drives that input from its own dp.change event, so writing to the visible box alone
+    // shows the date and submits nothing (#2652). Going through the picker fires that event.
+    // Its script comes from a CDN, and when that has not loaded there is no hidden input:
+    // the visible box still carries the field's name, so assigning to it is what posts.
+    function setDateValue(dateInput, value) {
+        const picker = window.jQuery && jQuery(dateInput).closest(".dbdp").data("DateTimePicker");
+        if (picker) {
+            picker.date(moment(value, "YYYY-MM-DD"));
+        } else {
+            dateInput.value = value;
+        }
+    }
+
     // Parse date string as local date to avoid timezone issues
     function parseLocalDate(dateStr) {
         const [year, month, day] = dateStr.split('-').map(Number);
@@ -160,7 +175,7 @@
         // set copied values
         const newDateInput = document.querySelector(`#id_form-${newIndex}-date`);
         if (newDateInput && nextDateStr) {
-            newDateInput.value = nextDateStr;
+            setDateValue(newDateInput, nextDateStr);
         }
         // Assigned even when blank, so a caller-supplied blank clears the label carried
         // forward above. On a row nobody supplied values for, the field is empty either way.
@@ -265,7 +280,7 @@
                 // copying into an empty semester does not leave a stray empty row behind.
                 const blank = visibleDateInputs().find(input => !input.value);
                 if (blank) {
-                    blank.value = entry.date;
+                    setDateValue(blank, entry.date);
                     document.getElementById(blank.id.replace(/-date$/, "-label")).value = entry.label;
                 } else {
                     AddForm(entry.date, entry.label);


### PR DESCRIPTION
### What?

The first date the **Copy dates from your other semesters** button brought over is now saved instead of disappearing.

Closes #2652

> **This is broken in production**, since #2650 went out with #2651 today, and it fails on every use of the button rather than in an edge case. Opened against `develop` as usual, but say the word and I will rebase it onto `staging` as a hotfix.

### Why?

The date picker rewrites every date field on the page. `datepicker-widget.js` moves the field's `name` off the visible box onto a hidden input beside it, and updates that hidden input only when its own `dp.change` event fires:

```js
formInputElement.setAttribute("name", inputElement.getAttribute("name"));
formInputElement.value = inputElement.value;
inputElement.removeAttribute("name");
```

So the copy, which assigned to `input.value`, showed the teacher a date and posted nothing for it. The row reached the server with a label and no date, which is what "This field is required." is reporting.

**Only the first date was lost** because the picker had already processed the blank row waiting at the end of the form, seeding its hidden input with the empty string. Rows the copy *adds* are filled synchronously before the picker's `MutationObserver` reaches them, so it snapshots a field that already holds the date. That is why the rest of them survived.

**This is exactly the blind spot I flagged in #2650 and then failed to account for.** That PR noted the picker's script comes from a CDN this environment blocks. I treated that as a cosmetic artifact worth a footnote. It was not: with no picker, the visible inputs keep their `name`s, so the code under test was never the code that runs on a real deck.

### How?

One place now knows how to put a date into a row:

```js
function setDateValue(dateInput, value) {
    const picker = window.jQuery && jQuery(dateInput).closest(".dbdp").data("DateTimePicker");
    if (picker) {
        picker.date(moment(value, "YYYY-MM-DD"));
    } else {
        dateInput.value = value;
    }
}
```

Handing the value to the picker fires `dp.change`, so the hidden input follows and the picker's own state stays consistent with what is on screen. When the picker did not load there is no hidden input, the visible box still carries the field's name, and assigning to it is what posts. Both the copy loop and `AddForm` go through it, so a row is filled the same way however it got there.

### Testing?

`ruff check src` clean, and the `courses` app `Ran 357 tests ... OK`. No test changes: the defect is entirely in which input carries the value in the browser, and the server cannot tell the two apart. This repo has no JavaScript test harness, so it was verified by driving the real widget instead.

**To do that I had to make the picker load.** This environment's network policy blocks `cdn.jsdelivr.net`, so I fetched the same two files from npm (`moment@2.29.4`, `eonasdan-bootstrap-datetimepicker@4.17.49`) plus the widget script already installed in `site-packages`, and served them to the page from disk. The deck is the real seeded `hackerspace` one; only the asset origin differs.

Reading the values the page shows against the values it would post, on Night School 2026 copying three dates from Fall 2026:

| | shown in the form | actually posted |
| --- | --- | --- |
| **released code** | `['2026-10-12', '2026-09-25', '2026-10-30', '2026-11-11']` | `['2026-10-12', '', '2026-10-30', '2026-11-11']` |
| **this branch** | `['2026-10-12', '2026-09-25', '2026-10-30', '2026-11-11']` | `['2026-10-12', '2026-09-25', '2026-10-30', '2026-11-11']` |

Released, the save bounces back to the form with the error. Fixed, it redirects to the semester list.

Checked in four states, each on the released code and again on this branch:

* copying into a semester that already has excluded dates (the report's case),
* copying into one with none, which fails the same way, so the button never worked on a real deck,
* the `+` button, whose new row still gets its picker from the widget's observer and saves,
* and the no-picker path, so a deck that cannot reach the CDN keeps working.

### Screenshots (if front end is affected)

**Before**, after pressing Update: the first copied date is gone and its label is stranded.

![The Update Semester form for Night School 2026, the first copied row with an empty date field, "This field is required." beneath it, and its Pro-D Day label still filled in](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2652/before.png)

**After**: the save goes through, and Night School 2026 carries the four dates.

![The Semesters list showing Night School 2026 with 4 under # Excluded Dates](https://raw.githubusercontent.com/bytedeck/bytedeck/pr-assets/2652/after.png)

### Anything Else?

**`AddForm` still initializes a picker on each new row itself, and that call can no longer do anything**: this version of the package attaches to the `.dbdp` wrapper from a `MutationObserver`, not to the input that line passes it. I confirmed new rows are picked up without it, but left it alone rather than widen a production fix. Filed as #2654.

**The real lesson is the harness.** A browser check that silently runs without the page's third-party assets can pass while the shipped page is broken, which is what happened here. The local-asset trick above is a small thing to keep; whether it is worth turning into something the repo runs is #2655.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed copied course dates not being correctly reflected in submitted forms when the date picker is enabled.
  - Improved date updates when copying course details or excluding dates, ensuring the displayed and submitted values stay synchronized.
  - Preserved date entry behavior when the date picker is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->