### PR TITLE
perf: collapse a run of saves into one map regeneration (#2658)

### DIFF
--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -1022,34 +1022,48 @@ class CytoScape(models.Model):
             on_lock_acquired: optional callable, run once this map's row is held and
                 immediately before the rebuild reads anything. `regenerate_map` releases
                 its claim on the map there (djcytoscape/tasks.py): up to that moment the
-                task has read nothing, so it still covers every save made while it waited
-                for the row, and past it, it does not.
+                rebuild has read nothing it keeps, so it still covers every save made
+                while it waited for the row, and past it, it does not.
 
         Raises:
             InitialObjectDoesNotExist: if the object the map starts from is gone, in which
                 case the map deletes itself, since it has nothing left to draw.
         """
-        if self.initial_content_object is None:
+        try:
+            with transaction.atomic():
+                # One regeneration of a map at a time. Saving any Quest, Badge, Rank or Prereq
+                # queues regenerate_map for each related map (djcytoscape/signals.py), so editing a
+                # single quest can put several tasks on the same map. Each of them starts by
+                # deleting the elements the others are midway through building on, and the loser
+                # either meets a campaign node it did not create or writes an edge to a node that
+                # has just been deleted (#2656). Taking the map's own row makes the second task
+                # wait for the first and then rebuild from a settled starting point.
+                #
+                # Holding it for the whole rebuild is also what keeps the map readable throughout:
+                # the delete and the nodes replacing it land together, so nobody loading the page
+                # meets the empty gap between them.
+                CytoScape.objects.select_for_update().get(pk=self.pk)
+
+                # Load this map, and the object it starts from, again now that the row is
+                # ours. Waiting for it can take as long as the whole rebuild ahead of it, and
+                # every save made during that wait is collapsed into this rebuild rather than
+                # given one of its own (djcytoscape/tasks.py), so building from what was read
+                # before the wait would publish a map missing them with nothing queued to
+                # correct it. refresh_from_db clears the cached initial_content_object too,
+                # which is the one calculate_nodes builds the map's first node from.
+                self.refresh_from_db()
+
+                if on_lock_acquired is not None:
+                    on_lock_acquired()
+
+                if self.initial_content_object is None:
+                    raise self.InitialObjectDoesNotExist
+
+                # Delete existing nodes
+                CytoElement.objects.all_for_scape(self).delete()
+                self.calculate_nodes()
+        except self.InitialObjectDoesNotExist:
+            # Out here rather than inside the block above: raising rolls that block back,
+            # so a delete made in it would be undone along with everything else.
             self.delete()
-            raise (self.InitialObjectDoesNotExist)
-
-        with transaction.atomic():
-            # One regeneration of a map at a time. Saving any Quest, Badge, Rank or Prereq
-            # queues regenerate_map for each related map (djcytoscape/signals.py), so editing a
-            # single quest can put several tasks on the same map. Each of them starts by
-            # deleting the elements the others are midway through building on, and the loser
-            # either meets a campaign node it did not create or writes an edge to a node that
-            # has just been deleted (#2656). Taking the map's own row makes the second task
-            # wait for the first and then rebuild from a settled starting point.
-            #
-            # Holding it for the whole rebuild is also what keeps the map readable throughout:
-            # the delete and the nodes replacing it land together, so nobody loading the page
-            # meets the empty gap between them.
-            CytoScape.objects.select_for_update().get(pk=self.pk)
-
-            if on_lock_acquired is not None:
-                on_lock_acquired()
-
-            # Delete existing nodes
-            CytoElement.objects.all_for_scape(self).delete()
-            self.calculate_nodes()
+            raise

--- a/src/djcytoscape/models.py
+++ b/src/djcytoscape/models.py
@@ -1015,8 +1015,15 @@ class CytoScape(models.Model):
         self.update_cache()
         self.save()
 
-    def regenerate(self):
+    def regenerate(self, on_lock_acquired=None):
         """Rebuild this map's elements from the objects it maps.
+
+        Args:
+            on_lock_acquired: optional callable, run once this map's row is held and
+                immediately before the rebuild reads anything. `regenerate_map` releases
+                its claim on the map there (djcytoscape/tasks.py): up to that moment the
+                task has read nothing, so it still covers every save made while it waited
+                for the row, and past it, it does not.
 
         Raises:
             InitialObjectDoesNotExist: if the object the map starts from is gone, in which
@@ -1039,6 +1046,9 @@ class CytoScape(models.Model):
             # the delete and the nodes replacing it land together, so nobody loading the page
             # meets the empty gap between them.
             CytoScape.objects.select_for_update().get(pk=self.pk)
+
+            if on_lock_acquired is not None:
+                on_lock_acquired()
 
             # Delete existing nodes
             CytoElement.objects.all_for_scape(self).delete()

--- a/src/djcytoscape/signals.py
+++ b/src/djcytoscape/signals.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.dispatch import receiver
 from django.db.models.signals import post_save, post_delete
 
@@ -8,7 +9,7 @@ from quest_manager.models import Quest
 from courses.models import Rank
 from prerequisites.models import Prereq
 
-from djcytoscape.tasks import regenerate_map
+from djcytoscape.tasks import MAP_REGENERATION_DELAY, MAP_REGENERATION_PENDING_TIMEOUT, pending_regeneration_key, regenerate_map
 from utilities.signals import disable_for_loaddata
 
 
@@ -16,17 +17,27 @@ def regenerate_related_maps(instance):
     """ Helper function for models that can exist as CytoElements.
     Attach to a models [post_save, pre_delete] signal to regenerate all related maps when
     said model is updated or deleted.
+
+    A map that already has a regeneration waiting to run is left to it instead of being
+    given a second one. One edit fires this several times over (the quest, then each of
+    its prereqs) and a bulk operation such as a library import fires it a great many
+    times, and each of those rebuilds the whole map from scratch (#2658).
     """
     if not SiteConfig.get().map_auto_update:
         return
 
-    # get related maps
-    related_map_ids = list(CytoScape.objects.get_related_maps(instance).values_list('id', flat=True))
-    if not related_map_ids:
+    # get related maps, claiming each one that has no regeneration waiting yet. cache.add
+    # writes only where the key is absent, so of several saves arriving together exactly
+    # one claims a given map and the rest are collapsed into the rebuild it queues.
+    map_ids_to_regenerate = [
+        map_id for map_id in CytoScape.objects.get_related_maps(instance).values_list('id', flat=True)
+        if cache.add(pending_regeneration_key(map_id), True, MAP_REGENERATION_PENDING_TIMEOUT)
+    ]
+    if not map_ids_to_regenerate:
         return
 
-    # run task in background
-    regenerate_map.apply_async(args=[related_map_ids], queue='default')
+    # run task in background, once the rest of this run of saves has had time to land
+    regenerate_map.apply_async(args=[map_ids_to_regenerate], countdown=MAP_REGENERATION_DELAY, queue='default')
 
 
 @receiver([post_save, post_delete], sender=Badge)

--- a/src/djcytoscape/signals.py
+++ b/src/djcytoscape/signals.py
@@ -22,6 +22,10 @@ def regenerate_related_maps(instance):
     given a second one. One edit fires this several times over (the quest, then each of
     its prereqs) and a bulk operation such as a library import fires it a great many
     times, and each of those rebuilds the whole map from scratch (#2658).
+
+    Args:
+        instance: the Quest, Badge or Rank that was saved or deleted, or for a Prereq,
+            the parent object it belongs to.
     """
     if not SiteConfig.get().map_auto_update:
         return

--- a/src/djcytoscape/tasks.py
+++ b/src/djcytoscape/tasks.py
@@ -1,4 +1,7 @@
+from functools import partial
+
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 
 from hackerspace_online.celery import app
 
@@ -8,6 +11,35 @@ from siteconfig.models import SiteConfig
 from .models import CytoScape
 
 User = get_user_model()
+
+# Seconds a regeneration queued by a signal waits before it runs. While one is
+# waiting, the signal will not queue a second for the same map, so a run of
+# saves costs one rebuild rather than one each. The wait is also what makes
+# collapsing them sound: it gives the rest of the run time to land, so the one
+# rebuild that does happen reads a database that already holds all of it.
+MAP_REGENERATION_DELAY = 10
+
+# How long the "already queued" marker survives on its own. `regenerate_map`
+# clears it as it starts, so this only decides how long a map keeps deduplicating
+# against a regeneration that never arrives (a worker lost, the queue purged, the
+# map deleted before the task reached it): shortly after the task was due, the
+# next save queues a fresh one instead.
+MAP_REGENERATION_PENDING_TIMEOUT = MAP_REGENERATION_DELAY * 2
+
+
+def pending_regeneration_key(map_id):
+    """Cache key marking that a regeneration of this map is queued and has not begun.
+
+    The cache namespaces keys by schema (`django_tenants.cache.make_key`), so the
+    same map id on two decks gets a marker each.
+
+    Args:
+        map_id (int): id of the Cytoscape map.
+
+    Returns:
+        str: the cache key for that map's pending regeneration.
+    """
+    return f'djcytoscape.pending_regeneration.{map_id}'
 
 
 @app.task(name='djcytoscape.tasks.regenerate_all_maps')
@@ -44,7 +76,17 @@ def regenerate_map(map_ids):
         map_ids (list[int]): list of ids belonging to Cytoscape maps
     """
     for scape in CytoScape.objects.filter(id__in=map_ids):
+        # Give up the claim from inside the rebuild, once this map's row is held and just
+        # before it reads. Waiting for that row can take as long as the rebuild ahead of
+        # it, and a rebuild that has read nothing still covers every save made while it
+        # waits, so releasing there rather than on the way in keeps the whole wait
+        # deduplicated. Past that point it may have read over a change already, so a save
+        # landing then has to queue a regeneration of its own rather than be lost in this.
+        release_claim = partial(cache.delete, pending_regeneration_key(scape.id))
+
         try:
-            scape.regenerate()
+            scape.regenerate(on_lock_acquired=release_claim)
         except scape.InitialObjectDoesNotExist:
+            # The map deleted itself before reaching its row, so the claim was never
+            # released. Nothing can ask for a deleted map again, so it just expires.
             pass

--- a/src/djcytoscape/tasks.py
+++ b/src/djcytoscape/tasks.py
@@ -72,6 +72,10 @@ def regenerate_map(map_ids):
     Since this function will be mainly used by post signals, notifications to a user wont be functional
     Unlike `regenerate_all_maps`
 
+    Each map's claim (the marker that keeps a second regeneration of it off the queue) is
+    given up from inside its rebuild, once that rebuild holds the map's row and just before
+    it reads, so the wait for the row stays deduplicated and the read does not.
+
     ARGS:
         map_ids (list[int]): list of ids belonging to Cytoscape maps
     """

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -627,6 +627,31 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         ]
         self.assertTrue(locking, "regenerate() did not lock the map row it is about to rebuild")
 
+    def test_regenerate__builds_from_the_initial_object_as_it_is_once_the_row_is_taken(self):
+        """The rebuild reads the object the map starts from after it holds the map's row.
+
+        Waiting for that row can take as long as the rebuild ahead of it, and every save
+        made during the wait is collapsed into this rebuild rather than given one of its
+        own (#2658), so building from what was loaded before the wait would publish a map
+        without those saves and queue nothing to correct it.
+
+        The wait is stood in for by resolving the initial object and then changing it in
+        the database behind the loaded instance, which is the state a task that waited is
+        in: `initial_content_object` is a GenericForeignKey, so the instance it hands back
+        is cached from whenever it was first asked for.
+        """
+        scape = CytoScape.objects.get(pk=self.map.pk)  # a fresh instance, as the task loads one
+        initial_quest = scape.initial_content_object  # resolved and cached before the wait
+        Quest.objects.filter(pk=initial_quest.pk).update(name='renamed while the rebuild waited')
+
+        scape.regenerate()
+
+        labels = CytoElement.objects.all_for_scape(scape).values_list('label', flat=True)
+        self.assertTrue(
+            any('renamed while the rebuild waited' in (label or '') for label in labels),
+            "the map's first node was built from the initial object as it was before the wait",
+        )
+
     def test_regenerate__runs_on_lock_acquired_between_taking_the_row_and_reading(self):
         """`on_lock_acquired` runs once the map's row is held and before anything is read.
 

--- a/src/djcytoscape/tests/test_models.py
+++ b/src/djcytoscape/tests/test_models.py
@@ -627,6 +627,28 @@ class CytoScapeModelTest(JSONTestCaseMixin, ByteDeckTenantTestCase):
         ]
         self.assertTrue(locking, "regenerate() did not lock the map row it is about to rebuild")
 
+    def test_regenerate__runs_on_lock_acquired_between_taking_the_row_and_reading(self):
+        """`on_lock_acquired` runs once the map's row is held and before anything is read.
+
+        `regenerate_map` gives up its claim on the map there (#2658), so where it runs is
+        exactly what decides which saves are collapsed into that task. Everything up to
+        this point is still covered by it, the wait for the row included, and nothing
+        after it is.
+        """
+        seen = {}
+
+        def record():
+            seen['row taken'] = any(
+                'FOR UPDATE' in query['sql'] and 'djcytoscape_cytoscape' in query['sql']
+                for query in queries.captured_queries
+            )
+            seen['nothing read yet'] = CytoElement.objects.all_for_scape(self.map).exists()
+
+        with CaptureQueriesContext(connection) as queries:
+            self.map.regenerate(on_lock_acquired=record)
+
+        self.assertEqual(seen, {'row taken': True, 'nothing read yet': True})
+
     def test_regenerate__a_failure_part_way_through_leaves_the_map_alone(self):
         """A regeneration that raises leaves the map that was there, rather than a deleted one.
 

--- a/src/djcytoscape/tests/test_signals.py
+++ b/src/djcytoscape/tests/test_signals.py
@@ -118,10 +118,10 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
         """A run of saves touching one map queues a single regeneration, not one apiece.
 
         Editing a quest with a few prereqs fires this signal several times over, and a
-        bulk operation such as a library import fires it a great many times. Each of
-        those used to queue a full rebuild of the same map, and since they take the
-        map's row in turn they then ran one after another, each throwing away the last
-        one's work (#2658).
+        bulk operation such as a library import fires it a great many times. A map that
+        already has a regeneration claimed is left to it, so the whole run costs one
+        rebuild between them. One per save would queue behind that map's row and rebuild
+        it in turn, each throwing away the last one's work (#2658).
         """
         quest = baker.make(Quest)
         scape = CytoScape.generate_map(quest, "Map")

--- a/src/djcytoscape/tests/test_signals.py
+++ b/src/djcytoscape/tests/test_signals.py
@@ -1,7 +1,12 @@
 from unittest.mock import patch
+
+from django.core.cache import cache
+
 from model_bakery import baker
 
 from djcytoscape.models import CytoScape
+from djcytoscape.tasks import MAP_REGENERATION_DELAY
+from djcytoscape.tests.utils import simulate_regeneration_starting
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from siteconfig.models import SiteConfig
 from badges.models import Badge
@@ -25,6 +30,7 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
 
         # should regenerate map on delete
         # the CytoElement linked also deleted (cascade). Therefore, no related maps
+        simulate_regeneration_starting(scape.id)
         object_.delete()
         self.assertEqual(task.call_count, 2)
         self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
@@ -34,6 +40,9 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
         self.config.map_auto_update = False
         self.config.save()
 
+        # clear the marker first, so the flag is the only thing that can be keeping
+        # this save off the queue
+        simulate_regeneration_starting(scape.id)
         object_.save()
         self.assertEqual(task.call_count, 2)
 
@@ -90,6 +99,7 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
         self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
 
         # should regenerate map on delete
+        simulate_regeneration_starting(scape.id)
         prereq.delete()
         self.assertEqual(task.call_count, 2)
         self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
@@ -98,13 +108,86 @@ class TestRegenerateMapSignals(ByteDeckTenantTestCase):
         self.config.map_auto_update = False
         self.config.save()
 
+        # clear the marker first, so the flag is the only thing that can be keeping
+        # this save off the queue
+        simulate_regeneration_starting(scape.id)
         prereq.save()
         self.assertEqual(task.call_count, 2)
+
+    def test_regenerate_related_maps__a_run_of_saves_queues_one_regeneration(self, task):
+        """A run of saves touching one map queues a single regeneration, not one apiece.
+
+        Editing a quest with a few prereqs fires this signal several times over, and a
+        bulk operation such as a library import fires it a great many times. Each of
+        those used to queue a full rebuild of the same map, and since they take the
+        map's row in turn they then ran one after another, each throwing away the last
+        one's work (#2658).
+        """
+        quest = baker.make(Quest)
+        scape = CytoScape.generate_map(quest, "Map")
+
+        for _ in range(5):
+            quest.save()
+
+        self.assertEqual(task.call_count, 1)
+        self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
+
+        # the wait is what makes collapsing them sound: the one rebuild that runs reads
+        # the database after the rest of the run of saves has landed
+        self.assertEqual(task.call_args.kwargs['countdown'], MAP_REGENERATION_DELAY)
+
+    def test_regenerate_related_maps__a_save_after_the_regeneration_starts_queues_another(self, task):
+        """A save landing once the queued regeneration has begun gets one of its own.
+
+        That rebuild may already have read past the change, so folding this save into it
+        would drop the edit rather than merely defer it: the map would stay as it was
+        until something else happened to be saved.
+        """
+        quest = baker.make(Quest)
+        scape = CytoScape.generate_map(quest, "Map")
+
+        quest.save()
+        self.assertEqual(task.call_count, 1)
+
+        simulate_regeneration_starting(scape.id)
+
+        quest.save()
+        self.assertEqual(task.call_count, 2)
+        self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
+
+    def test_regenerate_related_maps__collapses_per_map_not_per_save(self, task):
+        """Each map is collapsed on its own: one still pending doesn't hold up another.
+
+        A quest appears on as many maps as reference it, and they are rebuilt by
+        separate tasks that finish at different times, so a save has to be able to queue
+        a rebuild of one of them while another's is still waiting.
+        """
+        origin_a = baker.make(Quest, name='origin a')
+        origin_b = baker.make(Quest, name='origin b')
+        quest = baker.make(Quest, name='quest')
+        quest.add_simple_prereqs([origin_a, origin_b])
+
+        map_a = CytoScape.generate_map(origin_a, "Map A")
+        map_b = CytoScape.generate_map(origin_b, "Map B")
+
+        # start counting from the built fixture rather than from the saves that built it
+        task.reset_mock()
+        cache.clear()
+
+        quest.save()
+        self.assertEqual(task.call_count, 1)
+        self.assertEqual(sorted(task.call_args.kwargs['args'][0]), sorted([map_a.id, map_b.id]))
+
+        simulate_regeneration_starting(map_a.id)
+
+        quest.save()
+        self.assertEqual(task.call_count, 2)
+        self.assertEqual(task.call_args.kwargs['args'][0], [map_a.id], "map B's pending regeneration should still cover it")
 
     def test_prereq_signal__handles_all_registered_parent_models(self, task):
         """Saving a Prereq must not crash the map-regeneration signal for any
         registered prereq model as the parent. Loops through every model that
-        implements IsAPrereqMixin — the only models that are supposed to be
+        implements IsAPrereqMixin, the only models that are supposed to be
         used in a Prereq's generic foreign keys."""
         from django.contrib.contenttypes.models import ContentType
         from prerequisites.models import IsAPrereqMixin

--- a/src/djcytoscape/tests/test_tasks.py
+++ b/src/djcytoscape/tests/test_tasks.py
@@ -1,10 +1,13 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 
 from model_bakery import baker
 
 from djcytoscape.models import CytoScape
-from djcytoscape.tasks import regenerate_all_maps, regenerate_map
+from djcytoscape.tasks import pending_regeneration_key, regenerate_all_maps, regenerate_map
 from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from notifications.models import Notification
 
@@ -72,3 +75,28 @@ class CytoScapeTaskTests(ByteDeckTenantTestCase):
 
         # should be 3 as self.quest got linked to 3 maps
         self.assertEqual(CytoScape.objects.get_related_maps(self.quest).count(), 3)
+
+    def test_regenerate_map__gives_up_its_claim_from_inside_the_rebuild(self):
+        """The task holds its claim on a map until the rebuild has that map's row.
+
+        The claim is what keeps a second regeneration off the queue. Giving it up on the
+        way in would surrender it before the wait for the row, which can be as long as
+        the rebuild ahead of it, and queue a redundant rebuild for every save made during
+        that wait: saves this task has not read past and so still covers. Holding it past
+        the row would lose them instead, since the rebuild is reading from there (#2658).
+        """
+        scape = CytoScape.generate_map(self.quest, "Map")
+        key = pending_regeneration_key(scape.id)
+        cache.set(key, True, 60)
+
+        claim = {}
+
+        def rebuild(map_, on_lock_acquired=None):
+            claim['on the way in'] = cache.get(key)
+            on_lock_acquired()
+            claim['once the row is held'] = cache.get(key)
+
+        with patch.object(CytoScape, 'regenerate', autospec=True, side_effect=rebuild):
+            regenerate_map.apply(args=[[scape.id]], queue='default').get()
+
+        self.assertEqual(claim, {'on the way in': True, 'once the row is held': None})

--- a/src/djcytoscape/tests/utils.py
+++ b/src/djcytoscape/tests/utils.py
@@ -7,9 +7,9 @@ from djcytoscape.tasks import pending_regeneration_key
 def simulate_regeneration_starting(map_id):
     """Clear the marker that keeps a second regeneration off the queue for this map.
 
-    `regenerate_map` clears it itself, as the first thing it does for each map, so
-    that a save landing from then on queues its own rebuild instead of relying on
-    one that may already have read past it.
+    `regenerate_map` clears it once it holds the map's row and just before the
+    rebuild reads, so that a save landing from then on queues its own rebuild rather
+    than relying on one that may already have read past it.
 
     Tests that count queued regenerations mock `apply_async`, so no task ever runs
     to clear the marker: without this, everything saved after the first save is

--- a/src/djcytoscape/tests/utils.py
+++ b/src/djcytoscape/tests/utils.py
@@ -1,0 +1,23 @@
+"""Helpers shared by the map tests."""
+from django.core.cache import cache
+
+from djcytoscape.tasks import pending_regeneration_key
+
+
+def simulate_regeneration_starting(map_id):
+    """Clear the marker that keeps a second regeneration off the queue for this map.
+
+    `regenerate_map` clears it itself, as the first thing it does for each map, so
+    that a save landing from then on queues its own rebuild instead of relying on
+    one that may already have read past it.
+
+    Tests that count queued regenerations mock `apply_async`, so no task ever runs
+    to clear the marker: without this, everything saved after the first save is
+    collapsed into a regeneration that is forever pending, and nothing else is
+    queued. Calling this between two saves puts a test in the state a real deck is
+    in once the first save's task has started.
+
+    Args:
+        map_id (int): id of the Cytoscape map whose regeneration has notionally begun.
+    """
+    cache.delete(pending_regeneration_key(map_id))

--- a/src/prerequisites/tests/test_signals.py
+++ b/src/prerequisites/tests/test_signals.py
@@ -11,6 +11,7 @@ from hackerspace_online.tests.utils import ByteDeckTenantTestCase
 from prerequisites.models import Prereq
 from quest_manager.models import Quest, QuestSubmission
 from djcytoscape.models import CytoScape
+from djcytoscape.tests.utils import simulate_regeneration_starting
 from siteconfig.models import SiteConfig
 
 User = get_user_model()
@@ -231,6 +232,7 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
 
         # should regenerate map on delete
+        simulate_regeneration_starting(scape.id)
         prereq.delete()
         self.assertEqual(task.call_count, 2)
         self.assertEqual(task.call_args.kwargs['args'][0], [scape.id])
@@ -240,6 +242,9 @@ class PrerequisitesSignalsTest(ByteDeckTenantTestCase):
         sc.map_auto_update = False
         sc.save()
 
+        # clear the marker first, so the flag is the only thing that can be keeping
+        # this save off the queue
+        simulate_regeneration_starting(scape.id)
         prereq.save()
         self.assertEqual(task.call_count, 2)
 


### PR DESCRIPTION
### What?

A run of saves that touches one map now costs one regeneration of that map rather than one per save.

Closes #2658

### Why?

Saving a Quest, Badge, Rank or Prereq queues `regenerate_map` for every map that object appears on (`djcytoscape/signals.py`), and nothing collapsed those.

Until #2656 the duplicates overlapped and corrupted each other, which is what that issue was about. They now take the map's row in turn, so the queue is correct: each duplicate rebuilds the whole map in its turn and throws away the work of the one before it. A rebuild deletes every element on the map and walks the prerequisite graph to write them all back, so N of them is N times that work and N times that lock contention, for a map that ends up identical to what the first attempt produced.

Counted on a generated deck, with `apply_async` mocked so the tasks are only counted rather than run:

| | tasks queued, before | after |
| --- | --- | --- |
| Editing one quest and giving it five prerequisites | 6 | 1 |
| Touching the 36 quests of a campaign that share one map (what a library import or a bulk edit does) | 36 | 1 |

### How?

**The signal claims each map before it queues, and queues only what it claimed.**

```python
map_ids_to_regenerate = [
    map_id for map_id in CytoScape.objects.get_related_maps(instance).values_list('id', flat=True)
    if cache.add(pending_regeneration_key(map_id), True, MAP_REGENERATION_PENDING_TIMEOUT)
]
```

`cache.add` writes only where the key is absent, so of several saves arriving together exactly one claims a given map and the rest are collapsed into the rebuild it queues. The claim is per map rather than per save, so a map whose regeneration is still waiting does not hold up a different map that has none. It is the same reservation idiom already used in `tenant/views.py`, and the cache namespaces keys by schema, so two decks with the same map id get a claim each.

**The task is queued with a short countdown**, and that is what makes collapsing them sound rather than merely cheaper. The rest of the run of saves lands during the wait, so the one rebuild that runs reads a database that already holds all of it. Without the wait the first save's rebuild could start immediately and the saves collapsed into it would be genuinely lost.

**The task gives up its claim from inside the rebuild, at the one moment that is neither too early nor too late.** `regenerate()` takes an optional `on_lock_acquired`, run once it holds the map's row and immediately before it reads:

```python
with transaction.atomic():
    CytoScape.objects.select_for_update().get(pk=self.pk)
    self.refresh_from_db()

    if on_lock_acquired is not None:
        on_lock_acquired()

    if self.initial_content_object is None:
        raise self.InitialObjectDoesNotExist

    CytoElement.objects.all_for_scape(self).delete()
    self.calculate_nodes()
```

Both sides of that line matter, and they pull in opposite directions:

* **Later would lose saves.** From the read onward the rebuild may already have passed over a change, so a save landing then has to queue a regeneration of its own. Hold the claim through the rebuild and that save is folded into a task that will never see it, leaving the map stale until something unrelated is saved.
* **Earlier would queue redundant rebuilds.** Waiting for the row can take as long as the whole rebuild ahead of it, and a task that has read nothing still covers every save made while it waits. Releasing the claim on the way into `regenerate_map`, before that wait, would queue a fresh task roughly every countdown of continuous editing, each one lining up behind the same row.

Passing the release in as a callback rather than clearing the key inside `regenerate()` keeps the claim owned by the task that made it. The other rebuild paths (the per-map regenerate button, `regenerate_all_maps`) pass nothing and leave any outstanding claim alone, which is right: a queued task still exists and will still run, so a save during one of those rebuilds should be collapsed into it rather than given a second task.

**The rebuild reads the map again once it holds the row.** Extending the claim across that wait means every save made during it is collapsed into this rebuild, so this rebuild has to see them, and the instance it was handed was loaded before the wait. `initial_content_object` is a GenericForeignKey, which caches the object it resolves on the instance, so `calculate_nodes()` would have built the map's first node from the quest as it was before the wait and queued nothing to correct it. `self.refresh_from_db()` straight after the lock re-reads the row and clears those cached relations (Django 4.2 onwards, [#34137](https://code.djangoproject.com/ticket/34137)), so the object is resolved fresh.

That moves the "has the map still got something to draw?" check inside the lock too, since the initial object may have been deleted during the wait. The `self.delete()` that goes with it stays outside the block: raising rolls the block back, so a delete made inside would be undone with it.

The claim carries a timeout of twice the countdown, so a task that never runs (a worker lost, the queue purged, the map deleted before the task reached it) cannot stop a map from ever regenerating again. Erring that way is deliberate: a claim released too early costs a duplicate rebuild, which is the behaviour this replaces, while one held too long costs a map that silently stops updating.

### Testing?

Full suite `Ran 2943 tests ... OK`, plus `ruff check src`, `manage.py check` and `makemigrations --check --dry-run` (no changes detected). `signals.py`, `tasks.py` and the changed part of `models.py` are at 100% line and branch coverage.

Six new tests. Each was confirmed to fail when the part of the change it covers is reverted, and the ones that pin an ordering were checked against a mutation in each direction:

| Test | Mutation | What it reports |
| --- | --- | --- |
| `test_regenerate_related_maps__a_run_of_saves_queues_one_regeneration` | queue on every save again | `AssertionError: 5 != 1` |
| (same test, countdown assertion) | drop the `countdown` | `KeyError: 'countdown'` |
| `test_regenerate_related_maps__collapses_per_map_not_per_save` | queue on every save again | `Lists differ: [4, 5] != [4]` |
| `test_regenerate_map__gives_up_its_claim_from_inside_the_rebuild` | release on the way in, before the wait for the row | `{'on the way in': None, ...} != {'on the way in': True, ...}` |
| " | never release it | the task raises, `on_lock_acquired` never called |
| `test_regenerate__runs_on_lock_acquired_between_taking_the_row_and_reading` | run the callback before taking the row | `{'row taken': False, ...} != {'row taken': True, ...}` |
| " | run it after the elements are deleted | `{..., 'nothing read yet': False} != {..., 'nothing read yet': True}` |
| `test_regenerate__builds_from_the_initial_object_as_it_is_once_the_row_is_taken` | drop the `refresh_from_db` | `the map's first node was built from the initial object as it was before the wait` |
| the two pre-existing self-delete tests | move `self.delete()` inside the transaction | both fail on the map still existing, which is why the handler is outside |

`test_regenerate_related_maps__a_save_after_the_regeneration_starts_queues_another` guards the other direction: it still passes with the debounce removed entirely, because what it asserts is that a task *is* queued once the previous one has started. It is what would fail if the collapsing were made too eager.

The existing signal tests save an object and then delete it, counting a task for each. With a debounce those two are only separately visible once the first one's task has started, which in a test never happens because `apply_async` is mocked, so they now clear the claim in between through `simulate_regeneration_starting` (`djcytoscape/tests/utils.py`). The same call was added before the `map_auto_update = False` check in each of them, which is not bookkeeping: without it that assertion would pass because the claim was suppressing the save rather than because the setting was.

### Screenshots (if front end is affected)

N/A: nothing a user sees changes. A map still updates itself after an edit, it is just rebuilt once instead of several times. The one visible difference is timing: the rebuild starts ten seconds after the edit rather than immediately, which is well inside the delay a background task already had.

### Anything Else?

**The task is still queued before the transaction that changed the map commits.** `post_save` fires inside the transaction, so a worker picking the task up early can read the database without the change in it. An ordinary save in autocommit has already committed by then, but the library importer and a few other paths wrap a batch of saves in `transaction.atomic()`, which is exactly the bulk case this PR is about. The countdown makes the window much harder to hit than it was, since the rebuild no longer starts the instant the task is queued, but it does not close it: `transaction.on_commit` does, and that needs the existing signal tests reworked around `captureOnCommitCallbacks`. Predates this change and is filed separately as #2659.

### Review request
@tylerecouture

- Claude Code (`bytedeck - single session`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map regeneration reliability by using refreshed data after database locking.
  * Prevented duplicate regeneration tasks during bursts of related-object changes.
  * Delayed regeneration until pending saves are completed.
  * Improved handling of deleted or invalid map source objects.
  * Ensured regeneration notifications and cleanup occur correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->