### PR TITLE
fix: stop two regenerations of one map from wrecking each other (#2656)

### DIFF
--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
-from django.db import models
+from django.db import models, transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
@@ -747,7 +747,7 @@ class CytoScape(models.Model):
             # Create a node for this campaign (or get it if it already exists).
             # selector_id ties the compound node back to its Category (like quest/badge nodes do),
             # so the map can order campaigns left-to-right by Category.map_order (issue #1977).
-            campaign_node, campaign_created = CytoElement.objects.get_or_create(
+            campaign_node, _ = CytoElement.objects.get_or_create(
                 scape=self,
                 group=CytoElement.NODES,
                 label=CytoScape.generate_label(obj.campaign),
@@ -760,9 +760,16 @@ class CytoScape(models.Model):
             target_node.save()
 
             # TempCampaign utility for cleaning up the edges and making the resulting map look good, after the entire map is built
-            if campaign_created:
-                self.campaign_list.append(TempCampaign(campaign_node.id))
+            # Whether this run has met the campaign yet, which is what the caller and the edge
+            # cleanup both want to know. get_or_create reports whether it wrote the row, and the
+            # two answers differ whenever the node is already in the table: campaign_list is
+            # rebuilt per run, so it would hold nothing for that node and the add_node below
+            # would be reached with None (#2656).
             temp_campaign = self.get_temp_campaign(campaign_node.id)  # not a Django model, so custom method
+            campaign_created = temp_campaign is None
+            if campaign_created:
+                temp_campaign = TempCampaign(campaign_node.id)
+                self.campaign_list.append(temp_campaign)
 
             # TODO: Nodes might be present multiple times through different source nodes?  check and combine
             temp_campaign.add_node(target_node.id, source_node.id)
@@ -1009,10 +1016,30 @@ class CytoScape(models.Model):
         self.save()
 
     def regenerate(self):
+        """Rebuild this map's elements from the objects it maps.
+
+        Raises:
+            InitialObjectDoesNotExist: if the object the map starts from is gone, in which
+                case the map deletes itself, since it has nothing left to draw.
+        """
         if self.initial_content_object is None:
             self.delete()
             raise (self.InitialObjectDoesNotExist)
 
-        # Delete existing nodes
-        CytoElement.objects.all_for_scape(self).delete()
-        self.calculate_nodes()
+        with transaction.atomic():
+            # One regeneration of a map at a time. Saving any Quest, Badge, Rank or Prereq
+            # queues regenerate_map for each related map (djcytoscape/signals.py), so editing a
+            # single quest can put several tasks on the same map. Each of them starts by
+            # deleting the elements the others are midway through building on, and the loser
+            # either meets a campaign node it did not create or writes an edge to a node that
+            # has just been deleted (#2656). Taking the map's own row makes the second task
+            # wait for the first and then rebuild from a settled starting point.
+            #
+            # Holding it for the whole rebuild is also what keeps the map readable throughout:
+            # the delete and the nodes replacing it land together, so nobody loading the page
+            # meets the empty gap between them.
+            CytoScape.objects.select_for_update().get(pk=self.pk)
+
+            # Delete existing nodes
+            CytoElement.objects.all_for_scape(self).delete()
+            self.calculate_nodes()

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -1,11 +1,14 @@
 import json
 from collections import defaultdict
 from itertools import cycle
+from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import SimpleTestCase
+from django.test.utils import CaptureQueriesContext
 
 from model_bakery import baker
 
@@ -583,6 +586,62 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
 
         # should have been deleted at this point
         self.assertFalse(CytoScape.objects.filter(name="bad map").exists())
+
+    def test_calculate_nodes__campaign_nodes_already_in_the_table_are_still_tracked(self):
+        """Building a map whose campaign nodes are already there tracks them all the same.
+
+        `campaign_list` is rebuilt for each run, so a campaign node that is in the table but was
+        not written by this run has nothing in it. Deciding whether to track a campaign from
+        whether `get_or_create` wrote the row is what left `get_temp_campaign` returning None on
+        the line before it is asked to add a node (#2656). Two regenerations of one map racing
+        each other is how that state arises: each starts by deleting what the other is building
+        on, and the one that loses meets the winner's campaign nodes.
+        """
+        campaign_nodes = CytoElement.objects.all_for_scape(self.map).filter(classes='campaign')
+        self.assertTrue(campaign_nodes.exists(), "fixture has no campaigns to exercise this with")
+
+        # No delete first: this is the map's own elements standing in for another run's.
+        self.map.calculate_nodes()
+
+        tracked = {campaign.node_id for campaign in self.map.campaign_list}
+        self.assertTrue(tracked, "no campaign was tracked for the edge cleanup")
+        self.assertTrue(
+            tracked.issubset(set(campaign_nodes.values_list('id', flat=True))),
+            "a tracked campaign does not correspond to a campaign node on the map",
+        )
+
+    def test_regenerate__takes_the_maps_row_so_two_of_them_cannot_interleave(self):
+        """Regenerating locks the map's own row, so a second regeneration waits for the first.
+
+        Saving any Quest, Badge, Rank or Prereq queues `regenerate_map` for every related map,
+        so several tasks land on one map routinely. Each begins by deleting the elements the
+        others are building on, which leaves the loser writing edges to nodes that no longer
+        exist (#2656). The lock is what stops them overlapping, so its absence is the failure.
+        """
+        with CaptureQueriesContext(connection) as queries:
+            self.map.regenerate()
+
+        locking = [
+            query['sql'] for query in queries
+            if 'FOR UPDATE' in query['sql'] and 'djcytoscape_cytoscape' in query['sql']
+        ]
+        self.assertTrue(locking, "regenerate() did not lock the map row it is about to rebuild")
+
+    def test_regenerate__a_failure_part_way_through_leaves_the_map_alone(self):
+        """A regeneration that raises leaves the map that was there, rather than a deleted one.
+
+        The rebuild drops every element before writing the new ones, so without a transaction
+        around the pair, anything that goes wrong in between leaves the deck with an empty map.
+        """
+        before = list(CytoElement.objects.all_for_scape(self.map).values_list('id', flat=True))
+        self.assertTrue(before, "fixture map has no elements to preserve")
+
+        with patch.object(CytoScape, 'calculate_nodes', side_effect=RuntimeError('boom')):
+            with self.assertRaises(RuntimeError):
+                self.map.regenerate()
+
+        after = list(CytoElement.objects.all_for_scape(self.map).values_list('id', flat=True))
+        self.assertEqual(after, before)
 
     def test_get_related_maps__counts_maps_per_quest(self):
         """ Check if CytoScape.objects.get_related_maps returns the correct maps per quest.


### PR DESCRIPTION
### What?

Two `regenerate_map` tasks rebuilding the same map at once no longer collide, and a rebuild that fails part way no longer leaves the deck with an empty map.

Closes #2656

### Why?

The issue reports two exceptions. They are the same cause, and the second one names it:

```
IntegrityError: insert or update on table "djcytoscape_cytoelement" violates foreign key
constraint ... Key (data_source_id)=(122069) is not present in table "djcytoscape_cytoelement".
```

That edge's source is the campaign node **the same run had created two lines earlier** (`campaign_node_created` was True on the line above it in the traceback), and the database says the node is gone. `regenerate()` opens with `CytoElement.objects.all_for_scape(self).delete()`, so another run deleted it mid-build.

Two runs colliding is routine rather than exotic: `regenerate_map` is queued from a `post_save`/`post_delete` on every Quest, Badge, Rank and Prereq (`djcytoscape/signals.py`), so editing one quest with a few prereqs puts several tasks on the same map.

**The `AttributeError` has a second cause of its own,** which reproduces with no concurrency at all. `add_to_campaign` decided whether to track a campaign from whether `get_or_create` *wrote the row*:

```python
campaign_node, campaign_created = CytoElement.objects.get_or_create(...)
if campaign_created:
    self.campaign_list.append(TempCampaign(campaign_node.id))
temp_campaign = self.get_temp_campaign(campaign_node.id)
temp_campaign.add_node(target_node.id, source_node.id)   # None when the row already existed
```

`campaign_list` is rebuilt per run, so "did I write this row" and "has this run met this campaign" are different questions, and they disagree exactly when the node is already in the table. The method's own docstring already describes the second one: *"campaign_created = False if obj is in campaign, but the campaign was created by an earlier node"*. The implementation had drifted from it.

**And a third problem nobody has reported.** The delete and the rebuild were not in a transaction, so anything raising between them left the map empty until some later save happened to queue another regeneration. The two crashes above were doing precisely that, so decks were almost certainly losing maps for a while, not just logging errors.

### How?

**`regenerate()` takes the map's own row for the length of the rebuild.**

```python
with transaction.atomic():
    CytoScape.objects.select_for_update().get(pk=self.pk)
    CytoElement.objects.all_for_scape(self).delete()
    self.calculate_nodes()
```

The second task waits for the first and then rebuilds from a settled starting point rather than from underneath it. One transaction also means the delete and the elements replacing it land together, so a failure rolls back to the map that was there, and nobody loading the page meets the gap in between.

**`add_to_campaign` tracks by what this run has met**, so the flag it returns means what its docstring says. That flag also drives `if campaign_node_created: find_reliant_objects_and_add_target_nodes(...)` in the caller, which wants the same "first time this run has seen this campaign" answer.

### Testing?

Full suite `Ran 2937 tests ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected).

Three new tests, each confirmed to fail when only the part of the fix it covers is reverted:

| Test | Mutation | What it reports |
| --- | --- | --- |
| `test_calculate_nodes__campaign_nodes_already_in_the_table_are_still_tracked` | track from `get_or_create`'s flag again | `AttributeError: 'NoneType' object has no attribute 'add_node'`, the reported traceback verbatim |
| `test_regenerate__takes_the_maps_row_so_two_of_them_cannot_interleave` | drop the `select_for_update` | `[] is not true : regenerate() did not lock the map row it is about to rebuild` |
| `test_regenerate__a_failure_part_way_through_leaves_the_map_alone` | drop the `transaction.atomic` | `Lists differ: [] != [1, 3, 5, 7, 2, 10, 13, 16, ...]`, the map wiped |

The first is a real reproduction rather than a stand-in: building the primary map and calling `calculate_nodes()` again while its elements are still in the table puts the code in exactly the state a losing concurrent run finds, and it raises at `models.py:768` just as production did.

The third is worth reading for its output. Without the transaction the map comes back **empty**, which is the harm the reported crashes were doing in the background.

The lock itself is asserted through the SQL it emits rather than by racing two threads: a threaded test against a tenant schema would be both slow and flaky, and what actually prevents the crash is that the statement is issued at all.

### Screenshots (if front end is affected)

N/A: nothing a user sees changes. This is the model layer, and a map that regenerates without crashing renders exactly as it did before. What changes is that it stops going blank.

### Anything Else?

**Two more `get_temp_campaign` results are used without a None check**, in `find_reliant_objects_and_add_target_nodes`:

```python
temp_campaign: TempCampaign = self.get_temp_campaign(source_node.data_parent.id)
temp_campaign.add_reliant(source_node.id, target_node.id)
```

Left alone. With the lock in place a run only ever meets campaign nodes it created itself, so neither can return None today, and adding guards against a state that cannot arise would say something untrue about the code. Worth revisiting if a caller is ever added that rebuilds without deleting first.

**Every save still queues a task per related map**, so a bulk edit can queue a lot of duplicate regenerations of one map. They are now correct but serialised, which means slower rather than broken. Deduplicating them is a separate piece of work; filed as #2658.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3TGVu2FGuSeYeVq7s9Qox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Regenerated diagrams now maintain a consistent element order and layout across repeated regenerations.
  - Existing campaign nodes are correctly recognized, preventing them from being treated as newly created.
  - Concurrent regenerations are handled safely to prevent conflicting updates.
  - If regeneration fails partway through, existing diagram elements are preserved instead of being removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->